### PR TITLE
Syntax Prototype

### DIFF
--- a/Sources/LiveViewNative/Property Wrappers/LiveContext.swift
+++ b/Sources/LiveViewNative/Property Wrappers/LiveContext.swift
@@ -64,8 +64,9 @@ public struct LiveContext<R: RootRegistry>: DynamicProperty {
     ) -> (NodeChildrenSequence.Element) -> Bool {
         { child in
             if case let .element(element) = child.data,
-               element.namespace == namespace,
-               element.tag == tagName
+               element.namespace == nil,
+               element.tag == "template",
+               element.attributes.contains(where: { $0.id.rawValue == "#\(tagName)" })
             {
                 return true
             } else {
@@ -112,7 +113,7 @@ public struct LiveContext<R: RootRegistry>: DynamicProperty {
         if namedSlotChildren.isEmpty && includeDefaultSlot {
             let defaultSlotChildren = children.filter({
                 if case let .element(element) = $0.data {
-                    return element.namespace != namespace
+                    return element.tag != "template"
                 } else {
                     return true
                 }

--- a/Sources/LiveViewNative/Property Wrappers/LiveContext.swift
+++ b/Sources/LiveViewNative/Property Wrappers/LiveContext.swift
@@ -110,17 +110,18 @@ public struct LiveContext<R: RootRegistry>: DynamicProperty {
     ) -> some View {
         let children = element.children()
         let namedSlotChildren = children.filter(Self.elementWithName(tagName, namespace: namespace))
-        if namedSlotChildren.isEmpty && includeDefaultSlot {
+        let namedSlotAttributeChildren = element.elementChildren().filter({ $0.attributeValue(for: "argument") == tagName || $0.attributeBoolean(for: .init(stringLiteral: "#\(tagName)")) })
+        if namedSlotChildren.isEmpty && namedSlotAttributeChildren.isEmpty && includeDefaultSlot {
             let defaultSlotChildren = children.filter({
                 if case let .element(element) = $0.data {
-                    return element.tag != "template"
+                    return element.tag != "template" && !element.attributes.contains(where: { $0.id.rawValue == "argument" || $0.id.rawValue.starts(with: "#") })
                 } else {
                     return true
                 }
             })
             return coordinator.builder.fromNodes(defaultSlotChildren, context: storage)
         } else {
-            return coordinator.builder.fromNodes(namedSlotChildren.flatMap { $0.children() }, context: storage)
+            return coordinator.builder.fromNodes(namedSlotChildren.flatMap { $0.children() } + namedSlotAttributeChildren.map(\.node), context: storage)
         }
     }
 }

--- a/Sources/LiveViewNative/Property Wrappers/LiveContext.swift
+++ b/Sources/LiveViewNative/Property Wrappers/LiveContext.swift
@@ -65,8 +65,8 @@ public struct LiveContext<R: RootRegistry>: DynamicProperty {
         { child in
             if case let .element(element) = child.data,
                element.namespace == nil,
-               element.tag == "template",
-               element.attributes.contains(where: { $0.id.rawValue == "#\(tagName)" })
+               element.tag == "template" && element.attributes.contains(where: { $0.id.rawValue == "#\(tagName)" })
+                || element.tag == tagName
             {
                 return true
             } else {


### PR DESCRIPTION
This branch supports any of the following forms for creating Views with multiple child builders (#142). It'd be great to get some feedback on which approaches work/feel best for solving this issue.

> We are avoiding overlap with LV's concept of a "slot", so these should not refer to that syntax or naming in any way.

Here is the problematic SwiftUI code that needs to be mapped to markup:

```swift
GroupBox(
    content: {
        Label("Title Label", systemImage: "hand.wave.fill")
    },
    label: {
        Text("This is the content")
    }
)
```
<img src="https://user-images.githubusercontent.com/13581484/219477652-0d65ffa7-9861-49bf-9417-4c41f1deb06f.png" width="300" />

As you can see, the `GroupBox` view has both a `content` and `label` parameter which can contain one or more Views.

Here are all of the different forms this branch will let you use.

> For more discussion on the benefits and drawbacks of each method, see #142 

## 1. Argument Attribute
Similar to WebComponents and Svelte. The `argument` attribute specifies which part of the `GroupBox` it goes in, the `label` or the `content`. The same goes for the `Label` view, which takes a `title` and an `icon` argument.
```html
<GroupBox>
    <Label argument="label">
        <Text argument="title">Title Label</Text>
        <Image system-name="hand.wave.fill" argument="icon" />
    </Label>
    <Text argument="content">
        This is the content
    </Text>
</GroupBox>
```

## 2. `#` Attribute
Similar to Vue. Use the `#argument-name` syntax to specify which part of the `GroupBox` it goes in.
```html
<GroupBox>
    <template #label>
        <Label>
            <template #title>Title Label</template>
            <template #icon><Image system-name="hand.wave.fill" /></template>
        </Label>
    </template>
    <template #content>
        <Text>
            This is the content
        </Text>
    </template>
</GroupBox>
```

## 3. `#` Attribute (without `<template>`)
To make things more concise, this branch will also allow a potential syntax where the `#label`/`#content` attributes can go directly on the element instead of on a `<template>` element.

```html
<GroupBox>
    <Label #label>
        <Text #title>Title Label</Text>
        <Image #icon system-name="hand.wave.fill" />
    </Label>
    <Text #content>
        This is the content
    </Text>
</GroupBox>
```

## 3. Capitalization
It's likely Views will be written in the markup in their original capitalized form in the future. This would open up the possibility to use lowercase element names to represent the arguments, and uppercase to represent a View.
```html
<GroupBox>
    <label>
        <Label>
            <title>Title Label</title>
            <icon><Image system-name="hand.wave.fill" /></icon>
        </Label>
    </label>
    <content>
        <Text>
            This is the content
        </Text>
    </content>
</GroupBox>
```