### PR TITLE
Add monospaced and monospacedDigit modifiers

### DIFF
--- a/Sources/LiveViewNative/Modifiers/Text Input and Output Modifiers/MonospacedDigitModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Text Input and Output Modifiers/MonospacedDigitModifier.swift
@@ -1,0 +1,33 @@
+
+//
+//  MonospacedDigitModifier.swift
+// LiveViewNative
+//
+//  Created by May Matyi on 4/1/23.
+//
+
+import SwiftUI
+
+/// Changes any element to use fixed-width digits.
+///
+/// ```html
+/// <Text
+///     modifiers={
+///         monospaced_digit(@native)
+///     }
+/// >
+///   The following numbers are monospaced: 1234567890
+/// </Text>
+/// ```
+#if swift(>=5.8)
+@_documentation(visibility: public)
+#endif
+struct MonospacedDigitModifier: ViewModifier, Decodable, Equatable {
+    init(from decoder: Decoder) throws {
+        self
+    }
+
+    func body(content: Content) -> some View {
+        return content.monospacedDigit()
+    }
+}

--- a/Sources/LiveViewNative/Modifiers/Text Input and Output Modifiers/MonospacedDigitModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Text Input and Output Modifiers/MonospacedDigitModifier.swift
@@ -24,7 +24,6 @@ import SwiftUI
 #endif
 struct MonospacedDigitModifier: ViewModifier, Decodable, Equatable {
     init(from decoder: Decoder) throws {
-        self
     }
 
     func body(content: Content) -> some View {

--- a/Sources/LiveViewNative/Modifiers/Text Input and Output Modifiers/MonospacedModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Text Input and Output Modifiers/MonospacedModifier.swift
@@ -1,0 +1,47 @@
+
+//
+//  MonospacedModifier.swift
+// LiveViewNative
+//
+//  Created by May Matyi on 4/1/23.
+//
+
+import SwiftUI
+
+/// Changes the font within any element to be monospaced.
+///
+/// ```html
+/// <Text
+///     modifiers={
+///         monospaced(@native, is_active: true)
+///     }
+/// >
+///   This text is monospaced.
+/// </Text>
+/// ```
+///
+/// ## Arguments
+/// * ``isActive``: A boolean that indicates whether the monospaced font should be used.
+#if swift(>=5.8)
+@_documentation(visibility: public)
+#endif
+struct MonospacedModifier: ViewModifier, Decodable, Equatable {
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
+    private let isActive: Bool
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        self.isActive = try container.decode(Bool.self, forKey: .isActive)
+    }
+
+    func body(content: Content) -> some View {
+        return content.monospaced(isActive)
+    }
+    
+    enum CodingKeys: String, CodingKey {
+        case isActive = "is_active"
+    }
+}

--- a/Sources/LiveViewNative/Modifiers/Text Input and Output Modifiers/MonospacedModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Text Input and Output Modifiers/MonospacedModifier.swift
@@ -21,11 +21,12 @@ import SwiftUI
 /// ```
 ///
 /// ## Arguments
-/// * ``isActive``: A boolean that indicates whether the monospaced font should be used.
+/// * ``isActive``
 #if swift(>=5.8)
 @_documentation(visibility: public)
 #endif
 struct MonospacedModifier: ViewModifier, Decodable, Equatable {
+    /// A boolean that indicates whether the monospaced font should be used.
     #if swift(>=5.8)
     @_documentation(visibility: public)
     #endif

--- a/Sources/LiveViewNative/Registries/BuiltinRegistry.swift
+++ b/Sources/LiveViewNative/Registries/BuiltinRegistry.swift
@@ -196,6 +196,7 @@ struct BuiltinRegistry: BuiltinRegistryProtocol {
         case listRowInsets = "list_row_insets"
         case listRowSeparator = "list_row_separator"
         case matchedGeometryEffect = "matched_geometry_effect"
+        case monospaced
         case navigationTitle = "navigation_title"
         case opacity
         case padding
@@ -257,6 +258,8 @@ struct BuiltinRegistry: BuiltinRegistryProtocol {
             try ListRowSeparatorModifier(from: decoder)
         case .matchedGeometryEffect:
             try MatchedGeometryEffectModifier(from: decoder)
+        case .monospaced:
+            try MonospacedModifier(from: decoder)
         case .navigationTitle:
             try NavigationTitleModifier(from: decoder)
         case .opacity:

--- a/Sources/LiveViewNative/Registries/BuiltinRegistry.swift
+++ b/Sources/LiveViewNative/Registries/BuiltinRegistry.swift
@@ -197,6 +197,7 @@ struct BuiltinRegistry: BuiltinRegistryProtocol {
         case listRowSeparator = "list_row_separator"
         case matchedGeometryEffect = "matched_geometry_effect"
         case monospaced
+        case monospacedDigit = "monospaced_digit"
         case navigationTitle = "navigation_title"
         case opacity
         case padding
@@ -260,6 +261,8 @@ struct BuiltinRegistry: BuiltinRegistryProtocol {
             try MatchedGeometryEffectModifier(from: decoder)
         case .monospaced:
             try MonospacedModifier(from: decoder)
+        case .monospacedDigit:
+            try MonospacedDigitModifier(from: decoder)
         case .navigationTitle:
             try NavigationTitleModifier(from: decoder)
         case .opacity:

--- a/lib/live_view_native_swift_ui/modifiers/monospaced.ex
+++ b/lib/live_view_native_swift_ui/modifiers/monospaced.ex
@@ -1,0 +1,7 @@
+defmodule LiveViewNativeSwiftUi.Modifiers.Monospaced do
+  use LiveViewNativePlatform.Modifier
+
+  modifier_schema "monospaced" do
+    field :is_active, :boolean, default: true
+  end
+end

--- a/lib/live_view_native_swift_ui/modifiers/monospaced_digit.ex
+++ b/lib/live_view_native_swift_ui/modifiers/monospaced_digit.ex
@@ -1,0 +1,5 @@
+defmodule LiveViewNativeSwiftUi.Modifiers.MonospacedDigit do
+  use LiveViewNativePlatform.Modifier
+
+  modifier_schema "monospaced_digit"
+end

--- a/lib/live_view_native_swift_ui/platform.ex
+++ b/lib/live_view_native_swift_ui/platform.ex
@@ -42,6 +42,7 @@ defmodule LiveViewNativeSwiftUi.Platform do
           list_row_insets: Modifiers.ListRowInsets,
           list_row_separator: Modifiers.ListRowSeparator,
           matched_geometry_effect: Modifiers.MatchedGeometryEffect,
+          monospaced: Modifiers.Monospaced,
           navigation_title: Modifiers.NavigationTitle,
           opacity: Modifiers.Opacity,
           padding: Modifiers.Padding,

--- a/lib/live_view_native_swift_ui/platform.ex
+++ b/lib/live_view_native_swift_ui/platform.ex
@@ -43,6 +43,7 @@ defmodule LiveViewNativeSwiftUi.Platform do
           list_row_separator: Modifiers.ListRowSeparator,
           matched_geometry_effect: Modifiers.MatchedGeometryEffect,
           monospaced: Modifiers.Monospaced,
+          monospaced_digit: Modifiers.MonospacedDigit,
           navigation_title: Modifiers.NavigationTitle,
           opacity: Modifiers.Opacity,
           padding: Modifiers.Padding,


### PR DESCRIPTION
Adds the [monospaced](https://developer.apple.com/documentation/swiftui/view/monospaced(_:)) and [monospacedDigit](https://developer.apple.com/documentation/swiftui/view/monospaceddigit()) modifiers:

```heex
<VStack>
  <Label modifiers={monospaced(@native, is_active: true)}>This text is monospaced</Label>
  <Label modifiers={monospaced(@native, is_active: false)}>This text is not</Label>
  <Label modifiers={monospaced_digit(@native)}>1234567890</Label>
  <Label>1234567890</Label>
</VStack>
```

![Screenshot 2023-04-01 at 6 41 42 PM](https://user-images.githubusercontent.com/5893007/229326497-8acd66c4-2d24-4356-8747-c9d77d1c5dce.png)

Closes https://github.com/liveview-native/liveview-client-swiftui/issues/304
Closes https://github.com/liveview-native/liveview-client-swiftui/issues/305