### PR TITLE
Add `border` modifier

### DIFF
--- a/Sources/LiveViewNative/Modifiers/Drawing and Graphics Modifiers/BorderModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Drawing and Graphics Modifiers/BorderModifier.swift
@@ -1,0 +1,52 @@
+//
+//  BorderModifier.swift
+// LiveViewNative
+//
+//  Created by May Matyi on 4/24/23.
+//
+
+import SwiftUI
+
+/// Applies a border to any element.
+///
+/// ```html
+/// <Text modifiers={border(@native, content: {:color, :purple}, width: 4)}>
+///   Purple border inside the view bounds.
+/// </Text>
+/// ```
+///
+/// ## Arguments
+/// * ``content``
+/// * ``width``
+#if swift(>=5.8)
+@_documentation(visibility: public)
+#endif
+struct BorderModifier: ViewModifier, Decodable {
+    /// The content of the border as a `ShapeStyle`.
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
+    private var content: AnyShapeStyle
+
+    /// The thickness of the border.
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
+    private var width: CGFloat
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        self.content = try container.decode(AnyShapeStyle.self, forKey: .content)
+        self.width = try container.decode(CGFloat.self, forKey: .width)
+    }
+
+    func body(content: Content) -> some View {
+        content.border(self.content, width: width)
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case content
+        case width
+    }
+}

--- a/lib/live_view_native_swift_ui/modifiers/drawing_and_graphics/border.ex
+++ b/lib/live_view_native_swift_ui/modifiers/drawing_and_graphics/border.ex
@@ -1,0 +1,10 @@
+defmodule LiveViewNativeSwiftUi.Modifiers.Border do
+  use LiveViewNativePlatform.Modifier
+
+  alias LiveViewNativeSwiftUi.Types.ShapeStyle
+
+  modifier_schema "border" do
+    field :content, ShapeStyle
+    field :width, :float, default: 0.0
+  end
+end


### PR DESCRIPTION
This PR adds the [border](https://developer.apple.com/documentation/swiftui/view/border(_:width:)) drawing and graphics modifier:

```heex
<VStack id="border">
  <Text modifiers={border(@native, content: {:color, :purple}, width: 4)}>
    Purple border inside the view bounds.
  </Text>
  <Text modifiers={@native |> padding(all: 4) |> border(content: {:color, :purple}, width: 4)}>
    Purple border outside the view bounds.
  </Text>
</VStack>
```

![Screenshot 2023-04-24 at 10 20 46 AM](https://user-images.githubusercontent.com/5893007/234070933-e13bc42f-3f73-44cb-890f-a37b9e2ff4a9.png)

Closes #264 