### PR TITLE
Add tool for JSON encoding modifier stack

### DIFF
--- a/util/encode_modifiers.exs
+++ b/util/encode_modifiers.exs
@@ -10,13 +10,13 @@ defmodule ModifierEncoder do
     custom_modifiers: [],
     platform_modifiers: @native.platform_modifiers
 
-  defmacro encode() do
+  defmacro quote_argv() do
     Code.string_to_quoted!(hd(System.argv()))
   end
 
-  def encode!() do
-    IO.write(Phoenix.HTML.Safe.to_iodata(encode().modifiers) |> IO.iodata_to_binary)
+  def encode() do
+    IO.write(Phoenix.HTML.Safe.to_iodata(quote_argv().modifiers) |> IO.iodata_to_binary)
   end
 end
 
-ModifierEncoder.encode!()
+ModifierEncoder.encode()

--- a/util/encode_modifiers.exs
+++ b/util/encode_modifiers.exs
@@ -1,0 +1,22 @@
+Mix.install([
+  {:live_view_native_swift_ui, path: "."},
+  {:live_view_native, git: "https://github.com/liveview-native/live_view_native", branch: "main"},
+])
+
+defmodule ModifierEncoder do
+  @native LiveViewNativePlatform.context(%LiveViewNativeSwiftUi.Platform{})
+
+  use LiveViewNative.Extensions.Modifiers,
+    custom_modifiers: [],
+    platform_modifiers: @native.platform_modifiers
+
+  defmacro encode() do
+    Code.string_to_quoted!(hd(System.argv()))
+  end
+
+  def encode!() do
+    IO.write(Phoenix.HTML.Safe.to_iodata(encode().modifiers) |> IO.iodata_to_binary)
+  end
+end
+
+ModifierEncoder.encode!()


### PR DESCRIPTION
The tool can be used when writing tests for modifiers to generate the JSON for a modifier stack.

For example, running the following command:
```sh
elixir util/encode_modifiers.exs "@native |> frame(width: 100, height: 100)"
```
will produce this JSON output, which can be pasted into the test:
```
[{&quot;alignment&quot;:null,&quot;height&quot;:100.0,&quot;type&quot;:&quot;frame&quot;,&quot;width&quot;:100.0}]
```