### PR TITLE
Fix `testPicker`

### DIFF
--- a/Sources/LiveViewNative/Modifiers/View Configuration Modifiers/StatusBarHiddenModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/View Configuration Modifiers/StatusBarHiddenModifier.swift
@@ -24,6 +24,7 @@ import SwiftUI
 #if swift(>=5.8)
 @_documentation(visibility: public)
 #endif
+@available(iOS 16.0, *)
 struct StatusBarHiddenModifier: ViewModifier, Decodable, Equatable {
     /// A boolean indicating whether to hide the status bar.
     #if swift(>=5.8)
@@ -38,7 +39,9 @@ struct StatusBarHiddenModifier: ViewModifier, Decodable, Equatable {
     }
 
     func body(content: Content) -> some View {
+        #if os(iOS)
         content.statusBarHidden(hidden)
+        #endif
     }
 
     enum CodingKeys: String, CodingKey {

--- a/Tests/RenderingTests/PickerTests.swift
+++ b/Tests/RenderingTests/PickerTests.swift
@@ -84,8 +84,6 @@ final class PickerTests: XCTestCase {
                     ForEach(["paperplane", "graduationcap", "ellipsis.bubble"], id: \.self) { name in
                         Label {
                             Text(name)
-                                // the Picker imposes a slightly different font by default, but our Text view uses nil, so match that
-                                .font(nil)
                         } icon: {
                             Image(systemName: name)
                         }


### PR DESCRIPTION
There was a workaround that is no longer needed in the test.