### PR TITLE
Fix mismatch between Elixir and Swift values for `text_field_style`

### DIFF
--- a/Sources/LiveViewNative/Modifiers/Text Input and Output Modifiers/TextFieldStyleModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Text Input and Output Modifiers/TextFieldStyleModifier.swift
@@ -71,14 +71,13 @@ private enum TextFieldStyle: String, Decodable {
     @_documentation(visibility: public)
     #endif
     case plain
-    /// `rounded-border`
+    /// `rounded_border`
     #if swift(>=5.8)
     @_documentation(visibility: public)
     #endif
     @available(iOS 16.0, tvOS 16.0, macOS 13.0, *)
     case roundedBorder = "rounded_border"
-
-    /// `square-border`
+    /// `square_border`
     #if swift(>=5.8)
     @_documentation(visibility: public)
     #endif

--- a/lib/live_view_native_swift_ui/modifiers/text_field_style.ex
+++ b/lib/live_view_native_swift_ui/modifiers/text_field_style.ex
@@ -2,6 +2,6 @@ defmodule LiveViewNativeSwiftUi.Modifiers.TextFieldStyle do
   use LiveViewNativePlatform.Modifier
 
   modifier_schema "text_field_style" do
-    field :style, Ecto.Enum, values: ~w(automatic plain rounded-border square-border)a
+    field :style, Ecto.Enum, values: ~w(automatic plain rounded_border square_border)a
   end
 end


### PR DESCRIPTION
@carson-katri I was testing other `TextField` modifiers and ran into this mismatch between the Elixir and Swift values. Underscore is what I'm seeing used elsewhere so I changed it to that.