### PR TITLE
Add statusBarHidden modifier

### DIFF
--- a/Sources/LiveViewNative/Modifiers/View Configuration Modifiers/StatusBarHiddenModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/View Configuration Modifiers/StatusBarHiddenModifier.swift
@@ -1,0 +1,46 @@
+//
+//  StatusBarHiddenModifier.swift
+// LiveViewNative
+//
+//  Created by May Matyi on 4/1/23.
+//
+
+import SwiftUI
+
+/// Hides or shows the status bar.
+///
+/// ```html
+/// <VStack>
+///     modifiers={
+///         status_bar_hidden(@native, hidden: true)
+///     }
+/// >
+///   <Text>The status bar should be hidden</Text>
+/// </VStack>
+/// ```
+///
+/// ## Arguments
+/// * ``hidden``: A boolean indicating whether to hide the status bar.
+#if swift(>=5.8)
+@_documentation(visibility: public)
+#endif
+struct StatusBarHiddenModifier: ViewModifier, Decodable, Equatable {
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
+    private let hidden: Bool
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        self.hidden = try container.decode(Bool.self, forKey: .hidden)
+    }
+
+    func body(content: Content) -> some View {
+        content.statusBarHidden(hidden)
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case hidden
+    }
+}

--- a/Sources/LiveViewNative/Modifiers/View Configuration Modifiers/StatusBarHiddenModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/View Configuration Modifiers/StatusBarHiddenModifier.swift
@@ -20,11 +20,12 @@ import SwiftUI
 /// ```
 ///
 /// ## Arguments
-/// * ``hidden``: A boolean indicating whether to hide the status bar.
+/// * ``hidden``
 #if swift(>=5.8)
 @_documentation(visibility: public)
 #endif
 struct StatusBarHiddenModifier: ViewModifier, Decodable, Equatable {
+    /// A boolean indicating whether to hide the status bar.
     #if swift(>=5.8)
     @_documentation(visibility: public)
     #endif

--- a/Sources/LiveViewNative/Registries/BuiltinRegistry.swift
+++ b/Sources/LiveViewNative/Registries/BuiltinRegistry.swift
@@ -202,6 +202,7 @@ struct BuiltinRegistry: BuiltinRegistryProtocol {
         case renameAction = "rename_action"
         case rotation3DEffect = "rotation_3d_effect"
         case rotationEffect = "rotation_effect"
+        case statusBarHidden = "status_bar_hidden"
         case strikethrough
         case tag
         case textSelection = "text_selection"
@@ -266,6 +267,8 @@ struct BuiltinRegistry: BuiltinRegistryProtocol {
             try Rotation3DEffectModifier(from: decoder)
         case .rotationEffect:
             try RotationEffectModifier(from: decoder)
+        case .statusBarHidden:
+            try StatusBarHiddenModifier(from: decoder)
         case .strikethrough:
             try StrikethroughModifier(from: decoder)
         case .tag:

--- a/lib/live_view_native_swift_ui/modifiers/status_bar_hidden.ex
+++ b/lib/live_view_native_swift_ui/modifiers/status_bar_hidden.ex
@@ -1,0 +1,7 @@
+defmodule LiveViewNativeSwiftUi.Modifiers.StatusBarHidden do
+  use LiveViewNativePlatform.Modifier
+
+  modifier_schema "status_bar_hidden" do
+    field :hidden, :boolean
+  end
+end

--- a/lib/live_view_native_swift_ui/platform.ex
+++ b/lib/live_view_native_swift_ui/platform.ex
@@ -47,6 +47,7 @@ defmodule LiveViewNativeSwiftUi.Platform do
           refreshable: Modifiers.Refreshable,
           rotation_3d_effect: Modifiers.Rotation3DEffect,
           rotation_effect: Modifiers.RotationEffect,
+          status_bar_hidden: Modifiers.StatusBarHidden,
           strikethrough: Modifiers.Strikethrough,
           tag: Modifiers.Tag,
           text_selection: Modifiers.TextSelection,


### PR DESCRIPTION
Adds [statusBarHidden](https://developer.apple.com/documentation/swiftui/view/statusbarhidden(_:)). With:

```heex
<VStack nav-title="SwiftUI Demo" modifiers={status_bar_hidden(@native, hidden: true)}>
  <Text>Hello World</Text>
</VStack>
```

![Screenshot 2023-04-01 at 3 41 50 PM](https://user-images.githubusercontent.com/5893007/229319483-1bbdffe6-d6de-48c9-8ef3-90ba1b3243e8.png)

Without:

```heex
<VStack nav-title="SwiftUI Demo" modifiers={status_bar_hidden(@native, hidden: false)}>
  <Text>Hello World</Text>
</VStack>
```

![Screenshot 2023-04-01 at 3 42 01 PM](https://user-images.githubusercontent.com/5893007/229319485-d94a8a1b-7eab-4ab0-8886-4cc94197ff24.png)

Closes https://github.com/liveview-native/liveview-client-swiftui/issues/429