### PR TITLE
Support availability checks in BuiltinRegistryGenerator

### DIFF
--- a/Sources/BuiltinRegistryGenerator/BuiltinRegistryGenerator.swift
+++ b/Sources/BuiltinRegistryGenerator/BuiltinRegistryGenerator.swift
@@ -42,10 +42,6 @@ struct BuiltinRegistryGenerator: ParsableCommand {
         "RoundedRectangle": "Shape(shape: RoundedRectangle(from: element))",
     ]
     
-    static let modifierAvailability = [
-        "FontDesignModifier": "iOS 16.1, watchOS 9.1, *"
-    ]
-    
     func run() throws {
         let views = try views
             .map(URL.init(fileURLWithPath:))

--- a/Sources/LiveViewNative/Modifiers/Text Input and Output Modifiers/FontDesignModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Text Input and Output Modifiers/FontDesignModifier.swift
@@ -21,6 +21,7 @@ import SwiftUI
 #if swift(>=5.8)
 @_documentation(visibility: public)
 #endif
+@available(iOS 16.1, watchOS 9.1, *)
 struct FontDesignModifier: ViewModifier, Decodable {
     /// The font design to apply to the view.
     #if swift(>=5.8)
@@ -47,11 +48,7 @@ struct FontDesignModifier: ViewModifier, Decodable {
     }
 
     func body(content: Content) -> some View {
-        if #available(iOS 16.1, watchOS 9.1, *) {
-            content.fontDesign(design)
-        } else {
-            content
-        }
+        content.fontDesign(design)
     }
     
     enum CodingKeys: String, CodingKey {


### PR DESCRIPTION
If an `@available` attribute is applied to a View or ViewModifier, it will be wrapped in `if #available`. This required some additions to the `ViewModifierBuilder`. Availability checks should be avoided if possible because they require type erasure. I'm not sure if the compiler automatically strips them if the deployment target is higher, but I assume it would.