### PR TITLE
Add `safe_area_inset` modifier

### DIFF
--- a/Sources/LiveViewNative/Modifiers/Layout Adjustments Modifiers/SafeAreaInsetModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Layout Adjustments Modifiers/SafeAreaInsetModifier.swift
@@ -1,0 +1,128 @@
+//
+//  SafeAreaInsetModifier.swift
+//  LiveViewNative
+//
+//  Created by Carson Katri on 4/6/2023.
+//
+
+import SwiftUI
+
+/// Overlays content while shifting the safe area.
+///
+/// Use this modifier to overlay content on scrollable areas.
+/// This will ensure the content it covers is never completely hidden.
+///
+/// Nested content is referenced by its namespace using the ``content`` argument.
+///
+/// ```html
+/// <List modifiers={safe_area_inset(@native, edge: :bottom, content: :bottom_bar)}>
+///     ...
+///     <safe_area_inset:bottom_bar id="bottom_bar">
+///         <GroupBox>
+///             <GroupBox:label>
+///                 <HStack>
+///                     <Text font-weight="bold" font="title2">Bottom Bar</Text>
+///                     <Spacer />
+///                 </HStack>
+///             </GroupBox:label>
+///             <Text>This will allow the list to scroll further up so no rows are covered.</Text>
+///         </GroupBox>
+///     </safe_area_inset:bottom_bar>
+/// </List>
+/// ```
+///
+/// ## Arguments
+/// * ``edge``
+/// * ``alignment``
+/// * ``spacing``
+/// * ``content``
+#if swift(>=5.8)
+@_documentation(visibility: public)
+#endif
+struct SafeAreaInsetModifier<R: RootRegistry>: ViewModifier, Decodable {
+    /// The edge to position the safe area on.
+    ///
+    /// Possible values:
+    /// * `leading`
+    /// * `trailing`
+    /// * `top`
+    /// * `bottom`
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
+    private let edge: AnyEdge
+    
+    enum AnyEdge {
+        case horizontal(HorizontalEdge)
+        case vertical(VerticalEdge)
+    }
+
+    /// The alignment of the inset.
+    ///
+    /// When the ``edge`` is `leading` or `trailing`, use a ``LiveViewNative/SwiftUI/VerticalAlignment``.
+    ///
+    /// When the ``edge`` is `top` or `bottom`, use a ``LiveViewNative/SwiftUI/HorizontalAlignment``.
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
+    private let alignment: Alignment
+
+    /// Space between the underlying content and the inset.
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
+    private let spacing: CGFloat?
+
+    /// The name of the child element to place in the inset.
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
+    private let content: String
+    
+    @ObservedElement private var element
+    @LiveContext<R> private var context
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        switch try container.decode(String.self, forKey: .edge) {
+        case "leading": self.edge = .horizontal(.leading)
+        case "trailing": self.edge = .horizontal(.trailing)
+        case "top": self.edge = .vertical(.top)
+        case "bottom": self.edge = .vertical(.bottom)
+        case let fallback: throw DecodingError.dataCorrupted(.init(codingPath: container.codingPath, debugDescription: "Unknown edge '\(fallback)'"))
+        }
+
+        self.alignment = try container.decode(Alignment.self, forKey: .alignment)
+        self.spacing = try container.decodeIfPresent(CGFloat.self, forKey: .spacing)
+        self.content = try container.decode(String.self, forKey: .content)
+    }
+
+    func body(content: Content) -> some View {
+        switch edge {
+        case .horizontal(let horizontalEdge):
+            content.safeAreaInset(
+                edge: horizontalEdge,
+                alignment: alignment.vertical,
+                spacing: spacing
+            ) {
+                context.buildChildren(of: element, withTagName: self.content, namespace: "safe_area_inset", includeDefaultSlot: false)
+            }
+        case .vertical(let verticalEdge):
+            content.safeAreaInset(
+                edge: verticalEdge,
+                alignment: alignment.horizontal,
+                spacing: spacing
+            ) {
+                context.buildChildren(of: element, withTagName: self.content, namespace: "safe_area_inset", includeDefaultSlot: false)
+            }
+        }
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case edge
+        case alignment
+        case spacing
+        case content
+    }
+}

--- a/lib/live_view_native_swift_ui/modifiers/safe_area_inset.ex
+++ b/lib/live_view_native_swift_ui/modifiers/safe_area_inset.ex
@@ -1,0 +1,12 @@
+defmodule LiveViewNativeSwiftUi.Modifiers.SafeAreaInset do
+  use LiveViewNativePlatform.Modifier
+
+  alias LiveViewNativeSwiftUi.Types.KeyName
+
+  modifier_schema "safe_area_inset" do
+    field :edge, Ecto.Enum, values: ~w(leading trailing top bottom)a
+    field :alignment, Ecto.Enum, values: ~w(leading trailing top bottom center)a, default: :center
+    field :spacing, :float
+    field :content, KeyName
+  end
+end


### PR DESCRIPTION
Closes #510

https://user-images.githubusercontent.com/13581484/230462561-c3f2afa2-fd74-462e-a8c4-6db2d3da3c14.mp4

```html
<List modifiers={safe_area_inset(@native, edge: :bottom, content: :bottom_bar)}>
    <%= for item <- 1..25 do %>
        <Text id={Integer.to_string(item)}><%= item %></Text>
    <% end %>
    <safe_area_inset:bottom_bar id="bottom_bar">
        <GroupBox modifiers={padding(@native, all: 32)}>
            <GroupBox:label>
                <HStack>
                    <Text font-weight="bold" font="title2">Bottom Bar</Text>
                    <Spacer />
                </HStack>
            </GroupBox:label>
            <Text>
                This will allow the list to scroll further up so no rows are covered.
            </Text>
        </GroupBox>
    </safe_area_inset:bottom_bar>
</List>
```