### PR TITLE
Add `foreground_color` modifier

### DIFF
--- a/Sources/LiveViewNative/Modifiers/Drawing and Graphics Modifiers/ForegroundColorModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Drawing and Graphics Modifiers/ForegroundColorModifier.swift
@@ -1,0 +1,42 @@
+//
+//  ForegroundColorModifier.swift
+// LiveViewNative
+//
+//  Created by May Matyi on 4/24/23.
+//
+
+import SwiftUI
+
+/// Applies a foreground color to a view.
+/// ```html
+/// <Text modifiers={foreground_color(@native, color: :mint)}>
+///   Minty fresh text.
+/// </Text>
+/// ```
+///
+/// ## Arguments
+/// * ``color``
+#if swift(>=5.8)
+@_documentation(visibility: public)
+#endif
+struct ForegroundColorModifier: ViewModifier, Decodable {
+    /// The foreground color to use when rendering the view.
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
+    private var color: SwiftUI.Color
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        self.color = try container.decode(SwiftUI.Color.self, forKey: .color)
+    }
+
+    func body(content: Content) -> some View {
+        content.foregroundColor(color)
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case color
+    }
+}

--- a/lib/live_view_native_swift_ui/modifiers/drawing_and_graphics/foreground_color.ex
+++ b/lib/live_view_native_swift_ui/modifiers/drawing_and_graphics/foreground_color.ex
@@ -1,0 +1,9 @@
+defmodule LiveViewNativeSwiftUi.Modifiers.ForegroundColor do
+  use LiveViewNativePlatform.Modifier
+
+  alias LiveViewNativeSwiftUi.Types.Color
+
+  modifier_schema "foreground_color" do
+    field :color, Color
+  end
+end


### PR DESCRIPTION
This PR adds support for the [foregroundColor](https://developer.apple.com/documentation/swiftui/view/foregroundcolor(_:)) drawing and graphics modifier:

```heex
<VStack id="foreground_color">
  <Text modifiers={foreground_color(@native, color: "#7b1fa2")}>
    This text is colored with a hex code
  </Text>
  <Text modifiers={foreground_color(@native, color: :mint)}>
    This text is colored with a standard color
  </Text>
  <Text modifiers={foreground_color(@native, color: :primary)}>
    This text is colored with a system color
  </Text>
</VStack>
```

https://user-images.githubusercontent.com/5893007/234078315-d6a3911c-007c-4c9d-9079-b24b08572fbd.mov

Closes #258