### PR TITLE
Document Lazy*Stack

### DIFF
--- a/Sources/DocumentationExtensionGenerator/DocumentationExtensionGenerator.swift
+++ b/Sources/DocumentationExtensionGenerator/DocumentationExtensionGenerator.swift
@@ -39,7 +39,7 @@ struct DocumentationExtensionGenerator {
             let symbolPath = (["LiveViewNative"] + symbol.pathComponents).joined(separator: "/")
             
             let markdownURL = extensionsURL
-                .appending(path: symbol.pathComponents.joined(separator: "/"))
+                .appending(path: symbol.pathComponents.joined(separator: "-"))
                 .appendingPathExtension("md")
             
             try FileManager.default.createDirectory(at: markdownURL.deletingLastPathComponent(), withIntermediateDirectories: true)
@@ -111,7 +111,7 @@ struct DocumentationExtensionGenerator {
             let symbolPath = (["LiveViewNative"] + symbol.pathComponents).joined(separator: "/")
             
             let markdownURL = extensionsURL
-                .appending(path: symbol.pathComponents.joined(separator: "/"))
+                .appending(path: symbol.pathComponents.joined(separator: "-"))
                 .appendingPathExtension("md")
             
             try FileManager.default.createDirectory(at: markdownURL.deletingLastPathComponent(), withIntermediateDirectories: true)

--- a/Sources/LiveViewNative/Views/Layout Containers/Lazy Stacks/LazyHStack.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Lazy Stacks/LazyHStack.swift
@@ -7,12 +7,55 @@
 
 import SwiftUI
 
+/// Horizontal stack that creates Views lazily.
+///
+/// Lazy stacks behave similar to their non-lazy counterparts.
+///
+/// Use the ``pinnedViews`` attribute to pin section headers/footers when contained in a `ScrollView`.
+///
+/// ```html
+/// <ScrollView axes="horizontal">
+///     <LazyHStack>
+///         <%= for i <- 1..50 do %>
+///             <Text id={i |> Integer.to_string} font="largeTitle"><%= i %></Text>
+///         <% end %>
+///     </LazyHStack>
+/// </ScrollView>
+/// ```
+///
+/// ## Attributes
+/// * ``alignment``
+/// * ``spacing``
+/// * ``pinnedViews``
+///
+/// ## See Also
+/// ### Stacks
+/// * ``HStack``
+#if swift(>=5.8)
+@_documentation(visibility: public)
+#endif
 struct LazyHStack<R: RootRegistry>: View {
     @ObservedElement private var element: ElementNode
     @LiveContext<R> private var context
     
+    /// The vertical alignment of views within the stack. Defaults to center-aligned.
+    ///
+    /// See ``LiveViewNative/SwiftUI/VerticalAlignment``.
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
     @Attribute("alignment") private var alignment: VerticalAlignment = .center
+    /// The spacing between views in the stack. If not provided, the stack uses the system spacing.
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
     @Attribute("spacing") private var spacing: Double?
+    /// Pins section headers/footers.
+    ///
+    /// See ``LiveViewNative/SwiftUI/PinnedScrollableViews``.
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
     @Attribute("pinned-views") private var pinnedViews: PinnedScrollableViews = []
     
     public var body: some View {

--- a/Sources/LiveViewNative/Views/Layout Containers/Lazy Stacks/LazyVStack.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Lazy Stacks/LazyVStack.swift
@@ -7,12 +7,55 @@
 
 import SwiftUI
 
+/// Vertical stack that creates Views lazily.
+///
+/// Lazy stacks behave similar to their non-lazy counterparts.
+///
+/// Use the ``pinnedViews`` attribute to pin section headers/footers when contained in a `ScrollView`.
+///
+/// ```html
+/// <ScrollView axes="vertical">
+///     <LazyVStack>
+///         <%= for i <- 1..50 do %>
+///             <Text id={i |> Integer.to_string} font="largeTitle"><%= i %></Text>
+///         <% end %>
+///     </LazyVStack>
+/// </ScrollView>
+/// ```
+///
+/// ## Attributes
+/// * ``alignment``
+/// * ``spacing``
+/// * ``pinnedViews``
+///
+/// ## See Also
+/// ### Stacks
+/// * ``VStack``
+#if swift(>=5.8)
+@_documentation(visibility: public)
+#endif
 struct LazyVStack<R: RootRegistry>: View {
     @ObservedElement private var element: ElementNode
     @LiveContext<R> private var context
     
+    /// The horizontal alignment of views within the stack. Defaults to center-aligned.
+    ///
+    /// See ``LiveViewNative/SwiftUI/VerticalAlignment``.
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
     @Attribute("alignment") private var alignment: HorizontalAlignment = .center
+    /// The spacing between views in the stack. If not provided, the stack uses the system spacing.
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
     @Attribute("spacing") private var spacing: Double?
+    /// Pins section headers/footers.
+    ///
+    /// See ``LiveViewNative/SwiftUI/PinnedScrollableViews``.
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
     @Attribute("pinned-views") private var pinnedViews: PinnedScrollableViews = []
     
     public var body: some View {


### PR DESCRIPTION
Closes #374, #375

This also resolves an issue with the documentation extensions, where duplicate filenames were being handled incorrectly. The path for attribute extensions changed from `ViewType/attribute.md` to `ViewType-attribute.md`