### PR TITLE
Add scroll-position attribute

### DIFF
--- a/Sources/LiveViewNative/Utils/UnitPoint.swift
+++ b/Sources/LiveViewNative/Utils/UnitPoint.swift
@@ -6,8 +6,58 @@
 //
 
 import SwiftUI
+import LiveViewNativeCore
+import RegexBuilder
 
-extension UnitPoint: Decodable {
+extension UnitPoint: Decodable, AttributeDecodable {
+    public init(from attribute: LiveViewNativeCore.Attribute?) throws {
+        guard let value = attribute?.value else { throw AttributeDecodingError.missingAttribute(Self.self) }
+        switch value {
+        case "zero":
+            self = .zero
+        case "center":
+            self = .center
+        case "leading":
+            self = .leading
+        case "trailing":
+            self = .trailing
+        case "top":
+            self = .top
+        case "bottom":
+            self = .bottom
+        case "top-leading":
+            self = .topLeading
+        case "top-trailing":
+            self = .topTrailing
+        case "bottom-leading":
+            self = .bottomLeading
+        case "bottom-trailing":
+            self = .bottomTrailing
+        default:
+            let pattern = Regex {
+                Capture {
+                    OneOrMore(.digit)
+                } transform: { Double($0) }
+                OneOrMore {
+                    ChoiceOf {
+                        ","
+                        OneOrMore(.whitespace)
+                    }
+                }
+                Capture {
+                    OneOrMore(.digit)
+                } transform: { Double($0) }
+            }
+            .anchorsMatchLineEndings()
+
+            guard let (_, x, y) = value.firstMatch(of: pattern)?.output,
+                  let x,
+                  let y
+            else { throw AttributeDecodingError.badValue(Self.self) }
+            self = .init(x: x, y: y)
+        }
+    }
+    
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.init(

--- a/Sources/LiveViewNative/ViewTree.swift
+++ b/Sources/LiveViewNative/ViewTree.swift
@@ -76,9 +76,19 @@ struct ViewTreeBuilder<R: RootRegistry> {
         let jsonStr = element.attributeValue(for: "modifiers")
         let modified = applyModifiers(encoded: jsonStr, to: view, context: context)
         let bound = applyBindings(to: modified, element: element, context: context)
-        return bound
+        let withID = applyID(element: element, to: bound)
+        return withID
             .environment(\.element, element)
             .preference(key: ProvidedBindingsKey.self, value: []) // reset for the next View.
+    }
+    
+    @ViewBuilder
+    private func applyID(element: ElementNode, to view: some View) -> some View {
+        if let id = element.attributeValue(for: "id") {
+            view.id(id)
+        } else {
+            view
+        }
     }
     
     @ViewBuilder

--- a/Sources/LiveViewNative/Views/Layout Containers/Scroll Views/ScrollView.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Scroll Views/ScrollView.swift
@@ -13,7 +13,6 @@ struct ScrollView<R: RootRegistry>: View {
     
     @Attribute("axes") private var axes: Axis.Set = .vertical
     @Attribute("shows-indicators") private var showsIndicators: Bool
-    @LiveBinding(attribute: "scroll-position") private var scrollPosition: String? = nil
     
     init(element: ElementNode, context: LiveContext<R>) {
         self.context = context
@@ -27,7 +26,7 @@ struct ScrollView<R: RootRegistry>: View {
             ) {
                 context.buildChildren(of: element)
             }
-            .onChange(of: scrollPosition) { newValue in
+            .onChange(of: element.attributeValue(for: "scroll-position")) { newValue in
                 guard let newValue else { return }
                 proxy.scrollTo(
                     newValue,

--- a/Sources/LiveViewNative/Views/Layout Containers/Scroll Views/ScrollView.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Scroll Views/ScrollView.swift
@@ -19,6 +19,7 @@ struct ScrollView<R: RootRegistry>: View {
     }
     
     public var body: some View {
+        let scrollPosition = element.attributeValue(for: "scroll-position")
         SwiftUI.ScrollViewReader { proxy in
             SwiftUI.ScrollView(
                 axes,
@@ -27,11 +28,10 @@ struct ScrollView<R: RootRegistry>: View {
                 context.buildChildren(of: element)
             }
             .onAppear {
-                guard let scrollPosition = element.attributeValue(for: "scroll-position")
-                else { return }
+                guard let scrollPosition else { return }
                 proxy.scrollTo(scrollPosition, anchor: scrollPositionAnchor)
             }
-            .onChange(of: element.attributeValue(for: "scroll-position")) { newValue in
+            .onChange(of: scrollPosition) { newValue in
                 guard let newValue else { return }
                 proxy.scrollTo(newValue, anchor: scrollPositionAnchor)
             }

--- a/Sources/LiveViewNative/Views/Layout Containers/Scroll Views/ScrollView.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Scroll Views/ScrollView.swift
@@ -14,12 +14,14 @@ struct ScrollView<R: RootRegistry>: View {
     @Attribute("axes") private var axes: Axis.Set = .vertical
     @Attribute("shows-indicators") private var showsIndicators: Bool
     
+    @Attribute("scroll-position") private var scrollPosition: String?
+    @Attribute("scroll-position-anchor") private var scrollPositionAnchor: UnitPoint?
+    
     init(element: ElementNode, context: LiveContext<R>) {
         self.context = context
     }
     
     public var body: some View {
-        let scrollPosition = element.attributeValue(for: "scroll-position")
         SwiftUI.ScrollViewReader { proxy in
             SwiftUI.ScrollView(
                 axes,
@@ -36,11 +38,5 @@ struct ScrollView<R: RootRegistry>: View {
                 proxy.scrollTo(newValue, anchor: scrollPositionAnchor)
             }
         }
-    }
-    
-    private var scrollPositionAnchor: UnitPoint? {
-        element.attributeValue(for: "scroll-position-anchor")?
-            .data(using: .utf8)
-            .flatMap { try? JSONDecoder().decode(UnitPoint.self, from: $0) }
     }
 }

--- a/Sources/LiveViewNative/Views/Layout Containers/Scroll Views/ScrollView.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Scroll Views/ScrollView.swift
@@ -13,17 +13,29 @@ struct ScrollView<R: RootRegistry>: View {
     
     @Attribute("axes") private var axes: Axis.Set = .vertical
     @Attribute("shows-indicators") private var showsIndicators: Bool
+    @LiveBinding(attribute: "scroll-position") private var scrollPosition: String? = nil
     
     init(element: ElementNode, context: LiveContext<R>) {
         self.context = context
     }
     
     public var body: some View {
-        SwiftUI.ScrollView(
-            axes,
-            showsIndicators: showsIndicators
-        ) {
-            context.buildChildren(of: element)
+        SwiftUI.ScrollViewReader { proxy in
+            SwiftUI.ScrollView(
+                axes,
+                showsIndicators: showsIndicators
+            ) {
+                context.buildChildren(of: element)
+            }
+            .onChange(of: scrollPosition) { newValue in
+                guard let newValue else { return }
+                proxy.scrollTo(
+                    newValue,
+                    anchor: element.attributeValue(for: "scroll-position-anchor")?
+                        .data(using: .utf8)
+                        .flatMap { try? JSONDecoder().decode(UnitPoint.self, from: $0) }
+                )
+            }
         }
     }
 }

--- a/Sources/LiveViewNative/Views/Layout Containers/Scroll Views/ScrollView.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Scroll Views/ScrollView.swift
@@ -26,15 +26,21 @@ struct ScrollView<R: RootRegistry>: View {
             ) {
                 context.buildChildren(of: element)
             }
+            .onAppear {
+                guard let scrollPosition = element.attributeValue(for: "scroll-position")
+                else { return }
+                proxy.scrollTo(scrollPosition, anchor: scrollPositionAnchor)
+            }
             .onChange(of: element.attributeValue(for: "scroll-position")) { newValue in
                 guard let newValue else { return }
-                proxy.scrollTo(
-                    newValue,
-                    anchor: element.attributeValue(for: "scroll-position-anchor")?
-                        .data(using: .utf8)
-                        .flatMap { try? JSONDecoder().decode(UnitPoint.self, from: $0) }
-                )
+                proxy.scrollTo(newValue, anchor: scrollPositionAnchor)
             }
         }
+    }
+    
+    private var scrollPositionAnchor: UnitPoint? {
+        element.attributeValue(for: "scroll-position-anchor")?
+            .data(using: .utf8)
+            .flatMap { try? JSONDecoder().decode(UnitPoint.self, from: $0) }
     }
 }

--- a/Tests/LiveViewNativeTests/DecodeUnitPointTests.swift
+++ b/Tests/LiveViewNativeTests/DecodeUnitPointTests.swift
@@ -1,0 +1,40 @@
+//
+//  DecodeUnitPointTests.swift
+//  
+//
+//  Created by Carson Katri on 3/15/23.
+//
+
+import XCTest
+import SwiftUI
+@testable import LiveViewNative
+@testable import LiveViewNativeCore
+
+final class DecodeUnitPointTests: XCTestCase {
+    func testLiteral() throws {
+        XCTAssertEqual(try UnitPoint(from: "zero"), .zero)
+        XCTAssertEqual(try UnitPoint(from: "center"), .center)
+        XCTAssertEqual(try UnitPoint(from: "leading"), .leading)
+        XCTAssertEqual(try UnitPoint(from: "trailing"), .trailing)
+        XCTAssertEqual(try UnitPoint(from: "top"), .top)
+        XCTAssertEqual(try UnitPoint(from: "bottom"), .bottom)
+        XCTAssertEqual(try UnitPoint(from: "top-leading"), .topLeading)
+        XCTAssertEqual(try UnitPoint(from: "top-trailing"), .topTrailing)
+        XCTAssertEqual(try UnitPoint(from: "bottom-leading"), .bottomLeading)
+        XCTAssertEqual(try UnitPoint(from: "bottom-trailing"), .bottomTrailing)
+    }
+    
+    func testInteger() throws {
+        XCTAssertEqual(try UnitPoint(from: "0,0"), .init(x: 0, y: 0))
+        XCTAssertEqual(try UnitPoint(from: "1,0"), .init(x: 1, y: 0))
+        XCTAssertEqual(try UnitPoint(from: "-1,2"), .init(x: -1, y: 2))
+        XCTAssertEqual(try UnitPoint(from: "-1,-20"), .init(x: -1, y: -20))
+    }
+    
+    func testDecimal() throws {
+        XCTAssertEqual(try UnitPoint(from: "0.0,0"), .init(x: 0, y: 0))
+        XCTAssertEqual(try UnitPoint(from: "1,1.00"), .init(x: 1, y: 1))
+        XCTAssertEqual(try UnitPoint(from: "-11.255,20.3"), .init(x: -11.255, y: 20.3))
+        XCTAssertEqual(try UnitPoint(from: "-1.1,-2.3"), .init(x: -1.1, y: -2.3))
+    }
+}


### PR DESCRIPTION
Closes #121 

This is intended to cover `ScrollViewReader`'s use cases. Pass the `scroll-position` attribute to `<scroll-view>` and optionally a unit point for the anchor. Any time the value changes, the View with that ID will be scrolled into frame.

Currently, no animations are provided. These could be enabled later with a `scroll-position-animation` attribute once we have an `Animation` type in the Elixir library.

I have also updated the builder so that any time a View has an `id` attribute it is given an `.id(_:)` modifier. This could also be refactored to be a normal modifier for more control over where it applies in the stack.

```html
<z-stack alignment="bottom">
  <scroll-view scroll-position={@scroll_position} scroll-position-anchor={%LiveViewNativeSwiftUi.Types.UnitPoint{ x: 0, y: 0 } |> Jason.encode!}>
    <button phx-click="scroll_to" phx-value-id="100">Scroll to Bottom</button>
    <vstack spacing="0">
      <%= for i <- 0..100 do %>
        <color red={i / 100} green={1 - (i / 100)} blue={0.5} id={i |> Integer.to_string} modifiers={@native |> frame(height: 20)} />
      <% end %>
    </vstack>
    <button phx-click="scroll_to" phx-value-id="0">Scroll to Top</button>
  </scroll-view>
  <phx-form id="scroll_form" phx-submit="scroll_to">
    <group-box modifiers={@native |> padding(all: 16)}>
        <group-box:label><text-field name="id" format="number" placeholder="Position" /></group-box:label>
        <group-box:content><phx-submit-button button-style="bordered-prominent">Scroll</phx-submit-button></group-box:content>
    </group-box>
  </phx-form>
</z-stack>
```

https://user-images.githubusercontent.com/13581484/221023557-e7bbe167-616a-4810-842c-23dbdfa387af.mp4
