### PR TITLE
Add `hidden` modifier

### DIFF
--- a/Sources/LiveViewNative/Modifiers/View Configuration Modifiers/HiddenModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/View Configuration Modifiers/HiddenModifier.swift
@@ -1,0 +1,47 @@
+//
+//  HiddenModifier.swift
+// LiveViewNative
+//
+//  Created by May Matyi on 4/21/23.
+//
+
+import SwiftUI
+
+/// Hides any element.
+///
+/// ```html
+/// <VStack>
+///    <Text modifiers={hidden(@native, is_active: true)}>This text is hidden</Text>
+///    <Text modifiers={hidden(@native, is_active: false)}>This text is visible</Text>
+/// </VStack>
+///
+/// ## Arguments
+/// * ``is_active``
+#if swift(>=5.8)
+@_documentation(visibility: public)
+#endif
+struct HiddenModifier: ViewModifier, Decodable {
+    /// A boolean indicating whether the view should be hidden.
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
+    private var isActive: Bool
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        self.isActive = try container.decode(Bool.self, forKey: .isActive)
+    }
+
+    func body(content: Content) -> some View {
+        if isActive {
+            content.hidden()
+        } else {
+            content
+        }
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case isActive = "is_active"
+    }
+}

--- a/lib/live_view_native_swift_ui/modifiers/view_configuration/hidden.ex
+++ b/lib/live_view_native_swift_ui/modifiers/view_configuration/hidden.ex
@@ -1,0 +1,7 @@
+defmodule LiveViewNativeSwiftUi.Modifiers.Hidden do
+  use LiveViewNativePlatform.Modifier
+
+  modifier_schema "hidden" do
+    field :is_active, :boolean
+  end
+end


### PR DESCRIPTION
This PR adds the [hidden](https://developer.apple.com/documentation/swiftui/view/hidden()) view configuration modifier. It uses a `isActive` argument to toggle the modifier on and off which isn't defined by the SwiftUI spec, but it seemed useful to be able to conditionally hide and show based on LiveView assigns (other modifiers with 0-arity do this, like `BoldModifier` and `ItalicModifier`):

```elixir
# hidden_live.ex
defmodule ScratchboardWeb.HiddenLive do
  use Phoenix.LiveView
  use LiveViewNative.LiveView

  @impl true
  def render(assigns) do
    render_native(assigns)
  end

  @impl true
  def mount(_params, _session, socket) do
    Process.send_after(self(), :tick, 500)

    {:ok, assign(socket, hidden: false)}
  end

  def handle_info(:tick, socket) do
    Process.send_after(self(), :tick, 500)

    {:noreply, assign(socket, hidden: !socket.assigns.hidden)}
  end
end
```

```heex
<% # hidden_live.ios.heex %>
<VStack>
  <Text modifiers={hidden(@native, is_active: @hidden)}>This text blinks</Text>
</VStack>
```


https://user-images.githubusercontent.com/5893007/233727184-ef7fe2ed-0582-418c-a6d3-55583c8ec2e6.mov

Closes https://github.com/liveview-native/liveview-client-swiftui/issues/287