### PR TITLE
Workaround for exceeding stack limit on iOS devices

### DIFF
--- a/Sources/LiveViewNative/Registries/BuiltinRegistry.swift
+++ b/Sources/LiveViewNative/Registries/BuiltinRegistry.swift
@@ -17,9 +17,166 @@ protocol BuiltinRegistryProtocol {
 }
 
 struct BuiltinRegistry<R: RootRegistry>: BuiltinRegistryProtocol {
-    // note: the context parameter is unused, but it needs to be there for swift to infer the generic type R
-    @ViewBuilder
     static func lookup(_ name: String, _ element: ElementNode) -> some View {
+        return BuiltinElement<R>(name: name, element: element)
+    }
+
+    enum ModifierType: String {
+        case animation
+        case aspectRatio = "aspect_ratio"
+        case background = "background"
+        case backgroundStyle = "background_style"
+        case blur
+        case bold
+        case baselineOffset = "baseline_offset"
+        case contentTransition = "content_transition"
+        case disabled
+        case dynamicTypeSize = "dynamic_type_size"
+        case fixedSize = "fixed_size"
+        case font
+        case fontWeight = "font_weight"
+        case fontWidth = "font_width"
+        case foregroundStyle = "foreground_style"
+        case frame
+        case gridCellAnchor = "grid_cell_anchor"
+        case gridCellColumns = "grid_cell_columns"
+        case gridCellUnsizedAxes = "grid_cell_unsized_axes"
+        case gridColumnAlignment = "grid_column_alignment"
+        case headerProminence = "header_prominence"
+        case hueRotation = "hue_rotation"
+        case italic
+        case layoutPriority = "layout_priority"
+        case listRowInsets = "list_row_insets"
+        case listRowSeparator = "list_row_separator"
+        case listStyle = "list_style"
+        case matchedGeometryEffect = "matched_geometry_effect"
+        case monospaced
+        case monospacedDigit = "monospaced_digit"
+        case navigationTitle = "navigation_title"
+        case opacity
+        case padding
+        case position
+        case refreshable
+        case renameAction = "rename_action"
+        case rotation3DEffect = "rotation_3d_effect"
+        case rotationEffect = "rotation_effect"
+        case statusBarHidden = "status_bar_hidden"
+        case strikethrough
+        case tag
+        case textCase = "text_case"
+        case textFieldStyle = "text_field_style"
+        case textSelection = "text_selection"
+        case tint
+        case transition
+    }
+
+    @ViewModifierBuilder
+    static func decodeModifier(_ type: ModifierType, from decoder: Decoder) throws -> some ViewModifier {
+        switch type {
+        case .animation:
+            try AnimationModifier(from: decoder)
+        case .aspectRatio:
+            try AspectRatioModifier(from: decoder)
+        case .background:
+            try BackgroundModifier<R>(from: decoder)
+        case .backgroundStyle:
+            try BackgroundStyleModifier(from: decoder)
+        case .blur:
+            try BlurModifier(from: decoder)
+        case .bold:
+            try BoldModifier(from: decoder)
+        case .baselineOffset:
+            try BaselineOffsetModifier(from: decoder)
+        case .contentTransition:
+            try ContentTransitionModifier(from: decoder)
+        case .disabled:
+            try DisabledModifier(from: decoder)
+        case .dynamicTypeSize:
+            try DynamicTypeSizeModifier(from: decoder)
+        case .foregroundStyle:
+            try ForegroundStyleModifier(from: decoder)
+        case .fixedSize:
+            try FixedSizeModifier(from: decoder)
+        case .font:
+            try FontModifier(from: decoder)
+        case .fontWeight:
+            try FontWeightModifier(from: decoder)
+        case .fontWidth:
+            try FontWidthModifier(from: decoder)
+        case .frame:
+            try FrameModifier(from: decoder)
+        case .gridCellAnchor:
+            try GridCellAnchorModifier(from: decoder)
+        case .gridCellColumns:
+            try GridCellColumnsModifier(from: decoder)
+        case .gridCellUnsizedAxes:
+            try GridCellUnsizedAxesModifier(from: decoder)
+        case .gridColumnAlignment:
+            try GridColumnAlignmentModifier(from: decoder)
+        case .headerProminence:
+            try HeaderProminenceModifier(from: decoder)
+        case .hueRotation:
+            try HueRotationModifier(from: decoder)
+        case .italic:
+            try ItalicModifier(from: decoder)
+        case .layoutPriority:
+            try LayoutPriorityModifier(from: decoder)
+        case .listRowInsets:
+            try ListRowInsetsModifier(from: decoder)
+        case .listRowSeparator:
+            try ListRowSeparatorModifier(from: decoder)
+        case .listStyle:
+            try ListStyleModifier(from: decoder)
+        case .matchedGeometryEffect:
+            try MatchedGeometryEffectModifier(from: decoder)
+        case .monospaced:
+            try MonospacedModifier(from: decoder)
+        case .monospacedDigit:
+            try MonospacedDigitModifier(from: decoder)
+        case .navigationTitle:
+            try NavigationTitleModifier(from: decoder)
+        case .opacity:
+            try OpacityModifier(from: decoder)
+        case .padding:
+            try PaddingModifier(from: decoder)
+        case .position:
+            try PositionModifier(from: decoder)
+        case .refreshable:
+            try RefreshableModifier(from: decoder)
+        case .renameAction:
+            try RenameActionModifier(from: decoder)
+        case .rotation3DEffect:
+            try Rotation3DEffectModifier(from: decoder)
+        case .rotationEffect:
+            try RotationEffectModifier(from: decoder)
+        case .statusBarHidden:
+            try StatusBarHiddenModifier(from: decoder)
+        case .strikethrough:
+            try StrikethroughModifier(from: decoder)
+        case .tag:
+            try TagModifier(from: decoder)
+        case .textCase:
+            try TextCaseModifier(from: decoder)
+        case .textFieldStyle:
+            try TextFieldStyleModifier(from: decoder)
+        case .textSelection:
+            try TextSelectionModifier(from: decoder)
+        case .tint:
+            try TintModifier(from: decoder)
+        case .transition:
+            try TransitionModifier<R>(from: decoder)
+        }
+    }
+}
+
+// This switch can't be inlined into BuiltinRegistry.lookup because it results in that method's return type
+// being a massive pile of nested _ConditionalContents. Instead, lift it out into a separate View type
+// that lookup can return, so it doesn't blow up the stack.
+// See #806 for more details.
+struct BuiltinElement<R: RootRegistry>: View {
+    let name: String
+    let element: ElementNode
+    var body: some View {
         switch name {
         case "AsyncImage":
             AsyncImage<R>()
@@ -168,153 +325,6 @@ struct BuiltinRegistry<R: RootRegistry>: BuiltinRegistryProtocol {
         default:
             // log here that view type cannot be found
             EmptyView()
-        }
-    }
-
-    enum ModifierType: String {
-        case animation
-        case aspectRatio = "aspect_ratio"
-        case background = "background"
-        case backgroundStyle = "background_style"
-        case blur
-        case bold
-        case baselineOffset = "baseline_offset"
-        case contentTransition = "content_transition"
-        case disabled
-        case dynamicTypeSize = "dynamic_type_size"
-        case fixedSize = "fixed_size"
-        case font
-        case fontWeight = "font_weight"
-        case fontWidth = "font_width"
-        case foregroundStyle = "foreground_style"
-        case frame
-        case gridCellAnchor = "grid_cell_anchor"
-        case gridCellColumns = "grid_cell_columns"
-        case gridCellUnsizedAxes = "grid_cell_unsized_axes"
-        case gridColumnAlignment = "grid_column_alignment"
-        case headerProminence = "header_prominence"
-        case hueRotation = "hue_rotation"
-        case italic
-        case layoutPriority = "layout_priority"
-        case listRowInsets = "list_row_insets"
-        case listRowSeparator = "list_row_separator"
-        case listStyle = "list_style"
-        case matchedGeometryEffect = "matched_geometry_effect"
-        case monospaced
-        case monospacedDigit = "monospaced_digit"
-        case navigationTitle = "navigation_title"
-        case opacity
-        case padding
-        case position
-        case refreshable
-        case renameAction = "rename_action"
-        case rotation3DEffect = "rotation_3d_effect"
-        case rotationEffect = "rotation_effect"
-        case statusBarHidden = "status_bar_hidden"
-        case strikethrough
-        case tag
-        case textCase = "text_case"
-        case textFieldStyle = "text_field_style"
-        case textSelection = "text_selection"
-        case tint
-        case transition
-    }
-
-    @ViewModifierBuilder
-    static func decodeModifier(_ type: ModifierType, from decoder: Decoder) throws -> some ViewModifier {
-        switch type {
-        case .animation:
-            try AnimationModifier(from: decoder)
-        case .aspectRatio:
-            try AspectRatioModifier(from: decoder)
-        case .background:
-            try BackgroundModifier<R>(from: decoder)
-        case .backgroundStyle:
-            try BackgroundStyleModifier(from: decoder)
-        case .blur:
-            try BlurModifier(from: decoder)
-        case .bold:
-            try BoldModifier(from: decoder)
-        case .baselineOffset:
-            try BaselineOffsetModifier(from: decoder)
-        case .contentTransition:
-            try ContentTransitionModifier(from: decoder)
-        case .disabled:
-            try DisabledModifier(from: decoder)
-        case .dynamicTypeSize:
-            try DynamicTypeSizeModifier(from: decoder)
-        case .foregroundStyle:
-            try ForegroundStyleModifier(from: decoder)
-        case .fixedSize:
-            try FixedSizeModifier(from: decoder)
-        case .font:
-            try FontModifier(from: decoder)
-        case .fontWeight:
-            try FontWeightModifier(from: decoder)
-        case .fontWidth:
-            try FontWidthModifier(from: decoder)
-        case .frame:
-            try FrameModifier(from: decoder)
-        case .gridCellAnchor:
-            try GridCellAnchorModifier(from: decoder)
-        case .gridCellColumns:
-            try GridCellColumnsModifier(from: decoder)
-        case .gridCellUnsizedAxes:
-            try GridCellUnsizedAxesModifier(from: decoder)
-        case .gridColumnAlignment:
-            try GridColumnAlignmentModifier(from: decoder)
-        case .headerProminence:
-            try HeaderProminenceModifier(from: decoder)
-        case .hueRotation:
-            try HueRotationModifier(from: decoder)
-        case .italic:
-            try ItalicModifier(from: decoder)
-        case .layoutPriority:
-            try LayoutPriorityModifier(from: decoder)
-        case .listRowInsets:
-            try ListRowInsetsModifier(from: decoder)
-        case .listRowSeparator:
-            try ListRowSeparatorModifier(from: decoder)
-        case .listStyle:
-            try ListStyleModifier(from: decoder)
-        case .matchedGeometryEffect:
-            try MatchedGeometryEffectModifier(from: decoder)
-        case .monospaced:
-            try MonospacedModifier(from: decoder)
-        case .monospacedDigit:
-            try MonospacedDigitModifier(from: decoder)
-        case .navigationTitle:
-            try NavigationTitleModifier(from: decoder)
-        case .opacity:
-            try OpacityModifier(from: decoder)
-        case .padding:
-            try PaddingModifier(from: decoder)
-        case .position:
-            try PositionModifier(from: decoder)
-        case .refreshable:
-            try RefreshableModifier(from: decoder)
-        case .renameAction:
-            try RenameActionModifier(from: decoder)
-        case .rotation3DEffect:
-            try Rotation3DEffectModifier(from: decoder)
-        case .rotationEffect:
-            try RotationEffectModifier(from: decoder)
-        case .statusBarHidden:
-            try StatusBarHiddenModifier(from: decoder)
-        case .strikethrough:
-            try StrikethroughModifier(from: decoder)
-        case .tag:
-            try TagModifier(from: decoder)
-        case .textCase:
-            try TextCaseModifier(from: decoder)
-        case .textFieldStyle:
-            try TextFieldStyleModifier(from: decoder)
-        case .textSelection:
-            try TextSelectionModifier(from: decoder)
-        case .tint:
-            try TintModifier(from: decoder)
-        case .transition:
-            try TransitionModifier<R>(from: decoder)
         }
     }
 }


### PR DESCRIPTION
Closes #806

The root cause of the on-device crash is that the stack grows by an absurd amount in the `ViewTreeBuilder.fromNodes` call—so much so that we exceed the 1MB stack limit.

In `fromNodes`, the stack grows by about 10KB per call to `f` in the function, regardless of whether the call is actually made. And with 55 call sites, that puts us at ~550KB stack growth and over the limit. I'm not entirely certain, but I suspect that's all coming from type metadata for the massive `_ConditionalContent` that is the result of `BuiltinRegistry.lookup` (commenting out most of the switch cases in that method dramatically reduces the stack size).

We can workaround this by moving that giant lookup switch to a separate view type, which effectively splits the stack growth into two separate phases—one for the `fromNodes` call (~177KB, which is 3.2KB per `f` call site) and one for `BuiltinElement.body` which contains the switch (~300KB)—so we don't hit the stack limit anymore.

This fixes the immediate issue, but this is still a lot more stack space I would like to be using. Unfortunately, I'm not sure there's anything more we can reasonably do, since I suspect the actual code that's using the stack excessively is being generated by the compiler.