### PR TITLE
Add bold and italic modifiers

### DIFF
--- a/Sources/LiveViewNative/Modifiers/BoldModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/BoldModifier.swift
@@ -1,0 +1,18 @@
+//
+//  BoldModifier.swift
+// LiveViewNative
+//
+//  Created by May Matyi on 3/23/23.
+//
+
+import SwiftUI
+
+struct BoldModifier: ViewModifier, Decodable {
+    init(from decoder: Decoder) throws {
+        self
+    }
+
+    func body(content: Content) -> some View {
+        content.bold()
+    }
+}

--- a/Sources/LiveViewNative/Modifiers/FontWeightModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/FontWeightModifier.swift
@@ -1,5 +1,5 @@
 //
-//  FontWeight.swift
+//  FontWeightModifier.swift
 // LiveViewNative
 //
 //  Created by May Matyi on 2/17/23.

--- a/Sources/LiveViewNative/Modifiers/ItalicModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/ItalicModifier.swift
@@ -1,0 +1,18 @@
+//
+//  ItalicModifier.swift
+// LiveViewNative
+//
+//  Created by May Matyi on 3/23/23.
+//
+
+import SwiftUI
+
+struct ItalicModifier: ViewModifier, Decodable {
+    init(from decoder: Decoder) throws {
+        self
+    }
+
+    func body(content: Content) -> some View {
+        content.italic()
+    }
+}

--- a/Sources/LiveViewNative/Registries/BuiltinRegistry.swift
+++ b/Sources/LiveViewNative/Registries/BuiltinRegistry.swift
@@ -174,6 +174,7 @@ struct BuiltinRegistry: BuiltinRegistryProtocol {
     
     enum ModifierType: String {
         case backgroundStyle = "background_style"
+        case bold
         case fontWeight = "font_weight"
         case foregroundStyle = "foreground_style"
         case frame
@@ -181,6 +182,7 @@ struct BuiltinRegistry: BuiltinRegistryProtocol {
         case gridCellColumns = "grid_cell_columns"
         case gridCellUnsizedAxes = "grid_cell_unsized_axes"
         case gridColumnAlignment = "grid_column_alignment"
+        case italic
         case listRowInsets = "list_row_insets"
         case listRowSeparator = "list_row_separator"
         case navigationTitle = "navigation_title"
@@ -195,6 +197,8 @@ struct BuiltinRegistry: BuiltinRegistryProtocol {
         switch type {
         case .backgroundStyle:
             try BackgroundStyleModifier(from: decoder)
+        case .bold:
+            try BoldModifier(from: decoder)
         case .foregroundStyle:
             try ForegroundStyleModifier(from: decoder)
         case .fontWeight:
@@ -209,6 +213,8 @@ struct BuiltinRegistry: BuiltinRegistryProtocol {
             try GridCellUnsizedAxesModifier(from: decoder)
         case .gridColumnAlignment:
             try GridColumnAlignmentModifier(from: decoder)
+        case .italic:
+            try ItalicModifier(from: decoder)
         case .listRowInsets:
             try ListRowInsetsModifier(from: decoder)
         case .listRowSeparator:

--- a/lib/live_view_native_swift_ui/modifiers/bold.ex
+++ b/lib/live_view_native_swift_ui/modifiers/bold.ex
@@ -1,0 +1,6 @@
+defmodule LiveViewNativeSwiftUi.Modifiers.Bold do
+  use LiveViewNativePlatform.Modifier
+
+  modifier_schema "bold" do
+  end
+end

--- a/lib/live_view_native_swift_ui/modifiers/italic.ex
+++ b/lib/live_view_native_swift_ui/modifiers/italic.ex
@@ -1,0 +1,6 @@
+defmodule LiveViewNativeSwiftUi.Modifiers.Italic do
+  use LiveViewNativePlatform.Modifier
+
+  modifier_schema "italic" do
+  end
+end

--- a/lib/live_view_native_swift_ui/platform.ex
+++ b/lib/live_view_native_swift_ui/platform.ex
@@ -26,9 +26,11 @@ defmodule LiveViewNativeSwiftUi.Platform do
         platform_modifiers: [
           background: Modifiers.Background,
           background_style: Modifiers.BackgroundStyle,
+          bold: Modifiers.Bold,
           font_weight: Modifiers.FontWeight,
           foreground_style: Modifiers.ForegroundStyle,
           frame: Modifiers.Frame,
+          italic: Modifiers.Italic,
           list_row_insets: Modifiers.ListRowInsets,
           list_row_separator: Modifiers.ListRowSeparator,
           navigation_title: Modifiers.NavigationTitle,


### PR DESCRIPTION
Adds support for [bold](https://developer.apple.com/documentation/swiftui/text/bold()) and [italic](https://developer.apple.com/documentation/swiftui/text/italic()) modifiers. Setting font weight is already possible since https://github.com/liveview-native/liveview-client-swiftui/pull/202 but https://github.com/liveview-native/liveview-client-swiftui/issues/183 called for implementing `bold`.

```heex
<VStack>
  <Text>This text is normal</Text>
  <Text modifiers={bold(@native)}>This text is bold</Text>
  <Text modifiers={italic(@native)}>This text is italic</Text>
  <Text modifiers={@native |> bold() |> italic()}>This text is bold and italic</Text>
</VStack>
```

![Screenshot 2023-03-23 at 8 59 49 PM](https://user-images.githubusercontent.com/5893007/227422371-cdf68d5c-65f5-42ea-b730-ccc4c7eec987.png)