### PR TITLE
Improve connection error messages

### DIFF
--- a/Sources/LiveViewNative/Coordinators/LiveConnectionError.swift
+++ b/Sources/LiveViewNative/Coordinators/LiveConnectionError.swift
@@ -11,7 +11,7 @@ import SwiftPhoenixClient
 /// An error that occurred when connecting to a live view.
 public enum LiveConnectionError: Error, LocalizedError {
     case initialFetchError(Error)
-    case initialFetchUnexpectedResponse(URLResponse)
+    case initialFetchUnexpectedResponse(URLResponse, String? = nil)
     /// An error encountered when parsing the initial HTML.
     case initialParseError(missingOrInvalid: InitialParseComponent)
     case socketError(Error)
@@ -22,8 +22,10 @@ public enum LiveConnectionError: Error, LocalizedError {
         switch self {
         case .initialFetchError(let error):
             return "initialFetchError(\(error))"
-        case .initialFetchUnexpectedResponse(let resp):
+        case .initialFetchUnexpectedResponse(let resp, nil):
             return "initialFetchUnexpectedResponse(\(resp))"
+        case .initialFetchUnexpectedResponse(let resp, let trace?):
+            return "initialFetchUnexpectedResponse(\(resp), \(trace))"
         case .initialParseError(let missingOrInvalid):
             return "Initial parse error: missing or invalid \(missingOrInvalid)"
         case .socketError(let error):

--- a/Sources/LiveViewNative/Coordinators/LiveConnectionError.swift
+++ b/Sources/LiveViewNative/Coordinators/LiveConnectionError.swift
@@ -9,29 +9,46 @@ import Foundation
 import SwiftPhoenixClient
 
 /// An error that occurred when connecting to a live view.
-public enum LiveConnectionError: Error {
+public enum LiveConnectionError: Error, LocalizedError {
     case initialFetchError(Error)
     case initialFetchUnexpectedResponse(URLResponse)
     /// An error encountered when parsing the initial HTML.
-    case initialParseError
+    case initialParseError(missingOrInvalid: InitialParseComponent)
     case socketError(Error)
     case joinError(Message)
     case eventError(Message)
     
-    var localizedDescription: String {
+    public var errorDescription: String? {
         switch self {
         case .initialFetchError(let error):
             return "initialFetchError(\(error))"
         case .initialFetchUnexpectedResponse(let resp):
             return "initialFetchUnexpectedResponse(\(resp))"
-        case .initialParseError:
-            return "initialParseError"
+        case .initialParseError(let missingOrInvalid):
+            return "Initial parse error: missing or invalid \(missingOrInvalid)"
         case .socketError(let error):
             return "socketError(\(error))"
         case .joinError(let message):
             return "joinError(\(message.payload))"
         case .eventError(let message):
             return "eventError(\(message.payload))"
+        }
+    }
+    
+    public enum InitialParseComponent: CustomStringConvertible {
+        case document
+        case csrfToken
+        case phxMain
+        
+        public var description: String {
+            switch self {
+            case .document:
+                return "document"
+            case .csrfToken:
+                return #"<meta name="csrf-token">"#
+            case .phxMain:
+                return #"<div data-phx-main="...">"#
+            }
         }
     }
 }

--- a/Sources/LiveViewNative/Coordinators/LiveSessionCoordinator.swift
+++ b/Sources/LiveViewNative/Coordinators/LiveSessionCoordinator.swift
@@ -133,7 +133,7 @@ public class LiveSessionCoordinator<R: RootRegistry>: ObservableObject {
             let doc = try SwiftSoup.parse(html)
             try self.extractDOMValues(doc)
         } catch {
-            internalState = .connectionFailed(LiveConnectionError.initialParseError)
+            internalState = .connectionFailed(error)
             return
         }
         
@@ -183,14 +183,14 @@ public class LiveSessionCoordinator<R: RootRegistry>: ObservableObject {
     private func extractDOMValues(_ doc: SwiftSoup.Document) throws -> Void {
         let metaRes = try doc.select("meta[name=\"csrf-token\"]")
         guard !metaRes.isEmpty() else {
-            throw LiveConnectionError.initialParseError
+            throw LiveConnectionError.initialParseError(missingOrInvalid: .csrfToken)
         }
         self.phxCSRFToken = try metaRes[0].attr("content")
         self.liveReloadEnabled = !(try doc.select("iframe[src=\"/phoenix/live_reload/frame\"]").isEmpty())
         
         let mainDivRes = try doc.select("div[data-phx-main]")
         guard !mainDivRes.isEmpty() else {
-            throw LiveConnectionError.initialParseError
+            throw LiveConnectionError.initialParseError(missingOrInvalid: .phxMain)
         }
         let mainDiv = mainDivRes[0]
         self.phxSession = try mainDiv.attr("data-phx-session")

--- a/Sources/LiveViewNative/Coordinators/LiveSessionCoordinator.swift
+++ b/Sources/LiveViewNative/Coordinators/LiveSessionCoordinator.swift
@@ -176,11 +176,9 @@ public class LiveSessionCoordinator<R: RootRegistry>: ObservableObject {
            let html = String(data: data, encoding: .utf8) {
             return html
         } else {
-            if let html = String(data: data, encoding: .utf8),
-               let document = try? SwiftSoup.parse(html),
-               let markdownError = try? document.select(#"textarea[role="copy-contents"]"#).first()?.html()
+            if let html = String(data: data, encoding: .utf8)
             {
-                throw LiveConnectionError.initialFetchUnexpectedResponse(resp, markdownError)
+                throw LiveConnectionError.initialFetchUnexpectedResponse(resp, html)
             } else {
                 throw LiveConnectionError.initialFetchUnexpectedResponse(resp)
             }

--- a/Sources/LiveViewNative/Coordinators/LiveSessionCoordinator.swift
+++ b/Sources/LiveViewNative/Coordinators/LiveSessionCoordinator.swift
@@ -176,7 +176,14 @@ public class LiveSessionCoordinator<R: RootRegistry>: ObservableObject {
            let html = String(data: data, encoding: .utf8) {
             return html
         } else {
-            throw LiveConnectionError.initialFetchUnexpectedResponse(resp)
+            if let html = String(data: data, encoding: .utf8),
+               let document = try? SwiftSoup.parse(html),
+               let markdownError = try? document.select(#"textarea[role="copy-contents"]"#).first()?.html()
+            {
+                throw LiveConnectionError.initialFetchUnexpectedResponse(resp, markdownError)
+            } else {
+                throw LiveConnectionError.initialFetchUnexpectedResponse(resp)
+            }
         }
     }
     

--- a/Sources/LiveViewNative/Coordinators/LiveViewCoordinator.swift
+++ b/Sources/LiveViewNative/Coordinators/LiveViewCoordinator.swift
@@ -229,14 +229,14 @@ public class LiveViewCoordinator<R: RootRegistry>: ObservableObject {
     private func extractDOMValues(_ doc: SwiftSoup.Document) throws -> (String, String, String, String) {
         let metaRes = try doc.select("meta[name=\"csrf-token\"]")
         guard !metaRes.isEmpty() else {
-            throw LiveConnectionError.initialParseError
+            throw LiveConnectionError.initialParseError(missingOrInvalid: .csrfToken)
         }
         let phxCSRFToken = try metaRes[0].attr("content")
 //        let liveReloadEnabled = !(try doc.select("iframe[src=\"/phoenix/live_reload/frame\"]").isEmpty())
         
         let mainDivRes = try doc.select("div[data-phx-main]")
         guard !mainDivRes.isEmpty() else {
-            throw LiveConnectionError.initialParseError
+            throw LiveConnectionError.initialParseError(missingOrInvalid: .phxMain)
         }
         let mainDiv = mainDivRes[0]
         let phxSession = try mainDiv.attr("data-phx-session")

--- a/Sources/LiveViewNative/ErrorView.swift
+++ b/Sources/LiveViewNative/ErrorView.swift
@@ -1,0 +1,48 @@
+//
+//  ErrorView.swift
+//  
+//
+//  Created by Carson Katri on 4/27/23.
+//
+
+import SwiftUI
+
+#if os(macOS)
+import WebKit
+struct ErrorView: NSViewRepresentable {
+    let html: String
+    
+    func makeNSView(context: Context) -> WKWebView {
+        let view = WKWebView()
+        view.loadHTMLString(html, baseURL: nil)
+        return view
+    }
+    
+    func updateNSView(_ nsView: WKWebView, context: Context) {
+        nsView.loadHTMLString(html, baseURL: nil)
+    }
+}
+#elseif os(iOS)
+import WebKit
+struct ErrorView: UIViewRepresentable {
+    let html: String
+    
+    func makeUIView(context: Context) -> WKWebView {
+        let view = WKWebView()
+        view.loadHTMLString(html, baseURL: nil)
+        return view
+    }
+    
+    func updateUIView(_ uiView: WKWebView, context: Context) {
+        uiView.loadHTMLString(html, baseURL: nil)
+    }
+}
+#else
+struct ErrorView: View {
+    let html: String
+    
+    var body: some View {
+        SwiftUI.Text("Unexpected response received from the server: \(html)")
+    }
+}
+#endif

--- a/Sources/LiveViewNative/LiveView.swift
+++ b/Sources/LiveViewNative/LiveView.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import SwiftUI
+import WebKit
 
 /// The SwiftUI root view for a Phoenix LiveView.
 ///
@@ -54,12 +55,7 @@ public struct LiveView<R: RootRegistry>: View {
                         if let error = error as? LiveConnectionError,
                            case let .initialFetchUnexpectedResponse(_, trace?) = error
                         {
-                            SwiftUI.ScrollView {
-                                SwiftUI.Text(trace)
-                                    .font(.caption.monospaced())
-                                    .frame(maxWidth: .infinity)
-                                    .padding()
-                            }
+                            ErrorView(html: trace)
                         } else {
                             SwiftUI.VStack {
                                 SwiftUI.Text("Connection Failed")

--- a/Sources/LiveViewNative/LiveView.swift
+++ b/Sources/LiveViewNative/LiveView.swift
@@ -51,10 +51,21 @@ public struct LiveView<R: RootRegistry>: View {
                     case .connecting:
                         SwiftUI.Text("Connecting")
                     case .connectionFailed(let error):
-                        SwiftUI.VStack {
-                            SwiftUI.Text("Connection Failed")
-                                .font(.subheadline)
-                            SwiftUI.Text(error.localizedDescription)
+                        if let error = error as? LiveConnectionError,
+                           case let .initialFetchUnexpectedResponse(_, trace?) = error
+                        {
+                            SwiftUI.ScrollView {
+                                SwiftUI.Text(trace)
+                                    .font(.caption.monospaced())
+                                    .frame(maxWidth: .infinity)
+                                    .padding()
+                            }
+                        } else {
+                            SwiftUI.VStack {
+                                SwiftUI.Text("Connection Failed")
+                                    .font(.subheadline)
+                                SwiftUI.Text(error.localizedDescription)
+                            }
                         }
                     }
                 } else {

--- a/Sources/LiveViewNative/LiveView.swift
+++ b/Sources/LiveViewNative/LiveView.swift
@@ -7,7 +7,6 @@
 
 import Foundation
 import SwiftUI
-import WebKit
 
 /// The SwiftUI root view for a Phoenix LiveView.
 ///


### PR DESCRIPTION
If the initial parse failed, there was no clear indication of what the issue was. The messages are improved in the PR to be more visible and descriptive.