### PR TITLE
Build `swift-docc-render` and use for docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ xcuserdata/
 docc_build/
 docs/
 tutorial/
+swift-docc-render/
 
 # Elixir
 

--- a/Plugins/SortDocumentationJSONPlugin/SortDocumentationJSONPlugin.swift
+++ b/Plugins/SortDocumentationJSONPlugin/SortDocumentationJSONPlugin.swift
@@ -3,6 +3,11 @@ import Foundation
 
 @main
 struct SortDocumentationJSONPlugin: CommandPlugin {
+    static let codeSyntaxTransformations = [
+        "ex": "elixir",
+        "heex": "html"
+    ]
+
     func performCommand(context: PluginContext, arguments: [String]) throws {
         let url = URL(fileURLWithPath: context.package.directory.appending(["docs"]).string, isDirectory: true)
         for fileURL in FileManager.default.enumerator(at: url, includingPropertiesForKeys: [.isRegularFileKey])! {
@@ -12,7 +17,19 @@ struct SortDocumentationJSONPlugin: CommandPlugin {
                   isRegularFile
             else { continue }
             let object = try JSONSerialization.jsonObject(with: try Data(contentsOf: fileURL))
-            try JSONSerialization.data(withJSONObject: object, options: [.sortedKeys, .prettyPrinted]).write(to: fileURL)
+            if var object = object as? [String:Any] {
+                // Transform "syntax" keys for file references.
+                if var references = object["references"] as? [String:[String:Any]] {
+                    for (file, value) in references {
+                        guard let syntax = value["syntax"] as? String else { continue }
+                        references[file]?["syntax"] = Self.codeSyntaxTransformations[syntax] ?? syntax
+                    }
+                    object["references"] = references
+                }
+                try JSONSerialization.data(withJSONObject: object, options: [.sortedKeys, .prettyPrinted]).write(to: fileURL)
+            } else {
+                try JSONSerialization.data(withJSONObject: object, options: [.sortedKeys, .prettyPrinted]).write(to: fileURL)
+            }
         }
     }
 }

--- a/util/build_docs.sh
+++ b/util/build_docs.sh
@@ -34,7 +34,8 @@ if [ ! -d docs ]; then
 fi
 
 echo "Generating static files..."
-xcrun docc process-archive transform-for-static-hosting docc_build/Build/Products/Debug-iphoneos/LiveViewNative.doccarchive --output-path docs --hosting-base-path /liveview-client-swiftui &> $output
+git clone git@github.com:liveview-native/liveview-client-swiftui.git --branch swift-docc-render --single-branch docc_build/swift-docc-render-artifact
+DOCC_HTML_DIR="docc_build/swift-docc-render-artifact" xcrun docc process-archive transform-for-static-hosting docc_build/Build/Products/Debug-iphoneos/LiveViewNative.doccarchive --output-path docs --hosting-base-path /liveview-client-swiftui &> $output
 
 # add index page to root with redirect to package docs
 cat > docs/index.html << EOF

--- a/util/build_docs.sh
+++ b/util/build_docs.sh
@@ -34,7 +34,7 @@ if [ ! -d docs ]; then
 fi
 
 echo "Generating static files..."
-git clone git@github.com:liveview-native/liveview-client-swiftui.git --branch swift-docc-render --single-branch docc_build/swift-docc-render-artifact
+git clone git@github.com:liveview-native/liveview-client-swiftui.git --branch swift-docc-render --single-branch docc_build/swift-docc-render-artifact &> $output || :
 DOCC_HTML_DIR="docc_build/swift-docc-render-artifact" xcrun docc process-archive transform-for-static-hosting docc_build/Build/Products/Debug-iphoneos/LiveViewNative.doccarchive --output-path docs --hosting-base-path /liveview-client-swiftui &> $output
 
 # add index page to root with redirect to package docs

--- a/util/build_swift_docc_render.sh
+++ b/util/build_swift_docc_render.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+git clone git@github.com:liveview-native/liveview-client-swiftui.git --branch swift-docc-render --single-branch swift-docc-render
+mkdir -p docc_build
+
+. $(brew --prefix nvm)/nvm.sh
+
+git clone git@github.com:apple/swift-docc-render.git docc_build/swift-docc-render
+(cd docc_build/swift-docc-render && nvm install && npm install && VUE_APP_HLJS_LANGUAGES=elixir npm run build)
+
+mv docc_build/swift-docc-render/dist/* swift-docc-render
+COMMIT=$(cd docc_build/swift-docc-render && git rev-parse HEAD)
+(cd swift-docc-render && git add . && git commit -m "Build https://github.com/apple/swift-docc-render/commit/${COMMIT}")


### PR DESCRIPTION
This adds a script that builds `swift-docc-render` and pushes the `dist` folder to the `swift-docc-render` branch of this repo.

Then in the `build_docs` script, that branch is cloned and used as the `DOCC_HTML_DIR`.

This will enable us to update the Vue site whenever necessary, without building it for every documentation change.