### PR TITLE
Add `text_field_style` modifier

### DIFF
--- a/Sources/LiveViewNative/Modifiers/Text Input and Output Modifiers/TextFieldStyleModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Text Input and Output Modifiers/TextFieldStyleModifier.swift
@@ -38,10 +38,50 @@ struct TextFieldStyleModifier: ViewModifier, Decodable {
     }
 
     func body(content: Content) -> some View {
-        content.applyTextFieldStyle(style)
+        switch style {
+        case .automatic:
+            content.textFieldStyle(.automatic)
+        case .plain:
+            content.textFieldStyle(.plain)
+        case .roundedBorder:
+            #if !os(watchOS)
+            content.textFieldStyle(.roundedBorder)
+            #endif
+        case .squareBorder:
+            #if os(macOS)
+            content.textFieldStyle(.squareBorder)
+            #endif
+        }
     }
 
     enum CodingKeys: String, CodingKey {
         case style
     }
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: public)
+#endif
+private enum TextFieldStyle: String, Decodable {
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
+    case automatic
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
+    case plain
+    /// `rounded-border`
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
+    @available(iOS 16.0, tvOS 16.0, macOS 13.0, *)
+    case roundedBorder = "rounded_border"
+
+    /// `square-border`
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
+    @available(macOS 13.0, *)
+    case squareBorder = "square_border"
 }

--- a/Sources/LiveViewNative/Modifiers/Text Input and Output Modifiers/TextFieldStyleModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Text Input and Output Modifiers/TextFieldStyleModifier.swift
@@ -1,0 +1,47 @@
+//
+//  TextFieldStyleModifier.swift
+//  LiveViewNative
+//
+//  Created by Carson Katri on 4/6/2023.
+//
+
+import SwiftUI
+
+/// Sets the style for ``TextField`` child elements.
+///
+/// Any child ``TextField`` will be given the specified ``style``.
+///
+/// ```html
+/// <VStack modifiers={text_field_style(@native, style: :plain)}>
+///     <TextField value-binding="email">Email</TextField>
+///     <TextField value-binding="password">Password</TextField>
+/// </VStack>
+/// ```
+///
+/// See ``TextFieldStyle`` for a list of possible styles.
+#if swift(>=5.8)
+@_documentation(visibility: public)
+#endif
+struct TextFieldStyleModifier: ViewModifier, Decodable {
+    /// The style to apply.
+    ///
+    /// See ``TextFieldStyle`` for a list of possible styles.
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
+    private let style: TextFieldStyle
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        self.style = try container.decode(TextFieldStyle.self, forKey: .style)
+    }
+
+    func body(content: Content) -> some View {
+        content.applyTextFieldStyle(style)
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case style
+    }
+}

--- a/Sources/LiveViewNative/Registries/BuiltinRegistry.swift
+++ b/Sources/LiveViewNative/Registries/BuiltinRegistry.swift
@@ -207,6 +207,7 @@ struct BuiltinRegistry: BuiltinRegistryProtocol {
         case strikethrough
         case tag
         case textCase = "text_case"
+        case textFieldStyle = "text_field_style"
         case textSelection = "text_selection"
         case tint
         case transition
@@ -279,6 +280,8 @@ struct BuiltinRegistry: BuiltinRegistryProtocol {
             try TagModifier(from: decoder)
         case .textCase:
             try TextCaseModifier(from: decoder)
+        case .textFieldStyle:
+            try TextFieldStyleModifier(from: decoder)
         case .textSelection:
             try TextSelectionModifier(from: decoder)
         case .tint:

--- a/Sources/LiveViewNative/Views/Text Input and Output/SecureField.swift
+++ b/Sources/LiveViewNative/Views/Text Input and Output/SecureField.swift
@@ -23,7 +23,6 @@ import SwiftUI
 /// * ``TextFieldProtocol/autocapitalization``
 /// * ``TextFieldProtocol/keyboard``
 /// * ``TextFieldProtocol/submitLabel``
-/// * ``TextFieldProtocol/textFieldStyle``
 ///
 /// ## Events
 /// * ``focusEvent``
@@ -60,7 +59,6 @@ struct SecureField<R: RootRegistry>: TextFieldProtocol {
         }
             .focused($isFocused)
             .onChange(of: isFocused, perform: handleFocus)
-            .applyTextFieldStyle(textFieldStyle)
             .applyAutocorrectionDisabled(disableAutocorrection)
 #if os(iOS) || os(tvOS)
             .textInputAutocapitalization(autocapitalization)

--- a/Sources/LiveViewNative/Views/Text Input and Output/TextField.swift
+++ b/Sources/LiveViewNative/Views/Text Input and Output/TextField.swift
@@ -66,7 +66,6 @@ import SwiftUI
 /// * ``TextFieldProtocol/autocapitalization``
 /// * ``TextFieldProtocol/keyboard``
 /// * ``TextFieldProtocol/submitLabel``
-/// * ``TextFieldProtocol/textFieldStyle``
 ///
 /// ## Events
 /// * ``focusEvent``
@@ -109,7 +108,6 @@ struct TextField<R: RootRegistry>: TextFieldProtocol {
         field
             .focused($isFocused)
             .onChange(of: isFocused, perform: handleFocus)
-            .applyTextFieldStyle(textFieldStyle)
             .applyAutocorrectionDisabled(disableAutocorrection)
 #if !os(macOS)
             .textInputAutocapitalization(autocapitalization)

--- a/Sources/LiveViewNative/Views/Text Input and Output/TextFieldProtocol.swift
+++ b/Sources/LiveViewNative/Views/Text Input and Output/TextFieldProtocol.swift
@@ -90,12 +90,12 @@ extension TextFieldProtocol {
     #if swift(>=5.8)
     @_documentation(visibility: public)
     #endif
-    var textFieldStyle: TextFieldStyle {
+    var textFieldStyle: TextFieldStyle? {
         if let s = element.attributeValue(for: "text-field-style"),
            let style = TextFieldStyle(rawValue: s) {
             return style
         } else {
-            return .automatic
+            return nil
         }
     }
     
@@ -250,7 +250,7 @@ extension TextFieldProtocol {
 #if swift(>=5.8)
 @_documentation(visibility: public)
 #endif
-enum TextFieldStyle: String {
+enum TextFieldStyle: String, Decodable {
     #if swift(>=5.8)
     @_documentation(visibility: public)
     #endif
@@ -276,7 +276,7 @@ enum TextFieldStyle: String {
 
 extension View {
     @ViewBuilder
-    func applyTextFieldStyle(_ style: TextFieldStyle) -> some View {
+    func applyTextFieldStyle(_ style: TextFieldStyle?) -> some View {
         switch style {
         case .automatic:
             self.textFieldStyle(.automatic)
@@ -290,6 +290,8 @@ extension View {
             #if os(macOS)
             self.textFieldStyle(.squareBorder)
             #endif
+        case nil:
+            self
         }
     }
     

--- a/Sources/LiveViewNative/Views/Text Input and Output/TextFieldProtocol.swift
+++ b/Sources/LiveViewNative/Views/Text Input and Output/TextFieldProtocol.swift
@@ -86,19 +86,6 @@ extension TextFieldProtocol {
         }
     }
     
-    /// The style to apply to this field.
-    #if swift(>=5.8)
-    @_documentation(visibility: public)
-    #endif
-    var textFieldStyle: TextFieldStyle? {
-        if let s = element.attributeValue(for: "text-field-style"),
-           let style = TextFieldStyle(rawValue: s) {
-            return style
-        } else {
-            return nil
-        }
-    }
-    
     /// Indicates if autocorrection should be enabled.
     ///
     /// Possible values:
@@ -247,54 +234,7 @@ extension TextFieldProtocol {
     }
 }
 
-#if swift(>=5.8)
-@_documentation(visibility: public)
-#endif
-enum TextFieldStyle: String, Decodable {
-    #if swift(>=5.8)
-    @_documentation(visibility: public)
-    #endif
-    case automatic
-    #if swift(>=5.8)
-    @_documentation(visibility: public)
-    #endif
-    case plain
-    /// `rounded-border`
-    #if swift(>=5.8)
-    @_documentation(visibility: public)
-    #endif
-    @available(iOS 16.0, tvOS 16.0, macOS 13.0, *)
-    case roundedBorder = "rounded-border"
-
-    /// `square-border`
-    #if swift(>=5.8)
-    @_documentation(visibility: public)
-    #endif
-    @available(macOS 13.0, *)
-    case squareBorder = "square-border"
-}
-
 extension View {
-    @ViewBuilder
-    func applyTextFieldStyle(_ style: TextFieldStyle?) -> some View {
-        switch style {
-        case .automatic:
-            self.textFieldStyle(.automatic)
-        case .plain:
-            self.textFieldStyle(.plain)
-        case .roundedBorder:
-            #if !os(watchOS)
-            self.textFieldStyle(.roundedBorder)
-            #endif
-        case .squareBorder:
-            #if os(macOS)
-            self.textFieldStyle(.squareBorder)
-            #endif
-        case nil:
-            self
-        }
-    }
-    
     @ViewBuilder
     func applyAutocorrectionDisabled(_ disableAutocorrection: Bool?) -> some View {
         if let disableAutocorrection {

--- a/lib/live_view_native_swift_ui/modifiers/text_field_style.ex
+++ b/lib/live_view_native_swift_ui/modifiers/text_field_style.ex
@@ -1,0 +1,7 @@
+defmodule LiveViewNativeSwiftUi.Modifiers.TextFieldStyle do
+  use LiveViewNativePlatform.Modifier
+
+  modifier_schema "text_field_style" do
+    field :style, Ecto.Enum, values: ~w(automatic plain rounded-border square-border)a
+  end
+end

--- a/lib/live_view_native_swift_ui/platform.ex
+++ b/lib/live_view_native_swift_ui/platform.ex
@@ -52,6 +52,7 @@ defmodule LiveViewNativeSwiftUi.Platform do
           strikethrough: Modifiers.Strikethrough,
           tag: Modifiers.Tag,
           text_case: Modifiers.TextCase,
+          text_field_style: Modifiers.TextFieldStyle,
           text_selection: Modifiers.TextSelection,
           tint: Modifiers.Tint,
           transition: Modifiers.Transition,


### PR DESCRIPTION
Closes #479 

Should the styles be underscored instead of dashed? Currently we can set the style of the field two ways:

```html
<TextField text-field-style="rounded-border" />
<TextField modifiers={text_field_style(@native, style: :"rounded-border")} />
```

If we make it underscored for both, the atom wouldn't need quotes. Could also use a different name for the attribute vs. modifier method.