### PR TITLE
Add support for frame-alignment attribute

### DIFF
--- a/Sources/PhoenixLiveViewNative/ViewTree.swift
+++ b/Sources/PhoenixLiveViewNative/ViewTree.swift
@@ -159,13 +159,40 @@ private extension View {
     private func frame(from element: Element) -> some View {
         var width: CGFloat?
         var height: CGFloat?
+        var alignment: Alignment
         if let s = element.attrIfPresent("frame-width"), let f = Double(s) {
             width = f
         }
         if let s = element.attrIfPresent("frame-height"), let f = Double(s) {
             height = f
         }
-        return self.frame(width: width, height: height)
+        switch element.attrIfPresent("frame-alignment") {
+        case "top-leading":
+            alignment = .topLeading
+        case "top":
+            alignment = .top
+        case "top-trailing":
+            alignment = .topTrailing
+        case "leading":
+            alignment = .leading
+        case "center":
+            alignment = .center
+        case "trailing":
+            alignment = .trailing
+        case "bottom-leading":
+            alignment = .bottomTrailing
+        case "bottom":
+            alignment = .bottom
+        case "bottom-trailing":
+            alignment = .bottomTrailing
+        case "leading-last-text-baseline":
+            alignment = .leadingLastTextBaseline
+        case "trailing-last-text-baseline":
+            alignment = .trailingLastTextBaseline
+        default:
+            alignment = .center
+        }
+        return self.frame(width: width, height: height, alignment: alignment)
     }
     
     private func padding(from element: Element) -> some View {


### PR DESCRIPTION
I needed SwiftUI [Alignments](https://developer.apple.com/documentation/swiftui/alignment/) but they didn't appear to be implemented so I added them to the subset of supported `frame` options. This is useful for fine-tuning the position of elements within stacks.

Just to demonstrate, all of the `VStack`s in the following screenshots have `frame-alignment="top"` and `frame-height="300"`. The first screenshot is without this change (incorrect), and the second screenshot is with it (correct).

![Screen Shot 2022-08-18 at 7 26 36 PM](https://user-images.githubusercontent.com/5893007/185529633-a0306acd-5c46-4b9f-a99b-c396f2758f84.png) ![Screen Shot 2022-08-18 at 7 26 20 PM](https://user-images.githubusercontent.com/5893007/185529655-2831cb00-c15e-4592-91ec-6b9f4494bfa0.png)

