### PR TITLE
Add aspect ratio modifier

### DIFF
--- a/Sources/LiveViewNative/Modifiers/AspectRatioModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/AspectRatioModifier.swift
@@ -1,0 +1,37 @@
+//
+//  AspectRatioModifier.swift
+// LiveViewNative
+//
+//  Created by May Matyi on 3/23/23.
+//
+
+import SwiftUI
+
+struct AspectRatioModifier: ViewModifier, Decodable {
+    private let aspectRatio: CGSize
+    private let contentMode: ContentMode
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        self.aspectRatio = try container.decode(CGSize.self, forKey: .aspectRatio)
+
+        switch try container.decode(String.self, forKey: .contentMode) {
+        case "fill":
+            self.contentMode = .fill
+        case "fit":
+            self.contentMode = .fit
+        default:
+            throw DecodingError.dataCorruptedError(forKey: .contentMode, in: container, debugDescription: "invalid value for contentMode")
+        }
+    }
+
+    func body(content: Content) -> some View {
+        content.aspectRatio(self.aspectRatio, contentMode: self.contentMode)
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case aspectRatio = "aspect_ratio"
+        case contentMode = "content_mode"
+    }
+}

--- a/Sources/LiveViewNative/Modifiers/AspectRatioModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/AspectRatioModifier.swift
@@ -8,13 +8,13 @@
 import SwiftUI
 
 struct AspectRatioModifier: ViewModifier, Decodable {
-    private let aspectRatio: CGSize
+    private let aspectRatio: CGSize?
     private let contentMode: ContentMode
 
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
-        self.aspectRatio = try container.decode(CGSize.self, forKey: .aspectRatio)
+        self.aspectRatio = try container.decodeIfPresent(CGSize.self, forKey: .aspectRatio)
 
         switch try container.decode(String.self, forKey: .contentMode) {
         case "fill":
@@ -27,7 +27,11 @@ struct AspectRatioModifier: ViewModifier, Decodable {
     }
 
     func body(content: Content) -> some View {
-        content.aspectRatio(self.aspectRatio, contentMode: self.contentMode)
+        if let aspectRatio {
+            content.aspectRatio(aspectRatio, contentMode: contentMode)
+        } else {
+            content.aspectRatio(contentMode: contentMode)
+        }
     }
 
     enum CodingKeys: String, CodingKey {

--- a/Sources/LiveViewNative/Registries/BuiltinRegistry.swift
+++ b/Sources/LiveViewNative/Registries/BuiltinRegistry.swift
@@ -173,6 +173,7 @@ struct BuiltinRegistry: BuiltinRegistryProtocol {
     }
     
     enum ModifierType: String {
+        case aspectRatio = "aspect_ratio"
         case backgroundStyle = "background_style"
         case fontWeight = "font_weight"
         case foregroundStyle = "foreground_style"
@@ -193,6 +194,8 @@ struct BuiltinRegistry: BuiltinRegistryProtocol {
     @ViewModifierBuilder
     static func decodeModifier(_ type: ModifierType, from decoder: Decoder) throws -> some ViewModifier {
         switch type {
+        case .aspectRatio:
+            try AspectRatioModifier(from: decoder)
         case .backgroundStyle:
             try BackgroundStyleModifier(from: decoder)
         case .foregroundStyle:

--- a/Sources/LiveViewNative/Views/Images/Image.swift
+++ b/Sources/LiveViewNative/Views/Images/Image.swift
@@ -28,6 +28,10 @@ import SwiftUI
 @_documentation(visibility: public)
 #endif
 struct Image: View {
+    /// When enabled, resizes the Image to fill all available space
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
     @Attribute("resizable") private var resizable: Bool
     @ObservedElement private var observedElement: ElementNode
     private let overrideElement: ElementNode?

--- a/Sources/LiveViewNative/Views/Images/Image.swift
+++ b/Sources/LiveViewNative/Views/Images/Image.swift
@@ -28,6 +28,7 @@ import SwiftUI
 @_documentation(visibility: public)
 #endif
 struct Image: View {
+    @Attribute("resizable") private var resizable: Bool
     @ObservedElement private var observedElement: ElementNode
     private let overrideElement: ElementNode?
     private var element: ElementNode {
@@ -41,6 +42,7 @@ struct Image: View {
     public var body: some View {
         image
             // todo: this probably only works for symbols
+            .resizableIfPresent(resizable: resizable)
             .scaledIfPresent(scale: symbolScale)
             .foregroundColor(symbolColor)
     }
@@ -113,6 +115,14 @@ extension Image {
 }
 
 fileprivate extension SwiftUI.Image {
+    func resizableIfPresent(resizable: Bool) -> SwiftUI.Image {
+        if resizable {
+            return self.resizable()
+        } else {
+            return self
+        }
+    }
+
     @ViewBuilder
     func scaledIfPresent(scale: SwiftUI.Image.Scale?) -> some View {
         if let scale = scale {

--- a/lib/live_view_native_swift_ui/modifiers/aspect_ratio.ex
+++ b/lib/live_view_native_swift_ui/modifiers/aspect_ratio.ex
@@ -1,0 +1,8 @@
+defmodule LiveViewNativeSwiftUi.Modifiers.AspectRatio do
+  use LiveViewNativePlatform.Modifier
+
+  modifier_schema "aspect_ratio" do
+    field :aspect_ratio, {:array, :float}, default: [1.0, 1.0]
+    field :content_mode, Ecto.Enum, values: ~w(fill fit)a
+  end
+end

--- a/lib/live_view_native_swift_ui/platform.ex
+++ b/lib/live_view_native_swift_ui/platform.ex
@@ -24,6 +24,7 @@ defmodule LiveViewNativeSwiftUi.Platform do
         modifiers: %LiveViewNativeSwiftUi.Modifiers{stack: []},
         platform_id: :ios,
         platform_modifiers: [
+          aspect_ratio: Modifiers.AspectRatio,
           background: Modifiers.Background,
           background_style: Modifiers.BackgroundStyle,
           font_weight: Modifiers.FontWeight,


### PR DESCRIPTION
Adds support for the [aspectRatio](https://developer.apple.com/documentation/swiftui/view/aspectratio(_:contentmode:)-771ow) modifier:

```heex
<VStack>
  <Spacer />
  <Image name="AspectTest" resizable modifiers={@native |> aspect_ratio(content_mode: "fit") |> frame(width: 300, height: 225)} />
  <Spacer />
  <Image name="AspectTest" resizable modifiers={@native |> aspect_ratio(content_mode: "fill") |> frame(width: 300, height: 225)} />
  <Spacer />
</VStack>
```

![Screenshot 2023-03-23 at 8 42 56 PM](https://user-images.githubusercontent.com/5893007/227419502-bad7745f-a10d-4adf-be62-a851690ac9f5.png)