### PR TITLE
Refactor and document padding modifier

### DIFF
--- a/Sources/LiveViewNative/Modifiers/Layout Adjustments Modifiers/PaddingModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Layout Adjustments Modifiers/PaddingModifier.swift
@@ -7,19 +7,85 @@
 
 import SwiftUI
 
+/// Adds space around the element.
+///
+/// Pass ``LiveViewNative/SwiftUI/EdgeInsets`` to the ``insets`` argument to set different padding amounts for each edge.
+///
+/// ```html
+/// <Text modifiers={padding(@native, insets: [top: 10, bottom: 20])}>
+///     ...
+/// </Text>
+/// ```
+///
+/// Set a ``length`` value to inset a set of ``edges`` by the same amount.
+///
+/// ```html
+/// <Text modifiers={padding(@native, length: 10)}>
+///     ...
+/// </Text>
+/// <Text modifiers={padding(@native, edges: :horizontal, length: 10)}>
+///     ...
+/// </Text>
+/// ```
+///
+/// To use the system padding amount, omit the ``length`` argument.
+///
+/// ```html
+/// <Text modifiers={padding(@native)}>
+///     ...
+/// </Text>
+/// ```
+///
+/// ## Arguments
+/// * ``insets``
+/// * ``edges``
+/// * ``length``
+#if swift(>=5.8)
+@_documentation(visibility: public)
+#endif
 struct PaddingModifier: ViewModifier, Decodable, Equatable {
-    private let insets: EdgeInsets
+    /// The amount to inset by.
+    ///
+    /// This argument takes precedence over other options.
+    ///
+    /// See ``LiveViewNative/SwiftUI/EdgeInsets`` for more details on creating insets.
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
+    private let insets: EdgeInsets?
+    
+    /// The edges to inset. Defaults to `all`.
+    ///
+    /// See ``LiveViewNative/SwiftUI/Edge`` for more details on creating insets.
+#if swift(>=5.8)
+    @_documentation(visibility: public)
+#endif
+    private let edges: Edge.Set
+    
+    /// The amount to inset all ``edges`` by.
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
+    private let length: CGFloat?
     
     init(from decoder: Decoder) throws {
-        let container = try decoder.singleValueContainer()
-        self.insets = try container.decode(EdgeInsets.self)
-    }
-    
-    init(insets: EdgeInsets) {
-        self.insets = insets
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.insets = try container.decodeIfPresent(EdgeInsets.self, forKey: .insets)
+        self.edges = try container.decodeIfPresent(Edge.Set.self, forKey: .edges) ?? .all
+        self.length = try container.decodeIfPresent(CGFloat.self, forKey: .length)
     }
     
     func body(content: Content) -> some View {
-        content.padding(insets)
+        if let insets {
+            content.padding(insets)
+        } else {
+            content.padding(edges, length)
+        }
+    }
+    
+    enum CodingKeys: CodingKey {
+        case insets
+        case edges
+        case length
     }
 }

--- a/Sources/LiveViewNative/Modifiers/Lists Modifiers/ListRowInsetsModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Lists Modifiers/ListRowInsetsModifier.swift
@@ -7,12 +7,35 @@
 
 import SwiftUI
 
+/// Sets the inset for an element in a ``List``.
+///
+/// Apply this modifier to an element inside of a ``List`` to change the inset from the system default.
+///
+/// ```html
+/// <List>
+///     <Text id="item" modifiers={list_row_insets(@native, insets: [top: 0, leading: 25, bottom: 0, trailing: 0])}>
+///         Item
+///     </Text>
+/// </List>
+/// ```
+///
+/// ## Arguments
+/// * ``insets``
+#if swift(>=5.8)
+@_documentation(visibility: public)
+#endif
 struct ListRowInsetsModifier: ViewModifier, Decodable, Equatable {
-    private let insets: EdgeInsets
+    /// The amount to inset by.
+    ///
+    /// See ``LiveViewNative/SwiftUI/EdgeInsets`` for more details on creating insets.
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
+    private let insets: EdgeInsets?
     
     init(from decoder: Decoder) throws {
-        let container = try decoder.singleValueContainer()
-        self.insets = try container.decode(EdgeInsets.self)
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.insets = try container.decodeIfPresent(EdgeInsets.self, forKey: .insets)
     }
     
     init(insets: EdgeInsets) {
@@ -21,5 +44,9 @@ struct ListRowInsetsModifier: ViewModifier, Decodable, Equatable {
     
     func body(content: Content) -> some View {
         content.listRowInsets(insets)
+    }
+    
+    enum CodingKeys: CodingKey {
+        case insets
     }
 }

--- a/Sources/LiveViewNative/Utils/Edge.swift
+++ b/Sources/LiveViewNative/Utils/Edge.swift
@@ -28,3 +28,41 @@ extension Edge: Decodable {
         }
     }
 }
+
+/// A value that represents a set of sides.
+///
+/// Possible values:
+/// * `all`
+/// * `horizontal`
+/// * `vertical`
+/// * `top`
+/// * `leading`
+/// * `bottom`
+/// * `trailing`
+/// * An array of these values
+#if swift(>=5.8)
+@_documentation(visibility: public)
+#endif
+extension Edge.Set: Decodable {
+    public init(from decoder: Decoder) throws {
+        if var container = try? decoder.unkeyedContainer() {
+            var result = Self()
+            while !container.isAtEnd {
+                result.insert(try container.decode(Edge.Set.self))
+            }
+            self = result
+        } else {
+            let container = try decoder.singleValueContainer()
+            switch try container.decode(String.self) {
+            case "all":
+                self = .all
+            case "horizontal":
+                self = .horizontal
+            case "vertical":
+                self = .vertical
+            default:
+                self = [.init(try container.decode(Edge.self))]
+            }
+        }
+    }
+}

--- a/Sources/LiveViewNative/Utils/EdgeInsets.swift
+++ b/Sources/LiveViewNative/Utils/EdgeInsets.swift
@@ -21,7 +21,6 @@ extension EdgeInsets: Decodable {
             if let f = try container.decodeIfPresent(CGFloat.self, forKey: .all) {
                 self = EdgeInsets(top: f, leading: f, bottom: f, trailing: f)
             } else {
-                // TODO: support null for system default padding (requires separate "mode" since default can't be represented by EdgeInsets)
                 var insets = EdgeInsets()
                 if let f = try container.decodeIfPresent(CGFloat.self, forKey: .top) {
                     insets.top = f

--- a/Tests/LiveViewNativeTests/DecodeModifiersTest.swift
+++ b/Tests/LiveViewNativeTests/DecodeModifiersTest.swift
@@ -57,13 +57,6 @@ final class DecodeModifiersTest: XCTestCase {
         try assertDecodeModifier(data, expected: NavigationTitleModifier(title: "hello"))
     }
     
-    func testDecodePadding() throws {
-        let data = """
-        {"type": "padding", "top": 10, "leading": 5, "bottom": 10, "trailing": 5}
-        """
-        try assertDecodeModifier(data, expected: PaddingModifier(insets: EdgeInsets(top: 10, leading: 5, bottom: 10, trailing: 5)))
-    }
-    
     func testDecodeTint() throws {
         let data = """
         {"type": "tint", "color": {"string": "system-pink", "rgb_color_space": null}}

--- a/Tests/LiveViewNativeTests/DecodeModifiersTest.swift
+++ b/Tests/LiveViewNativeTests/DecodeModifiersTest.swift
@@ -38,7 +38,7 @@ final class DecodeModifiersTest: XCTestCase {
     
     func testDecodeListRowInsets() throws {
         let data = """
-        {"type": "list_row_insets", "all": 10}
+        {"type": "list_row_insets", "insets": 10}
         """
         try assertDecodeModifier(data, expected: ListRowInsetsModifier(insets: EdgeInsets(top: 10, leading: 10, bottom: 10, trailing: 10)))
     }

--- a/lib/live_view_native_swift_ui/modifiers/layout_adjustments/padding.ex
+++ b/lib/live_view_native_swift_ui/modifiers/layout_adjustments/padding.ex
@@ -2,9 +2,11 @@ defmodule LiveViewNativeSwiftUi.Modifiers.Padding do
   use LiveViewNativePlatform.Modifier
 
   alias LiveViewNativeSwiftUi.Types.EdgeInsets
+  alias LiveViewNativeSwiftUi.Types.EdgeSet
 
   modifier_schema "padding" do
-    field :all, :float
     field :insets, EdgeInsets
+    field :edges, EdgeSet
+    field :length, :float
   end
 end

--- a/lib/live_view_native_swift_ui/types/edge_insets.ex
+++ b/lib/live_view_native_swift_ui/types/edge_insets.ex
@@ -1,6 +1,6 @@
 defmodule LiveViewNativeSwiftUi.Types.EdgeInsets do
   @derive Jason.Encoder
-  defstruct [:top, :bottom, :leading, :trailing]
+  defstruct [:top, :leading, :bottom, :trailing]
 
   use LiveViewNativePlatform.Modifier.Type
   def type, do: :map

--- a/lib/live_view_native_swift_ui/types/edge_set.ex
+++ b/lib/live_view_native_swift_ui/types/edge_set.ex
@@ -1,0 +1,9 @@
+defmodule LiveViewNativeSwiftUi.Types.EdgeSet do
+  @derive Jason.Encoder
+  use LiveViewNativePlatform.Modifier.Type
+  def type, do: {:array, :string}
+
+  def cast(value) when is_atom(value), do: {:ok, [Atom.to_string(value)]}
+  def cast(value) when is_list(value), do: {:ok, Enum.map(value, &Atom.to_string/1)}
+  def cast(_), do: :error
+end


### PR DESCRIPTION
This refactors the padding modifier to make accessing the system padding amount possible.

```html
<Text modifiers={padding(@native)}>Use the system padding</Text>
<Text modifiers={padding(@native, edges: :horizontal, length: 10)}>Affect specific edges</Text>
<Text modifiers={padding(@native, insets: [top: 8, bottom: 16])}>Use EdgeInsets</Text>
```