### PR TITLE
Add offset modifier

### DIFF
--- a/Sources/LiveViewNative/Modifiers/Layout Adjustments Modifiers/OffsetModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Layout Adjustments Modifiers/OffsetModifier.swift
@@ -1,0 +1,54 @@
+//
+//  OffsetModifier.swift
+// LiveViewNative
+//
+//  Created by May Matyi on 4/1/23.
+//
+
+import SwiftUI
+
+/// Applies an offset to any element.
+///
+/// ```html
+/// <Text
+///     modifiers={
+///         offset(@native, x: 24, y: 48)
+///     }
+/// >
+///   This text is offset by 24 on the x axis and 48 on the y axis.
+/// </Text>
+/// ```
+///
+/// ## Arguments
+/// * ``x``: The offset to apply to the x axis.
+/// * ``y``: The offset to apply to the y axis.
+
+#if swift(>=5.8)
+@_documentation(visibility: public)
+#endif
+struct OffsetModifier: ViewModifier, Decodable, Equatable {
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
+    private let x: CGFloat
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
+    private let y: CGFloat
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        self.x = try container.decode(CGFloat.self, forKey: .x)
+        self.y = try container.decode(CGFloat.self, forKey: .y)
+    }
+
+    func body(content: Content) -> some View {
+        content.offset(x: x, y: y)
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case x
+        case y
+    }
+}

--- a/Sources/LiveViewNative/Modifiers/Layout Adjustments Modifiers/OffsetModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Layout Adjustments Modifiers/OffsetModifier.swift
@@ -22,7 +22,6 @@ import SwiftUI
 /// ## Arguments
 /// * ``x``: The offset to apply to the x axis.
 /// * ``y``: The offset to apply to the y axis.
-
 #if swift(>=5.8)
 @_documentation(visibility: public)
 #endif

--- a/Sources/LiveViewNative/Modifiers/Layout Adjustments Modifiers/OffsetModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Layout Adjustments Modifiers/OffsetModifier.swift
@@ -20,16 +20,18 @@ import SwiftUI
 /// ```
 ///
 /// ## Arguments
-/// * ``x``: The offset to apply to the x axis.
-/// * ``y``: The offset to apply to the y axis.
+/// * ``x``
+/// * ``y``
 #if swift(>=5.8)
 @_documentation(visibility: public)
 #endif
 struct OffsetModifier: ViewModifier, Decodable, Equatable {
+    /// The offset to apply to the x axis.
     #if swift(>=5.8)
     @_documentation(visibility: public)
     #endif
     private let x: CGFloat
+    /// The offset to apply to the y axis.
     #if swift(>=5.8)
     @_documentation(visibility: public)
     #endif

--- a/lib/live_view_native_swift_ui/modifiers/offset.ex
+++ b/lib/live_view_native_swift_ui/modifiers/offset.ex
@@ -1,0 +1,8 @@
+defmodule LiveViewNativeSwiftUi.Modifiers.Offset do
+  use LiveViewNativePlatform.Modifier
+
+  modifier_schema "offset" do
+    field :x, :float
+    field :y, :float
+  end
+end

--- a/lib/live_view_native_swift_ui/modifiers/offset.ex
+++ b/lib/live_view_native_swift_ui/modifiers/offset.ex
@@ -2,7 +2,7 @@ defmodule LiveViewNativeSwiftUi.Modifiers.Offset do
   use LiveViewNativePlatform.Modifier
 
   modifier_schema "offset" do
-    field :x, :float
-    field :y, :float
+    field :x, :float, default: 0.0
+    field :y, :float, default: 0.0
   end
 end


### PR DESCRIPTION
Adds the [offset](https://developer.apple.com/documentation/swiftui/view/offset(x:y:)) modifier. I didn't include the `CGSize` constructor as it seemed redundant in this case, but let me know if you think it should be supported:

```heex
<VStack>
  <Text>This text is not offset</Text>
  <Text modifiers={offset(@native, x: 4, y: 8)}>This text is slightly offset</Text>
  <Text modifiers={offset(@native, x: 32, y: 64)}>This text is very offset</Text>
</VStack>
```

![Screenshot 2023-04-01 at 3 17 55 PM](https://user-images.githubusercontent.com/5893007/229316647-fd265c93-f92c-4123-a3ad-b975af9f36c2.png)

Closes https://github.com/liveview-native/liveview-client-swiftui/issues/497