### PR TITLE
Add platform metadata to connection params

### DIFF
--- a/Sources/LiveViewNative/Coordinators/LiveViewCoordinator.swift
+++ b/Sources/LiveViewNative/Coordinators/LiveViewCoordinator.swift
@@ -307,6 +307,8 @@ public class LiveViewCoordinator<R: RootRegistry>: ObservableObject {
     private func getDeviceClass() -> String {
         #if os(watchOS)
         return "watch"
+        #elseif os(macOS)
+        return "mac"
         #else
         switch UIDevice.current.userInterfaceIdiom {
         case .phone:

--- a/Sources/LiveViewNative/Coordinators/LiveViewCoordinator.swift
+++ b/Sources/LiveViewNative/Coordinators/LiveViewCoordinator.swift
@@ -299,14 +299,36 @@ public class LiveViewCoordinator<R: RootRegistry>: ObservableObject {
     private func getPlatformMetadata() throws -> String {
         let encoder = JSONEncoder()
         let metadata: [String : String] = [
-            "platform_variant": getPlatformVariant()
+            "device_class": getDeviceClass(),
+            "os_name": getOSName(),
+            "os_version": getOSVersion()
         ]
         let encodedMetadata = try encoder.encode(metadata)
 
         return String(data: encodedMetadata, encoding: .utf8)!
     }
-    
-    private func getPlatformVariant() -> String {
+
+    private func getDeviceClass() -> String {
+        #if os(watchOS)
+        return "watch"
+        #else
+        switch UIDevice.current.userInterfaceIdiom {
+        case .phone:
+            return "phone"
+        case .pad:
+            return "pad"
+        case .mac:
+            return "mac"
+        case .tv:
+            return "tv"
+        default:
+            return "unspecified"
+        }
+        #endif
+    }
+
+
+    private func getOSName() -> String {
         #if os(macOS)
         return "macOS"
         #elseif os(tvOS)
@@ -314,7 +336,15 @@ public class LiveViewCoordinator<R: RootRegistry>: ObservableObject {
         #elseif os(watchOS)
         return "watchOS"
         #else
-        return UIDevice.current.userInterfaceIdiom == .pad ? "iPadOS" : "iOS"
+        return "iOS"
+        #endif
+    }
+
+    private func getOSVersion() -> String {
+        #if os(watchOS)
+            return WKInterfaceDevice.currentDevice().systemVersion
+        #else
+            return UIDevice.current.systemVersion
         #endif
     }
 

--- a/Sources/LiveViewNative/Coordinators/LiveViewCoordinator.swift
+++ b/Sources/LiveViewNative/Coordinators/LiveViewCoordinator.swift
@@ -318,7 +318,7 @@ public class LiveViewCoordinator<R: RootRegistry>: ObservableObject {
 
     private func getOSVersion() -> String {
         #if os(watchOS)
-        return WKInterfaceDevice.currentDevice().systemVersion
+        return WKInterfaceDevice.current().systemVersion
         #elseif os(macOS)
         let operatingSystemVersion = ProcessInfo.processInfo.operatingSystemVersion
         let majorVersion = operatingSystemVersion.majorVersion

--- a/Sources/LiveViewNative/Coordinators/LiveViewCoordinator.swift
+++ b/Sources/LiveViewNative/Coordinators/LiveViewCoordinator.swift
@@ -318,11 +318,11 @@ public class LiveViewCoordinator<R: RootRegistry>: ObservableObject {
 
     private func getOSVersion() -> String {
         #if os(watchOS)
-            return WKInterfaceDevice.currentDevice().systemVersion
+        return WKInterfaceDevice.currentDevice().systemVersion
         #elseif os(macOS)
-            return ProcessInfo.operatingSystemVersion
+        return ProcessInfo.processInfo.operatingSystemVersionString
         #else
-            return UIDevice.current.systemVersion
+        return UIDevice.current.systemVersion
         #endif
     }
 

--- a/Sources/LiveViewNative/Coordinators/LiveViewCoordinator.swift
+++ b/Sources/LiveViewNative/Coordinators/LiveViewCoordinator.swift
@@ -296,16 +296,12 @@ public class LiveViewCoordinator<R: RootRegistry>: ObservableObject {
         }
     }
     
-    private func getPlatformMetadata() throws -> String {
-        let encoder = JSONEncoder()
-        let metadata: [String : String] = [
+    private func getPlatformMetadata() throws -> Payload {
+        return [
             "device_class": getDeviceClass(),
             "os_name": getOSName(),
             "os_version": getOSVersion()
         ]
-        let encodedMetadata = try encoder.encode(metadata)
-
-        return String(data: encodedMetadata, encoding: .utf8)!
     }
 
     private func getDeviceClass() -> String {

--- a/Sources/LiveViewNative/Coordinators/LiveViewCoordinator.swift
+++ b/Sources/LiveViewNative/Coordinators/LiveViewCoordinator.swift
@@ -320,7 +320,12 @@ public class LiveViewCoordinator<R: RootRegistry>: ObservableObject {
         #if os(watchOS)
         return WKInterfaceDevice.currentDevice().systemVersion
         #elseif os(macOS)
-        return ProcessInfo.processInfo.operatingSystemVersionString
+        let operatingSystemVersion = ProcessInfo.processInfo.operatingSystemVersion
+        let majorVersion = operatingSystemVersion.majorVersion
+        let minorVersion = operatingSystemVersion.minorVersion
+        let patchVersion = operatingSystemVersion.patchVersion
+        
+        return "\(majorVersion).\(minorVersion).\(patchVersion)"
         #else
         return UIDevice.current.systemVersion
         #endif

--- a/Sources/LiveViewNative/Coordinators/LiveViewCoordinator.swift
+++ b/Sources/LiveViewNative/Coordinators/LiveViewCoordinator.swift
@@ -314,7 +314,7 @@ public class LiveViewCoordinator<R: RootRegistry>: ObservableObject {
         #elseif os(watchOS)
         return "watchOS"
         #else
-        return UIDevice.current.localizedModel == "iPhone" ? "iOS" : "iPadOS"
+        return UIDevice.current.userInterfaceIdiom == .pad ? "iPadOS" : "iOS"
         #endif
     }
 

--- a/Sources/LiveViewNative/Coordinators/LiveViewCoordinator.swift
+++ b/Sources/LiveViewNative/Coordinators/LiveViewCoordinator.swift
@@ -298,13 +298,35 @@ public class LiveViewCoordinator<R: RootRegistry>: ObservableObject {
     
     private func getPlatformMetadata() throws -> Payload {
         return [
-            "device_class": getDeviceClass(),
             "os_name": getOSName(),
-            "os_version": getOSVersion()
+            "os_version": getOSVersion(),
+            "user_interface_idiom": getUserInterfaceIdiom()
         ]
     }
 
-    private func getDeviceClass() -> String {
+    private func getOSName() -> String {
+        #if os(macOS)
+        return "macOS"
+        #elseif os(tvOS)
+        return "tvOS"
+        #elseif os(watchOS)
+        return "watchOS"
+        #else
+        return "iOS"
+        #endif
+    }
+
+    private func getOSVersion() -> String {
+        #if os(watchOS)
+            return WKInterfaceDevice.currentDevice().systemVersion
+        #elseif os(macOS)
+            return ProcessInfo.operatingSystemVersion
+        #else
+            return UIDevice.current.systemVersion
+        #endif
+    }
+
+    private func getUserInterfaceIdiom() -> String {
         #if os(watchOS)
         return "watch"
         #elseif os(macOS)
@@ -322,27 +344,6 @@ public class LiveViewCoordinator<R: RootRegistry>: ObservableObject {
         default:
             return "unspecified"
         }
-        #endif
-    }
-
-
-    private func getOSName() -> String {
-        #if os(macOS)
-        return "macOS"
-        #elseif os(tvOS)
-        return "tvOS"
-        #elseif os(watchOS)
-        return "watchOS"
-        #else
-        return "iOS"
-        #endif
-    }
-
-    private func getOSVersion() -> String {
-        #if os(watchOS)
-            return WKInterfaceDevice.currentDevice().systemVersion
-        #else
-            return UIDevice.current.systemVersion
         #endif
     }
 

--- a/Sources/LiveViewNative/Coordinators/LiveViewCoordinator.swift
+++ b/Sources/LiveViewNative/Coordinators/LiveViewCoordinator.swift
@@ -8,6 +8,7 @@
 import Foundation
 import SwiftPhoenixClient
 import SwiftSoup
+import SwiftUI
 import Combine
 import LiveViewNativeCore
 import OSLog
@@ -251,7 +252,8 @@ public class LiveViewCoordinator<R: RootRegistry>: ObservableObject {
         connectParams["_mounts"] = 0
         connectParams["_csrf_token"] = session.phxCSRFToken
         connectParams["_platform"] = "swiftui"
-        
+        connectParams["_platform_meta"] = try getPlatformMetadata()
+
         let params: Payload = [
             "session": session.phxSession,
             "static": session.phxStatic,
@@ -294,6 +296,28 @@ public class LiveViewCoordinator<R: RootRegistry>: ObservableObject {
         }
     }
     
+    private func getPlatformMetadata() throws -> String {
+        let encoder = JSONEncoder()
+        let metadata: [String : String] = [
+            "platform_variant": getPlatformVariant()
+        ]
+        let encodedMetadata = try encoder.encode(metadata)
+
+        return String(data: encodedMetadata, encoding: .utf8)!
+    }
+    
+    private func getPlatformVariant() -> String {
+        #if os(macOS)
+        return "macOS"
+        #elseif os(tvOS)
+        return "tvOS"
+        #elseif os(watchOS)
+        return "watchOS"
+        #else
+        return UIDevice.current.localizedModel == "iPhone" ? "iOS" : "iPadOS"
+        #endif
+    }
+
     private func setupChannelJoinHandlers(channel: Channel) {
         channel.join()
             .receive("ok") { [weak self, weak channel] message in

--- a/lib/live_view_native_swift_ui/platform.ex
+++ b/lib/live_view_native_swift_ui/platform.ex
@@ -8,10 +8,10 @@ defmodule LiveViewNativeSwiftUi.Platform do
 
   defstruct [
     :app_name,
-    :device_class,
     :os_name,
     :os_version,
     :simulator_opts,
+    :user_interface_idiom,
     custom_modifiers: []
   ]
 

--- a/lib/live_view_native_swift_ui/platform.ex
+++ b/lib/live_view_native_swift_ui/platform.ex
@@ -8,13 +8,11 @@ defmodule LiveViewNativeSwiftUi.Platform do
 
   defstruct [
     :app_name,
-    :bundle_name,
-    :project_path,
-    custom_modifiers: [],
-    default_simulator_device: "iPhone 13",
-    default_simulator_os: "iOS",
-    default_simulator_os_version: "16-0",
-    xcode_path: "/Applications/Xcode.app"
+    :device_class,
+    :os_name,
+    :os_version,
+    :simulator_opts,
+    custom_modifiers: []
   ]
 
   defimpl LiveViewNativePlatform do
@@ -30,12 +28,14 @@ defmodule LiveViewNativeSwiftUi.Platform do
     def start_simulator(struct, opts \\ []) do
       %{
         app_name: app_name,
-        bundle_name: bundle_name,
-        default_simulator_device: default_simulator_device,
-        default_simulator_os: default_simulator_os,
-        default_simulator_os_version: default_simulator_os_version,
-        project_path: project_path,
-        xcode_path: xcode_path
+        simulator_opts: %{
+          bundle_name: bundle_name,
+          default_simulator_device: default_simulator_device,
+          default_simulator_os: default_simulator_os,
+          default_simulator_os_version: default_simulator_os_version,
+          project_path: project_path,
+          xcode_path: xcode_path
+        }
       } = struct
 
       # Raises if either `xcrun` or `xcodebuild` are missing from the current system PATH.


### PR DESCRIPTION
This PR proposes including additional metadata through the connection params so that it can be available to the backend LiveView application. Currently this only includes the platform variant (iOS, iPadOS, macOS, watchOS or tvOS) which developers using LiveView Native might want to match on, but it could be expanded to include other information about the client device.