### PR TITLE
Add and fix documentation

### DIFF
--- a/Sources/LiveViewNative/Coordinators/LiveViewCoordinator.swift
+++ b/Sources/LiveViewNative/Coordinators/LiveViewCoordinator.swift
@@ -69,7 +69,7 @@ public class LiveViewCoordinator<R: RootRegistry>: ObservableObject {
     ///
     /// - Parameter type: The type of event that is being sent (e.g., `click` or `form`). Note: this is not currently used by the LiveView backend.
     /// - Parameter event: The name of the LiveView event handler that the event is being dispatched to.
-    /// - Parameter value: The event value to provide to the backend event handler. The value _must_ be  serializable using ``JSONSerialization``.
+    /// - Parameter value: The event value to provide to the backend event handler. The value _must_ be  serializable using `JSONSerialization`.
     /// - Parameter target: The value of the `phx-target` attribute.
     /// - Throws: ``LiveConnectionError/eventError(_:)`` if an error is encountered sending the event or processing it on the backend, `CancellationError` if the coordinator navigates to a different page while the event is being handled
     public func pushEvent(type: String, event: String, value: Any, target: Int? = nil) async throws {

--- a/Sources/LiveViewNative/LiveViewNative.docc/LiveViewNative.md
+++ b/Sources/LiveViewNative/LiveViewNative.docc/LiveViewNative.md
@@ -95,8 +95,10 @@ be found at <https://hexdocs.pm/live_view_native_swift_ui>.
 - <doc:ListsModifiers>
 - <doc:ModalPresentations>
 - <doc:NavigationModifiers>
+- <doc:ScrollViewsModifiers>
 - <doc:SearchModifiers>
 - <doc:TextInputAndOutputModifiers>
+- <doc:ToolbarsModifiers>
 - <doc:ViewConfigurationModifiers>
 - <doc:ViewFundamentalsModifiers>
 - <doc:ViewStylesModifiers>

--- a/Sources/LiveViewNative/LiveViewNative.docc/LiveViewNative.md
+++ b/Sources/LiveViewNative/LiveViewNative.docc/LiveViewNative.md
@@ -81,6 +81,7 @@ be found at <https://hexdocs.pm/live_view_native_swift_ui>.
 - <doc:LayoutContainers>
 - <doc:Shapes>
 - <doc:TextInputAndOutput>
+- <doc:Toolbars>
 
 ### Supported Modifiers
 - <doc:AnimationsModifiers>

--- a/Sources/LiveViewNative/Modifiers/Drawing and Graphics Modifiers/AspectRatioModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Drawing and Graphics Modifiers/AspectRatioModifier.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 struct AspectRatioModifier: ViewModifier, Decodable {
+    // TODO: Documentation
     private let aspectRatio: CGSize?
     private let contentMode: ContentMode
 

--- a/Sources/LiveViewNative/Modifiers/Drawing and Graphics Modifiers/BackgroundStyleModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Drawing and Graphics Modifiers/BackgroundStyleModifier.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 struct BackgroundStyleModifier: ViewModifier, Decodable {
+    // TODO: Documentation
     private let style: AnyShapeStyle
 
     func body(content: Content) -> some View {

--- a/Sources/LiveViewNative/Modifiers/Drawing and Graphics Modifiers/BlendModeModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Drawing and Graphics Modifiers/BlendModeModifier.swift
@@ -25,7 +25,7 @@ import SwiftUI
 /// ```
 ///
 /// ## Arguments
-/// * ``blend_mode``
+/// * ``blendMode``
 #if swift(>=5.8)
 @_documentation(visibility: public)
 #endif

--- a/Sources/LiveViewNative/Modifiers/Drawing and Graphics Modifiers/DrawingGroupModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Drawing and Graphics Modifiers/DrawingGroupModifier.swift
@@ -26,7 +26,7 @@ import SwiftUI
 ///
 /// ## Arguments
 /// * ``opaque``
-/// * ``color_mode``
+/// * ``colorMode``
 #if swift(>=5.8)
 @_documentation(visibility: public)
 #endif
@@ -37,7 +37,7 @@ struct DrawingGroupModifier: ViewModifier, Decodable {
     #endif
     private let opaque: Bool
     
-    /// One of the working color space and storage formats. The default is ``non_linear``
+    /// One of the working color space and storage formats. The default is `non_linear`
     ///
     /// Possible values:
     /// * `extended_linear`

--- a/Sources/LiveViewNative/Modifiers/Drawing and Graphics Modifiers/ForegroundStyleModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Drawing and Graphics Modifiers/ForegroundStyleModifier.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 struct ForegroundStyleModifier: ViewModifier, Decodable {
+    // TODO: Documentation
     private let primary: AnyShapeStyle
     private let secondary: AnyShapeStyle?
     private let tertiary: AnyShapeStyle?

--- a/Sources/LiveViewNative/Modifiers/Drawing and Graphics Modifiers/MaskModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Drawing and Graphics Modifiers/MaskModifier.swift
@@ -29,7 +29,7 @@ import SwiftUI
 @_documentation(visibility: public)
 #endif
 struct MaskModifier<R: RootRegistry>: ViewModifier, Decodable {
-    /// The alignment in relation to this view. Defaults to ``center``
+    /// The alignment in relation to this view. Defaults to `center`
     ///
     /// See ``LiveViewNative/SwiftUI/Alignment``.
     #if swift(>=5.8)

--- a/Sources/LiveViewNative/Modifiers/Drawing and Graphics Modifiers/TintModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Drawing and Graphics Modifiers/TintModifier.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 struct TintModifier: ViewModifier, Decodable, Equatable {
+    // TODO: Documentation
     private let color: SwiftUI.Color?
     
     init(color: SwiftUI.Color) {

--- a/Sources/LiveViewNative/Modifiers/Input Events Modifiers/AllowsHitTestingModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Input Events Modifiers/AllowsHitTestingModifier.swift
@@ -21,6 +21,9 @@ import SwiftUI
 ///
 /// ## Arguments
 /// * ``enabled``
+#if swift(>=5.8)
+@_documentation(visibility: public)
+#endif
 struct AllowsHitTestingModifier: ViewModifier, Decodable {
     #if swift(>=5.8)
     @_documentation(visibility: public)

--- a/Sources/LiveViewNative/Modifiers/Input Events Modifiers/DigitalCrownAccessoryVisibilityModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Input Events Modifiers/DigitalCrownAccessoryVisibilityModifier.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 /// Specifies the visibility of Digital Crown accessory Views on Apple Watch.
 ///
-/// Use this method to customize the visibility of a Digital Crown accessory View created with the ``digital_crown_accessory`` modifier.
+/// Use this method to customize the visibility of a Digital Crown accessory View created with ``DigitalCrownAccessoryModifier``.
 ///
 /// ```html
 /// <List modifiers={

--- a/Sources/LiveViewNative/Modifiers/Input Events Modifiers/HoverEffectModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Input Events Modifiers/HoverEffectModifier.swift
@@ -24,7 +24,7 @@ import SwiftUI
 #endif
 @available(iOS 16.0, tvOS 16.0, *)
 struct HoverEffectModifier: ViewModifier, Decodable {
-    /// The effect applied when the pointer hovers over a view. Defaults to ``automatic``.
+    /// The effect applied when the pointer hovers over a view. Defaults to `automatic`.
     ///
     /// Possible values:
     /// * `automatic`

--- a/Sources/LiveViewNative/Modifiers/Layout Adjustments Modifiers/FrameModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Layout Adjustments Modifiers/FrameModifier.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 enum FrameModifier: ViewModifier, Decodable, Equatable {
+    // TODO: Documentation
     case fixed(width: CGFloat?, height: CGFloat?, alignment: Alignment)
     case flexible(minWidth: CGFloat?, idealWidth: CGFloat?, maxWidth: CGFloat?, minHeight: CGFloat?, idealHeight: CGFloat?, maxHeight: CGFloat?, alignment: Alignment)
     

--- a/Sources/LiveViewNative/Modifiers/Lists Modifiers/DeleteDisabledModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Lists Modifiers/DeleteDisabledModifier.swift
@@ -19,6 +19,9 @@ import SwiftUI
 ///
 /// ## Arguments
 /// * ``isDisabled``
+#if swift(>=5.8)
+@_documentation(visibility: public)
+#endif
 struct DeleteDisabledModifier: ViewModifier, Decodable {
     #if swift(>=5.8)
     @_documentation(visibility: public)

--- a/Sources/LiveViewNative/Modifiers/Lists Modifiers/DeleteDisabledModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Lists Modifiers/DeleteDisabledModifier.swift
@@ -18,7 +18,7 @@ import SwiftUI
 /// ```
 ///
 /// ## Arguments
-/// * ``is_disabled``
+/// * ``isDisabled``
 struct DeleteDisabledModifier: ViewModifier, Decodable {
     #if swift(>=5.8)
     @_documentation(visibility: public)

--- a/Sources/LiveViewNative/Modifiers/Lists Modifiers/ListRowSeparatorModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Lists Modifiers/ListRowSeparatorModifier.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 struct ListRowSeparatorModifier: ViewModifier, Decodable, Equatable {
+    // TODO: Documentation
     private let visibility: Visibility
     private let edges: VerticalEdge.Set
     

--- a/Sources/LiveViewNative/Modifiers/Lists Modifiers/MoveDisabledModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Lists Modifiers/MoveDisabledModifier.swift
@@ -18,7 +18,7 @@ import SwiftUI
 /// ```
 ///
 /// ## Arguments
-/// * ``is_disabled``
+/// * ``isDisabled``
 struct MoveDisabledModifier: ViewModifier, Decodable {
     #if swift(>=5.8)
     @_documentation(visibility: public)

--- a/Sources/LiveViewNative/Modifiers/Lists Modifiers/MoveDisabledModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Lists Modifiers/MoveDisabledModifier.swift
@@ -19,6 +19,9 @@ import SwiftUI
 ///
 /// ## Arguments
 /// * ``isDisabled``
+#if swift(>=5.8)
+@_documentation(visibility: public)
+#endif
 struct MoveDisabledModifier: ViewModifier, Decodable {
     #if swift(>=5.8)
     @_documentation(visibility: public)

--- a/Sources/LiveViewNative/Modifiers/Navigation Modifiers/NavigationBarBackButtonHiddenModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Navigation Modifiers/NavigationBarBackButtonHiddenModifier.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-/// Hides the navigation bar back button for the view. This modifier only takes effect when this view is inside of and visible within a ``NavigationView``.
+/// Hides the navigation bar back button for the view.
 ///
 /// While this modifier defaults to false when used, the typical usage of SwiftUI is to not call this modifier and allow showing of the back button.
 ///
@@ -19,7 +19,7 @@ import SwiftUI
 /// ```
 ///
 /// ## Arguments
-/// * ``hides_back_button``
+/// * ``hidesBackButton``
 #if swift(>=5.8)
 @_documentation(visibility: public)
 #endif

--- a/Sources/LiveViewNative/Modifiers/Navigation Modifiers/NavigationBarTitleDisplayModeModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Navigation Modifiers/NavigationBarTitleDisplayModeModifier.swift
@@ -23,7 +23,7 @@ import SwiftUI
 /// ```
 ///
 /// ## Arguments
-/// * ``display_mode``
+/// * ``displayMode``
 #if swift(>=5.8)
 @_documentation(visibility: public)
 #endif

--- a/Sources/LiveViewNative/Modifiers/Navigation Modifiers/NavigationTitleModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Navigation Modifiers/NavigationTitleModifier.swift
@@ -7,7 +7,25 @@
 
 import SwiftUI
 
+/// Configures the view’s title for purposes of navigation, using a string.
+///
+/// ```html
+/// <VStack modifiers={navigation_title(@native, title: "Navigation Title")}>
+///     <Text>Top</Text>
+///     <Text>Bottom</Text>
+/// </VStack>
+/// ```
+///
+/// ## Arguments
+/// * ``title``
+#if swift(>=5.8)
+@_documentation(visibility: public)
+#endif
 struct NavigationTitleModifier: ViewModifier, Decodable, Equatable {
+    /// The string to display.
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
     fileprivate let title: String
     private let cached: Bool
     

--- a/Sources/LiveViewNative/Modifiers/Scroll Views Modifiers/ScrollBounceBehaviorModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Scroll Views Modifiers/ScrollBounceBehaviorModifier.swift
@@ -1,6 +1,6 @@
 //
 //  ScrollBounceBehaviorModifier.swift
-//  
+//  LiveViewNative
 //
 //  Created by Dylan.Ginsburg on 4/28/23.
 //
@@ -36,7 +36,7 @@ struct ScrollBounceBehaviorModifier: ViewModifier, Decodable {
     
     /// The set of axes to apply behavior to.. Defaults to `vertical`.
     ///
-    /// See ``LiveViewNative/SwiftUI/Axis.Set`` for a list of possible values.
+    /// See ``LiveViewNative/SwiftUI/Axis/Set`` for a list of possible values.
     #if swift(>=5.8)
     @_documentation(visibility: public)
     #endif

--- a/Sources/LiveViewNative/Modifiers/Scroll Views Modifiers/ScrollIndicatorsModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Scroll Views Modifiers/ScrollIndicatorsModifier.swift
@@ -35,7 +35,7 @@ struct ScrollIndicatorsModifier: ViewModifier, Decodable {
     
     /// The axes of scrollable views that the visibility applies to. Defaults to `all`.
     ///
-    /// See ``LiveViewNative/SwiftUI/Axis`` for a list of possible values.
+    /// See ``LiveViewNative/SwiftUI/Axis/Set`` for a list of possible values.
     #if swift(>=5.8)
     @_documentation(visibility: public)
     #endif

--- a/Sources/LiveViewNative/Modifiers/Scroll Views Modifiers/ScrollIndicatorsModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Scroll Views Modifiers/ScrollIndicatorsModifier.swift
@@ -35,7 +35,7 @@ struct ScrollIndicatorsModifier: ViewModifier, Decodable {
     
     /// The axes of scrollable views that the visibility applies to. Defaults to `all`.
     ///
-    /// See ``LiveViewNative/SwiftUI/Axis.Set`` for a list of possible values.
+    /// See ``LiveViewNative/SwiftUI/Axis`` for a list of possible values.
     #if swift(>=5.8)
     @_documentation(visibility: public)
     #endif

--- a/Sources/LiveViewNative/Modifiers/Text Input and Output Modifiers/LineSpacingModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Text Input and Output Modifiers/LineSpacingModifier.swift
@@ -16,7 +16,7 @@ import SwiftUI
 /// ```
 ///
 /// ## Arguments
-/// * ``line_spacing``
+/// * ``lineSpacing``
 #if swift(>=5.8)
 @_documentation(visibility: public)
 #endif

--- a/Sources/LiveViewNative/Modifiers/Text Input and Output Modifiers/SubmitLabelModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Text Input and Output Modifiers/SubmitLabelModifier.swift
@@ -16,7 +16,7 @@ import SwiftUI
 /// ```
 ///
 /// ## Arguments
-/// * ``submit_label``
+/// * ``submitLabel``
 #if swift(>=5.8)
 @_documentation(visibility: public)
 #endif

--- a/Sources/LiveViewNative/Modifiers/Text Input and Output Modifiers/TextContentTypeModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Text Input and Output Modifiers/TextContentTypeModifier.swift
@@ -23,7 +23,7 @@ import SwiftUI
 /// ```
 ///
 /// ## Arguments
-/// * ``text_content_type``
+/// * ``textContentType``
 #if swift(>=5.8)
 @_documentation(visibility: public)
 #endif

--- a/Sources/LiveViewNative/Modifiers/View Configuration Modifiers/HiddenModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/View Configuration Modifiers/HiddenModifier.swift
@@ -16,7 +16,7 @@ import SwiftUI
 /// </VStack>
 ///
 /// ## Arguments
-/// * ``is_active``
+/// * ``isActive``
 #if swift(>=5.8)
 @_documentation(visibility: public)
 #endif

--- a/Sources/LiveViewNative/Modifiers/View Configuration Modifiers/PreferredColorSchemeModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/View Configuration Modifiers/PreferredColorSchemeModifier.swift
@@ -22,7 +22,7 @@ import SwiftUI
 /// ```
 ///
 /// ## Arguments
-/// * ``color_scheme``
+/// * ``colorScheme``
 #if swift(>=5.8)
 @_documentation(visibility: public)
 #endif

--- a/Sources/LiveViewNative/Views/Layout Containers/Groups/DisclosureGroup.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Groups/DisclosureGroup.swift
@@ -36,9 +36,6 @@ import SwiftUI
 /// end
 /// ```
 ///
-/// ## Attributes
-/// * ``style``
-///
 /// ## Bindings
 /// * ``isExpanded``
 ///

--- a/Sources/LiveViewNative/Views/Layout Containers/Presentation Containers/TabView.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Presentation Containers/TabView.swift
@@ -35,6 +35,9 @@ struct TabView<R: RootRegistry>: View {
     /// Synchronizes the selected tab with the server.
     ///
     /// Use the ``TagModifier`` modifier to set the selection value for a given tab.
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
     @LiveBinding(attribute: "selection") private var selection: String?
     
     var body: some View {

--- a/Sources/LiveViewNative/Views/Text Input and Output/TextField.swift
+++ b/Sources/LiveViewNative/Views/Text Input and Output/TextField.swift
@@ -91,10 +91,47 @@ struct TextField<R: RootRegistry>: TextFieldProtocol {
     @FormState var value: String?
     @FocusState private var isFocused: Bool
     
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
     @Event("phx-focus", type: "focus") var focusEvent
+    
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
     @Event("phx-blur", type: "blur") var blurEvent
+
+    /// Possible values:
+    /// * `date-time`
+    /// * `url`
+    /// * `iso8601`
+    /// * `number`
+    /// * `percent`
+    /// * `currency`
+    /// * `name`
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
     @Attribute("format") private var format: String?
+    
+    /// The currency code for the locale.
+    ///
+    /// Example currency codes include `USD`, `EUR`, and `JPY`.
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
     @Attribute("currency-code") private var currencyCode: String?
+    
+    /// A type used to format a person’s name with a style appropriate for the given locale.
+    /// 
+    /// Possible values:
+    /// * `short`
+    /// * `medium`
+    /// * `long`
+    /// * `abbreviated`
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
     @Attribute(
         "name-style",
         transform: {


### PR DESCRIPTION
I started this exercise to check that my own documentation was being generated correctly and ended up making a full pass to fix the low hanging fruit.

- Reduced the number of documentation generation errors from 62 to 14 by fixing references and writing a few more entries.
- Added `// TODO: Documentation` comments for structs that have no documentation.


There was a class of error I'm not sure how to fix. 6 of the remaining 14 are errors like this in trying to reference functions.
> /Registries/CustomRegistry.swift:31:7: warning: Topic reference 'decodeModifier(_:from:context:)-4cqvs' couldn't be resolved. No local documentation matches this reference.
