### PR TITLE
Add `z_index` modifier

### DIFF
--- a/Sources/LiveViewNative/Modifiers/Layout Fundamentals Modifiers/ZIndexModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Layout Fundamentals Modifiers/ZIndexModifier.swift
@@ -1,0 +1,43 @@
+//
+//  ZIndexModifier.swift
+// LiveViewNative
+//
+//  Created by May Matyi on 4/21/23.
+//
+
+import SwiftUI
+
+/// Sets the drawing order of any element.
+///
+/// ```html
+/// <VStack>
+///    <Text modifiers={z_index(@native, value: 2.0)}>This element will be above</Text>
+///    <Text modifiers={z_index(@native, value: 1.0)}>This element will be below</Text>
+/// </VStack>
+///
+/// ## Arguments
+/// * ``value``
+#if swift(>=5.8)
+@_documentation(visibility: public)
+#endif
+struct ZIndexModifier: ViewModifier, Decodable {
+    /// A relative front-to-back ordering for the view
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
+    private var value: Double
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        self.value = try container.decode(Double.self, forKey: .value)
+    }
+
+    func body(content: Content) -> some View {
+        content.zIndex(value)
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case value
+    }
+}

--- a/lib/live_view_native_swift_ui/modifiers/layout_fundamentals/z_index.ex
+++ b/lib/live_view_native_swift_ui/modifiers/layout_fundamentals/z_index.ex
@@ -1,0 +1,7 @@
+defmodule LiveViewNativeSwiftUi.Modifiers.ZIndex do
+  use LiveViewNativePlatform.Modifier
+
+  modifier_schema "z_index" do
+    field :value, :float
+  end
+end


### PR DESCRIPTION
This PR adds support for the [zIndex](https://developer.apple.com/documentation/swiftui/view/zindex(_:)) modifier:

```heex
<ZStack id="z_index">
  <ZStack>
    <% # Without setting z_index, elements are layered according to order in the template %>
    <Circle modifiers={@native |> frame(width: 64, height: 64) |> foreground_style(primary: {:color, :red})} />
    <Circle modifiers={@native |> frame(width: 64, height: 64) |> offset(x: 8, y: 8) |> foreground_style(primary: {:color, :green})} />
    <Circle modifiers={@native |> frame(width: 64, height: 64) |> offset(x: 16, y: 16) |> foreground_style(primary: {:color, :blue}) } />
  </ZStack>

  <ZStack modifiers={@native |> offset(x: 0, y: 128)}>
    <% # Using z_index, we can override the default layering  %>
    <Circle modifiers={@native |> z_index(value: 3) |> frame(width: 64, height: 64) |> foreground_style(primary: {:color, :red})} />
    <Circle modifiers={@native |> z_index(value: 2) |> frame(width: 64, height: 64) |> offset(x: 8, y: 8) |> foreground_style(primary: {:color, :green})} />
    <Circle modifiers={@native |> z_index(value: 1) |> frame(width: 64, height: 64) |> offset(x: 16, y: 16) |> foreground_style(primary: {:color, :blue}) } />
  </ZStack>
</ZStack>
```

![Screenshot 2023-04-21 at 3 07 58 PM](https://user-images.githubusercontent.com/5893007/233747234-1de1ea7e-36bc-486b-8a78-2514bdead828.png)

Closes https://github.com/liveview-native/liveview-client-swiftui/issues/511