### PR TITLE
Change `platform_id` from `ios` to `swiftui`

### DIFF
--- a/Sources/LiveViewNative/Coordinators/LiveViewCoordinator.swift
+++ b/Sources/LiveViewNative/Coordinators/LiveViewCoordinator.swift
@@ -254,7 +254,7 @@ public class LiveViewCoordinator<R: RootRegistry>: ObservableObject {
         var connectParams = session.config.connectParams?(self.url) ?? [:]
         connectParams["_mounts"] = 0
         connectParams["_csrf_token"] = session.phxCSRFToken
-        connectParams["_platform"] = "ios"
+        connectParams["_platform"] = "swiftui"
         
         let params: Payload = [
             "session": session.phxSession,

--- a/lib/live_view_native_swift_ui/platform.ex
+++ b/lib/live_view_native_swift_ui/platform.ex
@@ -21,7 +21,7 @@ defmodule LiveViewNativeSwiftUi.Platform do
     require Logger
 
     def context(struct) do
-      LiveViewNativePlatform.Context.define(:ios,
+      LiveViewNativePlatform.Context.define(:swiftui,
         custom_modifiers: struct.custom_modifiers,
         otp_app: :live_view_native_swift_ui
       )


### PR DESCRIPTION
This PR changes the `platform_id` to be more semantically correct. If you're rendering SwiftUI views in a LiveView Native project using template files, you'll need to rename them to use the `.swiftui.heex` extension rather than the `.ios.heex` extension they have been using up until now.