### PR TITLE
Add `swipe_actions` modifier

### DIFF
--- a/Sources/LiveViewNative/Modifiers/Lists Modifiers/SwipeActionsModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Lists Modifiers/SwipeActionsModifier.swift
@@ -82,7 +82,7 @@ struct SwipeActionsModifier<R: RootRegistry>: ViewModifier, Decodable {
     }
 
     enum CodingKeys: String, CodingKey {
-        case allowsFullSwipe = "allows_full_swipe"
+        case allowsFullSwipe
         case content
         case edge
     }

--- a/Sources/LiveViewNative/Modifiers/Lists Modifiers/SwipeActionsModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Lists Modifiers/SwipeActionsModifier.swift
@@ -1,0 +1,89 @@
+//
+//  SwipeActionsModifier.swift
+// LiveViewNative
+//
+//  Created by May Matyi on 5/1/23.
+//
+
+import SwiftUI
+
+/// Adds custom swipe actions to any item within a list.
+///
+/// Nested content is referenced by its namespace using the `content` argument.
+///
+/// ```html
+/// <List id="swipe_actions_example">
+///   <%= for item <- @items do %>
+///     <HStack
+///       id={@item.id}
+///       modifiers={
+///         @native
+///         |> swipe_actions(edge: :trailing, allows_full_swipe: false, content: :delete)
+///         |> swipe_actions(edge: :trailing, allows_full_swipe: false, content: :flag)
+///       }>
+///       <Text><%= item %></Text>
+///       <swipe_actions:flag>
+///         <Button phx-click="flag_item" phx-value-item-id={@item.id}>
+///           <Image system-name="flag" />
+///         </Button>
+///       </swipe_actions:flag>
+///       <swipe_actions:delete>
+///         <Button phx-click="delete_item" phx-value-item-id={@item.id} modifiers={tint(@native, color: :red)}>
+///           <Image system-name="trash" />
+///         </Button>
+///       </swipe_actions:delete>
+///     </HStack>
+///   <% end %>
+/// </List>
+///
+/// ## Arguments
+/// * ``allowsFullSwipe``
+/// * ``content``
+/// * ``edge``
+#if swift(>=5.8)
+@_documentation(visibility: public)
+#endif
+struct SwipeActionsModifier<R: RootRegistry>: ViewModifier, Decodable {
+    @ObservedElement private var element
+    @LiveContext<R> private var context
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
+    /// The edge of the list item to associate the swipe actions with.
+    let edge: HorizontalEdge
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
+    /// A boolean value that indicates whether the swipe action should be allowed to span the entire width of the screen.
+    let allowsFullSwipe: Bool
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
+    /// The content of the swipe action.
+    let content: String
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        switch try container.decodeIfPresent(String.self, forKey: .edge) {
+        case "leading":
+            self.edge = .leading
+        default:
+            self.edge = .trailing
+        }
+        self.allowsFullSwipe = try container.decode(Bool.self, forKey: .allowsFullSwipe)
+        self.content = try container.decode(String.self, forKey: .content)
+    }
+
+    func body(content: Content) -> some View {
+        content.swipeActions(edge: edge, allowsFullSwipe: allowsFullSwipe) {
+            context.buildChildren(of: element, withTagName: self.content, namespace: "swipe_actions")
+        }
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case allowsFullSwipe = "allows_full_swipe"
+        case content
+        case edge
+    }
+}

--- a/Sources/LiveViewNative/Modifiers/Lists Modifiers/SwipeActionsModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Lists Modifiers/SwipeActionsModifier.swift
@@ -22,16 +22,12 @@ import SwiftUI
 ///         |> swipe_actions(edge: :trailing, allows_full_swipe: false, content: :flag)
 ///       }>
 ///       <Text><%= item %></Text>
-///       <swipe_actions:flag>
-///         <Button phx-click="flag_item" phx-value-item-id={@item.id}>
-///           <Image system-name="flag" />
-///         </Button>
-///       </swipe_actions:flag>
-///       <swipe_actions:delete>
-///         <Button phx-click="delete_item" phx-value-item-id={@item.id} modifiers={tint(@native, color: :red)}>
-///           <Image system-name="trash" />
-///         </Button>
-///       </swipe_actions:delete>
+///       <Button template={:flag} phx-click="flag_item" phx-value-item-id={@item.id}>
+///         <Image system-name="flag" />
+///       </Button>
+///       <Button template={:delete} phx-click="delete_item" phx-value-item-id={@item.id} modifiers={tint(@native, color: :red)}>
+///         <Image system-name="trash" />
+///       </Button>
 ///     </HStack>
 ///   <% end %>
 /// </List>
@@ -77,7 +73,7 @@ struct SwipeActionsModifier<R: RootRegistry>: ViewModifier, Decodable {
 
     func body(content: Content) -> some View {
         content.swipeActions(edge: edge, allowsFullSwipe: allowsFullSwipe) {
-            context.buildChildren(of: element, withTagName: self.content, namespace: "swipe_actions")
+            context.buildChildren(of: element, forTemplate: self.content)
         }
     }
 

--- a/Sources/LiveViewNative/Modifiers/Lists Modifiers/SwipeActionsModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Lists Modifiers/SwipeActionsModifier.swift
@@ -42,20 +42,20 @@ import SwiftUI
 struct SwipeActionsModifier<R: RootRegistry>: ViewModifier, Decodable {
     @ObservedElement private var element
     @LiveContext<R> private var context
-    #if swift(>=5.8)
-    @_documentation(visibility: public)
-    #endif
     /// The edge of the list item to associate the swipe actions with.
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
     let edge: HorizontalEdge
-    #if swift(>=5.8)
-    @_documentation(visibility: public)
-    #endif
     /// A boolean value that indicates whether the swipe action should be allowed to span the entire width of the screen.
-    let allowsFullSwipe: Bool
     #if swift(>=5.8)
     @_documentation(visibility: public)
     #endif
+    let allowsFullSwipe: Bool
     /// The content of the swipe action.
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
     let content: String
 
     init(from decoder: Decoder) throws {

--- a/lib/live_view_native_swift_ui/modifiers/lists/swipe_actions.ex
+++ b/lib/live_view_native_swift_ui/modifiers/lists/swipe_actions.ex
@@ -1,0 +1,11 @@
+defmodule LiveViewNativeSwiftUi.Modifiers.SwipeActions do
+  use LiveViewNativePlatform.Modifier
+
+  alias LiveViewNativeSwiftUi.Types.KeyName
+
+  modifier_schema "swipe_actions" do
+    field :allows_full_swipe, :boolean, default: true
+    field :content, KeyName
+    field :edge, Ecto.Enum, values: ~w(leading trailing)a, default: :trailing
+  end
+end


### PR DESCRIPTION
This PR adds support for the [swipeActions](https://developer.apple.com/documentation/swiftui/view/swipeactions(edge:allowsfullswipe:content:)) List modifier.

```heex
<VStack id="swipe_actions">
  <Text>
    <%= @swipe_event_message %>
  </Text>
  <Spacer />
  <List>
    <%= for {item, is_unread?} <- [{"Foo", true}, {"Bar", false}, {"Baz", false}] do %>
      <HStack
        id={item}
        modifiers={
          @native
          |> swipe_actions(edge: :leading, allows_full_swipe: false, content: :hello)
          |> swipe_actions(edge: :trailing, allows_full_swipe: false, content: :delete)
          |> swipe_actions(edge: :trailing, allows_full_swipe: false, content: :flag)
        }>
        <Text><%= item %></Text>
        <swipe_actions:hello>
          <%= if is_unread? do %>
            <Button>
              <Image system-name="envelope.badge" />
            </Button>
          <% else %>
            <Button modifiers={tint(@native, color: :accent)}>
              <Image system-name="envelope.open" />
            </Button>
          <% end %>
        </swipe_actions:hello>
        <swipe_actions:flag>
          <% tapping the flag_item event will update the @swipe_event_message assign %>
          <Button phx-click="flag_item" phx-value-item={item}>
            <Image system-name="flag" />
          </Button>
        </swipe_actions:flag>
        <swipe_actions:delete>
          <Button modifiers={tint(@native, color: :red)}>
            <Image system-name="trash" />
          </Button>
        </swipe_actions:delete>
      </HStack>
    <% end %>
  </List>
</VStack>
```

https://user-images.githubusercontent.com/5893007/235537826-ab584c8d-90f4-4fa3-b6e3-34b17eed2c5c.mov

Closes #549 