### PR TITLE
Fix build warnings and add `active` to bold/italic

### DIFF
--- a/Sources/LiveViewNative/Modifiers/Text Input and Output Modifiers/BoldModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Text Input and Output Modifiers/BoldModifier.swift
@@ -9,11 +9,14 @@ import SwiftUI
 
 struct BoldModifier: ViewModifier, Decodable {
     /// Enables/disables the bold effect.
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
     private var active: Bool
     
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        self.active = try container.decodeIfPresent(Bool.self, forKey: .active) ?? true
+        self.active = try container.decode(Bool.self, forKey: .active)
     }
 
     func body(content: Content) -> some View {

--- a/Sources/LiveViewNative/Modifiers/Text Input and Output Modifiers/BoldModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Text Input and Output Modifiers/BoldModifier.swift
@@ -8,11 +8,19 @@
 import SwiftUI
 
 struct BoldModifier: ViewModifier, Decodable {
+    /// Enables/disables the bold effect.
+    private var active: Bool
+    
     init(from decoder: Decoder) throws {
-        self
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.active = try container.decodeIfPresent(Bool.self, forKey: .active) ?? true
     }
 
     func body(content: Content) -> some View {
-        content.bold()
+        content.bold(active)
+    }
+    
+    enum CodingKeys: String, CodingKey {
+        case active
     }
 }

--- a/Sources/LiveViewNative/Modifiers/Text Input and Output Modifiers/BoldModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Text Input and Output Modifiers/BoldModifier.swift
@@ -7,23 +7,34 @@
 
 import SwiftUI
 
+/// Makes any child ``Text`` elements bold.
+///
+/// The effect can be toggled with the [`is_active`](doc:BoldModifier/isActive) argument.
+///
+/// ```html
+/// <Text modifiers={bold(@native)}>Hello, world!</Text>
+/// <Text modifiers={bold(@native, is_active: false)}>Hello, world!</Text>
+/// ```
+#if swift(>=5.8)
+@_documentation(visibility: public)
+#endif
 struct BoldModifier: ViewModifier, Decodable {
     /// Enables/disables the bold effect.
     #if swift(>=5.8)
     @_documentation(visibility: public)
     #endif
-    private var active: Bool
+    private var isActive: Bool
     
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        self.active = try container.decode(Bool.self, forKey: .active)
+        self.isActive = try container.decode(Bool.self, forKey: .isActive)
     }
 
     func body(content: Content) -> some View {
-        content.bold(active)
+        content.bold(isActive)
     }
     
     enum CodingKeys: String, CodingKey {
-        case active
+        case isActive = "is_active"
     }
 }

--- a/Sources/LiveViewNative/Modifiers/Text Input and Output Modifiers/ItalicModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Text Input and Output Modifiers/ItalicModifier.swift
@@ -7,23 +7,34 @@
 
 import SwiftUI
 
+/// Makes any child ``Text`` elements italic.
+///
+/// The effect can be toggled with the [`is_active`](doc:ItalicModifier/isActive) argument.
+///
+/// ```html
+/// <Text modifiers={italic(@native)}>Hello, world!</Text>
+/// <Text modifiers={italic(@native, is_active: false)}>Hello, world!</Text>
+/// ```
+#if swift(>=5.8)
+@_documentation(visibility: public)
+#endif
 struct ItalicModifier: ViewModifier, Decodable {
     /// Enables/disables the italic effect.
     #if swift(>=5.8)
     @_documentation(visibility: public)
     #endif
-    private var active: Bool
+    private var isActive: Bool
     
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        self.active = try container.decode(Bool.self, forKey: .active)
+        self.isActive = try container.decode(Bool.self, forKey: .isActive)
     }
 
     func body(content: Content) -> some View {
-        content.italic(active)
+        content.italic(isActive)
     }
     
     enum CodingKeys: String, CodingKey {
-        case active
+        case isActive = "is_active"
     }
 }

--- a/Sources/LiveViewNative/Modifiers/Text Input and Output Modifiers/ItalicModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Text Input and Output Modifiers/ItalicModifier.swift
@@ -8,11 +8,19 @@
 import SwiftUI
 
 struct ItalicModifier: ViewModifier, Decodable {
+    /// Enables/disables the italic effect.
+    private var active: Bool
+    
     init(from decoder: Decoder) throws {
-        self
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.active = try container.decodeIfPresent(Bool.self, forKey: .active) ?? true
     }
 
     func body(content: Content) -> some View {
-        content.italic()
+        content.italic(active)
+    }
+    
+    enum CodingKeys: String, CodingKey {
+        case active
     }
 }

--- a/Sources/LiveViewNative/Modifiers/Text Input and Output Modifiers/ItalicModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Text Input and Output Modifiers/ItalicModifier.swift
@@ -9,11 +9,14 @@ import SwiftUI
 
 struct ItalicModifier: ViewModifier, Decodable {
     /// Enables/disables the italic effect.
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
     private var active: Bool
     
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        self.active = try container.decodeIfPresent(Bool.self, forKey: .active) ?? true
+        self.active = try container.decode(Bool.self, forKey: .active)
     }
 
     func body(content: Content) -> some View {

--- a/lib/live_view_native_swift_ui/modifiers/bold.ex
+++ b/lib/live_view_native_swift_ui/modifiers/bold.ex
@@ -2,6 +2,6 @@ defmodule LiveViewNativeSwiftUi.Modifiers.Bold do
   use LiveViewNativePlatform.Modifier
 
   modifier_schema "bold" do
-    field :active, :boolean, default: true
+    field :is_active, :boolean, default: true
   end
 end

--- a/lib/live_view_native_swift_ui/modifiers/bold.ex
+++ b/lib/live_view_native_swift_ui/modifiers/bold.ex
@@ -2,5 +2,6 @@ defmodule LiveViewNativeSwiftUi.Modifiers.Bold do
   use LiveViewNativePlatform.Modifier
 
   modifier_schema "bold" do
+    field :active, :boolean
   end
 end

--- a/lib/live_view_native_swift_ui/modifiers/bold.ex
+++ b/lib/live_view_native_swift_ui/modifiers/bold.ex
@@ -2,6 +2,6 @@ defmodule LiveViewNativeSwiftUi.Modifiers.Bold do
   use LiveViewNativePlatform.Modifier
 
   modifier_schema "bold" do
-    field :active, :boolean
+    field :active, :boolean, default: true
   end
 end

--- a/lib/live_view_native_swift_ui/modifiers/italic.ex
+++ b/lib/live_view_native_swift_ui/modifiers/italic.ex
@@ -2,6 +2,6 @@ defmodule LiveViewNativeSwiftUi.Modifiers.Italic do
   use LiveViewNativePlatform.Modifier
 
   modifier_schema "italic" do
-    field :active, :boolean
+    field :active, :boolean, default: true
   end
 end

--- a/lib/live_view_native_swift_ui/modifiers/italic.ex
+++ b/lib/live_view_native_swift_ui/modifiers/italic.ex
@@ -2,6 +2,6 @@ defmodule LiveViewNativeSwiftUi.Modifiers.Italic do
   use LiveViewNativePlatform.Modifier
 
   modifier_schema "italic" do
-    field :active, :boolean, default: true
+    field :is_active, :boolean, default: true
   end
 end

--- a/lib/live_view_native_swift_ui/modifiers/italic.ex
+++ b/lib/live_view_native_swift_ui/modifiers/italic.ex
@@ -2,5 +2,6 @@ defmodule LiveViewNativeSwiftUi.Modifiers.Italic do
   use LiveViewNativePlatform.Modifier
 
   modifier_schema "italic" do
+    field :active, :boolean
   end
 end


### PR DESCRIPTION
This fixes the warnings from the `BoldModifier` and `ItalicModifier` initializers. I also added the `active` property to these modifiers.