### PR TITLE
Document shapes

### DIFF
--- a/Sources/DocumentationExtensionGenerator/DocumentationExtensionGenerator.swift
+++ b/Sources/DocumentationExtensionGenerator/DocumentationExtensionGenerator.swift
@@ -8,7 +8,12 @@ let logger = Logger(subsystem: "LiveViewNative", category: "DocumentationExtensi
 @main
 struct DocumentationExtensionGenerator {
     static let denylist = [
-        "LiveView"
+        "LiveView",
+        "Shape",
+    ]
+    
+    static let categoryDenyList = [
+        "Shapes"
     ]
     
     static func main() throws {
@@ -169,6 +174,7 @@ struct DocumentationExtensionGenerator {
     static func viewCategories(directory: URL, output: URL) throws {
         for category in try FileManager.default.contentsOfDirectory(at: directory, includingPropertiesForKeys: nil)
             where category.hasDirectoryPath
+                  && !Self.categoryDenyList.contains(category.lastPathComponent)
         {
             let fileName = category.lastPathComponent.capitalized.replacing(" ", with: "")
             var categoryFile = ["# \(category.lastPathComponent)", "## Topics"]

--- a/Sources/LiveViewNative/LiveViewNative.docc/Shapes.md
+++ b/Sources/LiveViewNative/LiveViewNative.docc/Shapes.md
@@ -1,0 +1,7 @@
+# Shapes
+## Topics
+### Views
+- ``Shape``
+- <doc:Rectangle>
+- ``LiveViewNative/SwiftUI/RoundedRectangle``
+- ``LiveViewNative/SwiftUI/Capsule``

--- a/Sources/LiveViewNative/LiveViewNative.docc/Shapes/Rectangle.md
+++ b/Sources/LiveViewNative/LiveViewNative.docc/Shapes/Rectangle.md
@@ -1,0 +1,12 @@
+# Rectangle
+
+A rectangular shape that fills the view containing it.
+
+See ``Shape`` for supported attributes.
+
+```html
+<Rectangle fill-color="#00ff00" />
+```
+
+## SwiftUI Documentation
+See [`SwiftUI.Rectangle`](https://developer.apple.com/documentation/swiftui/Rectangle) for more details on this View.

--- a/Sources/LiveViewNative/Views/Shapes/Shape.swift
+++ b/Sources/LiveViewNative/Views/Shapes/Shape.swift
@@ -7,12 +7,34 @@
 
 import SwiftUI
 
+/// A view that displays the a shape.
+///
+/// This view isn't used directly as an element. Instead, use the shape itself (e.g., `<Rectangle>`).
+///
+/// Attributes:
+/// - ``fillColor``
+/// - ``strokeColor``
+#if swift(>=5.8)
+@_documentation(visibility: public)
+#endif
 struct Shape<S: SwiftUI.Shape>: View {
     @ObservedElement private var element: ElementNode
     private let shape: S
 
-    @Attribute("fill-color", transform: { $0?.value.flatMap(SwiftUI.Color.init(fromNamedOrCSSHex:)) }) private var fillColor: SwiftUI.Color?
-    @Attribute("stroke-color", transform: { $0?.value.flatMap(SwiftUI.Color.init(fromNamedOrCSSHex:)) }) private var strokeColor: SwiftUI.Color?
+    /// The color the shape is filled with.
+    ///
+    /// See ``LiveViewNative/SwiftUI/Color/init(fromNamedOrCSSHex:)``.
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
+    @Attribute("fill-color") private var fillColor: SwiftUI.Color? = nil
+    /// The color the shape stroke is drawn with.
+    ///
+    /// See ``LiveViewNative/SwiftUI/Color/init(fromNamedOrCSSHex:)``.
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
+    @Attribute("stroke-color") private var strokeColor: SwiftUI.Color? = nil
     
     init(shape: S) {
         self.shape = shape
@@ -29,6 +51,22 @@ struct Shape<S: SwiftUI.Shape>: View {
     }
 }
 
+/// A rounded rectangle shape.
+///
+/// ```html
+/// <RoundedRectangle corner-radius="8" style="continuous" fill-color="#0000ff" />
+/// ```
+///
+/// Attributes:
+/// - `corner-radius` (double): The radius of the shape's corners.
+/// - `corner-width` (double): The width of the shape's corners (has precedence over `corner-radius`).
+/// - `corner-height` (double): The height of the shape's corners (has precedence over `corner-radius`).
+/// - `style`: Whether the corners are rounded with the quarter-circle style or continuously. Possible values:
+///     - `circular`
+///     - `continuous`
+#if swift(>=5.8)
+@_documentation(visibility: public)
+#endif
 extension RoundedRectangle {
     init(from element: ElementNode) {
         let radius = element.attributeValue(for: "corner-radius").flatMap(Double.init) ?? 0
@@ -42,6 +80,15 @@ extension RoundedRectangle {
     }
 }
 
+/// A capsule shape. A capsule is a rounded rectangle where the corner size is half of the rectangle's smaller edge.
+///
+/// Attributes:
+/// - `style`: Whether the corners are rounded with the quarter-circle style or continuously. Possible values:
+///     - `circular`
+///     - `continuous`
+#if swift(>=5.8)
+@_documentation(visibility: public)
+#endif
 extension Capsule {
     init(from element: ElementNode) {
         self.init(


### PR DESCRIPTION
Shapes are excluded from the automatic extension generation, since there aren't structs for each shape. The shapes which have extensions with element initializers are documented on the extensions, and Rectangle is documented in a separate article.