### PR TITLE
Remove fatalError wherever possible

### DIFF
--- a/Sources/LiveViewNative/Coordinators/LiveConnectionError.swift
+++ b/Sources/LiveViewNative/Coordinators/LiveConnectionError.swift
@@ -17,6 +17,7 @@ public enum LiveConnectionError: Error, LocalizedError {
     case socketError(Error)
     case joinError(Message)
     case eventError(Message)
+    case missingDocument
     
     public var errorDescription: String? {
         switch self {
@@ -34,6 +35,8 @@ public enum LiveConnectionError: Error, LocalizedError {
             return "joinError(\(message.payload))"
         case .eventError(let message):
             return "eventError(\(message.payload))"
+        case .missingDocument:
+            return "State is `.connected`, but no `Document` was found."
         }
     }
     

--- a/Sources/LiveViewNative/Coordinators/LiveConnectionError.swift
+++ b/Sources/LiveViewNative/Coordinators/LiveConnectionError.swift
@@ -17,7 +17,6 @@ public enum LiveConnectionError: Error, LocalizedError {
     case socketError(Error)
     case joinError(Message)
     case eventError(Message)
-    case missingDocument
     
     public var errorDescription: String? {
         switch self {
@@ -35,8 +34,6 @@ public enum LiveConnectionError: Error, LocalizedError {
             return "joinError(\(message.payload))"
         case .eventError(let message):
             return "eventError(\(message.payload))"
-        case .missingDocument:
-            return "State is `.connected`, but no `Document` was found."
         }
     }
     

--- a/Sources/LiveViewNative/Coordinators/LiveSessionCoordinator.swift
+++ b/Sources/LiveViewNative/Coordinators/LiveSessionCoordinator.swift
@@ -156,7 +156,6 @@ public class LiveSessionCoordinator<R: RootRegistry>: ObservableObject {
         internalState = .notConnected(reconnectAutomatically: false)
     }
     
-    @_spi(NarwinChat)
     public func reconnect() async {
         disconnect()
         await connect()

--- a/Sources/LiveViewNative/Coordinators/LiveSessionCoordinator.swift
+++ b/Sources/LiveViewNative/Coordinators/LiveSessionCoordinator.swift
@@ -156,6 +156,11 @@ public class LiveSessionCoordinator<R: RootRegistry>: ObservableObject {
         internalState = .notConnected(reconnectAutomatically: false)
     }
     
+    /// Forces the session to disconnect then connect.
+    ///
+    /// All state will be lost when the reload occurs, as an entirely new LiveView is mounted.
+    ///
+    /// This can be used to force the LiveView to reset, for example after an unrecoverable error occurs.
     public func reconnect() async {
         disconnect()
         await connect()

--- a/Sources/LiveViewNative/Coordinators/LiveViewCoordinator.swift
+++ b/Sources/LiveViewNative/Coordinators/LiveViewCoordinator.swift
@@ -105,11 +105,7 @@ public class LiveViewCoordinator<R: RootRegistry>: ObservableObject {
         }
         
         if let diffPayload = replyPayload["diff"] as? Payload {
-            do {
-                try self.handleDiff(payload: diffPayload, baseURL: self.url)
-            } catch {
-                fatalError("todo")
-            }
+            try self.handleDiff(payload: diffPayload, baseURL: self.url)
         } else if session.config.navigationMode.permitsRedirects,
                   let redirect = (replyPayload["live_redirect"] as? Payload).flatMap({ LiveRedirect(from: $0, relativeTo: self.url) }) {
             await session.redirect(redirect)
@@ -208,7 +204,7 @@ public class LiveViewCoordinator<R: RootRegistry>: ObservableObject {
         do {
             try await connectLiveView()
         } catch {
-            fatalError(error.localizedDescription)
+            self.internalState = .connectionFailed(error)
         }
     }
     

--- a/Sources/LiveViewNative/ErrorModifier.swift
+++ b/Sources/LiveViewNative/ErrorModifier.swift
@@ -7,14 +7,14 @@
 
 import SwiftUI
 
-struct ErrorModifier: ViewModifier {
+struct ErrorModifier<R: RootRegistry>: ViewModifier {
     let type: String
     let error: any Error
     
     func body(content: Content) -> some View {
-        SwiftUI.VStack {
-            SwiftUI.Text("Error Decoding Modifier of Type '\(type)'")
-            SwiftUI.Text(String(describing: error))
-        }
+        content
+            .overlay {
+                ErrorView<R>(error)
+            }
     }
 }

--- a/Sources/LiveViewNative/LiveView.swift
+++ b/Sources/LiveViewNative/LiveView.swift
@@ -54,7 +54,7 @@ public struct LiveView<R: RootRegistry>: View {
                         if let error = error as? LiveConnectionError,
                            case let .initialFetchUnexpectedResponse(_, trace?) = error
                         {
-                            ErrorView(html: trace)
+                            ErrorView<R>(html: trace)
                         } else {
                             SwiftUI.VStack {
                                 SwiftUI.Text("Connection Failed")

--- a/Sources/LiveViewNative/Modifiers/Animations Modifiers/MatchedGeometryEffectModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Animations Modifiers/MatchedGeometryEffectModifier.swift
@@ -96,7 +96,7 @@ struct MatchedGeometryEffectModifier: ViewModifier, Decodable {
         case "frame": self.properties = .frame
         case "position": self.properties = .position
         case "size": self.properties = .size
-        default: fatalError("Unknown value for properties")
+        case let `default`: throw DecodingError.dataCorrupted(.init(codingPath: container.codingPath, debugDescription: "Unknown properties '\(`default`)'"))
         }
 
         self.anchor = try container.decodeIfPresent(UnitPoint.self, forKey: .anchor) ?? .center

--- a/Sources/LiveViewNative/Modifiers/Input Events Modifiers/HoverEffectModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Input Events Modifiers/HoverEffectModifier.swift
@@ -47,7 +47,7 @@ struct HoverEffectModifier: ViewModifier, Decodable {
             throw DecodingError.dataCorruptedError(forKey: .effect, in: container, debugDescription: "invalid value for \(CodingKeys.effect.rawValue)")
         }
         #else
-        fatalError()
+        throw DecodingError.typeMismatch(Self.self, .init(codingPath: container.codingPath, debugDescription: "`hover_effect` modifier not available on this platform"))
         #endif
     }
     

--- a/Sources/LiveViewNative/Modifiers/Navigation Modifiers/NavigationBarTitleDisplayModeModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Navigation Modifiers/NavigationBarTitleDisplayModeModifier.swift
@@ -51,7 +51,7 @@ struct NavigationBarTitleDisplayModeModifier: ViewModifier, Decodable {
         default: throw DecodingError.dataCorruptedError(forKey: .displayMode, in: container, debugDescription: "invalid value for \(CodingKeys.displayMode.rawValue)")
         }
         #else
-        fatalError()
+        throw DecodingError.typeMismatch(Self.self, .init(codingPath: container.codingPath, debugDescription: "`navigation_bar_title_display_mode` modifier not available on this platform"))
         #endif
     }
 

--- a/Sources/LiveViewNative/Modifiers/Text Input and Output Modifiers/KeyboardTypeModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Text Input and Output Modifiers/KeyboardTypeModifier.swift
@@ -76,7 +76,7 @@ struct KeyboardTypeModifier: ViewModifier, Decodable {
             throw DecodingError.dataCorruptedError(forKey: .type, in: container, debugDescription: "invalid value for \(CodingKeys.type.rawValue)")
         }
         #else
-        fatalError()
+        throw DecodingError.typeMismatch(Self.self, .init(codingPath: container.codingPath, debugDescription: "`keyboard_type` modifier not available on this platform"))
         #endif
     }
     

--- a/Sources/LiveViewNative/Modifiers/Text Input and Output Modifiers/TextInputAutocapitalizationModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Text Input and Output Modifiers/TextInputAutocapitalizationModifier.swift
@@ -53,7 +53,7 @@ struct TextInputAutocapitalizationModifier: ViewModifier, Decodable {
             throw DecodingError.dataCorruptedError(forKey: .autocapitalization, in: container, debugDescription: "invalid value for \(CodingKeys.autocapitalization.rawValue)")
         }
         #else
-        fatalError()
+        throw DecodingError.typeMismatch(Self.self, .init(codingPath: container.codingPath, debugDescription: "`text_input_autocapitalization` modifier not available on this platform"))
         #endif
     }
     

--- a/Sources/LiveViewNative/Modifiers/Toolbars Modifiers/ToolbarModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Toolbars Modifiers/ToolbarModifier.swift
@@ -146,7 +146,8 @@ struct ToolbarTreeBuilder<R: RootRegistry> {
         case 10:
             return ToolbarContentBuilder.buildBlock(f(e[0], c), f(e[1], c), f(e[2], c), f(e[3], c), f(e[4], c), f(e[5], c), f(e[6], c), f(e[7], c), f(e[8], c), f(e[9], c))
         default:
-            fatalError("Too many children in toolbar content")
+            // Too many children in toolbar content
+            return ToolbarContentBuilder.buildBlock(f(nil, c), f(nil, c), f(nil, c), f(nil, c), f(nil, c), f(nil, c), f(nil, c), f(nil, c), f(nil, c), f(nil, c))
         }
     }
     
@@ -158,10 +159,9 @@ struct ToolbarTreeBuilder<R: RootRegistry> {
     
     @ToolbarContentBuilder
     fileprivate func fromNode(_ node: Node, context: LiveContextStorage<R>) -> some ToolbarContent {
+        // ToolbarTreeBuilder.fromNode may not be called with a root or leaf node")
         if case .element(let element) = node.data {
             Self.lookup(ElementNode(node: node, data: element))
-        } else {
-            fatalError("ToolbarTreeBuilder.fromNode may not be called with a root or leaf node")
         }
     }
     
@@ -175,7 +175,7 @@ struct ToolbarTreeBuilder<R: RootRegistry> {
         case "ToolbarTitleMenu":
             ToolbarTitleMenu<R>(element: node)
         default:
-            fatalError("Unsupported toolbar content '\(node.tag)'")
+            Optional<SwiftUI.ToolbarItem<String, Never>>.none
         }
     }
 }
@@ -207,7 +207,8 @@ struct CustomizableToolbarTreeBuilder<R: RootRegistry> {
         case 10:
             return ToolbarContentBuilder.buildBlock(f(e[0], c), f(e[1], c), f(e[2], c), f(e[3], c), f(e[4], c), f(e[5], c), f(e[6], c), f(e[7], c), f(e[8], c), f(e[9], c))
         default:
-            fatalError("Too many children in toolbar content")
+            // Too many children in toolbar content
+            return ToolbarContentBuilder.buildBlock(f(nil, c), f(nil, c), f(nil, c), f(nil, c), f(nil, c), f(nil, c), f(nil, c), f(nil, c), f(nil, c), f(nil, c))
         }
     }
     
@@ -219,10 +220,9 @@ struct CustomizableToolbarTreeBuilder<R: RootRegistry> {
     
     @ToolbarContentBuilder
     fileprivate func fromNode(_ node: Node, context: LiveContextStorage<R>) -> some CustomizableToolbarContent {
+        // CustomizableToolbarTreeBuilder.fromNode may not be called with a root or leaf node")
         if case .element(let element) = node.data {
             Self.lookup(ElementNode(node: node, data: element))
-        } else {
-            fatalError("CustomizableToolbarTreeBuilder.fromNode may not be called with a root or leaf node")
         }
     }
     
@@ -234,7 +234,7 @@ struct CustomizableToolbarTreeBuilder<R: RootRegistry> {
         case "ToolbarTitleMenu":
             ToolbarTitleMenu<R>(element: node)
         default:
-            fatalError("Unsupported toolbar content '\(node.tag)'")
+            Optional<SwiftUI.ToolbarItem<String, Never>>.none
         }
     }
 }

--- a/Sources/LiveViewNative/Modifiers/Toolbars Modifiers/ToolbarModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Toolbars Modifiers/ToolbarModifier.swift
@@ -119,6 +119,11 @@ struct ToolbarModifier<R: RootRegistry>: ViewModifier, Decodable {
     }
 }
 
+private enum FromNodeValue {
+    case n(Node)
+    case e(Error)
+}
+
 /// A builder for `ToolbarContent`.
 struct ToolbarTreeBuilder<R: RootRegistry> {
     func fromNodes<Nodes>(_ e: Nodes, context c: LiveContextStorage<R>) -> some ToolbarContent
@@ -126,42 +131,49 @@ struct ToolbarTreeBuilder<R: RootRegistry> {
     {
         switch e.count {
         case 1:
-            return ToolbarContentBuilder.buildBlock(f(e[0], c), f(nil, c), f(nil, c), f(nil, c), f(nil, c), f(nil, c), f(nil, c), f(nil, c), f(nil, c), f(nil, c))
+            return ToolbarContentBuilder.buildBlock(f(.n(e[0]), c), f(nil, c), f(nil, c), f(nil, c), f(nil, c), f(nil, c), f(nil, c), f(nil, c), f(nil, c), f(nil, c))
         case 2:
-            return ToolbarContentBuilder.buildBlock(f(e[0], c), f(e[1], c), f(nil, c), f(nil, c), f(nil, c), f(nil, c), f(nil, c), f(nil, c), f(nil, c), f(nil, c))
+            return ToolbarContentBuilder.buildBlock(f(.n(e[0]), c), f(.n(e[1]), c), f(nil, c), f(nil, c), f(nil, c), f(nil, c), f(nil, c), f(nil, c), f(nil, c), f(nil, c))
         case 3:
-            return ToolbarContentBuilder.buildBlock(f(e[0], c), f(e[1], c), f(e[2], c), f(nil, c), f(nil, c), f(nil, c), f(nil, c), f(nil, c), f(nil, c), f(nil, c))
+            return ToolbarContentBuilder.buildBlock(f(.n(e[0]), c), f(.n(e[1]), c), f(.n(e[2]), c), f(nil, c), f(nil, c), f(nil, c), f(nil, c), f(nil, c), f(nil, c), f(nil, c))
         case 4:
-            return ToolbarContentBuilder.buildBlock(f(e[0], c), f(e[1], c), f(e[2], c), f(e[3], c), f(nil, c), f(nil, c), f(nil, c), f(nil, c), f(nil, c), f(nil, c))
+            return ToolbarContentBuilder.buildBlock(f(.n(e[0]), c), f(.n(e[1]), c), f(.n(e[2]), c), f(.n(e[3]), c), f(nil, c), f(nil, c), f(nil, c), f(nil, c), f(nil, c), f(nil, c))
         case 5:
-            return ToolbarContentBuilder.buildBlock(f(e[0], c), f(e[1], c), f(e[2], c), f(e[3], c), f(e[4], c), f(nil, c), f(nil, c), f(nil, c), f(nil, c), f(nil, c))
+            return ToolbarContentBuilder.buildBlock(f(.n(e[0]), c), f(.n(e[1]), c), f(.n(e[2]), c), f(.n(e[3]), c), f(.n(e[4]), c), f(nil, c), f(nil, c), f(nil, c), f(nil, c), f(nil, c))
         case 6:
-            return ToolbarContentBuilder.buildBlock(f(e[0], c), f(e[1], c), f(e[2], c), f(e[3], c), f(e[4], c), f(e[5], c), f(nil, c), f(nil, c), f(nil, c), f(nil, c))
+            return ToolbarContentBuilder.buildBlock(f(.n(e[0]), c), f(.n(e[1]), c), f(.n(e[2]), c), f(.n(e[3]), c), f(.n(e[4]), c), f(.n(e[5]), c), f(nil, c), f(nil, c), f(nil, c), f(nil, c))
         case 7:
-            return ToolbarContentBuilder.buildBlock(f(e[0], c), f(e[1], c), f(e[2], c), f(e[3], c), f(e[4], c), f(e[5], c), f(e[6], c), f(nil, c), f(nil, c), f(nil, c))
+            return ToolbarContentBuilder.buildBlock(f(.n(e[0]), c), f(.n(e[1]), c), f(.n(e[2]), c), f(.n(e[3]), c), f(.n(e[4]), c), f(.n(e[5]), c), f(.n(e[6]), c), f(nil, c), f(nil, c), f(nil, c))
         case 8:
-            return ToolbarContentBuilder.buildBlock(f(e[0], c), f(e[1], c), f(e[2], c), f(e[3], c), f(e[4], c), f(e[5], c), f(e[6], c), f(e[7], c), f(nil, c), f(nil, c))
+            return ToolbarContentBuilder.buildBlock(f(.n(e[0]), c), f(.n(e[1]), c), f(.n(e[2]), c), f(.n(e[3]), c), f(.n(e[4]), c), f(.n(e[5]), c), f(.n(e[6]), c), f(.n(e[7]), c), f(nil, c), f(nil, c))
         case 9:
-            return ToolbarContentBuilder.buildBlock(f(e[0], c), f(e[1], c), f(e[2], c), f(e[3], c), f(e[4], c), f(e[5], c), f(e[6], c), f(e[7], c), f(e[8], c), f(nil, c))
+            return ToolbarContentBuilder.buildBlock(f(.n(e[0]), c), f(.n(e[1]), c), f(.n(e[2]), c), f(.n(e[3]), c), f(.n(e[4]), c), f(.n(e[5]), c), f(.n(e[6]), c), f(.n(e[7]), c), f(.n(e[8]), c), f(nil, c))
         case 10:
-            return ToolbarContentBuilder.buildBlock(f(e[0], c), f(e[1], c), f(e[2], c), f(e[3], c), f(e[4], c), f(e[5], c), f(e[6], c), f(e[7], c), f(e[8], c), f(e[9], c))
+            return ToolbarContentBuilder.buildBlock(f(.n(e[0]), c), f(.n(e[1]), c), f(.n(e[2]), c), f(.n(e[3]), c), f(.n(e[4]), c), f(.n(e[5]), c), f(.n(e[6]), c), f(.n(e[7]), c), f(.n(e[8]), c), f(.n(e[9]), c))
         default:
             // Too many children in toolbar content
-            return ToolbarContentBuilder.buildBlock(f(nil, c), f(nil, c), f(nil, c), f(nil, c), f(nil, c), f(nil, c), f(nil, c), f(nil, c), f(nil, c), f(nil, c))
+            return ToolbarContentBuilder.buildBlock(f(.e(ToolbarError.badChildCount(e.count)), c), f(nil, c), f(nil, c), f(nil, c), f(nil, c), f(nil, c), f(nil, c), f(nil, c), f(nil, c), f(nil, c))
         }
     }
     
     // alias for typing
     @inline(__always)
-    fileprivate func f(_ n: Node?, _ c: LiveContextStorage<R>) -> some ToolbarContent {
+    fileprivate func f(_ n: FromNodeValue?, _ c: LiveContextStorage<R>) -> some ToolbarContent {
         return n.flatMap({ fromNode($0, context: c) })
     }
     
     @ToolbarContentBuilder
-    fileprivate func fromNode(_ node: Node, context: LiveContextStorage<R>) -> some ToolbarContent {
-        // ToolbarTreeBuilder.fromNode may not be called with a root or leaf node")
-        if case .element(let element) = node.data {
-            Self.lookup(ElementNode(node: node, data: element))
+    fileprivate func fromNode(_ node: FromNodeValue, context: LiveContextStorage<R>) -> some ToolbarContent {
+        // ToolbarTreeBuilder.fromNode may not be called with a root or leaf node
+        switch node {
+        case let .n(node):
+            if case .element(let element) = node.data {
+                Self.lookup(ElementNode(node: node, data: element))
+            }
+        case let .e(error):
+            SwiftUI.ToolbarItem {
+                ErrorView<R>(error)
+            }
         }
     }
     
@@ -175,7 +187,9 @@ struct ToolbarTreeBuilder<R: RootRegistry> {
         case "ToolbarTitleMenu":
             ToolbarTitleMenu<R>(element: node)
         default:
-            Optional<SwiftUI.ToolbarItem<String, Never>>.none
+            SwiftUI.ToolbarItem {
+                ErrorView<R>(ToolbarError.unknownTag(node.tag))
+            }
         }
     }
 }
@@ -187,42 +201,49 @@ struct CustomizableToolbarTreeBuilder<R: RootRegistry> {
     {
         switch e.count {
         case 1:
-            return ToolbarContentBuilder.buildBlock(f(e[0], c), f(nil, c), f(nil, c), f(nil, c), f(nil, c), f(nil, c), f(nil, c), f(nil, c), f(nil, c), f(nil, c))
+            return ToolbarContentBuilder.buildBlock(f(.n(e[0]), c), f(nil, c), f(nil, c), f(nil, c), f(nil, c), f(nil, c), f(nil, c), f(nil, c), f(nil, c), f(nil, c))
         case 2:
-            return ToolbarContentBuilder.buildBlock(f(e[0], c), f(e[1], c), f(nil, c), f(nil, c), f(nil, c), f(nil, c), f(nil, c), f(nil, c), f(nil, c), f(nil, c))
+            return ToolbarContentBuilder.buildBlock(f(.n(e[0]), c), f(.n(e[1]), c), f(nil, c), f(nil, c), f(nil, c), f(nil, c), f(nil, c), f(nil, c), f(nil, c), f(nil, c))
         case 3:
-            return ToolbarContentBuilder.buildBlock(f(e[0], c), f(e[1], c), f(e[2], c), f(nil, c), f(nil, c), f(nil, c), f(nil, c), f(nil, c), f(nil, c), f(nil, c))
+            return ToolbarContentBuilder.buildBlock(f(.n(e[0]), c), f(.n(e[1]), c), f(.n(e[2]), c), f(nil, c), f(nil, c), f(nil, c), f(nil, c), f(nil, c), f(nil, c), f(nil, c))
         case 4:
-            return ToolbarContentBuilder.buildBlock(f(e[0], c), f(e[1], c), f(e[2], c), f(e[3], c), f(nil, c), f(nil, c), f(nil, c), f(nil, c), f(nil, c), f(nil, c))
+            return ToolbarContentBuilder.buildBlock(f(.n(e[0]), c), f(.n(e[1]), c), f(.n(e[2]), c), f(.n(e[3]), c), f(nil, c), f(nil, c), f(nil, c), f(nil, c), f(nil, c), f(nil, c))
         case 5:
-            return ToolbarContentBuilder.buildBlock(f(e[0], c), f(e[1], c), f(e[2], c), f(e[3], c), f(e[4], c), f(nil, c), f(nil, c), f(nil, c), f(nil, c), f(nil, c))
+            return ToolbarContentBuilder.buildBlock(f(.n(e[0]), c), f(.n(e[1]), c), f(.n(e[2]), c), f(.n(e[3]), c), f(.n(e[4]), c), f(nil, c), f(nil, c), f(nil, c), f(nil, c), f(nil, c))
         case 6:
-            return ToolbarContentBuilder.buildBlock(f(e[0], c), f(e[1], c), f(e[2], c), f(e[3], c), f(e[4], c), f(e[5], c), f(nil, c), f(nil, c), f(nil, c), f(nil, c))
+            return ToolbarContentBuilder.buildBlock(f(.n(e[0]), c), f(.n(e[1]), c), f(.n(e[2]), c), f(.n(e[3]), c), f(.n(e[4]), c), f(.n(e[5]), c), f(nil, c), f(nil, c), f(nil, c), f(nil, c))
         case 7:
-            return ToolbarContentBuilder.buildBlock(f(e[0], c), f(e[1], c), f(e[2], c), f(e[3], c), f(e[4], c), f(e[5], c), f(e[6], c), f(nil, c), f(nil, c), f(nil, c))
+            return ToolbarContentBuilder.buildBlock(f(.n(e[0]), c), f(.n(e[1]), c), f(.n(e[2]), c), f(.n(e[3]), c), f(.n(e[4]), c), f(.n(e[5]), c), f(.n(e[6]), c), f(nil, c), f(nil, c), f(nil, c))
         case 8:
-            return ToolbarContentBuilder.buildBlock(f(e[0], c), f(e[1], c), f(e[2], c), f(e[3], c), f(e[4], c), f(e[5], c), f(e[6], c), f(e[7], c), f(nil, c), f(nil, c))
+            return ToolbarContentBuilder.buildBlock(f(.n(e[0]), c), f(.n(e[1]), c), f(.n(e[2]), c), f(.n(e[3]), c), f(.n(e[4]), c), f(.n(e[5]), c), f(.n(e[6]), c), f(.n(e[7]), c), f(nil, c), f(nil, c))
         case 9:
-            return ToolbarContentBuilder.buildBlock(f(e[0], c), f(e[1], c), f(e[2], c), f(e[3], c), f(e[4], c), f(e[5], c), f(e[6], c), f(e[7], c), f(e[8], c), f(nil, c))
+            return ToolbarContentBuilder.buildBlock(f(.n(e[0]), c), f(.n(e[1]), c), f(.n(e[2]), c), f(.n(e[3]), c), f(.n(e[4]), c), f(.n(e[5]), c), f(.n(e[6]), c), f(.n(e[7]), c), f(.n(e[8]), c), f(nil, c))
         case 10:
-            return ToolbarContentBuilder.buildBlock(f(e[0], c), f(e[1], c), f(e[2], c), f(e[3], c), f(e[4], c), f(e[5], c), f(e[6], c), f(e[7], c), f(e[8], c), f(e[9], c))
+            return ToolbarContentBuilder.buildBlock(f(.n(e[0]), c), f(.n(e[1]), c), f(.n(e[2]), c), f(.n(e[3]), c), f(.n(e[4]), c), f(.n(e[5]), c), f(.n(e[6]), c), f(.n(e[7]), c), f(.n(e[8]), c), f(.n(e[9]), c))
         default:
             // Too many children in toolbar content
-            return ToolbarContentBuilder.buildBlock(f(nil, c), f(nil, c), f(nil, c), f(nil, c), f(nil, c), f(nil, c), f(nil, c), f(nil, c), f(nil, c), f(nil, c))
+            return ToolbarContentBuilder.buildBlock(f(.e(ToolbarError.badChildCount(e.count)), c), f(nil, c), f(nil, c), f(nil, c), f(nil, c), f(nil, c), f(nil, c), f(nil, c), f(nil, c), f(nil, c))
         }
     }
     
     // alias for typing
     @inline(__always)
-    fileprivate func f(_ n: Node?, _ c: LiveContextStorage<R>) -> some CustomizableToolbarContent {
+    fileprivate func f(_ n: FromNodeValue?, _ c: LiveContextStorage<R>) -> some CustomizableToolbarContent {
         return n.flatMap({ fromNode($0, context: c) })
     }
     
     @ToolbarContentBuilder
-    fileprivate func fromNode(_ node: Node, context: LiveContextStorage<R>) -> some CustomizableToolbarContent {
-        // CustomizableToolbarTreeBuilder.fromNode may not be called with a root or leaf node")
-        if case .element(let element) = node.data {
-            Self.lookup(ElementNode(node: node, data: element))
+    fileprivate func fromNode(_ node: FromNodeValue, context: LiveContextStorage<R>) -> some CustomizableToolbarContent {
+        // CustomizableToolbarTreeBuilder.fromNode may not be called with a root or leaf node
+        switch node {
+        case let .n(node):
+            if case .element(let element) = node.data {
+                Self.lookup(ElementNode(node: node, data: element))
+            }
+        case let .e(error):
+            SwiftUI.ToolbarItem(id: error.localizedDescription) {
+                ErrorView<R>(error)
+            }
         }
     }
     
@@ -234,7 +255,23 @@ struct CustomizableToolbarTreeBuilder<R: RootRegistry> {
         case "ToolbarTitleMenu":
             ToolbarTitleMenu<R>(element: node)
         default:
-            Optional<SwiftUI.ToolbarItem<String, Never>>.none
+            SwiftUI.ToolbarItem(id: node.tag) {
+                ErrorView<R>(ToolbarError.unknownTag(node.tag))
+            }
+        }
+    }
+}
+
+enum ToolbarError: LocalizedError {
+    case badChildCount(Int)
+    case unknownTag(String)
+    
+    var errorDescription: String? {
+        switch self {
+        case let .badChildCount(count):
+            return "\(count) is an invalid number of children for a toolbar. Toolbar supports 1-10 children."
+        case let .unknownTag(tag):
+            return "Unsupported toolbar content '\(tag)'"
         }
     }
 }

--- a/Sources/LiveViewNative/NavStackEntryView.swift
+++ b/Sources/LiveViewNative/NavStackEntryView.swift
@@ -53,15 +53,11 @@ struct NavStackEntryView<R: RootRegistry>: View {
         if coordinator.url == entry.url {
             switch coordinator.state {
             case .connected:
-                if let doc = coordinator.document {
-                    coordinator.builder.fromNodes(doc[doc.root()].children(), coordinator: coordinator, url: coordinator.url)
-                        .environment(\.coordinatorEnvironment, CoordinatorEnvironment(coordinator, document: doc))
-                        .onPreferenceChange(NavigationTitleModifierKey.self) { navigationTitle in
-                            self.liveViewModel.cachedNavigationTitle = navigationTitle
-                        }
-                } else {
-                    R.loadingView(for: coordinator.url, state: .connectionFailed(LiveConnectionError.missingDocument))
-                }
+                coordinator.builder.fromNodes(coordinator.document![coordinator.document!.root()].children(), coordinator: coordinator, url: coordinator.url)
+                    .environment(\.coordinatorEnvironment, CoordinatorEnvironment(coordinator, document: coordinator.document!))
+                    .onPreferenceChange(NavigationTitleModifierKey.self) { navigationTitle in
+                        self.liveViewModel.cachedNavigationTitle = navigationTitle
+                    }
             default:
                 let content = SwiftUI.Group {
                     if R.LoadingView.self == Never.self {

--- a/Sources/LiveViewNative/NavStackEntryView.swift
+++ b/Sources/LiveViewNative/NavStackEntryView.swift
@@ -60,7 +60,7 @@ struct NavStackEntryView<R: RootRegistry>: View {
                             self.liveViewModel.cachedNavigationTitle = navigationTitle
                         }
                 } else {
-                    fatalError("State is `.connected`, but no `Document` was found.")
+                    R.loadingView(for: coordinator.url, state: .connectionFailed(LiveConnectionError.missingDocument))
                 }
             default:
                 let content = SwiftUI.Group {

--- a/Sources/LiveViewNative/Property Wrappers/FormState.swift
+++ b/Sources/LiveViewNative/Property Wrappers/FormState.swift
@@ -117,7 +117,7 @@ public struct FormState<Value: FormValue> {
                 return value
             case .form(let formModel):
                 guard let elementName = element.attributeValue(for: "name") else {
-                    fatalError("Expected @FormState in form mode to have element with name")
+                    return initialValue
                 }
                 if let existing = formModel[elementName],
                    let value = existing as? Value {
@@ -143,7 +143,7 @@ public struct FormState<Value: FormValue> {
                 data.objectWillChange.send()
             case .form(let formModel):
                 guard let elementName = element.attributeValue(for: "name") else {
-                    fatalError("Expected @FormState in form mode to have element with name")
+                    return
                 }
                 formModel[elementName] = newValue
                 // todo: this will send a change event for both the form and the input if the input has one, check if that matches web

--- a/Sources/LiveViewNative/Property Wrappers/FormState.swift
+++ b/Sources/LiveViewNative/Property Wrappers/FormState.swift
@@ -7,6 +7,9 @@
 
 import SwiftUI
 import Combine
+import OSLog
+
+private let logger = Logger(subsystem: "LiveViewNative", category: "FormState")
 
 /// A property wrapper that stores the primary value of a form element.
 ///
@@ -117,6 +120,7 @@ public struct FormState<Value: FormValue> {
                 return value
             case .form(let formModel):
                 guard let elementName = element.attributeValue(for: "name") else {
+                    logger.log(level: .error, "Expected @FormState in form mode to have element with name")
                     return initialValue
                 }
                 if let existing = formModel[elementName],
@@ -143,6 +147,7 @@ public struct FormState<Value: FormValue> {
                 data.objectWillChange.send()
             case .form(let formModel):
                 guard let elementName = element.attributeValue(for: "name") else {
+                    logger.log(level: .error, "Expected @FormState in form mode to have element with name")
                     return
                 }
                 formModel[elementName] = newValue

--- a/Sources/LiveViewNative/Registries/CustomRegistry.swift
+++ b/Sources/LiveViewNative/Registries/CustomRegistry.swift
@@ -92,6 +92,10 @@ public protocol CustomRegistry {
     ///
     /// Generally, implementors will use an opaque return type on their ``loadingView(for:state:)-6jd3b`` implementations and this will be inferred automatically.
     associatedtype LoadingView: View = Never
+    /// The type of view this registry produces for error views.
+    ///
+    /// Generally, implementors will use an opaque return type on their ``errorView(for:)`` implementations and this will be inferred automatically.
+    associatedtype ErrorView: View = Never
     
     /// This method is called by LiveView Native when it needs to construct a custom view.
     ///
@@ -123,11 +127,26 @@ public protocol CustomRegistry {
     /// - Parameter state: The current state of the coordinator. This method is never called with ``LiveSessionState/connected``.
     @ViewBuilder
     static func loadingView(for url: URL, state: LiveSessionState) -> LoadingView
+    
+    /// This method is called when it needs a view to display when an error occurs in the View hierarchy.
+    ///
+    /// If you do not implement this method, the framework provides a view which displays a simple text representation of the error.
+    ///
+    /// - Parameter error: The error of the view is reporting.
+    @ViewBuilder
+    static func errorView(for error: Error) -> ErrorView
 }
 
 extension CustomRegistry where LoadingView == Never {
     /// A default  implementation that falls back to the default framework loading view.
     public static func loadingView(for url: URL, state: LiveSessionState) -> Never {
+        fatalError()
+    }
+}
+
+extension CustomRegistry where ErrorView == Never {
+    /// A default  implementation that falls back to the default framework error view.
+    public static func errorView(for error: Error) -> Never {
         fatalError()
     }
 }

--- a/Sources/LiveViewNative/ViewTree.swift
+++ b/Sources/LiveViewNative/ViewTree.swift
@@ -279,12 +279,12 @@ internal struct ElementView<R: RootRegistry>: View {
 
 // not fileprivate because List needs ot use it so it has access to ForEach modifiers
 func forEach<R: CustomRegistry>(nodes: some Collection<Node>, context: LiveContextStorage<R>) -> ForEach<[(ElementNode, String)], String, some View> {
-    let elements = nodes.map { (node) -> (ElementNode, String) in
+    let elements = nodes.compactMap { (node) -> (ElementNode, String)? in
         guard let element = node.asElement() else {
-            preconditionFailure("node in list or parent with more than 10 children must be an element")
+            return nil
         }
         guard let id = element.attributeValue(for: "id") else {
-            preconditionFailure("element in list or parent with more than 10 children must have an id")
+            return nil
         }
         return (element, id)
     }

--- a/Sources/LiveViewNative/Views/Images/Image.swift
+++ b/Sources/LiveViewNative/Views/Images/Image.swift
@@ -44,29 +44,31 @@ struct Image: View {
     }
     
     public var body: some View {
-        image
+        image?
             // todo: this probably only works for symbols
             .resizableIfPresent(resizable: resizable)
             .scaledIfPresent(scale: symbolScale)
             .foregroundColorIfPresent(color: symbolColor)
     }
     
-    var image: SwiftUI.Image {
+    var image: SwiftUI.Image? {
         switch mode {
         case .symbol(let name):
             return SwiftUI.Image(systemName: name)
         case .asset(let name):
             return SwiftUI.Image(name)
+        default:
+            return nil
         }
     }
     
-    private var mode: Mode {
+    private var mode: Mode? {
         if let systemName = element.attributeValue(for: "system-name") {
             return .symbol(systemName)
         } else if let name = element.attributeValue(for: "name") {
             return .asset(name)
         } else {
-            preconditionFailure("<image> must have system-name or name")
+            return nil
         }
     }
     
@@ -105,8 +107,8 @@ struct Image: View {
             return .medium
         case "large":
             return .large
-        case .some(let attr):
-            fatalError("invalid value '\(attr)' for symbol-scale")
+        default:
+            return nil
         }
     }
 }

--- a/Sources/LiveViewNative/Views/Layout Containers/Collection Containers/Table.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Collection Containers/Table.swift
@@ -263,7 +263,8 @@ struct Table<R: RootRegistry>: View {
                 columns[9]
             }
         default:
-            fatalError("Too many columns in table: \(columns.count)")
+            // Too many columns in table
+            Optional<AnyView>.none
         }
     }
     
@@ -271,7 +272,7 @@ struct Table<R: RootRegistry>: View {
         element.elementChildren()
             .filter { $0.tag == "rows" && $0.namespace == "Table" }
             .flatMap { $0.elementChildren() }
-            .compactMap { $0.tag == "TableRow" ? TableRow(element: $0) : nil }
+            .compactMap { $0.tag == "TableRow" && $0.attribute(named: "id") != nil ? TableRow(element: $0) : nil }
     }
     
     private var columns: [TableColumn<TableRow, TableColumnSort, some View, SwiftUI.Text>] {

--- a/Sources/LiveViewNative/Views/Layout Containers/Collection Containers/Table.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Collection Containers/Table.swift
@@ -263,8 +263,7 @@ struct Table<R: RootRegistry>: View {
                 columns[9]
             }
         default:
-            // Too many columns in table
-            Optional<AnyView>.none
+            ErrorView<R>(TableError.badColumnCount(columns.count))
         }
     }
     
@@ -300,6 +299,17 @@ struct Table<R: RootRegistry>: View {
         }
     }
     #endif
+}
+
+enum TableError: LocalizedError {
+    case badColumnCount(Int)
+    
+    var errorDescription: String? {
+        switch self {
+        case let .badColumnCount(count):
+            return "\(count) is an invalid number of columns for <Table>. Only 1-10 columns are supported."
+        }
+    }
 }
 
 fileprivate struct TableRow: Identifiable {

--- a/Sources/LiveViewNative/Views/Text Input and Output/Text.swift
+++ b/Sources/LiveViewNative/Views/Text Input and Output/Text.swift
@@ -172,7 +172,9 @@ struct Text<R: RootRegistry>: View {
                             .init("[\(element.innerText())](\(element.attributeValue(for: "destination")!))")
                         )
                     case "Image":
-                        prev = prev + SwiftUI.Text(Image(overrideElement: element).image)
+                        if let image = Image(overrideElement: element).image {
+                            prev = prev + SwiftUI.Text(image)
+                        }
                     default:
                         break
                     }


### PR DESCRIPTION
`fatalError`/`preconditionFailure` calls are replaced with throwing methods or `ErrorView` whenever possible. This should prevent the app from requiring a restart whenever something simple goes wrong.

By default, errors are presented with an alert:
<img src="https://user-images.githubusercontent.com/13581484/235708973-f5aa881a-2dcf-4721-9f70-0226cc6889ac.png" width="300" />

In the `CustomRegistry`, implement the `errorView(for:)` method to override this behavior:

```swift
struct AppRegistry: RootRegistry {
    static func errorView(for error: Error) -> some View {
        Label(error.localizedDescription, systemImage: "xmark.diamond.fill")
            .bold()
            .foregroundStyle(.red)
    }
}
```
<img src="https://user-images.githubusercontent.com/13581484/235710308-874fcf6a-5756-4f7a-bdb6-a200463d7ead.png" width="300" />