### PR TITLE
Use `<... template={...}>` for named children

### DIFF
--- a/Sources/LiveViewNative/Modifiers/Drawing and Graphics Modifiers/MaskModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Drawing and Graphics Modifiers/MaskModifier.swift
@@ -15,12 +15,10 @@ import SwiftUI
 ///         @native
 ///         |> foreground_color(color: :blue)
 ///         |> font(font: {:system, :large_title})
-///         |> mask(alignment: :center, content: :rectangle)
+///         |> mask(alignment: :center, content: :mask)
 ///     }
 /// >
-///     <mask:rectangle>
-///         <Rectangle modifiers={@native |> opacity(opacity: 0.1)} />
-///     </mask:rectangle>
+///     <Rectangle template={:mask} modifiers={@native |> opacity(opacity: 0.1)} />
 /// </Image>
 /// ```
 ///
@@ -57,7 +55,7 @@ struct MaskModifier<R: RootRegistry>: ViewModifier, Decodable {
 
     func body(content: Content) -> some View {
         content.mask(alignment: alignment) {
-            context.buildChildren(of: element, withTagName: self.content, namespace: "mask")
+            context.buildChildren(of: element, forTemplate: self.content)
         }
     }
 

--- a/Sources/LiveViewNative/Modifiers/Input Events Modifiers/DigitalCrownAccessoryModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Input Events Modifiers/DigitalCrownAccessoryModifier.swift
@@ -17,9 +17,7 @@ import SwiftUI
 ///     |> digital_crown_accessory(content: :dca_view)
 ///     |> digital_crown_accessory_visibility(visibility: :visible)
 /// }>
-///     <digital_crown_accessory:dca_view>
-///         <Image system-name="heart.fill" />
-///     </digital_crown_accessory:dca_view>
+///     <Image template={:dca_view} system-name="heart.fill" />
 /// </List>
 /// ```
 ///
@@ -49,7 +47,7 @@ struct DigitalCrownAccessoryModifier<R: RootRegistry>: ViewModifier, Decodable {
         content
             #if os(watchOS)
             .digitalCrownAccessory {
-                context.buildChildren(of: element, withTagName: self.content, namespace: "digital_crown_accessory")
+                context.buildChildren(of: element, forTemplate: self.content)
                     .environment(\.coordinatorEnvironment, coordinatorEnvironment)
                     .environment(\.anyLiveContextStorage, context.storage)
             }

--- a/Sources/LiveViewNative/Modifiers/Layout Adjustments Modifiers/SafeAreaInsetModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Layout Adjustments Modifiers/SafeAreaInsetModifier.swift
@@ -17,17 +17,13 @@ import SwiftUI
 /// ```html
 /// <List modifiers={safe_area_inset(@native, edge: :bottom, content: :bottom_bar)}>
 ///     ...
-///     <safe_area_inset:bottom_bar id="bottom_bar">
-///         <GroupBox>
-///             <GroupBox:label>
-///                 <HStack>
-///                     <Text font-weight="bold" font="title2">Bottom Bar</Text>
-///                     <Spacer />
-///                 </HStack>
-///             </GroupBox:label>
-///             <Text>This will allow the list to scroll further up so no rows are covered.</Text>
-///         </GroupBox>
-///     </safe_area_inset:bottom_bar>
+///     <GroupBox template={:bottom_bar} id="bottom_bar">
+///         <HStack template={:label}>
+///             <Text font-weight="bold" font="title2">Bottom Bar</Text>
+///             <Spacer />
+///         </HStack>
+///         <Text>This will allow the list to scroll further up so no rows are covered.</Text>
+///     </GroupBox>
 /// </List>
 /// ```
 ///
@@ -106,7 +102,7 @@ struct SafeAreaInsetModifier<R: RootRegistry>: ViewModifier, Decodable {
                 alignment: alignment.vertical,
                 spacing: spacing
             ) {
-                context.buildChildren(of: element, withTagName: self.content, namespace: "safe_area_inset", includeDefaultSlot: false)
+                context.buildChildren(of: element, forTemplate: self.content)
             }
         case .vertical(let verticalEdge):
             content.safeAreaInset(
@@ -114,7 +110,7 @@ struct SafeAreaInsetModifier<R: RootRegistry>: ViewModifier, Decodable {
                 alignment: alignment.horizontal,
                 spacing: spacing
             ) {
-                context.buildChildren(of: element, withTagName: self.content, namespace: "safe_area_inset", includeDefaultSlot: false)
+                context.buildChildren(of: element, forTemplate: self.content)
             }
         }
     }

--- a/Sources/LiveViewNative/Modifiers/Layout Fundamentals Modifiers/BackgroundModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Layout Fundamentals Modifiers/BackgroundModifier.swift
@@ -14,9 +14,7 @@ import SwiftUI
 /// ```html
 /// <HStack>
 ///   <Image system-name="heart.fill" modifiers={@native |> background(alignment: :center, content: :bg_content)}>
-///     <background:bg_content>
-///       <Circle />
-///     </background:bg_content>
+///     <Circle #bg_content />
 ///   </Image>
 /// </HStack>
 /// ```

--- a/Sources/LiveViewNative/Modifiers/Layout Fundamentals Modifiers/BackgroundModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Layout Fundamentals Modifiers/BackgroundModifier.swift
@@ -48,7 +48,7 @@ struct BackgroundModifier<R: RootRegistry>: ViewModifier, Decodable {
 
     func body(content: Content) -> some View {
         content.background(alignment: alignment) {
-            context.buildChildren(of: element, withTagName: self.content, namespace: "background")
+            context.buildChildren(of: element, forTemplate: self.content)
         }
     }
 

--- a/Sources/LiveViewNative/Modifiers/Layout Fundamentals Modifiers/BackgroundModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Layout Fundamentals Modifiers/BackgroundModifier.swift
@@ -14,7 +14,7 @@ import SwiftUI
 /// ```html
 /// <HStack>
 ///   <Image system-name="heart.fill" modifiers={@native |> background(alignment: :center, content: :bg_content)}>
-///     <Circle #bg_content />
+///     <Circle template={:bg_content} />
 ///   </Image>
 /// </HStack>
 /// ```

--- a/Sources/LiveViewNative/Modifiers/Lists Modifiers/ListRowBackgroundModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Lists Modifiers/ListRowBackgroundModifier.swift
@@ -17,9 +17,7 @@ import SwiftUI
 /// <List>
 ///     <Text modifiers={list_row_background(@native, content: :my_background)}>
 ///         ...
-///         <list_row_background:my_background>
-///             <Capsule fill-color="system-red" />
-///         </list_row_background:my_background>
+///         <Capsule template={:my_background} fill-color="system-red" />
 ///     </Text>
 /// </List>
 /// ```
@@ -46,7 +44,7 @@ struct ListRowBackgroundModifier<R: RootRegistry>: ViewModifier, Decodable {
     }
 
     func body(content: Content) -> some View {
-        content.listRowBackground(self.content.flatMap({ context.buildChildren(of: element, withTagName: $0, namespace: "list_row_background") }))
+        content.listRowBackground(self.content.flatMap({ context.buildChildren(of: element, forTemplate: $0) }))
     }
 
     enum CodingKeys: String, CodingKey {

--- a/Sources/LiveViewNative/Modifiers/Modal Presentations/AlertModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Modal Presentations/AlertModifier.swift
@@ -17,14 +17,14 @@ import SwiftUI
 ///     }
 /// >
 ///   Present Alert
-///   <alert:message>
+///   <Text template={:message}>
 ///     Hello, world!
-///   </alert:message>
-///   <alert:actions>
+///   </Text template={:message}>
+///   <Group template={:actions}>
 ///     <Button>
 ///       OK
 ///     </Button>
-///   </alert:actions>
+///   </Group template={:actions}>
 /// </Button>
 /// ```
 ///
@@ -90,10 +90,10 @@ struct AlertModifier<R: RootRegistry>: ViewModifier, Decodable {
     
     func body(content: Content) -> some View {
         content.alert(title, isPresented: $isPresented) {
-            context.buildChildren(of: element, withTagName: self.actions, namespace: "alert")
+            context.buildChildren(of: element, forTemplate: self.actions)
         } message: {
             if let message {
-                context.buildChildren(of: element, withTagName: message, namespace: "alert")
+                context.buildChildren(of: element, forTemplate: message)
             }
         }
     }

--- a/Sources/LiveViewNative/Modifiers/Modal Presentations/ConfirmationDialogModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Modal Presentations/ConfirmationDialogModifier.swift
@@ -17,11 +17,11 @@ import SwiftUI
 ///     }
 /// >
 ///   Present Confirmation Dialog
-///   <confirmation_dialog:actions>
+///   <Group template={:actions}>
 ///     <Button>
 ///       OK
 ///     </Button>
-///   </confirmation_dialog:actions>
+///   </Group template={:actions}>
 /// </Button>
 /// ```
 ///
@@ -101,10 +101,10 @@ struct ConfirmationDialogModifier<R: RootRegistry>: ViewModifier, Decodable {
     
     func body(content: Content) -> some View {
         content.confirmationDialog(title, isPresented: $isPresented, titleVisibility: titleVisibility) {
-            context.buildChildren(of: element, withTagName: self.actions, namespace: "alert")
+            context.buildChildren(of: element, forTemplate: self.actions)
         } message: {
             if let message {
-                context.buildChildren(of: element, withTagName: message, namespace: "alert")
+                context.buildChildren(of: element, forTemplate: message)
             }
         }
     }

--- a/Sources/LiveViewNative/Modifiers/Modal Presentations/PresentationBackgroundModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Modal Presentations/PresentationBackgroundModifier.swift
@@ -18,15 +18,13 @@ import SwiftUI
 /// <Button phx-click="toggle" modifiers={sheet(@native, content: :content, is_presented: :show)}>
 ///   Present Sheet
 ///
-///   <sheet:content>
-///     <VStack modifiers={presentation_background(@native, style: {:linear_gradient, [gradient: {:colors, [:red, :blue]}]})}>
-///       <presentation_background:background>
-///         <Color name="system-orange" />
-///       </presentation_background:background>
-///       <Text>Hello, world!</Text>
-///       <Button phx-click="toggle">Dismiss</Button>
-///     </VStack>
-///   </sheet:content>
+///   <VStack template={:content} modifiers={presentation_background(@native, style: {:linear_gradient, [gradient: {:colors, [:red, :blue]}]})}>
+///     <presentation_background:background>
+///       <Color name="system-orange" />
+///     </presentation_background:background>
+///     <Text>Hello, world!</Text>
+///     <Button phx-click="toggle">Dismiss</Button>
+///   </VStack>
 /// </Button>
 /// ```
 ///
@@ -80,7 +78,7 @@ struct PresentationBackgroundModifier<R: RootRegistry>: ViewModifier, Decodable 
             content.presentationBackground(style)
         } else {
             content.presentationBackground(alignment: alignment ?? .center) {
-                context.buildChildren(of: element, withTagName: self.content!, namespace: "presentation_background")
+                context.buildChildren(of: element, forTemplate: self.content!)
             }
         }
     }

--- a/Sources/LiveViewNative/Modifiers/Modal Presentations/SheetModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Modal Presentations/SheetModifier.swift
@@ -12,12 +12,10 @@ import SwiftUI
 /// ```html
 /// <Button phx-click="toggle" modifiers={sheet(@native, content: :content, is_presented: :show)}>
 ///   Present Sheet
-///   <sheet:content>
-///     <VStack>
-///       <Text>Hello, world!</Text>
-///       <Button phx-click="toggle">Dismiss</Button>
-///     </VStack>
-///   </sheet:content>
+///   <VStack template={:content}>
+///     <Text>Hello, world!</Text>
+///     <Button phx-click="toggle">Dismiss</Button>
+///   </VStack>
 /// </Button>
 /// ```
 ///
@@ -62,7 +60,7 @@ struct SheetModifier<R: RootRegistry>: ViewModifier, Decodable {
     
     func body(content: Content) -> some View {
         content.sheet(isPresented: $isPresented, onDismiss: $onDismiss) {
-            context.buildChildren(of: element, withTagName: self.content, namespace: "sheet")
+            context.buildChildren(of: element, forTemplate: self.content)
         }
     }
     

--- a/Sources/LiveViewNative/Modifiers/Navigation Modifiers/TabItemModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Navigation Modifiers/TabItemModifier.swift
@@ -14,10 +14,10 @@ import SwiftUI
 /// ```html
 /// <TabView>
 ///     <Rectangle modifiers={tab_item(@native, label: :my_label}>
-///         <tab_item:my_label>
+///         <Group #my_label>
 ///             <Image system-name="person.crop.circle.fill" />
 ///             <Text>Profile</Text>
-///         </tab_item:my_label>
+///         </Group #my_label>
 ///     </Rectangle>
 /// </TabView>
 /// ```
@@ -45,7 +45,7 @@ struct TabItemModifier<R: RootRegistry>: ViewModifier, Decodable {
 
     func body(content: Content) -> some View {
         content.tabItem {
-            context.buildChildren(of: element, withTagName: label, namespace: "tab_item")
+            context.buildChildren(of: element, forTemplate: label)
         }
     }
 

--- a/Sources/LiveViewNative/Modifiers/Navigation Modifiers/TabItemModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Navigation Modifiers/TabItemModifier.swift
@@ -14,10 +14,10 @@ import SwiftUI
 /// ```html
 /// <TabView>
 ///     <Rectangle modifiers={tab_item(@native, label: :my_label}>
-///         <Group #my_label>
+///         <Group template={:my_label}>
 ///             <Image system-name="person.crop.circle.fill" />
 ///             <Text>Profile</Text>
-///         </Group #my_label>
+///         </Group>
 ///     </Rectangle>
 /// </TabView>
 /// ```

--- a/Sources/LiveViewNative/Modifiers/Search Modifiers/SearchScopesModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Search Modifiers/SearchScopesModifier.swift
@@ -30,11 +30,11 @@ import SwiftUI
 ///     }
 /// >
 ///     ...
-///     <search_scopes:scope_list>
+///     <Group template={:scope_list}>
 ///         <Text modifiers='[{"type":"tag","value":"photos"}]'>Photos</Text>
 ///         <Text modifiers='[{"type":"tag","value":"videos"}]'>Videos</Text>
 ///         <Text modifiers='[{"type":"tag","value":"screenshots"}]'>Screenshots</Text>
-///     </search_scopes:scopes_list>
+///     </Group>
 /// </List>
 /// ```
 ///
@@ -95,11 +95,11 @@ struct SearchScopesModifier<R: RootRegistry>: ViewModifier, Decodable {
         #if os(iOS) || os(macOS) || os(tvOS)
         if #available(iOS 16.4, macOS 13.3, tvOS 16.4, *) {
             content.searchScopes($active, activation: searchScopeActivation) {
-                context.buildChildren(of: element, withTagName: scopes, namespace: "search_scopes")
+                context.buildChildren(of: element, forTemplate: scopes)
             }
         } else {
             content.searchScopes($active) {
-                context.buildChildren(of: element, withTagName: scopes, namespace: "search_scopes")
+                context.buildChildren(of: element, forTemplate: scopes)
             }
         }
         #else

--- a/Sources/LiveViewNative/Modifiers/Search Modifiers/SearchSuggestionsModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Search Modifiers/SearchSuggestionsModifier.swift
@@ -22,10 +22,10 @@ import SwiftUI
 ///     }
 /// >
 ///     ...
-///     <search_suggestions:my_suggestions>
+///     <Group template={:my_suggestions}>
 ///         <Text modifiers={search_completion(@native, completion: "text completion")}>text completion</Text>
 ///         <Text modifiers={search_completion(@native, token: "Custom")}>Custom Token</Text>
-///     </search_suggestions:my_suggestions>
+///     </Group>
 /// <List>
 /// ```
 #if swift(>=5.8)
@@ -49,7 +49,7 @@ struct SearchSuggestionsModifier<R: RootRegistry>: ViewModifier, Decodable {
 
     func body(content: Content) -> some View {
         content.searchSuggestions {
-            context.buildChildren(of: element, withTagName: suggestions, namespace: "search_suggestions")
+            context.buildChildren(of: element, forTemplate: suggestions)
         }
     }
 

--- a/Sources/LiveViewNative/Modifiers/Search Modifiers/SearchableModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Search Modifiers/SearchableModifier.swift
@@ -51,12 +51,8 @@ import SwiftUI
 ///     }
 /// >
 ///     ...
-///     <searchable:cats>
-///         <Label system-image="pawprint.fill">Cats</Label>
-///     </searchable:cats>
-///     <searchable:dogs>
-///         <Label system-image="pawprint">Dogs</Label>
-///     </searchable:dogs>
+///     <Label template={:cats} system-image="pawprint.fill">Cats</Label>
+///     <Label template={:dogs} system-image="pawprint">Dogs</Label>
 /// </List>
 /// ```
 ///
@@ -142,12 +138,12 @@ struct SearchableModifier<R: RootRegistry>: ViewModifier, Decodable {
         if let suggestedTokens {
             content
                 .searchable(text: $text, tokens: $tokens, suggestedTokens: .constant(suggestedTokens), placement: placement, prompt: prompt) { token in
-                    context.buildChildren(of: element, withTagName: token.value, namespace: "searchable")
+                    context.buildChildren(of: element, forTemplate: token.value)
                 }
         } else {
             content
                 .searchable(text: $text, tokens: $tokens, placement: placement, prompt: prompt) { token in
-                    context.buildChildren(of: element, withTagName: token.value, namespace: "searchable")
+                    context.buildChildren(of: element, forTemplate: token.value)
                 }
         }
         #else

--- a/Sources/LiveViewNative/Modifiers/Toolbars Modifiers/ToolbarModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Toolbars Modifiers/ToolbarModifier.swift
@@ -99,14 +99,14 @@ struct ToolbarModifier<R: RootRegistry>: ViewModifier, Decodable {
         if let id {
             content.toolbar(id: id) {
                 CustomizableToolbarTreeBuilder<R>().fromNodes(
-                    context.children(of: element, withTagName: self.content, namespace: "toolbar").flatMap { $0.children() },
+                    context.children(of: element, forTemplate: self.content).flatMap { $0.children() },
                     context: context.storage
                 )
             }
         } else {
             content.toolbar {
                 ToolbarTreeBuilder<R>().fromNodes(
-                    context.children(of: element, withTagName: self.content, namespace: "toolbar").flatMap { $0.children() },
+                    context.children(of: element, forTemplate: self.content).flatMap { $0.children() },
                     context: context.storage
                 )
             }

--- a/Sources/LiveViewNative/Modifiers/Toolbars Modifiers/ToolbarTitleMenuModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Toolbars Modifiers/ToolbarTitleMenuModifier.swift
@@ -46,7 +46,7 @@ struct ToolbarTitleMenuModifier<R: RootRegistry>: ViewModifier, Decodable {
 
     func body(content: Content) -> some View {
         content.toolbarTitleMenu {
-            context.buildChildren(of: element, withTagName: self.content, namespace: "toolbar_title_menu")
+            context.buildChildren(of: element, forTemplate: self.content)
         }
     }
 

--- a/Sources/LiveViewNative/Property Wrappers/LiveContext.swift
+++ b/Sources/LiveViewNative/Property Wrappers/LiveContext.swift
@@ -110,8 +110,9 @@ public struct LiveContext<R: RootRegistry>: DynamicProperty {
         if namedSlotChildren.isEmpty && includeDefaultSlot {
             let defaultSlotChildren = children.filter({
                 if case let .element(element) = $0.data {
-                    return (element.attributes.first(where: { $0.name == "template" })?.value != template)
-                        && !element.attributes.contains(where: { $0.name.rawValue.hasPrefix("#") })
+                    return !element.attributes.contains(where: {
+                        $0.name.rawValue == "template" || $0.name.rawValue.hasPrefix("#")
+                    })
                 } else {
                     return true
                 }

--- a/Sources/LiveViewNative/Property Wrappers/LiveContext.swift
+++ b/Sources/LiveViewNative/Property Wrappers/LiveContext.swift
@@ -82,14 +82,10 @@ public struct LiveContext<R: RootRegistry>: DynamicProperty {
     
     /// Builds a view representing only the children of the element which have the given template attribute.
     ///
-    /// The template attribute can be written in two ways:
-    /// 1. `template={:some_value}`
-    /// 2. `#some_value`
-    ///
     /// This can be use to build views which have multiple types of children, such as how ``Menu`` takes content and a label:
     /// ```html
     /// <Menu>
-    ///     <Group #label>
+    ///     <Group template={:label}>
     ///         My Menu
     ///     </Group>
     ///     <Button template={:content} phx-click="clicked">Hello</Button>

--- a/Sources/LiveViewNative/Property Wrappers/LiveContext.swift
+++ b/Sources/LiveViewNative/Property Wrappers/LiveContext.swift
@@ -123,12 +123,12 @@ public struct LiveContext<R: RootRegistry>: DynamicProperty {
         }
     }
     
+    /// Get the children of an element with the correct template attribute.
     func children(
         of element: ElementNode,
-        withTagName tagName: String,
-        namespace: String? = nil
-    ) -> [Node] {
-        element.children().filter(Self.elementWithName(tagName, namespace: namespace))
+        forTemplate template: String
+    ) -> [NodeChildrenSequence.Element] {
+        element.children().filter(Self.isTemplateElement(template))
     }
 }
 

--- a/Sources/LiveViewNative/Property Wrappers/LiveContext.swift
+++ b/Sources/LiveViewNative/Property Wrappers/LiveContext.swift
@@ -64,7 +64,6 @@ public struct LiveContext<R: RootRegistry>: DynamicProperty {
         { child in
             if case let .element(element) = child.data,
                element.attributes.first(where: { $0.name == "template" })?.value == template
-                || element.attributes.contains(where: { $0.name == .init(stringLiteral: "#\(template)") })
             {
                 return true
             } else {
@@ -111,7 +110,7 @@ public struct LiveContext<R: RootRegistry>: DynamicProperty {
             let defaultSlotChildren = children.filter({
                 if case let .element(element) = $0.data {
                     return !element.attributes.contains(where: {
-                        $0.name.rawValue == "template" || $0.name.rawValue.hasPrefix("#")
+                        $0.name.rawValue == "template"
                     })
                 } else {
                     return true

--- a/Sources/LiveViewNative/Views/Controls and Indicators/Indicators/Gauge.swift
+++ b/Sources/LiveViewNative/Views/Controls and Indicators/Indicators/Gauge.swift
@@ -14,10 +14,10 @@ import SwiftUI
 ///
 /// ```html
 /// <Gauge value="0.5">
-///     <Text #label>50%</Text>
-///     <Text #current-value-label>0.5</Text>
-///     <Text #minimum-value-label>0</Text>
-///     <Text #maximum-value-label>1</Text>
+///     <Text template={:label}>50%</Text>
+///     <Text template={:"current-value-label"}>0.5</Text>
+///     <Text template={:"minimum-value-label"}>0</Text>
+///     <Text template={:"maximum-value-label"}>1</Text>
 /// </Gauge>
 /// ```
 ///

--- a/Sources/LiveViewNative/Views/Controls and Indicators/Indicators/Gauge.swift
+++ b/Sources/LiveViewNative/Views/Controls and Indicators/Indicators/Gauge.swift
@@ -55,9 +55,9 @@ struct Gauge<R: RootRegistry>: View {
     
     public var body: some View {
         SwiftUI.Group {
-            if context.hasChild(of: element, withTagName: "current-value-label", namespace: "Gauge") ||
-               context.hasChild(of: element, withTagName: "minimum-value-label", namespace: "Gauge") ||
-               context.hasChild(of: element, withTagName: "maximum-value-label", namespace: "Gauge")
+            if context.hasTemplate(of: element, withID: "current-value-label") ||
+               context.hasTemplate(of: element, withID: "minimum-value-label") ||
+               context.hasTemplate(of: element, withID: "maximum-value-label")
             {
                 SwiftUI.Gauge(
                     value: self.value,
@@ -65,11 +65,11 @@ struct Gauge<R: RootRegistry>: View {
                 ) {
                     label
                 } currentValueLabel: {
-                    context.buildChildren(of: element, withTagName: "current-value-label", namespace: "Gauge")
+                    context.buildChildren(of: element, withID: "current-value-label")
                 } minimumValueLabel: {
-                    context.buildChildren(of: element, withTagName: "minimum-value-label", namespace: "Gauge")
+                    context.buildChildren(of: element, withID: "minimum-value-label")
                 } maximumValueLabel: {
-                    context.buildChildren(of: element, withTagName: "maximum-value-label", namespace: "Gauge")
+                    context.buildChildren(of: element, withID: "maximum-value-label")
                 }
             } else {
                 SwiftUI.Gauge(
@@ -83,7 +83,7 @@ struct Gauge<R: RootRegistry>: View {
     }
     
     private var label: some View {
-        context.buildChildren(of: element, withTagName: "label", namespace: "Gauge", includeDefaultSlot: true)
+        context.buildChildren(of: element, withID: "label", includeDefaultSlot: true)
     }
 }
 #endif

--- a/Sources/LiveViewNative/Views/Controls and Indicators/Indicators/Gauge.swift
+++ b/Sources/LiveViewNative/Views/Controls and Indicators/Indicators/Gauge.swift
@@ -14,10 +14,10 @@ import SwiftUI
 ///
 /// ```html
 /// <Gauge value="0.5">
-///     <Gauge:label>50%</Gauge:label>
-///     <Gauge:current-value-label>0.5</Gauge:current-value-label>
-///     <Gauge:minimum-value-label>0</Gauge:minimum-value-label>
-///     <Gauge:maximum-value-label>1</Gauge:maximum-value-label>
+///     <Text #label>50%</Text>
+///     <Text #current-value-label>0.5</Text>
+///     <Text #minimum-value-label>0</Text>
+///     <Text #maximum-value-label>1</Text>
 /// </Gauge>
 /// ```
 ///

--- a/Sources/LiveViewNative/Views/Controls and Indicators/Indicators/Gauge.swift
+++ b/Sources/LiveViewNative/Views/Controls and Indicators/Indicators/Gauge.swift
@@ -55,9 +55,9 @@ struct Gauge<R: RootRegistry>: View {
     
     public var body: some View {
         SwiftUI.Group {
-            if context.hasTemplate(of: element, withID: "current-value-label") ||
-               context.hasTemplate(of: element, withID: "minimum-value-label") ||
-               context.hasTemplate(of: element, withID: "maximum-value-label")
+            if context.hasTemplate(of: element, withName: "current-value-label") ||
+               context.hasTemplate(of: element, withName: "minimum-value-label") ||
+               context.hasTemplate(of: element, withName: "maximum-value-label")
             {
                 SwiftUI.Gauge(
                     value: self.value,
@@ -65,11 +65,11 @@ struct Gauge<R: RootRegistry>: View {
                 ) {
                     label
                 } currentValueLabel: {
-                    context.buildChildren(of: element, withID: "current-value-label")
+                    context.buildChildren(of: element, forTemplate: "current-value-label")
                 } minimumValueLabel: {
-                    context.buildChildren(of: element, withID: "minimum-value-label")
+                    context.buildChildren(of: element, forTemplate: "minimum-value-label")
                 } maximumValueLabel: {
-                    context.buildChildren(of: element, withID: "maximum-value-label")
+                    context.buildChildren(of: element, forTemplate: "maximum-value-label")
                 }
             } else {
                 SwiftUI.Gauge(
@@ -83,7 +83,7 @@ struct Gauge<R: RootRegistry>: View {
     }
     
     private var label: some View {
-        context.buildChildren(of: element, withID: "label", includeDefaultSlot: true)
+        context.buildChildren(of: element, forTemplate: "label", includeDefaultSlot: true)
     }
 }
 #endif

--- a/Sources/LiveViewNative/Views/Controls and Indicators/Indicators/ProgressView.swift
+++ b/Sources/LiveViewNative/Views/Controls and Indicators/Indicators/ProgressView.swift
@@ -106,21 +106,21 @@ struct ProgressView<R: RootRegistry>: View {
             {
                 // SwiftUI's default `currentValueLabel` is not present unless the argument is not included in the initializer.
                 // Check if we have it first otherwise use the default.
-                if context.hasChild(of: element, withTagName: "current-value-label", namespace: "ProgressView") {
+                if context.hasTemplate(of: element, withID: "current-value-label") {
                     SwiftUI.ProgressView(
                         timerInterval: timerIntervalStart...timerIntervalEnd,
                         countsDown: countsDown
                     ) {
-                        context.buildChildren(of: element, withTagName: "label", namespace: "ProgressView", includeDefaultSlot: true)
+                        context.buildChildren(of: element, withID: "label", includeDefaultSlot: true)
                     } currentValueLabel: {
-                        context.buildChildren(of: element, withTagName: "current-value-label", namespace: "ProgressView")
+                        context.buildChildren(of: element, withID: "current-value-label")
                     }
                 } else {
                     SwiftUI.ProgressView(
                         timerInterval: timerIntervalStart...timerIntervalEnd,
                         countsDown: countsDown
                     ) {
-                        context.buildChildren(of: element, withTagName: "label", namespace: "ProgressView", includeDefaultSlot: true)
+                        context.buildChildren(of: element, withID: "label", includeDefaultSlot: true)
                     }
                 }
             } else if let value {
@@ -128,13 +128,13 @@ struct ProgressView<R: RootRegistry>: View {
                     value: value,
                     total: total
                 ) {
-                    context.buildChildren(of: element, withTagName: "label", namespace: "ProgressView", includeDefaultSlot: true)
+                    context.buildChildren(of: element, withID: "label", includeDefaultSlot: true)
                 } currentValueLabel: {
-                    context.buildChildren(of: element, withTagName: "current-value-label", namespace: "ProgressView")
+                    context.buildChildren(of: element, withID: "current-value-label")
                 }
             } else {
                 SwiftUI.ProgressView {
-                    context.buildChildren(of: element, withTagName: "label", namespace: "ProgressView", includeDefaultSlot: true)
+                    context.buildChildren(of: element, withID: "label", includeDefaultSlot: true)
                 }
             }
         }

--- a/Sources/LiveViewNative/Views/Controls and Indicators/Indicators/ProgressView.swift
+++ b/Sources/LiveViewNative/Views/Controls and Indicators/Indicators/ProgressView.swift
@@ -106,21 +106,21 @@ struct ProgressView<R: RootRegistry>: View {
             {
                 // SwiftUI's default `currentValueLabel` is not present unless the argument is not included in the initializer.
                 // Check if we have it first otherwise use the default.
-                if context.hasTemplate(of: element, withID: "current-value-label") {
+                if context.hasTemplate(of: element, withName: "current-value-label") {
                     SwiftUI.ProgressView(
                         timerInterval: timerIntervalStart...timerIntervalEnd,
                         countsDown: countsDown
                     ) {
-                        context.buildChildren(of: element, withID: "label", includeDefaultSlot: true)
+                        context.buildChildren(of: element, forTemplate: "label", includeDefaultSlot: true)
                     } currentValueLabel: {
-                        context.buildChildren(of: element, withID: "current-value-label")
+                        context.buildChildren(of: element, forTemplate: "current-value-label")
                     }
                 } else {
                     SwiftUI.ProgressView(
                         timerInterval: timerIntervalStart...timerIntervalEnd,
                         countsDown: countsDown
                     ) {
-                        context.buildChildren(of: element, withID: "label", includeDefaultSlot: true)
+                        context.buildChildren(of: element, forTemplate: "label", includeDefaultSlot: true)
                     }
                 }
             } else if let value {
@@ -128,13 +128,13 @@ struct ProgressView<R: RootRegistry>: View {
                     value: value,
                     total: total
                 ) {
-                    context.buildChildren(of: element, withID: "label", includeDefaultSlot: true)
+                    context.buildChildren(of: element, forTemplate: "label", includeDefaultSlot: true)
                 } currentValueLabel: {
-                    context.buildChildren(of: element, withID: "current-value-label")
+                    context.buildChildren(of: element, forTemplate: "current-value-label")
                 }
             } else {
                 SwiftUI.ProgressView {
-                    context.buildChildren(of: element, withID: "label", includeDefaultSlot: true)
+                    context.buildChildren(of: element, forTemplate: "label", includeDefaultSlot: true)
                 }
             }
         }

--- a/Sources/LiveViewNative/Views/Controls and Indicators/Indicators/ProgressView.swift
+++ b/Sources/LiveViewNative/Views/Controls and Indicators/Indicators/ProgressView.swift
@@ -20,8 +20,8 @@ import SwiftUI
 /// ```html
 /// <ProgressView value={0.5} />
 /// <ProgressView value={0.5} total={2}>
-///     <ProgressView:label>Completed Percentage</ProgressView:label>
-///     <ProgressView:current-value-label>25%</ProgressView:current-value-label>
+///     <Text #label>Completed Percentage</Text>
+///     <Text #current-value-label>25%</Text>
 /// </ProgressView>
 /// ```
 ///

--- a/Sources/LiveViewNative/Views/Controls and Indicators/Indicators/ProgressView.swift
+++ b/Sources/LiveViewNative/Views/Controls and Indicators/Indicators/ProgressView.swift
@@ -20,8 +20,8 @@ import SwiftUI
 /// ```html
 /// <ProgressView value={0.5} />
 /// <ProgressView value={0.5} total={2}>
-///     <Text #label>Completed Percentage</Text>
-///     <Text #current-value-label>25%</Text>
+///     <Text template={:label}>Completed Percentage</Text>
+///     <Text template={:current-value-label}>25%</Text>
 /// </ProgressView>
 /// ```
 ///

--- a/Sources/LiveViewNative/Views/Controls and Indicators/Links/ShareLink.swift
+++ b/Sources/LiveViewNative/Views/Controls and Indicators/Links/ShareLink.swift
@@ -289,7 +289,7 @@ struct ShareLink<R: RootRegistry>: View {
     }
     
     private var label: some View {
-        context.buildChildren(of: element, withID: "label", includeDefaultSlot: true)
+        context.buildChildren(of: element, forTemplate: "label", includeDefaultSlot: true)
     }
     
     /// The set of values used to create the `SharePreview` for each item.

--- a/Sources/LiveViewNative/Views/Controls and Indicators/Links/ShareLink.swift
+++ b/Sources/LiveViewNative/Views/Controls and Indicators/Links/ShareLink.swift
@@ -342,10 +342,10 @@ struct ShareLink<R: RootRegistry>: View {
             .reduce(into: ([:], default: nil)) { pairs, element in
                 let title = element.attributeValue(for: "title") ?? ""
                 let image = element.elementChildren()
-                    .first(where: { $0.attributeBoolean(for: "#image") || $0.attributeValue(for: "template") == "image" })
+                    .first(where: { $0.attributeValue(for: "template") == "image" })
                     .flatMap({ Image(overrideElement: $0).image })
                 let icon = element.elementChildren()
-                    .first(where: { $0.attributeBoolean(for: "#icon") || $0.attributeValue(for: "template") == "icon" })
+                    .first(where: { $0.attributeValue(for: "template") == "icon" })
                     .flatMap({ Image(overrideElement: $0).image })
                 
                 let data = PreviewData(

--- a/Sources/LiveViewNative/Views/Controls and Indicators/Links/ShareLink.swift
+++ b/Sources/LiveViewNative/Views/Controls and Indicators/Links/ShareLink.swift
@@ -32,8 +32,8 @@ fileprivate let itemsDecoder = JSONDecoder()
 ///     message="Here's a link to the DockYard homepage"
 /// >
 ///     <SharePreview title="DockYard Homepage">
-///         <SharePreview:image><Image name="dockyard" /></SharePreview:image>
-///         <SharePreview:icon><Image name="dockyard" /></SharePreview:icon>
+///         <Image #image name="dockyard" />
+///         <Image #icon name="dockyard" />
 ///     </SharePreview>
 /// </ShareLink>
 /// ```
@@ -48,16 +48,16 @@ fileprivate let itemsDecoder = JSONDecoder()
 ///     message="Here are links to our favorite websites"
 /// >
 ///     <SharePreview item="https://dockyard.com" title="DockYard">
-///         <SharePreview:image><Image name="dockyard" /></SharePreview:image>
-///         <SharePreview:icon><Image name="dockyard" /></SharePreview:icon>
+///         <Image #image name="dockyard" />
+///         <Image #icon name="dockyard" />
 ///     </SharePreview>
 ///     <SharePreview item="https://news.ycombinator.com" title="Hacker News">
-///         <SharePreview:image><Image name="hackernews" /></SharePreview:image>
-///         <SharePreview:icon><Image name="hackernews" /></SharePreview:icon>
+///         <Image #image name="hackernews" />
+///         <Image #icon name="hackernews" />
 ///     </SharePreview>
 ///     <SharePreview item="https://apple.com" title="Apple">
-///         <SharePreview:image><Image name="apple" /></SharePreview:image>
-///         <SharePreview:icon><Image name="apple" /></SharePreview:icon>
+///         <Image #image name="apple" />
+///         <Image #icon name="apple" />
 ///     </SharePreview>
 /// </ShareLink>
 /// ```
@@ -342,14 +342,10 @@ struct ShareLink<R: RootRegistry>: View {
             .reduce(into: ([:], default: nil)) { pairs, element in
                 let title = element.attributeValue(for: "title") ?? ""
                 let image = element.elementChildren()
-                    .first(where: { $0.tag == "image" && $0.namespace == "SharePreview" })?
-                    .elementChildren()
-                    .first
+                    .first(where: { $0.attributeBoolean(for: "#image") || $0.attributeValue(for: "template") == "image" })
                     .flatMap({ Image(overrideElement: $0).image })
                 let icon = element.elementChildren()
-                    .first(where: { $0.tag == "icon" && $0.namespace == "SharePreview" })?
-                    .elementChildren()
-                    .first
+                    .first(where: { $0.attributeBoolean(for: "#icon") || $0.attributeValue(for: "template") == "icon" })
                     .flatMap({ Image(overrideElement: $0).image })
                 
                 let data = PreviewData(

--- a/Sources/LiveViewNative/Views/Controls and Indicators/Links/ShareLink.swift
+++ b/Sources/LiveViewNative/Views/Controls and Indicators/Links/ShareLink.swift
@@ -289,7 +289,7 @@ struct ShareLink<R: RootRegistry>: View {
     }
     
     private var label: some View {
-        context.buildChildren(of: element, withTagName: "label", namespace: "ShareLink", includeDefaultSlot: true)
+        context.buildChildren(of: element, withID: "label", includeDefaultSlot: true)
     }
     
     /// The set of values used to create the `SharePreview` for each item.

--- a/Sources/LiveViewNative/Views/Controls and Indicators/Links/ShareLink.swift
+++ b/Sources/LiveViewNative/Views/Controls and Indicators/Links/ShareLink.swift
@@ -32,8 +32,8 @@ fileprivate let itemsDecoder = JSONDecoder()
 ///     message="Here's a link to the DockYard homepage"
 /// >
 ///     <SharePreview title="DockYard Homepage">
-///         <Image #image name="dockyard" />
-///         <Image #icon name="dockyard" />
+///         <Image template={:image} name="dockyard" />
+///         <Image template={:icon} name="dockyard" />
 ///     </SharePreview>
 /// </ShareLink>
 /// ```
@@ -48,16 +48,16 @@ fileprivate let itemsDecoder = JSONDecoder()
 ///     message="Here are links to our favorite websites"
 /// >
 ///     <SharePreview item="https://dockyard.com" title="DockYard">
-///         <Image #image name="dockyard" />
-///         <Image #icon name="dockyard" />
+///         <Image template={:image} name="dockyard" />
+///         <Image template={:icon} name="dockyard" />
 ///     </SharePreview>
 ///     <SharePreview item="https://news.ycombinator.com" title="Hacker News">
-///         <Image #image name="hackernews" />
-///         <Image #icon name="hackernews" />
+///         <Image template={:image} name="hackernews" />
+///         <Image template={:icon} name="hackernews" />
 ///     </SharePreview>
 ///     <SharePreview item="https://apple.com" title="Apple">
-///         <Image #image name="apple" />
-///         <Image #icon name="apple" />
+///         <Image template={:image} name="apple" />
+///         <Image template={:icon} name="apple" />
 ///     </SharePreview>
 /// </ShareLink>
 /// ```

--- a/Sources/LiveViewNative/Views/Controls and Indicators/Menus/Menu.swift
+++ b/Sources/LiveViewNative/Views/Controls and Indicators/Menus/Menu.swift
@@ -53,9 +53,9 @@ struct Menu<R: RootRegistry>: View {
     public var body: some View {
         #if !os(watchOS)
         SwiftUI.Menu {
-            context.buildChildren(of: element, withTagName: "content", namespace: "Menu")
+            context.buildChildren(of: element, withID: "content")
         } label: {
-            context.buildChildren(of: element, withTagName: "label", namespace: "Menu", includeDefaultSlot: true)
+            context.buildChildren(of: element, withID: "label", includeDefaultSlot: true)
         }
         .applyMenuStyle(style)
         #endif

--- a/Sources/LiveViewNative/Views/Controls and Indicators/Menus/Menu.swift
+++ b/Sources/LiveViewNative/Views/Controls and Indicators/Menus/Menu.swift
@@ -13,14 +13,14 @@ import SwiftUI
 ///
 /// ```html
 /// <Menu>
-///     <Menu:label>
+///     <Text #label>
 ///         Edit Actions
-///     </Menu:label>
-///     <Menu:content>
+///     </Text>
+///     <Group #content>
 ///         <Button phx-click="arrange">Arrange</Button>
 ///         <Button phx-click="update">Update</Button>
 ///         <Button phx-click="remove">Remove</Button>
-///     </Menu:content>
+///     </Group>
 /// </Menu>
 /// ```
 ///

--- a/Sources/LiveViewNative/Views/Controls and Indicators/Menus/Menu.swift
+++ b/Sources/LiveViewNative/Views/Controls and Indicators/Menus/Menu.swift
@@ -13,10 +13,10 @@ import SwiftUI
 ///
 /// ```html
 /// <Menu>
-///     <Text #label>
+///     <Text template={:label}>
 ///         Edit Actions
 ///     </Text>
-///     <Group #content>
+///     <Group template={:content}>
 ///         <Button phx-click="arrange">Arrange</Button>
 ///         <Button phx-click="update">Update</Button>
 ///         <Button phx-click="remove">Remove</Button>

--- a/Sources/LiveViewNative/Views/Controls and Indicators/Menus/Menu.swift
+++ b/Sources/LiveViewNative/Views/Controls and Indicators/Menus/Menu.swift
@@ -53,9 +53,9 @@ struct Menu<R: RootRegistry>: View {
     public var body: some View {
         #if !os(watchOS)
         SwiftUI.Menu {
-            context.buildChildren(of: element, withID: "content")
+            context.buildChildren(of: element, forTemplate: "content", includeDefaultSlot: true)
         } label: {
-            context.buildChildren(of: element, withID: "label", includeDefaultSlot: true)
+            context.buildChildren(of: element, forTemplate: "label")
         }
         .applyMenuStyle(style)
         #endif

--- a/Sources/LiveViewNative/Views/Controls and Indicators/Pickers/Picker.swift
+++ b/Sources/LiveViewNative/Views/Controls and Indicators/Pickers/Picker.swift
@@ -15,8 +15,8 @@ import SwiftUI
 ///
 /// ```html
 /// <Picker value-binding="transport" picker-style="menu">
-///     <Text #label>Transportation</Text>
-///     <Group #content>
+///     <Text template={:label}>Transportation</Text>
+///     <Group template={:content}>
 ///         <Label system-image="car" modifiers={tag(@native, tag: "car")}>Car</Label>
 ///         <Label system-image="bus" modifiers={tag(@native, tag: "bus")}>Bus</Label>
 ///         <Label system-image="tram" modifiers={tag(@native, tag: "tram")}>Tram</Label>

--- a/Sources/LiveViewNative/Views/Controls and Indicators/Pickers/Picker.swift
+++ b/Sources/LiveViewNative/Views/Controls and Indicators/Pickers/Picker.swift
@@ -15,14 +15,12 @@ import SwiftUI
 ///
 /// ```html
 /// <Picker value-binding="transport" picker-style="menu">
-///     <Picker:content>
+///     <Text #label>Transportation</Text>
+///     <Group #content>
 ///         <Label system-image="car" modifiers={tag(@native, tag: "car")}>Car</Label>
 ///         <Label system-image="bus" modifiers={tag(@native, tag: "bus")}>Bus</Label>
 ///         <Label system-image="tram" modifiers={tag(@native, tag: "tram")}>Tram</Label>
-///     </Picker:content>
-///     <Picker:label>
-///         <Text>Transportation</Text>
-///     </Picker:label>
+///     </Group>
 /// </Picker>
 /// ```
 ///

--- a/Sources/LiveViewNative/Views/Controls and Indicators/Pickers/Picker.swift
+++ b/Sources/LiveViewNative/Views/Controls and Indicators/Pickers/Picker.swift
@@ -45,9 +45,9 @@ struct Picker<R: RootRegistry>: View {
     
     var body: some View {
         SwiftUI.Picker(selection: $value) {
-            context.buildChildren(of: element, withTagName: "content", namespace: "Picker", includeDefaultSlot: false)
+            context.buildChildren(of: element, withID: "content", includeDefaultSlot: false)
         } label: {
-            context.buildChildren(of: element, withTagName: "label", namespace: "Picker", includeDefaultSlot: false)
+            context.buildChildren(of: element, withID: "label", includeDefaultSlot: false)
         }
     }
     

--- a/Sources/LiveViewNative/Views/Controls and Indicators/Pickers/Picker.swift
+++ b/Sources/LiveViewNative/Views/Controls and Indicators/Pickers/Picker.swift
@@ -45,9 +45,9 @@ struct Picker<R: RootRegistry>: View {
     
     var body: some View {
         SwiftUI.Picker(selection: $value) {
-            context.buildChildren(of: element, withID: "content", includeDefaultSlot: false)
+            context.buildChildren(of: element, forTemplate: "content", includeDefaultSlot: false)
         } label: {
-            context.buildChildren(of: element, withID: "label", includeDefaultSlot: false)
+            context.buildChildren(of: element, forTemplate: "label", includeDefaultSlot: false)
         }
     }
     

--- a/Sources/LiveViewNative/Views/Controls and Indicators/Value Inputs/Slider.swift
+++ b/Sources/LiveViewNative/Views/Controls and Indicators/Value Inputs/Slider.swift
@@ -90,22 +90,22 @@ struct Slider<R: RootRegistry>: View {
                 in: lowerBound...upperBound,
                 step: step
             ) {
-                context.buildChildren(of: element, withTagName: "label", namespace: "Slider", includeDefaultSlot: true)
+                context.buildChildren(of: element, withID: "label", includeDefaultSlot: true)
             } minimumValueLabel: {
-                context.buildChildren(of: element, withTagName: "minimum-value-label", namespace: "Slider")
+                context.buildChildren(of: element, withID: "minimum-value-label")
             } maximumValueLabel: {
-                context.buildChildren(of: element, withTagName: "maximum-value-label", namespace: "Slider")
+                context.buildChildren(of: element, withID: "maximum-value-label")
             }
         } else {
             SwiftUI.Slider(
                 value: $value,
                 in: lowerBound...upperBound
             ) {
-                context.buildChildren(of: element, withTagName: "label", namespace: "Slider", includeDefaultSlot: true)
+                context.buildChildren(of: element, withID: "label", includeDefaultSlot: true)
             } minimumValueLabel: {
-                context.buildChildren(of: element, withTagName: "minimum-value-label", namespace: "Slider")
+                context.buildChildren(of: element, withID: "minimum-value-label")
             } maximumValueLabel: {
-                context.buildChildren(of: element, withTagName: "maximum-value-label", namespace: "Slider")
+                context.buildChildren(of: element, withID: "maximum-value-label")
             }
         }
     }

--- a/Sources/LiveViewNative/Views/Controls and Indicators/Value Inputs/Slider.swift
+++ b/Sources/LiveViewNative/Views/Controls and Indicators/Value Inputs/Slider.swift
@@ -90,22 +90,22 @@ struct Slider<R: RootRegistry>: View {
                 in: lowerBound...upperBound,
                 step: step
             ) {
-                context.buildChildren(of: element, withID: "label", includeDefaultSlot: true)
+                context.buildChildren(of: element, forTemplate: "label", includeDefaultSlot: true)
             } minimumValueLabel: {
-                context.buildChildren(of: element, withID: "minimum-value-label")
+                context.buildChildren(of: element, forTemplate: "minimum-value-label")
             } maximumValueLabel: {
-                context.buildChildren(of: element, withID: "maximum-value-label")
+                context.buildChildren(of: element, forTemplate: "maximum-value-label")
             }
         } else {
             SwiftUI.Slider(
                 value: $value,
                 in: lowerBound...upperBound
             ) {
-                context.buildChildren(of: element, withID: "label", includeDefaultSlot: true)
+                context.buildChildren(of: element, forTemplate: "label", includeDefaultSlot: true)
             } minimumValueLabel: {
-                context.buildChildren(of: element, withID: "minimum-value-label")
+                context.buildChildren(of: element, forTemplate: "minimum-value-label")
             } maximumValueLabel: {
-                context.buildChildren(of: element, withID: "maximum-value-label")
+                context.buildChildren(of: element, forTemplate: "maximum-value-label")
             }
         }
     }

--- a/Sources/LiveViewNative/Views/Controls and Indicators/Value Inputs/Slider.swift
+++ b/Sources/LiveViewNative/Views/Controls and Indicators/Value Inputs/Slider.swift
@@ -40,9 +40,9 @@ import SwiftUI
 ///
 /// ```html
 /// <Slider value-binding="value">
-///     <Text #label>Percent Completed</Text>
-///     <Text #minimum-value-label>0%</Text>
-///     <Text #maximum-value-label>100%</Text>
+///     <Text template={:label}>Percent Completed</Text>
+///     <Text template={:"minimum-value-label"}>0%</Text>
+///     <Text template={:"maximum-value-label"}>100%</Text>
 /// </Slider>
 /// ```
 ///

--- a/Sources/LiveViewNative/Views/Controls and Indicators/Value Inputs/Slider.swift
+++ b/Sources/LiveViewNative/Views/Controls and Indicators/Value Inputs/Slider.swift
@@ -39,10 +39,10 @@ import SwiftUI
 /// Customize the appearance of the slider with the children `label`, `minimum-value-label` and `maximum-value-label`.
 ///
 /// ```html
-/// <Slider value-binding="progress">
-///     <Slider:label>Percent Completed</Slider:label>
-///     <Slider:minimum-value-label>0%</Slider:minimum-value-label>
-///     <Slider:maximum-value-label>100%</Slider:maximum-value-label>
+/// <Slider value-binding="value">
+///     <Text #label>Percent Completed</Text>
+///     <Text #minimum-value-label>0%</Text>
+///     <Text #maximum-value-label>100%</Text>
 /// </Slider>
 /// ```
 ///

--- a/Sources/LiveViewNative/Views/Layout Containers/Collection Containers/Section.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Collection Containers/Section.swift
@@ -26,14 +26,14 @@ import SwiftUI
 ///
 /// ```html
 /// <Section>
-///     <Text #header>Group #1</Text>
-///     <Text #content>Item #1</Text>
-///     <Text #footer>The first group ends here</Text>
+///     <Text template={:header}>Group #1</Text>
+///     <Text template={:content}>Item #1</Text>
+///     <Text template={:footer}>The first group ends here</Text>
 /// </Section>
 /// <Section>
-///     <Text #header>Group #2</Text>
-///     <Text #content>Item #1</Text>
-///     <Text #footer>The second group ends here</Text>
+///     <Text template={:header}>Group #2</Text>
+///     <Text template={:content}>Item #1</Text>
+///     <Text template={:footer}>The second group ends here</Text>
 /// </Section>
 /// ```
 ///

--- a/Sources/LiveViewNative/Views/Layout Containers/Collection Containers/Section.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Collection Containers/Section.swift
@@ -67,11 +67,11 @@ struct Section<R: RootRegistry>: View {
     
     public var body: some View {
         SwiftUI.Section {
-            context.buildChildren(of: element, withID: "content", includeDefaultSlot: true)
+            context.buildChildren(of: element, forTemplate: "content", includeDefaultSlot: true)
         } header: {
-            context.buildChildren(of: element, withID: "header")
+            context.buildChildren(of: element, forTemplate: "header")
         } footer: {
-            context.buildChildren(of: element, withID: "footer")
+            context.buildChildren(of: element, forTemplate: "footer")
         }
         #if os(macOS)
             .collapsible(collapsible)

--- a/Sources/LiveViewNative/Views/Layout Containers/Collection Containers/Section.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Collection Containers/Section.swift
@@ -26,14 +26,14 @@ import SwiftUI
 ///
 /// ```html
 /// <Section>
-///     <Section:header>Group #1</Section:header>
-///     <Section:content>Item #1</Section:content>
-///     <Section:footer>The first group ends here</Section:footer>
+///     <Text #header>Group #1</Text>
+///     <Text #content>Item #1</Text>
+///     <Text #footer>The first group ends here</Text>
 /// </Section>
 /// <Section>
-///     <Section:header>Group #2</Section:header>
-///     <Section:content>Item #1</Section:content>
-///     <Section:footer>The second group ends here</Section:footer>
+///     <Text #header>Group #2</Text>
+///     <Text #content>Item #1</Text>
+///     <Text #footer>The second group ends here</Text>
 /// </Section>
 /// ```
 ///

--- a/Sources/LiveViewNative/Views/Layout Containers/Collection Containers/Section.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Collection Containers/Section.swift
@@ -67,11 +67,11 @@ struct Section<R: RootRegistry>: View {
     
     public var body: some View {
         SwiftUI.Section {
-            context.buildChildren(of: element, withTagName: "content", namespace: "Section", includeDefaultSlot: true)
+            context.buildChildren(of: element, withID: "content", includeDefaultSlot: true)
         } header: {
-            context.buildChildren(of: element, withTagName: "header", namespace: "Section")
+            context.buildChildren(of: element, withID: "header")
         } footer: {
-            context.buildChildren(of: element, withTagName: "footer", namespace: "Section")
+            context.buildChildren(of: element, withID: "footer")
         }
         #if os(macOS)
             .collapsible(collapsible)

--- a/Sources/LiveViewNative/Views/Layout Containers/Collection Containers/Table.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Collection Containers/Table.swift
@@ -17,12 +17,12 @@ import SwiftUI
 ///
 /// ```html
 /// <Table>
-///     <Table:columns>
+///     <Group #columns>
 ///         <TableColumn id="name">Name</TableColumn>
 ///         <TableColumn id="description">Description</TableColumn>
 ///         <TableColumn id="length">Length</TableColumn>
-///     </Table:columns>
-///     <Table:rows>
+///     </Group>
+///     <Group #rows>
 ///         <TableRow id="basketball">
 ///             <Text>Basketball</Text>
 ///             <Text>Players attempt to throw a ball into an elevated basket.</Text>
@@ -38,7 +38,7 @@ import SwiftUI
 ///             <Text>Players attempt to throw a ball into an end zone.</Text>
 ///             <Text>60 min</Text>
 ///         </TableRow>
-///     </Table:rows>
+///     </Group>
 /// </Table>
 /// ```
 ///
@@ -48,7 +48,7 @@ import SwiftUI
 /// ```html
 /// <Table sort-order="sports_sort_order">
 ///     ...
-///     <Table:rows>
+///     <Group #rows>
 ///         <%= for sport <- Enum.sort_by(
 ///             @sports,
 ///             fn sport -> sport[hd(@sports_sort_order)["id"]] end,
@@ -60,7 +60,7 @@ import SwiftUI
 ///                 <Text><%= sport["length"] %></Text>
 ///             </TableRow>
 ///         <% end %>
-///     </Table:rows>
+///     </Group>
 /// </Table>
 /// ```
 ///
@@ -269,14 +269,14 @@ struct Table<R: RootRegistry>: View {
     
     private var rows: [TableRow] {
         element.elementChildren()
-            .filter { $0.tag == "rows" && $0.namespace == "Table" }
+            .filter { $0.attributeValue(for: "template") == "rows" || $0.attributeBoolean(for: "#rows") }
             .flatMap { $0.elementChildren() }
             .compactMap { $0.tag == "TableRow" ? TableRow(element: $0) : nil }
     }
     
     private var columns: [TableColumn<TableRow, TableColumnSort, some View, SwiftUI.Text>] {
         let columnElements = element.elementChildren()
-            .filter { $0.tag == "columns" && $0.namespace == "Table" }
+            .filter { $0.attributeValue(for: "template") == "columns" || $0.attributeBoolean(for: "#columns") }
             .flatMap { $0.elementChildren() }
             .filter { $0.tag == "TableColumn" }
         return columnElements.enumerated().map { item in

--- a/Sources/LiveViewNative/Views/Layout Containers/Collection Containers/Table.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Collection Containers/Table.swift
@@ -269,14 +269,14 @@ struct Table<R: RootRegistry>: View {
     
     private var rows: [TableRow] {
         element.elementChildren()
-            .filter { $0.attributeValue(for: "template") == "rows" || $0.attributeBoolean(for: "#rows") }
+            .filter { $0.attributeValue(for: "template") == "rows" }
             .flatMap { $0.elementChildren() }
             .compactMap { $0.tag == "TableRow" ? TableRow(element: $0) : nil }
     }
     
     private var columns: [TableColumn<TableRow, TableColumnSort, some View, SwiftUI.Text>] {
         let columnElements = element.elementChildren()
-            .filter { $0.attributeValue(for: "template") == "columns" || $0.attributeBoolean(for: "#columns") }
+            .filter { $0.attributeValue(for: "template") == "columns" }
             .flatMap { $0.elementChildren() }
             .filter { $0.tag == "TableColumn" }
         return columnElements.enumerated().map { item in

--- a/Sources/LiveViewNative/Views/Layout Containers/Collection Containers/Table.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Collection Containers/Table.swift
@@ -17,12 +17,12 @@ import SwiftUI
 ///
 /// ```html
 /// <Table>
-///     <Group #columns>
+///     <Group template={:columns}>
 ///         <TableColumn id="name">Name</TableColumn>
 ///         <TableColumn id="description">Description</TableColumn>
 ///         <TableColumn id="length">Length</TableColumn>
 ///     </Group>
-///     <Group #rows>
+///     <Group template={:rows}>
 ///         <TableRow id="basketball">
 ///             <Text>Basketball</Text>
 ///             <Text>Players attempt to throw a ball into an elevated basket.</Text>
@@ -48,7 +48,7 @@ import SwiftUI
 /// ```html
 /// <Table sort-order="sports_sort_order">
 ///     ...
-///     <Group #rows>
+///     <Group template={:rows}>
 ///         <%= for sport <- Enum.sort_by(
 ///             @sports,
 ///             fn sport -> sport[hd(@sports_sort_order)["id"]] end,

--- a/Sources/LiveViewNative/Views/Layout Containers/Forms/LabeledContent.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Forms/LabeledContent.swift
@@ -13,8 +13,8 @@ import SwiftUI
 ///
 /// ```html
 /// <LabeledContent>
-///     <Text #label>Price</Text>
-///     <Text #content>$100.00</Text>
+///     <Text template={:label}>Price</Text>
+///     <Text template={:content}>$100.00</Text>
 /// </LabeledContent>
 /// ```
 ///

--- a/Sources/LiveViewNative/Views/Layout Containers/Forms/LabeledContent.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Forms/LabeledContent.swift
@@ -13,8 +13,8 @@ import SwiftUI
 ///
 /// ```html
 /// <LabeledContent>
-///     <LabeledContent:label>Price</LabeledContent:label>
-///     <LabeledContent:content>$100.00</LabeledContent:content>
+///     <Text #label>Price</Text>
+///     <Text #content>$100.00</Text>
 /// </LabeledContent>
 /// ```
 ///

--- a/Sources/LiveViewNative/Views/Layout Containers/Forms/LabeledContent.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Forms/LabeledContent.swift
@@ -75,9 +75,9 @@ struct LabeledContent<R: RootRegistry>: View {
                 }
             } else {
                 SwiftUI.LabeledContent {
-                    context.buildChildren(of: element, withTagName: "content", namespace: "LabeledContent", includeDefaultSlot: true)
+                    context.buildChildren(of: element, withID: "content", includeDefaultSlot: true)
                 } label: {
-                    context.buildChildren(of: element, withTagName: "label", namespace: "LabeledContent")
+                    context.buildChildren(of: element, withID: "label")
                 }
             }
         }

--- a/Sources/LiveViewNative/Views/Layout Containers/Forms/LabeledContent.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Forms/LabeledContent.swift
@@ -75,9 +75,9 @@ struct LabeledContent<R: RootRegistry>: View {
                 }
             } else {
                 SwiftUI.LabeledContent {
-                    context.buildChildren(of: element, withID: "content", includeDefaultSlot: true)
+                    context.buildChildren(of: element, forTemplate: "content", includeDefaultSlot: true)
                 } label: {
-                    context.buildChildren(of: element, withID: "label")
+                    context.buildChildren(of: element, forTemplate: "label")
                 }
             }
         }

--- a/Sources/LiveViewNative/Views/Layout Containers/Groups/ControlGroup.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Groups/ControlGroup.swift
@@ -51,9 +51,9 @@ struct ControlGroup<R: RootRegistry>: View {
     public var body: some View {
         #if os(iOS) || os(macOS)
         SwiftUI.ControlGroup {
-            context.buildChildren(of: element, withTagName: "content", namespace: "ControlGroup", includeDefaultSlot: true)
+            context.buildChildren(of: element, withID: "content", includeDefaultSlot: true)
         } label: {
-            context.buildChildren(of: element, withTagName: "label", namespace: "ControlGroup")
+            context.buildChildren(of: element, withID: "label")
         }
         .applyControlGroupStyle(style)
         #endif

--- a/Sources/LiveViewNative/Views/Layout Containers/Groups/ControlGroup.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Groups/ControlGroup.swift
@@ -13,14 +13,12 @@ import SwiftUI
 ///
 /// ```html
 /// <ControlGroup>
-///     <ControlGroup:label>
-///         Edit Actions
-///     </ControlGroup:label>
-///     <ControlGroup:content>
+///     <Text #label>Edit Actions</Text>
+///     <Group #content>
 ///         <Button phx-click="arrange">Arrange</Button>
 ///         <Button phx-click="update">Update</Button>
 ///         <Button phx-click="remove">Remove</Button>
-///     </ControlGroup:content>
+///     </Group>
 /// </ControlGroup>
 /// ```
 ///

--- a/Sources/LiveViewNative/Views/Layout Containers/Groups/ControlGroup.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Groups/ControlGroup.swift
@@ -51,9 +51,9 @@ struct ControlGroup<R: RootRegistry>: View {
     public var body: some View {
         #if os(iOS) || os(macOS)
         SwiftUI.ControlGroup {
-            context.buildChildren(of: element, withID: "content", includeDefaultSlot: true)
+            context.buildChildren(of: element, forTemplate: "content", includeDefaultSlot: true)
         } label: {
-            context.buildChildren(of: element, withID: "label")
+            context.buildChildren(of: element, forTemplate: "label")
         }
         .applyControlGroupStyle(style)
         #endif

--- a/Sources/LiveViewNative/Views/Layout Containers/Groups/ControlGroup.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Groups/ControlGroup.swift
@@ -13,8 +13,8 @@ import SwiftUI
 ///
 /// ```html
 /// <ControlGroup>
-///     <Text #label>Edit Actions</Text>
-///     <Group #content>
+///     <Text template={:label}>Edit Actions</Text>
+///     <Group template={:content}>
 ///         <Button phx-click="arrange">Arrange</Button>
 ///         <Button phx-click="update">Update</Button>
 ///         <Button phx-click="remove">Remove</Button>

--- a/Sources/LiveViewNative/Views/Layout Containers/Groups/DisclosureGroup.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Groups/DisclosureGroup.swift
@@ -68,9 +68,9 @@ struct DisclosureGroup<R: RootRegistry>: View {
     public var body: some View {
 #if os(iOS) || os(macOS)
         SwiftUI.DisclosureGroup(isExpanded: $isExpanded) {
-            context.buildChildren(of: element, withID: "content", includeDefaultSlot: true)
+            context.buildChildren(of: element, forTemplate: "content", includeDefaultSlot: true)
         } label: {
-            context.buildChildren(of: element, withID: "label", includeDefaultSlot: false)
+            context.buildChildren(of: element, forTemplate: "label", includeDefaultSlot: false)
         }
 #endif
     }

--- a/Sources/LiveViewNative/Views/Layout Containers/Groups/DisclosureGroup.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Groups/DisclosureGroup.swift
@@ -13,8 +13,8 @@ import SwiftUI
 ///
 /// ```html
 /// <DisclosureGroup>
-///     <Text #label>Edit Actions</Text>
-///     <Group #content>
+///     <Text template={:label}>Edit Actions</Text>
+///     <Group template={:content}>
 ///         <Button phx-click="arrange">Arrange</Button>
 ///         <Button phx-click="update">Update</Button>
 ///         <Button phx-click="remove">Remove</Button>

--- a/Sources/LiveViewNative/Views/Layout Containers/Groups/DisclosureGroup.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Groups/DisclosureGroup.swift
@@ -68,9 +68,9 @@ struct DisclosureGroup<R: RootRegistry>: View {
     public var body: some View {
 #if os(iOS) || os(macOS)
         SwiftUI.DisclosureGroup(isExpanded: $isExpanded) {
-            context.buildChildren(of: element, withTagName: "content", namespace: "DisclosureGroup", includeDefaultSlot: true)
+            context.buildChildren(of: element, withID: "content", includeDefaultSlot: true)
         } label: {
-            context.buildChildren(of: element, withTagName: "label", namespace: "DisclosureGroup", includeDefaultSlot: false)
+            context.buildChildren(of: element, withID: "label", includeDefaultSlot: false)
         }
 #endif
     }

--- a/Sources/LiveViewNative/Views/Layout Containers/Groups/DisclosureGroup.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Groups/DisclosureGroup.swift
@@ -13,14 +13,12 @@ import SwiftUI
 ///
 /// ```html
 /// <DisclosureGroup>
-///     <DisclosureGroup:label>
-///         Edit Actions
-///     </DisclosureGroup:label>
-///     <DisclosureGroup:content>
+///     <Text #label>Edit Actions</Text>
+///     <Group #content>
 ///         <Button phx-click="arrange">Arrange</Button>
 ///         <Button phx-click="update">Update</Button>
 ///         <Button phx-click="remove">Remove</Button>
-///     </DisclosureGroup:content>
+///     </Group>
 /// </DisclosureGroup>
 /// ```
 ///

--- a/Sources/LiveViewNative/Views/Layout Containers/Groups/GroupBox.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Groups/GroupBox.swift
@@ -13,14 +13,12 @@ import SwiftUI
 ///
 /// ```html
 /// <GroupBox>
-///     <GroupBox:label>
-///         Edit Actions
-///     </GroupBox:label>
-///     <GroupBox:content>
+///     <Text #label>Edit Actions</Text>
+///     <Group #content>
 ///         <Button phx-click="arrange">Arrange</Button>
 ///         <Button phx-click="update">Update</Button>
 ///         <Button phx-click="remove">Remove</Button>
-///     </GroupBox:content>
+///     </Group>
 /// </GroupBox>
 /// ```
 ///

--- a/Sources/LiveViewNative/Views/Layout Containers/Groups/GroupBox.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Groups/GroupBox.swift
@@ -74,9 +74,9 @@ struct GroupBox<R: RootRegistry>: View {
                 }
             } else {
                 SwiftUI.GroupBox {
-                    context.buildChildren(of: element, withID: "content", includeDefaultSlot: true)
+                    context.buildChildren(of: element, forTemplate: "content", includeDefaultSlot: true)
                 } label: {
-                    context.buildChildren(of: element, withID: "label")
+                    context.buildChildren(of: element, forTemplate: "label")
                 }
             }
         }

--- a/Sources/LiveViewNative/Views/Layout Containers/Groups/GroupBox.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Groups/GroupBox.swift
@@ -74,9 +74,9 @@ struct GroupBox<R: RootRegistry>: View {
                 }
             } else {
                 SwiftUI.GroupBox {
-                    context.buildChildren(of: element, withTagName: "content", namespace: "GroupBox", includeDefaultSlot: true)
+                    context.buildChildren(of: element, withID: "content", includeDefaultSlot: true)
                 } label: {
-                    context.buildChildren(of: element, withTagName: "label", namespace: "GroupBox")
+                    context.buildChildren(of: element, withID: "label")
                 }
             }
         }

--- a/Sources/LiveViewNative/Views/Layout Containers/Groups/GroupBox.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Groups/GroupBox.swift
@@ -13,8 +13,8 @@ import SwiftUI
 ///
 /// ```html
 /// <GroupBox>
-///     <Text #label>Edit Actions</Text>
-///     <Group #content>
+///     <Text template={:label}>Edit Actions</Text>
+///     <Group template={:content}>
 ///         <Button phx-click="arrange">Arrange</Button>
 ///         <Button phx-click="update">Update</Button>
 ///         <Button phx-click="remove">Remove</Button>

--- a/Sources/LiveViewNative/Views/Text Input and Output/Label.swift
+++ b/Sources/LiveViewNative/Views/Text Input and Output/Label.swift
@@ -51,12 +51,12 @@ struct Label<R: RootRegistry>: View {
     
     public var body: some View {
         SwiftUI.Label {
-            context.buildChildren(of: element, withTagName: "title", namespace: "Label", includeDefaultSlot: true)
+            context.buildChildren(of: element, withID: "title", includeDefaultSlot: true)
         } icon: {
             if let systemImage {
                 SwiftUI.Image(systemName: systemImage)
             } else {
-                context.buildChildren(of: element, withTagName: "icon", namespace: "Label")
+                context.buildChildren(of: element, withID: "icon")
             }
         }
     }

--- a/Sources/LiveViewNative/Views/Text Input and Output/Label.swift
+++ b/Sources/LiveViewNative/Views/Text Input and Output/Label.swift
@@ -51,12 +51,12 @@ struct Label<R: RootRegistry>: View {
     
     public var body: some View {
         SwiftUI.Label {
-            context.buildChildren(of: element, withID: "title", includeDefaultSlot: true)
+            context.buildChildren(of: element, forTemplate: "title", includeDefaultSlot: true)
         } icon: {
             if let systemImage {
                 SwiftUI.Image(systemName: systemImage)
             } else {
-                context.buildChildren(of: element, withID: "icon")
+                context.buildChildren(of: element, forTemplate: "icon")
             }
         }
     }

--- a/Sources/LiveViewNative/Views/Text Input and Output/Label.swift
+++ b/Sources/LiveViewNative/Views/Text Input and Output/Label.swift
@@ -13,8 +13,8 @@ import SwiftUI
 ///
 /// ```html
 /// <Label>
-///     <Text #title>John Doe</Text>
-///     <Image #icon system-name="person.crop.circle.fill" />
+///     <Text template={:title}>John Doe</Text>
+///     <Image template={:icon} system-name="person.crop.circle.fill" />
 /// </Label>
 /// ```
 ///

--- a/Sources/LiveViewNative/Views/Text Input and Output/Label.swift
+++ b/Sources/LiveViewNative/Views/Text Input and Output/Label.swift
@@ -13,12 +13,8 @@ import SwiftUI
 ///
 /// ```html
 /// <Label>
-///     <Label:title>
-///         <Text>John Doe</Text>
-///     </Label:title>
-///     <Label:icon>
-///         <Image system-name="person.crop.circle.fill" />
-///     </Label:icon>
+///     <Text #title>John Doe</Text>
+///     <Image #icon system-name="person.crop.circle.fill" />
 /// </Label>
 /// ```
 ///

--- a/Sources/LiveViewNative/Views/Toolbars/ToolbarItemGroup.swift
+++ b/Sources/LiveViewNative/Views/Toolbars/ToolbarItemGroup.swift
@@ -49,9 +49,9 @@ struct ToolbarItemGroup<R: RootRegistry>: ToolbarContent {
     
     var body: some ToolbarContent {
         SwiftUI.ToolbarItemGroup(placement: placement) {
-            context.buildChildren(of: element, withTagName: "content", namespace: "ToolbarItemGroup", includeDefaultSlot: true)
+            context.buildChildren(of: element, forTemplate: "content", includeDefaultSlot: true)
         } label: {
-            context.buildChildren(of: element, withTagName: "label", namespace: "ToolbarItemGroup")
+            context.buildChildren(of: element, forTemplate: "label")
         }
     }
 }

--- a/Tests/RenderingTests/CollectionContainerTests.swift
+++ b/Tests/RenderingTests/CollectionContainerTests.swift
@@ -38,9 +38,9 @@ final class CollectionContainerTests: XCTestCase {
         try assertMatch(
             #"""
             <Section>
-                <Section:header>Header</Section:header>
-                <Section:content>Content</Section:content>
-                <Section:footer>Footer</Section:footer>
+                <Text template="header">Header</Text>
+                <Text template="content">Content</Text>
+                <Text template="footer">Footer</Text>
             <Section>
             """#
         ) {
@@ -55,9 +55,9 @@ final class CollectionContainerTests: XCTestCase {
         try assertMatch(
             #"""
             <Section>
-                <Section:header>Header</Section:header>
+                <Text template="header">Header</Text>
                 Content
-                <Section:footer>Footer</Section:footer>
+                <Text template="footer">Footer</Text>
             </Section>
             """#
         ) {
@@ -83,12 +83,12 @@ final class CollectionContainerTests: XCTestCase {
         try assertMatch(
             #"""
             <Table>
-                <Table:columns>
+                <Group template="columns">
                     <TableColumn>A</TableColumn>
                     <TableColumn>B</TableColumn>
                     <TableColumn>C</TableColumn>
-                </Table:columns>
-                <Table:rows>
+                </Group>
+                <Group template="rows">
                     <TableRow id="1">
                         <Text>A1</Text>
                         <Text>B1</Text>
@@ -104,7 +104,7 @@ final class CollectionContainerTests: XCTestCase {
                         <Text>B3</Text>
                         <Text>C3</Text>
                     </TableRow>
-                </Table:rows>
+                </Table>
             </Table>
             """#,
             environment: { environment in

--- a/Tests/RenderingTests/FormTests.swift
+++ b/Tests/RenderingTests/FormTests.swift
@@ -79,7 +79,7 @@ final class FormTests: XCTestCase {
         try assertMatch(
             #"""
             <LabeledContent>
-                <LabeledContent:label>Label</LabeledContent:label>
+                <Text template="label">Label</Text>
                 Content
             </LabeledContent>
             """#,
@@ -97,8 +97,8 @@ final class FormTests: XCTestCase {
         try assertMatch(
             #"""
             <LabeledContent>
-                <LabeledContent:label>Label</LabeledContent:label>
-                <LabeledContent:content>Content</LabeledContent:content>
+                <Text template="label">Label</Text>
+                <Text template="content">Content</Text>
             </LabeledContent>
             """#,
             size: .init(width: 300, height: 100)

--- a/Tests/RenderingTests/GroupTests.swift
+++ b/Tests/RenderingTests/GroupTests.swift
@@ -17,12 +17,12 @@ final class GroupTests: XCTestCase {
         try assertMatch(
             #"""
             <GroupBox>
-                <GroupBox:label>
+                <Text template="label">
                     Label
-                </GroupBox:label>
-                <GroupBox:content>
+                </Text>
+                <Text template="content">
                     Content
-                </GroupBox:content>
+                </Text>
             </GroupBox>
             """#,
             size: .init(width: 300, height: 300)
@@ -39,9 +39,9 @@ final class GroupTests: XCTestCase {
         try assertMatch(
             #"""
             <GroupBox>
-                <GroupBox:label>
+                <Text template="label">
                     Label
-                </GroupBox:label>
+                </Text>
                 Content
             </GroupBox>
             """#,
@@ -94,14 +94,14 @@ final class GroupTests: XCTestCase {
         try assertMatch(
             #"""
             <ControlGroup>
-                <ControlGroup:label>
+                <Text template="label">
                     Label
-                </ControlGroup:label>
-                <ControlGroup:content>
+                </Text>
+                <Group template="content">
                     <Button>Action #1</Button>
                     <Button>Action #2</Button>
                     <Button>Action #3</Button>
-                </ControlGroup:content>
+                </Group>
             </ControlGroup>
             """#
         ) {
@@ -155,7 +155,7 @@ final class GroupTests: XCTestCase {
         try assertMatch(
             #"""
             <DisclosureGroup>
-                <DisclosureGroup:label>Expandable Section</DisclosureGroup:label>
+                <Text template="label">Expandable Section</Text>
                 Content
             </DisclosureGroup>
             """#
@@ -172,8 +172,8 @@ final class GroupTests: XCTestCase {
         try assertMatch(
             #"""
             <DisclosureGroup>
-                <DisclosureGroup:label>Expandable Section</DisclosureGroup:label>
-                <DisclosureGroup:content>Content</DisclosureGroup:content>
+                <Text template="label">Expandable Section</Text>
+                <Text template="content">Content</Text>
             </DisclosureGroup>
             """#
         ) {

--- a/Tests/RenderingTests/IndicatorTests.swift
+++ b/Tests/RenderingTests/IndicatorTests.swift
@@ -83,10 +83,10 @@ final class IndicatorTests: XCTestCase {
         try assertMatch(
             #"""
             <Gauge value="0.5">
-                <Gauge:label>50%</Gauge:label>
-                <Gauge:current-value-label>0.5</Gauge:current-value-label>
-                <Gauge:minimum-value-label>0</Gauge:minimum-value-label>
-                <Gauge:maximum-value-label>1</Gauge:maximum-value-label>
+                <Text template="label">50%</Text>
+                <Text template="current-value-label">0.5</Text>
+                <Text template="minimum-value-label">0</Text>
+                <Text template="maximum-value-label">1</Text>
             </Gauge>
             """#
         ) {
@@ -105,9 +105,9 @@ final class IndicatorTests: XCTestCase {
             #"""
             <Gauge value="0.5">
                 50%
-                <Gauge:current-value-label>0.5</Gauge:current-value-label>
-                <Gauge:minimum-value-label>0</Gauge:minimum-value-label>
-                <Gauge:maximum-value-label>1</Gauge:maximum-value-label>
+                <Text template="current-value-label">0.5</Text>
+                <Text template="minimum-value-label">0</GText>
+                <Text template="maximum-value-label">1</GText>
             </Gauge>
             """#
         ) {

--- a/Tests/RenderingTests/MenuTests.swift
+++ b/Tests/RenderingTests/MenuTests.swift
@@ -15,12 +15,12 @@ final class MenuTests: XCTestCase {
     func testSimple() throws {
         try assertMatch(#"""
 <Menu>
-    <Menu:label>
-        <Text>Open Menu</Text>
-    </Menu:label>
-    <Menu:content>
-        <Text>Menu Content</Text>
-    </Menu:content>
+    <Text template="label">
+        Open Menu
+    </Text>
+    <Text template="content">
+        Menu Content
+    </Text>
 </Menu>
 """#) {
             Menu {
@@ -34,10 +34,10 @@ final class MenuTests: XCTestCase {
     func testDefaultSlot() throws {
         try assertMatch(#"""
 <Menu>
-    <Text>Open Menu</Text>
-    <Menu:content>
-        <Text>Menu Content</Text>
-    </Menu:content>
+    <Text template="label">Open Menu</Text>
+    <Text>
+        Menu Content
+    </Text>
 </Menu>
 """#) {
             Menu {
@@ -52,12 +52,12 @@ final class MenuTests: XCTestCase {
         try assertMatch(#"""
 <Menu>
     <Text>Default Slot</Text>
-    <Menu:label>
-        <Text>Open Menu</Text>
-    </Menu:label>
-    <Menu:content>
-        <Text>Menu Content</Text>
-    </Menu:content>
+    <Text template="label">
+        Open Menu
+    </Text>
+    <Text template="content">
+        Menu Content
+    </Text>
 </Menu>
 """#) {
             Menu {

--- a/Tests/RenderingTests/PickerTests.swift
+++ b/Tests/RenderingTests/PickerTests.swift
@@ -44,12 +44,12 @@ final class PickerTests: XCTestCase {
         try assertMatch(
             #"""
             <Picker value="paperplane" modifiers='[{"type": "picker_style", "style": "automatic"}]'>
-                <Picker:label><Text>Pick an icon</Text></Picker:label>
-                <Picker:content>
+                <Text template="label">Pick an icon</Text>
+                <Group template="content">
                     <Label system-image="paperplane" modifiers='[{"type": "tag", "value": "paperplane"}]'><Text>paperplane</Text></Label>
                     <Label system-image="graduationcap" modifiers='[{"type": "tag", "value": "graduationcap"}]'><Text>graduationcap</Text></Label>
                     <Label system-image="ellipsis.bubble" modifiers='[{"type": "tag", "value": "ellipsis.bubble"}]'><Text>ellipsis.bubble</Text></Label>
-                </Picker:content>
+                </Group>
             </Picker>
             """#) {
                 Picker(selection: .constant("paperplane")) {
@@ -72,12 +72,12 @@ final class PickerTests: XCTestCase {
         try assertMatch(
             #"""
             <Picker value="paperplane" modifiers='[{"type": "picker_style", "style": "inline"}]'>
-                <Picker:label><Text>Pick an icon</Text></Picker:label>
-                <Picker:content>
+                <Text template="label">Pick an icon</Text>
+                <Group template="content">
                     <Label system-image="paperplane" modifiers='[{"type": "tag", "value": "paperplane"}]'><Text>paperplane</Text></Label>
                     <Label system-image="graduationcap" modifiers='[{"type": "tag", "value": "graduationcap"}]'><Text>graduationcap</Text></Label>
                     <Label system-image="ellipsis.bubble" modifiers='[{"type": "tag", "value": "ellipsis.bubble"}]'><Text>ellipsis.bubble</Text></Label>
-                </Picker:content>
+                </Group>
             </Picker>
             """#) {
                 Picker(selection: .constant("paperplane")) {

--- a/Tests/RenderingTests/TextTests.swift
+++ b/Tests/RenderingTests/TextTests.swift
@@ -147,8 +147,8 @@ This is some markdown text [click me](apple.com)
         try assertMatch(
             #"""
             <Label>
-                <Label:icon><Image system-name="bolt.fill" /></Label:icon>
-                <Label:title><Text>Lightning</Text></Label:title>
+                <Image template="icon" system-name="bolt.fill" />
+                <Text template="title">Lightning</Text>
             <Label>
             """#
         ) {

--- a/Tests/RenderingTests/ValueInputTests.swift
+++ b/Tests/RenderingTests/ValueInputTests.swift
@@ -22,15 +22,9 @@ final class ValueInputTests: XCTestCase {
     func testSliderLabels() throws {
         try assertMatch(#"""
 <Slider>
-    <Slider:label>
-        <Text>Label</Text>
-    </Slider:label>
-    <Slider:minimum-value-label>
-        <Text>Min</Text>
-    </Slider:minimum-value-label>
-    <Slider:maximum-value-label>
-        <Text>Max</Text>
-    </Slider:maximum-value-label>
+    <Text template="label">Label</Text>
+    <Text template="minimum-value-label">Min</Text>
+    <Text template="maximum-value-label">Max</Text>
 </Slider>
 """#, size: .init(width: 300, height: 100)) {
             Slider(value: .constant(0)) {


### PR DESCRIPTION
This changes the syntax for named children. Two main ways are supported:

1. `template={...}` attribute

This allows dynamic values to be used easily.
```html
<Text template={:label}> ... </Text>
```

2. Shorthand `#` boolean attribute

This can be preferred when the value is constant.
```html
<Text #label> ... </Text>
```

### Comparisons
Left is current syntax, right is new syntax.

<table>
<tr>
<td>

```html
<Menu>
  <Menu:label>
    Open Me
  </Menu:label>
  <Menu:content>
    <Button>Option 1</Button>
    <Button>Option 2</Button>
    <Button>Option 3</Button>
  </Menu:content>
</Menu>
```

</td>
<td>

```html
<Menu>
  <Text #label>
    Open Me
  </Text>
  <Group #content>
    <Button>Option 1</Button>
    <Button>Option 2</Button>
    <Button>Option 3</Button>
  </Group>
</Menu>
```

</td>
</tr>
</table>

Here's one case where this is very beneficial: dynamically changing what part of the content a template represents.

<table>
<tr>
<td>

```html
<Gauge>
  <Gauge:label>Value</Gauge:label>
  <%= content_tag :"Gauge:#{@min_or_max_label}" do %>
    This is either the minimum-value-label or maximum-value-label
  <% end %>
</Gauge>
```

</td>
<td>

```html
<Gauge>
  <Text #label>Value</Text>
  <Text template={@min_or_max_label}>
    This is either the minimum-value-label or maximum-value-label
  </Text>
</Gauge>
```

</td>
</tr>
</table>

According to the docs, the use of `content_tag` is discouraged. However I believe this is the only way that could be implemented with the current syntax. The new syntax makes this easy as you just pass the `id` of the template like a normal attribute.