### PR TITLE
Add `gesture` modifier and `AnyGesture`

### DIFF
--- a/Sources/LiveViewNative/Modifiers/Gestures Modifiers/GestureModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Gestures Modifiers/GestureModifier.swift
@@ -1,0 +1,162 @@
+//
+//  OnTapGestureModifier.swift
+//  LiveViewNative
+//
+//  Created by Carson Katri on 4/20/2023.
+//
+
+import SwiftUI
+
+/// Sends an event when a gesture is performed on the element.
+///
+/// - Note: Use the `phx-click` attribute to easily handle tap events.
+///
+/// Pass in a ``gesture`` and an event name.
+///
+/// ```html
+/// <Rectangle modifiers={gesture(@native, gesture: :spatial_tap, action: "on_tap")} />
+/// ```
+///
+/// ```elixir
+/// defmodule MyAppWeb.GestureLive do
+///   def handle_event("on_tap", %{ "x" => x, "y" => y }, socket) do
+///     {:noreply, assign(socket, :location, [x, y])}
+///   end
+/// end
+/// ```
+///
+/// See ``LiveViewNative/SwiftUI/AnyGesture`` for details on creating gestures.
+///
+/// ## Arguments
+/// * ``gesture``
+/// * ``action``
+/// * ``mask``
+/// * ``priority``
+///
+/// ## Topics
+/// ### Supporting Types
+/// * ``LiveViewNative/SwiftUI/AnyGesture``
+/// * ``GesturePriority``
+/// * ``LiveViewNative/SwiftUI/GestureMask``
+/// * ``Event``
+#if swift(>=5.8)
+@_documentation(visibility: public)
+#endif
+struct GestureModifier<R: RootRegistry>: ViewModifier, Decodable {
+    /// The gesture to observe.
+    ///
+    /// See ``LiveViewNative/SwiftUI/AnyGesture`` for details on creating gestures.
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
+    private let gesture: AnyGesture<Any>
+    
+    /// The event to trigger when tapped.
+    ///
+    /// See [`Event`](doc:Event/init(from:)) for more details on referencing events.
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
+    private let action: Event
+    
+    /// The priority of the gesture. Defaults to `low`.
+    ///
+    /// See ``GesturePriority`` for a list of possible values.
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
+    private let priority: GesturePriority
+    
+    /// Controls how this gestures impacts other gestures on the element and its children. Defaults to `all`.
+    ///
+    /// See ``LiveViewNative/SwiftUI/GestureMask`` for a list of possible values.
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
+    private let mask: GestureMask
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        self.gesture = try container.decode(AnyGesture<Any>.self, forKey: .gesture)
+        self.action = try container.decode(Event.self, forKey: .action)
+        self.priority = try container.decode(GesturePriority.self, forKey: .priority)
+        self.mask = try container.decode(GestureMask.self, forKey: .mask)
+    }
+
+    func body(content: Content) -> some View {
+        let gesture = self.gesture
+            .onEnded { value in
+                self.action.wrappedValue(value: value)
+            }
+        switch priority {
+        case .low:
+            content.gesture(gesture, including: mask)
+        case .high:
+            content.highPriorityGesture(gesture, including: mask)
+        case .simultaneous:
+            content.simultaneousGesture(gesture, including: mask)
+        }
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case gesture
+        case action
+        case priority
+        case mask
+    }
+}
+
+/// The priority of a gesture.
+///
+/// Possible values:
+/// * ``low``
+/// * ``high``
+/// * ``simultaneous``
+#if swift(>=5.8)
+@_documentation(visibility: public)
+#endif
+enum GesturePriority: String, Decodable {
+    /// Gives precedence to system gestures.
+    ///
+    /// ```html
+    /// <Button
+    ///     phx-click="button_event"
+    ///     modifiers={gesture(@native, gesture: :tap, action: "gesture_event", priority: :low)}
+    /// >
+    ///     Button Event Only
+    /// </Button>
+    /// ```
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
+    case low
+    /// Takes precedence over system gestures.
+    ///
+    /// ```html
+    /// <Button
+    ///     phx-click="button_event"
+    ///     modifiers={gesture(@native, gesture: :tap, action: "gesture_event", priority: :high)}
+    /// >
+    ///     Gesture Event Only
+    /// </Button>
+    /// ```
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
+    case high
+    /// Performs alongside system gestures.
+    ///
+    /// ```html
+    /// <Button
+    ///     phx-click="button_event"
+    ///     modifiers={gesture(@native, gesture: :tap, action: "gesture_event", priority: :simultaneous)}
+    /// >
+    ///     Button and Gesture Events
+    /// </Button>
+    /// ```
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
+    case simultaneous
+}

--- a/Sources/LiveViewNative/Modifiers/Layout Adjustments Modifiers/CoordinateSpaceModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Layout Adjustments Modifiers/CoordinateSpaceModifier.swift
@@ -1,0 +1,47 @@
+//
+//  CoordinateSpaceModifier.swift
+//  LiveViewNative
+//
+//  Created by Carson Katri on 4/20/2023.
+//
+
+import SwiftUI
+
+/// Creates a new named ``LiveViewNative/SwiftUI/CoordinateSpace``.
+///
+/// Specify a ``name`` for the coordinate space.
+///
+/// ```html
+/// <VStack modifiers={coordinate_space(@native, name: "stack")}>
+///     ...
+/// </VStack>
+/// ```
+///
+/// This space can then be referenced wherever a ``LiveViewNative/SwiftUI/CoordinateSpace`` type is expected.
+///
+/// ## Arguments
+/// * ``name``
+#if swift(>=5.8)
+@_documentation(visibility: public)
+#endif
+struct CoordinateSpaceModifier<R: RootRegistry>: ViewModifier, Decodable {
+    /// The custom name of the coordinate space.
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
+    private let name: String
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        self.name = try container.decode(String.self, forKey: .name)
+    }
+
+    func body(content: Content) -> some View {
+        content.coordinateSpace(name: name)
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case name
+    }
+}

--- a/Sources/LiveViewNative/Property Wrappers/Event.swift
+++ b/Sources/LiveViewNative/Property Wrappers/Event.swift
@@ -243,7 +243,7 @@ public struct Event: DynamicProperty, Decodable {
     public struct EventHandler {
         let owner: Event
         
-        public func callAsFunction(value: Any, didSend: (() -> Void)? = nil) {
+        public func callAsFunction(value: Any = [String:String](), didSend: (() -> Void)? = nil) {
             Task {
                 try await self.callAsFunction(value: value)
                 didSend?()

--- a/Sources/LiveViewNative/Utils/CoordinateSpace.swift
+++ b/Sources/LiveViewNative/Utils/CoordinateSpace.swift
@@ -1,0 +1,31 @@
+//
+//  CoordinateSpace.swift
+//  
+//
+//  Created by Carson Katri on 4/20/23.
+//
+
+import SwiftUI
+
+/// A named coordinate space for resolving locations.
+///
+/// Possible values:
+/// * `global`
+/// * `local`
+/// * custom named coordinate space
+///
+/// Create a named coordinate space with the ``CoordinateSpaceModifier`` modifier.
+#if swift(>=5.8)
+@_documentation(visibility: public)
+#endif
+extension CoordinateSpace: Decodable {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        switch try container.decode(String.self) {
+        case "global": self = .global
+        case "local": self = .local
+        case let custom:
+            self = .named(custom)
+        }
+    }
+}

--- a/Sources/LiveViewNative/Utils/Gesture/AnyGesture.swift
+++ b/Sources/LiveViewNative/Utils/Gesture/AnyGesture.swift
@@ -1,0 +1,196 @@
+//
+//  Gesture.swift
+//  
+//
+//  Created by Carson Katri on 4/20/23.
+//
+
+import SwiftUI
+
+/// Configuration for the ``GestureModifier`` modifier.
+///
+/// In their simplest form, gestures can be created with an atom. More complex gestures can have properties.
+///
+/// ```elixir
+/// :tap
+/// {:tap, [count: 2]} # a double tap
+/// {:sequential, [:long_press, {:tap, [count: 2]}]} # a sequence of gestures
+/// ```
+///
+/// ## Gestures
+/// Gestures with no required arguments can be represented with an atom.
+///
+/// ```elixir
+/// :tap
+/// ```
+///
+/// To pass arguments, use a tuple with a keyword list as the second element.
+///
+/// ```elixir
+/// {:tap, [count: 2]}
+/// ```
+///
+/// ### :tap
+/// Arguments:
+/// * `count` - The number of taps needed to trigger the event.
+///
+/// See [`SwiftUI.TapGesture`](https://developer.apple.com/documentation/swiftui/tapgesture) for more details on this gesture.
+///
+/// ### :spatial_tap
+/// Arguments:
+/// * `count` - The number of taps needed to trigger the event.
+/// * `coordinate_space` - The coordinate space to report the tap location in. See ``LiveViewNative/SwiftUI/CoordinateSpace`` for a list of possible values.
+///
+/// See [`SwiftUI.SpatialTapGesture`](https://developer.apple.com/documentation/swiftui/spatialtapgesture) for more details on this gesture.
+///
+/// ### :long_press
+/// Arguments:
+/// * `minimum_duration` - The minimum duration the press must be before succeeding.
+/// * `maximum_distance` - The maximum distance the cursor can move before the gesture fails.
+///
+/// See [`SwiftUI.LongPressGesture`](https://developer.apple.com/documentation/swiftui/longpressgesture) for more details on this gesture.
+///
+/// ### Sequential Gestures
+/// Gestures can be performed in sequence by passing an array.
+///
+/// ```elixir
+/// {:sequential, [:long_press, {:spatial_tap, [count: 2]}]}
+/// ```
+///
+/// In this example, the user must long press then tap again for the event to be sent.
+///
+/// ### Simultaneous Gestures
+/// All of the gestures passed will be observed at the same time.
+///
+/// ```elixir
+/// {:simultaneous, [:tap, :spatial_tap]}
+/// ```
+///
+/// In this example, the `tap` and `spatial_tap` results will be sent together in an array.
+///
+/// ### Exclusive Gestures
+/// One of the options will be performed, but not both.
+/// The first gesture is given precedence.
+///
+/// ```elixir
+/// {:exclusive, [:long_press, {:spatial_tap, [count: 2]}]}
+/// ```
+#if swift(>=5.8)
+@_documentation(visibility: public)
+#endif
+extension AnyGesture: Decodable {
+    enum CodingKeys: String, CodingKey {
+        case type
+        case properties
+        
+        enum Tap: String, CodingKey {
+            case count
+        }
+        
+        enum SpatialTap: String, CodingKey {
+            case count
+            case coordinateSpace = "coordinate_space"
+        }
+        
+        enum LongPress: String, CodingKey {
+            case minimumDuration = "minimum_duration"
+            case maximumDistance = "maximum_distance"
+        }
+        
+        enum Sequence: String, CodingKey {
+            case gestures
+        }
+    }
+    
+    enum GestureType: String, Decodable {
+        case tap
+        case spatialTap = "spatial_tap"
+        case longPress = "long_press"
+        case sequential
+        case simultaneous
+        case exclusive
+    }
+    
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        switch try container.decode(GestureType.self, forKey: .type) {
+        case .tap:
+            let properties = try container.nestedContainer(keyedBy: CodingKeys.Tap.self, forKey: .properties)
+            self = .init(
+                TapGesture(
+                    count: try properties.decodeIfPresent(Int.self, forKey: .count) ?? 1
+                )
+                .map { _ in [String:String]() as! Value }
+            )
+        case .spatialTap:
+            let properties = try container.nestedContainer(keyedBy: CodingKeys.SpatialTap.self, forKey: .properties)
+            self = .init(
+                SpatialTapGesture(
+                    count: try properties.decodeIfPresent(Int.self, forKey: .count) ?? 1,
+                    coordinateSpace: try properties.decodeIfPresent(CoordinateSpace.self, forKey: .coordinateSpace) ?? .local
+                )
+                .map { ["x": $0.location.x, "y": $0.location.y] as! Value }
+            )
+        case .longPress:
+            let properties = try container.nestedContainer(keyedBy: CodingKeys.LongPress.self, forKey: .properties)
+            self = .init(
+                LongPressGesture(
+                    minimumDuration: try properties.decodeIfPresent(Double.self, forKey: .minimumDuration) ?? 0.5,
+                    maximumDistance: try properties.decodeIfPresent(Double.self, forKey: .maximumDistance) ?? 10
+                )
+                .map { $0 as! Value }
+            )
+        case .sequential:
+            let properties = try container.nestedContainer(keyedBy: CodingKeys.Sequence.self, forKey: .properties)
+            let sequence = try properties.decode([AnyGesture<Value>].self, forKey: .gestures)
+            self = sequence.dropFirst().reduce(sequence.first!) { first, second in
+                AnyGesture<Value>(
+                    SequenceGesture(first, second)
+                        .map {
+                            switch $0 {
+                            case let .first(first):
+                                return first
+                            case let .second(first, second):
+                                if let array = first as? [Any] {
+                                    return (array + [second as Any]) as! Value
+                                } else {
+                                    return [first, second] as! Value
+                                }
+                            }
+                        }
+                )
+            }
+        case .simultaneous:
+            let properties = try container.nestedContainer(keyedBy: CodingKeys.Sequence.self, forKey: .properties)
+            let sequence = try properties.decode([AnyGesture<Value>].self, forKey: .gestures)
+            self = sequence.dropFirst().reduce(sequence.first!) { first, second in
+                AnyGesture<Value>(
+                    SimultaneousGesture(first, second)
+                        .map {
+                            if let array = $0.first as? [Any] {
+                                return (array + [$0.second as Any]) as! Value
+                            } else {
+                                return [$0.first, $0.second] as! Value
+                            }
+                        }
+                )
+            }
+        case .exclusive:
+            let properties = try container.nestedContainer(keyedBy: CodingKeys.Sequence.self, forKey: .properties)
+            let sequence = try properties.decode([AnyGesture<Value>].self, forKey: .gestures)
+            self = sequence.dropFirst().reduce(sequence.first!) { first, second in
+                AnyGesture<Value>(
+                    ExclusiveGesture(first, second)
+                        .map {
+                            switch $0 {
+                            case let .first(first):
+                                return first
+                            case let .second(second):
+                                return second
+                            }
+                        }
+                )
+            }
+        }
+    }
+}

--- a/Sources/LiveViewNative/Utils/Gesture/GestureMask.swift
+++ b/Sources/LiveViewNative/Utils/Gesture/GestureMask.swift
@@ -1,5 +1,5 @@
 //
-//  GestureOptions.swift
+//  GestureMask.swift
 //  
 //
 //  Created by Carson Katri on 4/20/23.

--- a/Sources/LiveViewNative/Utils/Gesture/GestureMask.swift
+++ b/Sources/LiveViewNative/Utils/Gesture/GestureMask.swift
@@ -1,0 +1,39 @@
+//
+//  GestureOptions.swift
+//  
+//
+//  Created by Carson Katri on 4/20/23.
+//
+
+import SwiftUI
+
+/// Configures how a ``GestureModifier`` modifier impacts other gestures on an element.
+///
+/// Possible values:
+/// * `none` - Disables the added gesture and all gestures on child elements.
+/// * `gesture` - Enables the added gesture and ignores gestures on child elements.
+/// * `subviews` - Enables gestures on child elements and ignores the added gesture.
+/// * `all` - Enables the added gesture and all existing gestures.
+#if swift(>=5.8)
+@_documentation(visibility: public)
+#endif
+extension GestureMask: Decodable {
+    public init(from decoder: Decoder) throws {
+        if let singleValue = try? decoder.singleValueContainer() {
+            switch try singleValue.decode(String.self) {
+            case "none": self = .none
+            case "gesture": self = .gesture
+            case "subviews": self = .subviews
+            case "all": self = .all
+            case let `default`: throw DecodingError.dataCorrupted(.init(codingPath: singleValue.codingPath, debugDescription: "unknown GestureMask '\(`default`)'"))
+            }
+        } else {
+            var unkeyed = try decoder.unkeyedContainer()
+            var result = Self()
+            while !unkeyed.isAtEnd {
+                result = result.union(try unkeyed.decode(Self.self))
+            }
+            self = result
+        }
+    }
+}

--- a/lib/live_view_native_swift_ui/modifiers/coordinate_space.ex
+++ b/lib/live_view_native_swift_ui/modifiers/coordinate_space.ex
@@ -1,0 +1,7 @@
+defmodule LiveViewNativeSwiftUi.Modifiers.CoordinateSpace do
+  use LiveViewNativePlatform.Modifier
+
+  modifier_schema "coordinate_space" do
+    field :name, :string
+  end
+end

--- a/lib/live_view_native_swift_ui/modifiers/gesture.ex
+++ b/lib/live_view_native_swift_ui/modifiers/gesture.ex
@@ -1,0 +1,13 @@
+defmodule LiveViewNativeSwiftUi.Modifiers.OnTapGesture do
+  use LiveViewNativePlatform.Modifier
+
+  alias LiveViewNativeSwiftUi.Types.Gesture
+  alias LiveViewNativeSwiftUi.Types.Event
+
+  modifier_schema "gesture" do
+    field :gesture, Gesture
+    field :action, Event
+    field :priority, Ecto.Enum, values: ~w(low high simultaneous)a, default: :low
+    field :mask, Ecto.Enum, values: ~w(none gesture subviews all)a, default: :all
+  end
+end

--- a/lib/live_view_native_swift_ui/types/gesture.ex
+++ b/lib/live_view_native_swift_ui/types/gesture.ex
@@ -1,0 +1,17 @@
+defmodule LiveViewNativeSwiftUi.Types.Gesture do
+  @derive Jason.Encoder
+  defstruct [:type, :properties]
+
+  use LiveViewNativePlatform.Modifier.Type
+  def type, do: :map
+
+  def cast({type, sequence}) when is_list(sequence) and type in [:sequential, :simultaneous, :exclusive] do
+    {:ok, %__MODULE__{ type: type, properties: %{ :gestures => Enum.map(sequence, fn g -> elem(cast(g), 1) end) } }}
+  end
+  def cast(type) when is_atom(type), do: {:ok, %__MODULE__{ type: type, properties: %{} }}
+  def cast({type, [{k, _} | _] = properties}) when is_atom(type) and is_list(properties) and is_atom(k) do
+    {:ok, %__MODULE__{ type: type, properties: Enum.into(properties, %{}) }}
+  end
+
+  def cast(_), do: :error
+end


### PR DESCRIPTION
This adds support for gestures with the `gesture` modifier. This modifier automatically maps to the `gesture`, `highPriorityGesture` or `simultaneousGesture` modifier based on the priority level.

Instead of implementing `onTapGesture`/`onLongPressGesture` the more general `gesture` modifier can be used with `:tap`, `:spatial_tap`, or `:long_press` gesture types.

Closes #556
Closes #557 
Closes #556 
Closes #551 
Closes #553 