### PR TITLE
Add `font_design` modifier

### DIFF
--- a/Sources/LiveViewNative/Modifiers/Text Input and Output Modifiers/FontDesignModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Text Input and Output Modifiers/FontDesignModifier.swift
@@ -45,7 +45,11 @@ struct FontDesignModifier: ViewModifier, Decodable {
     }
 
     func body(content: Content) -> some View {
-        content.font(.system(size: UIFont.labelFontSize, design: design))
+        if #available(iOS 16.1, *) {
+            content.fontDesign(design)
+        } else {
+            content
+        }
     }
     
     enum CodingKeys: String, CodingKey {

--- a/Sources/LiveViewNative/Modifiers/Text Input and Output Modifiers/FontDesignModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Text Input and Output Modifiers/FontDesignModifier.swift
@@ -45,7 +45,7 @@ struct FontDesignModifier: ViewModifier, Decodable {
     }
 
     func body(content: Content) -> some View {
-        if #available(iOS 16.1, *) {
+        if #available(iOS 16.1, watchOS 9.1, *) {
             content.fontDesign(design)
         } else {
             content

--- a/Sources/LiveViewNative/Modifiers/Text Input and Output Modifiers/FontDesignModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Text Input and Output Modifiers/FontDesignModifier.swift
@@ -9,10 +9,12 @@ import SwiftUI
 
 /// Applies a font design to any element.
 ///
+/// ```html
 /// <Text modifiers={font_design(@native, design: :default)}>This text is default</Text>
 /// <Text modifiers={font_design(@native, design: :monospaced)}>This text is monospaced</Text>
 /// <Text modifiers={font_design(@native, design: :rounded)}>This text is rounded</Text>
 /// <Text modifiers={font_design(@native, design: :serif)}>This text is serif</Text>
+/// ```
 ///
 /// ## Arguments
 /// * ``design``

--- a/Sources/LiveViewNative/Modifiers/Text Input and Output Modifiers/FontDesignModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Text Input and Output Modifiers/FontDesignModifier.swift
@@ -1,0 +1,54 @@
+//
+//  FontDesignModifier.swift
+// LiveViewNative
+//
+//  Created by May Matyi on 4/24/23.
+//
+
+import SwiftUI
+
+/// Applies a font design to any element.
+///
+/// <Text modifiers={font_design(@native, design: :default)}>This text is default</Text>
+/// <Text modifiers={font_design(@native, design: :monospaced)}>This text is monospaced</Text>
+/// <Text modifiers={font_design(@native, design: :rounded)}>This text is rounded</Text>
+/// <Text modifiers={font_design(@native, design: :serif)}>This text is serif</Text>
+///
+/// ## Arguments
+/// * ``design``
+#if swift(>=5.8)
+@_documentation(visibility: public)
+#endif
+struct FontDesignModifier: ViewModifier, Decodable {
+    /// The font design to apply to the view.
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
+    private var design: Font.Design
+    
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let designString = try container.decode(String.self, forKey: .design)
+
+        switch designString {
+        case "default":
+            design = .default
+        case "monospaced":
+            design = .monospaced
+        case "rounded":
+            design = .rounded
+        case "serif":
+            design = .serif
+        default:
+            throw DecodingError.dataCorruptedError(forKey: .design, in: container, debugDescription: "expected valid value for Font.Design");
+        }
+    }
+
+    func body(content: Content) -> some View {
+        content.font(.system(size: UIFont.labelFontSize, design: design))
+    }
+    
+    enum CodingKeys: String, CodingKey {
+        case design
+    }
+}

--- a/lib/live_view_native_swift_ui/modifiers/text_input_and_output/font_design.ex
+++ b/lib/live_view_native_swift_ui/modifiers/text_input_and_output/font_design.ex
@@ -1,0 +1,12 @@
+defmodule LiveViewNativeSwiftUi.Modifiers.FontDesign do
+  use LiveViewNativePlatform.Modifier
+
+  modifier_schema "font_design" do
+    field :design, Ecto.Enum, values: ~w(
+      default
+      monospaced
+      rounded
+      serif
+    )a
+  end
+end


### PR DESCRIPTION
Adds the [fontDesign](https://developer.apple.com/documentation/swiftui/view/fontdesign(_:)) text input and output modifier:

```heex
<VStack id="font_design">
  <Text modifiers={font_design(@native, design: :default)}>This text is default</Text>
  <Text modifiers={font_design(@native, design: :monospaced)}>This text is monospaced</Text>
  <Text modifiers={font_design(@native, design: :rounded)}>This text is rounded</Text>
  <Text modifiers={font_design(@native, design: :serif)}>This text is serif</Text>
</VStack>
```

![Screenshot 2023-04-24 at 11 30 15 AM](https://user-images.githubusercontent.com/5893007/234085544-818e800e-0836-4a55-8c18-dc65d7e3efd3.png)

Closes #300 