### PR TITLE
Add `image_scale` modifier

### DIFF
--- a/Sources/LiveViewNative/Modifiers/Images Modifiers/ImageScaleModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Images Modifiers/ImageScaleModifier.swift
@@ -1,0 +1,52 @@
+//
+//  ImageScaleModifier.swift
+// LiveViewNative
+//
+//  Created by May Matyi on 4/24/23.
+//
+
+import SwiftUI
+
+/// Adjusts the scaling of images within an element.
+///
+/// ```html
+/// <HStack modifiers={image_scale(@native, scale: :large)}>
+///   <Image system-name="heart.fill"></Image>
+/// </HStack>
+/// ```
+///
+/// ## Arguments
+/// * ``scale``
+#if swift(>=5.8)
+@_documentation(visibility: public)
+#endif
+struct ImageScaleModifier: ViewModifier, Decodable {
+    /// A relative size to scale images within the view.
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
+    private var scale: SwiftUI.Image.Scale
+    
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        switch try container.decode(String.self, forKey: .scale) {
+        case "small":
+            scale = .small
+        case "medium":
+            scale = .medium
+        case "large":
+            scale = .large
+        default:
+            throw DecodingError.dataCorruptedError(forKey: .scale, in: container, debugDescription: "invalid value for scale")
+        }
+    }
+
+    func body(content: Content) -> some View {
+        content.imageScale(scale)
+    }
+    
+    enum CodingKeys: String, CodingKey {
+        case scale
+    }
+}

--- a/lib/live_view_native_swift_ui/modifiers/images/image_scale.ex
+++ b/lib/live_view_native_swift_ui/modifiers/images/image_scale.ex
@@ -1,0 +1,7 @@
+defmodule LiveViewNativeSwiftUi.Modifiers.ImageScale do
+  use LiveViewNativePlatform.Modifier
+
+  modifier_schema "image_scale" do
+    field :scale, Ecto.Enum, values: ~w(small medium large)a
+  end
+end


### PR DESCRIPTION
This PR adds support for the [imageScale](https://developer.apple.com/documentation/swiftui/view/imagescale(_:)) modifier:

```heex
<VStack>
  <HStack modifiers={image_scale(@native, scale: :small)}>
    <Image system-name="heart.fill"></Image>
    <Text>Small</Text>
  </HStack>
  <HStack modifiers={image_scale(@native, scale: :medium)}>
    <Image system-name="heart.fill"></Image>
    <Text>Medium</Text>
  </HStack>
  <HStack modifiers={image_scale(@native, scale: :large)}>
    <Image system-name="heart.fill"></Image>
    <Text>Large</Text>
  </HStack>
</VStack>
```

![Screenshot 2023-04-24 at 3 19 14 PM](https://user-images.githubusercontent.com/5893007/234129545-f7a31013-743a-4370-97e9-1f4ac5ceed67.png)
