### PR TITLE
Add textCase modifier

### DIFF
--- a/Sources/LiveViewNative/Modifiers/Text Input and Output Modifiers/TextCaseModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Text Input and Output Modifiers/TextCaseModifier.swift
@@ -1,0 +1,53 @@
+//
+//  TextCaseModifier.swift
+// LiveViewNative
+//
+//  Created by May Matyi on 4/1/23.
+//
+
+import SwiftUI
+
+/// Changes the capitalization of the text for any element.
+///
+/// ```html
+/// <Text
+///     modifiers={
+///         textCase(@native, text_case: :uppercase)
+///     }
+/// >
+///   This text is displayed in uppercase.
+/// </Text>
+/// ```
+///
+/// ## Arguments
+/// * ``textCase``: One of the `Text.Case` enumerations.
+#if swift(>=5.8)
+@_documentation(visibility: public)
+#endif
+struct TextCaseModifier: ViewModifier, Decodable, Equatable {
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
+    private let textCase: SwiftUI.Text.Case
+    
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        switch try container.decode(String.self, forKey: .textCase) {
+        case "lowercase":
+            self.textCase = .lowercase
+        case "uppercase":
+            self.textCase = .uppercase
+        default:
+            throw DecodingError.dataCorruptedError(forKey: .textCase, in: container, debugDescription: "invalid value for textCase")
+        }
+    }
+    
+    func body(content: Content) -> some View {
+        content.textCase(textCase)
+    }
+    
+    enum CodingKeys: String, CodingKey {
+        case textCase = "text_case"
+    }
+}

--- a/Sources/LiveViewNative/Modifiers/Text Input and Output Modifiers/TextCaseModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Text Input and Output Modifiers/TextCaseModifier.swift
@@ -20,11 +20,12 @@ import SwiftUI
 /// ```
 ///
 /// ## Arguments
-/// * ``textCase``: One of the `Text.Case` enumerations.
+/// * ``textCase``
 #if swift(>=5.8)
 @_documentation(visibility: public)
 #endif
 struct TextCaseModifier: ViewModifier, Decodable, Equatable {
+    /// One of the `Text.Case` enumerations.
     #if swift(>=5.8)
     @_documentation(visibility: public)
     #endif

--- a/Sources/LiveViewNative/Registries/BuiltinRegistry.swift
+++ b/Sources/LiveViewNative/Registries/BuiltinRegistry.swift
@@ -205,6 +205,7 @@ struct BuiltinRegistry: BuiltinRegistryProtocol {
         case statusBarHidden = "status_bar_hidden"
         case strikethrough
         case tag
+        case textCase = "text_case"
         case textSelection = "text_selection"
         case tint
         case transition
@@ -273,6 +274,8 @@ struct BuiltinRegistry: BuiltinRegistryProtocol {
             try StrikethroughModifier(from: decoder)
         case .tag:
             try TagModifier(from: decoder)
+        case .textCase:
+            try TextCaseModifier(from: decoder)
         case .textSelection:
             try TextSelectionModifier(from: decoder)
         case .tint:

--- a/lib/live_view_native_swift_ui/modifiers/text_case.ex
+++ b/lib/live_view_native_swift_ui/modifiers/text_case.ex
@@ -1,0 +1,7 @@
+defmodule LiveViewNativeSwiftUi.Modifiers.TextCase do
+  use LiveViewNativePlatform.Modifier
+
+  modifier_schema "text_case" do
+    field :text_case, Ecto.Enum, values: ~w(lowercase uppercase)a
+  end
+end

--- a/lib/live_view_native_swift_ui/platform.ex
+++ b/lib/live_view_native_swift_ui/platform.ex
@@ -50,6 +50,7 @@ defmodule LiveViewNativeSwiftUi.Platform do
           status_bar_hidden: Modifiers.StatusBarHidden,
           strikethrough: Modifiers.Strikethrough,
           tag: Modifiers.Tag,
+          text_case: Modifiers.TextCase,
           text_selection: Modifiers.TextSelection,
           tint: Modifiers.Tint,
           transition: Modifiers.Transition,


### PR DESCRIPTION
Adds the [textCase](https://developer.apple.com/documentation/swiftui/view/textcase(_:)) modifier:

```heex
<VStack>
  <Text>This text is normal</Text>
  <Text modifiers={text_case(@native, text_case: :uppercase)}>This text is uppercase</Text>
  <Text modifiers={text_case(@native, text_case: :lowercase)}>This text is lowercase</Text>
</VStack>
```

![Screenshot 2023-04-01 at 4 14 05 PM](https://user-images.githubusercontent.com/5893007/229320441-fc1dd0d1-b036-4fe2-8a12-b8a9db3b763a.png)

Closes https://github.com/liveview-native/liveview-client-swiftui/issues/307.