### PR TITLE
Add support for Shape-specific modifiers

### DIFF
--- a/Plugins/DocumentationExtensionGeneratorPlugin/DocumentationExtensionGeneratorPlugin.swift
+++ b/Plugins/DocumentationExtensionGeneratorPlugin/DocumentationExtensionGeneratorPlugin.swift
@@ -13,7 +13,10 @@ struct DocumentationExtensionGeneratorPlugin: CommandPlugin {
             .filter({ $0.type == .source })
             .map(\.path)
         let modifierFiles = target.sourceFiles
-            .filter({ $0.path.string.starts(with: target.directory.appending("Modifiers").string) })
+            .filter({
+                $0.path.string.starts(with: target.directory.appending("Modifiers").string)
+                    || $0.path.string.starts(with: target.directory.appending("Shape Modifiers").string)
+            })
             .filter({ $0.type == .source })
             .map(\.path)
         

--- a/Sources/LiveViewNative/LiveViewNative.docc/Shapes.md
+++ b/Sources/LiveViewNative/LiveViewNative.docc/Shapes.md
@@ -8,3 +8,19 @@
 - <doc:Ellipse>
 - <doc:Rectangle>
 - ``LiveViewNative/SwiftUI/RoundedRectangle``
+
+### Transforming a shape
+- ``OffsetShapeModifier``
+- ``RotationModifier``
+- ``SizeModifier``
+- ``TrimModifier``
+
+### Insetting a shape
+- ``InsetModifier``
+
+### Stroking a shape
+- ``StrokeModifier``
+- ``StrokeBorderModifier``
+
+### Filling a shape
+- ``FillModifier``

--- a/Sources/LiveViewNative/Shape Modifiers/FillModifier.swift
+++ b/Sources/LiveViewNative/Shape Modifiers/FillModifier.swift
@@ -1,0 +1,21 @@
+//
+//  FillModifier.swift
+//  LiveViewNative
+//
+//  Created by Carson Katri on 5/11/23.
+//
+
+import SwiftUI
+
+struct FillModifier: FinalShapeModifier, Decodable {
+    let content: AnyShapeStyle
+    let style: FillStyle?
+    
+    func apply(to shape: any SwiftUI.Shape) -> some View {
+        AnyShape(shape).fill(content, style: style ?? .init())
+    }
+    
+    func apply(to shape: any InsettableShape) -> some View {
+        AnyShape(shape).fill(content, style: style ?? .init())
+    }
+}

--- a/Sources/LiveViewNative/Shape Modifiers/FillModifier.swift
+++ b/Sources/LiveViewNative/Shape Modifiers/FillModifier.swift
@@ -7,8 +7,35 @@
 
 import SwiftUI
 
+/// Fills a ``Shape`` with a ``LiveViewNative/SwiftUI/AnyShapeStyle``.
+///
+/// Optionally provide a ``LiveViewNative/SwiftUI/FillStyle`` to configure how the shape should be drawn.
+///
+/// ```html
+/// <Circle modifiers={fill(@native, content: {:color, :red}, style: [antialiased: false])} />
+/// ```
+///
+/// ## Arguments
+/// * ``content``
+/// * ``style``
+#if swift(>=5.8)
+@_documentation(visibility: public)
+#endif
 struct FillModifier: FinalShapeModifier, Decodable {
+    /// The shape style to fill the shape with.
+    ///
+    /// See ``LiveViewNative/SwiftUI/AnyShapeStyle`` for more details on creating shape styles.
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
     let content: AnyShapeStyle
+    
+    /// Configuration for the fill.
+    ///
+    /// See ``LiveViewNative/SwiftUI/FillStyle`` for more details on configuring fills.
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
     let style: FillStyle?
     
     func apply(to shape: any SwiftUI.Shape) -> some View {

--- a/Sources/LiveViewNative/Shape Modifiers/InsetModifier.swift
+++ b/Sources/LiveViewNative/Shape Modifiers/InsetModifier.swift
@@ -7,7 +7,25 @@
 
 import SwiftUI
 
+/// Insets a ``Shape`` by a given amount.
+///
+/// - Note: Only insettable shapes can use this modifier.
+/// Some modifiers cause shapes to no longer be insettable, such as ``TrimModifier``.
+///
+/// ```html
+/// <Circle modifiers={inset(@native, amount: 10)} />
+/// ```
+///
+/// ## Arguments
+/// * ``amount``
+#if swift(>=5.8)
+@_documentation(visibility: public)
+#endif
 struct InsetModifier: ShapeModifier, Decodable {
+    /// The amount to inset the ``Shape`` by.
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
     let amount: CGFloat
     
     enum CodingKeys: CodingKey {

--- a/Sources/LiveViewNative/Shape Modifiers/InsetModifier.swift
+++ b/Sources/LiveViewNative/Shape Modifiers/InsetModifier.swift
@@ -1,0 +1,29 @@
+//
+//  InsetModifier.swift
+//  
+//
+//  Created by Carson Katri on 5/11/23.
+//
+
+import SwiftUI
+
+struct InsetModifier: ShapeModifier, Decodable {
+    let amount: CGFloat
+    
+    enum CodingKeys: CodingKey {
+        case amount
+    }
+    
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.amount = try container.decode(CGFloat.self, forKey: .amount)
+    }
+    
+    func apply(to shape: some SwiftUI.Shape) -> any SwiftUI.Shape {
+        shape
+    }
+    
+    func apply(to shape: some SwiftUI.InsettableShape) -> any SwiftUI.Shape {
+        shape.inset(by: amount)
+    }
+}

--- a/Sources/LiveViewNative/Shape Modifiers/OffsetShapeModifier.swift
+++ b/Sources/LiveViewNative/Shape Modifiers/OffsetShapeModifier.swift
@@ -7,8 +7,26 @@
 
 import SwiftUI
 
+/// Moves a ``Shape`` by the given amount.
+///
+/// - Note: This modifier only applies to ``Shape`` elements, and is separate from the ``OffsetModifier`` modifier.
+///
+/// ```html
+/// <Circle modifiers={shape_offset(@native, x: 10, y: 50)} />
+/// ```
+#if swift(>=5.8)
+@_documentation(visibility: public)
+#endif
 struct OffsetShapeModifier: ShapeModifier, Decodable {
+    /// The horizontal offset distance. Defaults to `0`.
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
     let x: CGFloat
+    /// The vertical offset distance. Defaults to `0`.
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
     let y: CGFloat
     
     func apply(to shape: some SwiftUI.Shape) -> any SwiftUI.Shape {

--- a/Sources/LiveViewNative/Shape Modifiers/OffsetShapeModifier.swift
+++ b/Sources/LiveViewNative/Shape Modifiers/OffsetShapeModifier.swift
@@ -1,0 +1,21 @@
+//
+//  OffsetShapeModifier.swift
+//  
+//
+//  Created by Carson Katri on 5/11/23.
+//
+
+import SwiftUI
+
+struct OffsetShapeModifier: ShapeModifier, Decodable {
+    let x: CGFloat
+    let y: CGFloat
+    
+    func apply(to shape: some SwiftUI.Shape) -> any SwiftUI.Shape {
+        shape.offset(x: x, y: y)
+    }
+    
+    func apply(to shape: some SwiftUI.InsettableShape) -> any SwiftUI.Shape {
+        shape.offset(x: x, y: y)
+    }
+}

--- a/Sources/LiveViewNative/Shape Modifiers/RotationModifier.swift
+++ b/Sources/LiveViewNative/Shape Modifiers/RotationModifier.swift
@@ -1,0 +1,21 @@
+//
+//  RotationModifier.swift
+//
+//
+//  Created by Carson Katri on 5/11/23.
+//
+
+import SwiftUI
+
+struct RotationModifier: ShapeModifier, Decodable {
+    let angle: Angle
+    let anchor: UnitPoint?
+    
+    func apply(to shape: some SwiftUI.Shape) -> any SwiftUI.Shape {
+        shape.rotation(angle, anchor: anchor ?? .center)
+    }
+    
+    func apply(to shape: some SwiftUI.InsettableShape) -> any SwiftUI.Shape {
+        shape.rotation(angle, anchor: anchor ?? .center)
+    }
+}

--- a/Sources/LiveViewNative/Shape Modifiers/RotationModifier.swift
+++ b/Sources/LiveViewNative/Shape Modifiers/RotationModifier.swift
@@ -7,8 +7,35 @@
 
 import SwiftUI
 
+/// Rotates a ``Shape``.
+///
+/// Pass an ``LiveViewNative/SwiftUI/Angle`` to rotate by.
+///
+/// ```html
+/// <Circle modifiers={rotation(@native, angle: {:degrees, 10})} />
+/// ```
+///
+/// ## Arguments
+/// * ``angle``
+/// * ``anchor``
+#if swift(>=5.8)
+@_documentation(visibility: public)
+#endif
 struct RotationModifier: ShapeModifier, Decodable {
+    /// The amount to rotate by.
+    ///
+    /// See ``LiveViewNative/SwiftUI/Angle`` for more details on creating angles.
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
     let angle: Angle
+    
+    /// The origin of the rotation. Defaults to `center`.
+    ///
+    /// See ``LiveViewNative/SwiftUI/UnitPoint`` for a list of possible values.
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
     let anchor: UnitPoint?
     
     func apply(to shape: some SwiftUI.Shape) -> any SwiftUI.Shape {

--- a/Sources/LiveViewNative/Shape Modifiers/ShapeModifier.swift
+++ b/Sources/LiveViewNative/Shape Modifiers/ShapeModifier.swift
@@ -82,41 +82,27 @@ enum FinalShapeModifierBuilder {
     static func buildEither<
         TrueShapeModifier: FinalShapeModifier,
         FalseShapeModifier: FinalShapeModifier
-    >(first component: @autoclosure () throws -> TrueShapeModifier) rethrows -> _ConditionalShapeContent<TrueShapeModifier, FalseShapeModifier> {
+    >(first component: @autoclosure () throws -> TrueShapeModifier) rethrows -> _ConditionalFinalShapeModifier<TrueShapeModifier, FalseShapeModifier> {
         .init(storage: .trueContent(try component()))
     }
     static func buildEither<
         TrueShapeModifier: FinalShapeModifier,
         FalseShapeModifier: FinalShapeModifier
-    >(second component: @autoclosure () throws -> FalseShapeModifier) rethrows -> _ConditionalShapeContent<TrueShapeModifier, FalseShapeModifier> {
+    >(second component: @autoclosure () throws -> FalseShapeModifier) rethrows -> _ConditionalFinalShapeModifier<TrueShapeModifier, FalseShapeModifier> {
         .init(storage: .falseContent(try component()))
     }
 }
 
-/// A `ShapeModifier` or `FinalShapeModifier` that switches between two possible shape modifier types.
-struct _ConditionalShapeContent<TrueContent, FalseContent> {
+/// A `FinalShapeModifier` that switches between two possible shape modifier types.
+struct _ConditionalFinalShapeModifier<TrueContent, FalseContent>: FinalShapeModifier
+where TrueContent: FinalShapeModifier, FalseContent: FinalShapeModifier {
     enum Storage {
         case trueContent(TrueContent)
         case falseContent(FalseContent)
     }
     
     let storage: Storage
-}
-
-extension _ConditionalShapeContent: ShapeModifier
-where TrueContent: ShapeModifier, FalseContent: ShapeModifier {
-    func apply(to shape: some SwiftUI.Shape) -> any SwiftUI.Shape {
-        switch storage {
-        case let .trueContent(modifier):
-            return modifier.apply(to: shape)
-        case let .falseContent(modifier):
-            return modifier.apply(to: shape)
-        }
-    }
-}
-
-extension _ConditionalShapeContent: FinalShapeModifier
-where TrueContent: FinalShapeModifier, FalseContent: FinalShapeModifier {
+    
     @ViewBuilder
     func apply(to shape: any SwiftUI.Shape) -> some View {
         switch storage {
@@ -177,8 +163,8 @@ enum ShapeModifierRegistry: ShapeModifierRegistryProtocol {
     static func decodeFinalShapeModifier(
         _ type: FinalShapeModifierType,
         from decoder: Decoder
-    ) throws -> _ConditionalShapeContent<
-        _ConditionalShapeContent<
+    ) throws -> _ConditionalFinalShapeModifier<
+        _ConditionalFinalShapeModifier<
             FillModifier,
             StrokeModifier
         >,

--- a/Sources/LiveViewNative/Shape Modifiers/ShapeModifier.swift
+++ b/Sources/LiveViewNative/Shape Modifiers/ShapeModifier.swift
@@ -174,7 +174,6 @@ enum ShapeModifierRegistry: ShapeModifierRegistryProtocol {
         }
     }
     
-    @FinalShapeModifierBuilder
     static func decodeFinalShapeModifier(
         _ type: FinalShapeModifierType,
         from decoder: Decoder

--- a/Sources/LiveViewNative/Shape Modifiers/ShapeModifier.swift
+++ b/Sources/LiveViewNative/Shape Modifiers/ShapeModifier.swift
@@ -1,0 +1,206 @@
+//
+//  ShapeModifierProtocol.swift
+//  
+//
+//  Created by Carson Katri on 5/11/23.
+//
+
+import SwiftUI
+
+protocol ShapeModifier {
+    @_disfavoredOverload
+    func apply(to shape: some SwiftUI.Shape) -> any SwiftUI.Shape
+    func apply(to shape: some SwiftUI.InsettableShape) -> any SwiftUI.Shape
+}
+
+extension ShapeModifier {
+    func apply(to shape: EitherAnyShape) -> EitherAnyShape {
+        switch shape {
+        case let .shape(shape):
+            return .shape(self.apply(to: shape))
+        case let .insettable(shape):
+            let result = self.apply(to: shape)
+            if let insettable = result as? any InsettableShape {
+                return .insettable(insettable)
+            } else {
+                return .shape(result)
+            }
+        }
+    }
+}
+
+protocol FinalShapeModifier {
+    associatedtype Body: View
+    associatedtype InsettableBody: View
+    @_disfavoredOverload
+    func apply(to shape: any SwiftUI.Shape) -> Body
+    func apply(to shape: any SwiftUI.InsettableShape) -> InsettableBody
+}
+
+extension FinalShapeModifier {
+    @ViewBuilder
+    func apply(to shape: EitherAnyShape) -> some View {
+        switch shape {
+        case let .shape(shape):
+            self.apply(to: shape)
+        case let .insettable(shape):
+            self.apply(to: shape)
+        }
+    }
+}
+
+enum EitherAnyShape {
+    case shape(any SwiftUI.Shape)
+    case insettable(any InsettableShape)
+    
+    func eraseToAnyShape() -> AnyShape {
+        switch self {
+        case let .shape(shape):
+            return AnyShape(shape)
+        case let .insettable(shape):
+            return AnyShape(shape)
+        }
+    }
+}
+
+@resultBuilder
+struct ShapeModifierBuilder {
+    static func buildBlock(_ component: some ShapeModifier) -> some ShapeModifier {
+        component
+    }
+    
+    static func buildEither<
+        TrueShapeModifier: ShapeModifier,
+        FalseShapeModifier: ShapeModifier
+    >(first component: @autoclosure () throws -> TrueShapeModifier) rethrows -> _ConditionalShapeContent<TrueShapeModifier, FalseShapeModifier> {
+        .init(storage: .trueContent(try component()))
+    }
+    static func buildEither<
+        TrueShapeModifier: ShapeModifier,
+        FalseShapeModifier: ShapeModifier
+    >(second component: @autoclosure () throws -> FalseShapeModifier) rethrows -> _ConditionalShapeContent<TrueShapeModifier, FalseShapeModifier> {
+        .init(storage: .falseContent(try component()))
+    }
+}
+
+@resultBuilder
+struct FinalShapeModifierBuilder {
+    static func buildBlock<M: FinalShapeModifier>(_ component: M) -> M {
+        component
+    }
+    
+    static func buildEither<
+        TrueShapeModifier: FinalShapeModifier,
+        FalseShapeModifier: FinalShapeModifier
+    >(first component: @autoclosure () throws -> TrueShapeModifier) rethrows -> _ConditionalShapeContent<TrueShapeModifier, FalseShapeModifier> {
+        .init(storage: .trueContent(try component()))
+    }
+    static func buildEither<
+        TrueShapeModifier: FinalShapeModifier,
+        FalseShapeModifier: FinalShapeModifier
+    >(second component: @autoclosure () throws -> FalseShapeModifier) rethrows -> _ConditionalShapeContent<TrueShapeModifier, FalseShapeModifier> {
+        .init(storage: .falseContent(try component()))
+    }
+}
+
+/// A `ShapeModifier` that switches between two possible shape modifier types.
+struct _ConditionalShapeContent<TrueContent, FalseContent> {
+    enum Storage {
+        case trueContent(TrueContent)
+        case falseContent(FalseContent)
+    }
+    
+    let storage: Storage
+}
+
+extension _ConditionalShapeContent: ShapeModifier
+where TrueContent: ShapeModifier, FalseContent: ShapeModifier {
+    func apply(to shape: some SwiftUI.Shape) -> any SwiftUI.Shape {
+        switch storage {
+        case let .trueContent(modifier):
+            return modifier.apply(to: shape)
+        case let .falseContent(modifier):
+            return modifier.apply(to: shape)
+        }
+    }
+}
+
+extension _ConditionalShapeContent: FinalShapeModifier
+where TrueContent: FinalShapeModifier, FalseContent: FinalShapeModifier {
+    @ViewBuilder
+    func apply(to shape: any SwiftUI.Shape) -> some View {
+        switch storage {
+        case let .trueContent(modifier):
+            modifier.apply(to: shape)
+        case let .falseContent(modifier):
+            modifier.apply(to: shape)
+        }
+    }
+    
+    @ViewBuilder
+    func apply(to shape: any InsettableShape) -> some View {
+        switch storage {
+        case let .trueContent(modifier):
+            modifier.apply(to: shape)
+        case let .falseContent(modifier):
+            modifier.apply(to: shape)
+        }
+    }
+}
+
+protocol ShapeModifierRegistryProtocol {
+    associatedtype AggregateFinalShapeModifier: FinalShapeModifier
+    
+    @ShapeModifierBuilder
+    static func decodeShapeModifier(
+        _ type: ShapeModifierType,
+        from decoder: Decoder
+    ) throws -> ShapeModifier
+    
+    @FinalShapeModifierBuilder
+    static func decodeFinalShapeModifier(
+        _ type: FinalShapeModifierType,
+        from decoder: Decoder
+    ) throws -> AggregateFinalShapeModifier
+}
+
+enum ShapeModifierRegistry: ShapeModifierRegistryProtocol {
+    static func decodeShapeModifier(
+        _ type: ShapeModifierType,
+        from decoder: Decoder
+    ) throws -> ShapeModifier {
+        switch type {
+        case .inset:
+            return try InsetModifier(from: decoder)
+        case .offset:
+            return try OffsetShapeModifier(from: decoder)
+        case .rotation:
+            return try RotationModifier(from: decoder)
+        case .size:
+            return try SizeModifier(from: decoder)
+        case .trim:
+            return try TrimModifier(from: decoder)
+        }
+    }
+    
+    @FinalShapeModifierBuilder
+    static func decodeFinalShapeModifier(
+        _ type: FinalShapeModifierType,
+        from decoder: Decoder
+    ) throws -> _ConditionalShapeContent<
+        _ConditionalShapeContent<
+            FillModifier,
+            StrokeModifier
+        >,
+        StrokeBorderModifier
+    > {
+        switch type {
+        case .fill:
+            try FillModifier(from: decoder)
+        case .stroke:
+            try StrokeModifier(from: decoder)
+        case .strokeBorder:
+            try StrokeBorderModifier(from: decoder)
+        }
+    }
+}

--- a/Sources/LiveViewNative/Shape Modifiers/SizeModifier.swift
+++ b/Sources/LiveViewNative/Shape Modifiers/SizeModifier.swift
@@ -7,8 +7,32 @@
 
 import SwiftUI
 
+/// Sets the size of the ``Shape``.
+///
+/// - Note: This modifier does not affect the layout of elements.
+/// Use the ``FrameModifier`` modifier to adjust the bounding box of an element.
+///
+/// ```html
+/// <Rectangle modifiers={size(@native, width: 100, height: 100)} />
+/// ```
+///
+/// ## Arguments
+/// * ``width``
+/// * ``height``
+#if swift(>=5.8)
+@_documentation(visibility: public)
+#endif
 struct SizeModifier: ShapeModifier, Decodable {
+    /// The horizontal size of the shape.
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
     let width: CGFloat
+    
+    /// The vertical size of the shape.
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
     let height: CGFloat
     
     func apply(to shape: some SwiftUI.Shape) -> any SwiftUI.Shape {

--- a/Sources/LiveViewNative/Shape Modifiers/SizeModifier.swift
+++ b/Sources/LiveViewNative/Shape Modifiers/SizeModifier.swift
@@ -1,0 +1,21 @@
+//
+//  SizeModifier.swift
+//  
+//
+//  Created by Carson Katri on 5/11/23.
+//
+
+import SwiftUI
+
+struct SizeModifier: ShapeModifier, Decodable {
+    let width: CGFloat
+    let height: CGFloat
+    
+    func apply(to shape: some SwiftUI.Shape) -> any SwiftUI.Shape {
+        shape.size(width: width, height: height)
+    }
+    
+    func apply(to shape: some SwiftUI.InsettableShape) -> any SwiftUI.Shape {
+        shape.size(width: width, height: height)
+    }
+}

--- a/Sources/LiveViewNative/Shape Modifiers/StrokeBorderModifier.swift
+++ b/Sources/LiveViewNative/Shape Modifiers/StrokeBorderModifier.swift
@@ -7,9 +7,48 @@
 
 import SwiftUI
 
+/// Adds an inner stroke to a ``Shape``.
+///
+/// Pass a ``LiveViewNative/SwiftUI/AnyShapeStyle`` to the `content` argument to create the stroke.
+///
+/// Optionally provide a ``LiveViewNative/SwiftUI/StrokeStyle`` to configure the stroke.
+///
+/// ```html
+/// <Circle modifiers={stroke_border(@native, content: {:color, :red}, style: [line_width: 10])} />
+/// ```
+///
+/// - Note: Unlike the ``StrokeModifier`` modifier, this strokes the inside of the shape.
+/// This is equivalent to using a ``TrimModifier`` modifier set to half the line thickness, then stroking.
+/// This means that this modifier only operates on insettable shapes.
+///
+/// ## Arguments
+/// * ``content``
+/// * ``style``
+/// * ``antialiased``
+#if swift(>=5.8)
+@_documentation(visibility: public)
+#endif
 struct StrokeBorderModifier: FinalShapeModifier, Decodable {
+    /// The shape style to stroke with.
+    ///
+    /// See ``LiveViewNative/SwiftUI/AnyShapeStyle`` for more details on creating shape styles.
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
     let content: AnyShapeStyle
+    
+    /// Configuration for the stroke.
+    ///
+    /// See ``LiveViewNative/SwiftUI/StrokeStyle`` for more details on configuring strokes.
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
     let style: StrokeStyle?
+    
+    /// Enable/disable antialiasing on the shape's edges. Defaults to `true`.
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
     let antialiased: Bool
     
     func apply(to shape: any SwiftUI.Shape) -> some View {

--- a/Sources/LiveViewNative/Shape Modifiers/StrokeBorderModifier.swift
+++ b/Sources/LiveViewNative/Shape Modifiers/StrokeBorderModifier.swift
@@ -1,0 +1,22 @@
+//
+//  StrokeBorderModifier.swift
+//  LiveViewNative
+//
+//  Created by Carson Katri on 5/11/23.
+//
+
+import SwiftUI
+
+struct StrokeBorderModifier: FinalShapeModifier, Decodable {
+    let content: AnyShapeStyle
+    let style: StrokeStyle?
+    let antialiased: Bool
+    
+    func apply(to shape: any SwiftUI.Shape) -> some View {
+        AnyShape(shape)
+    }
+    
+    func apply(to shape: any InsettableShape) -> some View {
+        AnyView(shape.strokeBorder(content, style: style ?? .init(), antialiased: antialiased))
+    }
+}

--- a/Sources/LiveViewNative/Shape Modifiers/StrokeModifier.swift
+++ b/Sources/LiveViewNative/Shape Modifiers/StrokeModifier.swift
@@ -1,0 +1,21 @@
+//
+//  StrokeModifier.swift
+//  LiveViewNative
+//
+//  Created by Carson Katri on 5/11/23.
+//
+
+import SwiftUI
+
+struct StrokeModifier: FinalShapeModifier, Decodable {
+    let content: AnyShapeStyle
+    let style: StrokeStyle?
+    
+    func apply(to shape: any SwiftUI.Shape) -> some View {
+        AnyShape(shape).stroke(content, style: style ?? .init())
+    }
+    
+    func apply(to shape: any InsettableShape) -> some View {
+        AnyShape(shape).stroke(content, style: style ?? .init())
+    }
+}

--- a/Sources/LiveViewNative/Shape Modifiers/StrokeModifier.swift
+++ b/Sources/LiveViewNative/Shape Modifiers/StrokeModifier.swift
@@ -7,8 +7,40 @@
 
 import SwiftUI
 
+/// Strokes a ``Shape`` with a shape style.
+///
+/// Pass a ``LiveViewNative/SwiftUI/AnyShapeStyle`` to the `content` argument to create the stroke.
+///
+/// Optionally provide a ``LiveViewNative/SwiftUI/StrokeStyle`` to configure the stroke.
+///
+/// ```html
+/// <Circle modifiers={stroke(@native, content: {:color, :red}, style: [line_width: 10])}>
+/// ```
+///
+/// - Note: This modifier applies a stroke to the edges of the ``Shape``.
+/// To add an inner stroke, use the ``StrokeBorderModifier`` modifier.
+///
+/// ## Arguments
+/// * ``content``
+/// * ``style``
+#if swift(>=5.8)
+@_documentation(visibility: public)
+#endif
 struct StrokeModifier: FinalShapeModifier, Decodable {
+    /// The shape style to stroke with.
+    ///
+    /// See ``LiveViewNative/SwiftUI/AnyShapeStyle`` for more details on creating shape styles.
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
     let content: AnyShapeStyle
+    
+    /// Configuration for the stroke.
+    ///
+    /// See ``LiveViewNative/SwiftUI/StrokeStyle`` for more details on configuring strokes.
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
     let style: StrokeStyle?
     
     func apply(to shape: any SwiftUI.Shape) -> some View {

--- a/Sources/LiveViewNative/Shape Modifiers/TrimModifier.swift
+++ b/Sources/LiveViewNative/Shape Modifiers/TrimModifier.swift
@@ -1,0 +1,21 @@
+//
+//  TrimModifier.swift
+//  
+//
+//  Created by Carson Katri on 5/11/23.
+//
+
+import SwiftUI
+
+struct TrimModifier: ShapeModifier, Decodable {
+    let startFraction: CGFloat
+    let endFraction: CGFloat
+    
+    func apply(to shape: some SwiftUI.Shape) -> any SwiftUI.Shape {
+        shape.trim(from: startFraction, to: endFraction)
+    }
+    
+    func apply(to shape: some SwiftUI.InsettableShape) -> any SwiftUI.Shape {
+        shape.trim(from: startFraction, to: endFraction)
+    }
+}

--- a/Sources/LiveViewNative/Shape Modifiers/TrimModifier.swift
+++ b/Sources/LiveViewNative/Shape Modifiers/TrimModifier.swift
@@ -7,8 +7,31 @@
 
 import SwiftUI
 
+/// Trim the start/end points of a ``Shape``.
+///
+/// Provide a ``startFraction`` and/or ``endFraction`` to trim the beginning/end of the ``Shape``.
+///
+/// ```html
+/// <Circle modifiers={trim(@native, start_fraction: 0.5, end_fraction: 1)} />
+/// ```
+///
+/// ## Arguments
+/// * ``startFraction``
+/// * ``endFraction``
+#if swift(>=5.8)
+@_documentation(visibility: public)
+#endif
 struct TrimModifier: ShapeModifier, Decodable {
+    /// A decimal representing the offset from the start of the ``Shape``. Defaults to `0`.
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
     let startFraction: CGFloat
+    
+    /// A decimal representing the offset from the end of the ``Shape``. Defaults to `1`.
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
     let endFraction: CGFloat
     
     func apply(to shape: some SwiftUI.Shape) -> any SwiftUI.Shape {

--- a/Sources/LiveViewNative/Utils/Alignment.swift
+++ b/Sources/LiveViewNative/Utils/Alignment.swift
@@ -35,11 +35,11 @@ extension Alignment: Decodable, AttributeDecodable {
     
     init?(string: String) {
         switch string {
-        case "top-leading":
+        case "top-leading", "top_leading":
             self = .topLeading
         case "top":
             self = .top
-        case "top-trailing":
+        case "top-trailing", "top_trailing":
             self = .topTrailing
         case "leading":
             self = .leading
@@ -47,15 +47,15 @@ extension Alignment: Decodable, AttributeDecodable {
             self = .center
         case "trailing":
             self = .trailing
-        case "bottom-leading":
+        case "bottom-leading", "bottom_leading":
             self = .bottomTrailing
         case "bottom":
             self = .bottom
-        case "bottom-trailing":
+        case "bottom-trailing", "bottom_trailing":
             self = .bottomTrailing
-        case "leading-last-text-baseline":
+        case "leading-last-text-baseline", "leading_last_text_baseline":
             self = .leadingLastTextBaseline
-        case "trailing-last-text-baseline":
+        case "trailing-last-text-baseline", "trailing_last_text_baseline":
             self = .trailingLastTextBaseline
         default:
             return nil

--- a/Sources/LiveViewNative/Utils/FillStyle.swift
+++ b/Sources/LiveViewNative/Utils/FillStyle.swift
@@ -1,0 +1,34 @@
+//
+//  FillStyle.swift
+//  LiveViewNative
+//
+//  Created by Carson Katri on 5/11/23.
+//
+
+import SwiftUI
+
+/// Configuration for filling a ``Shape``.
+///
+/// Create a map or keyword list with values for `eo_fill` and/or `antialiased`.
+///
+/// ```elixir
+/// [eo_fill: true, antialiased: false]
+/// ```
+///
+/// ## Arguments
+/// * `eo_fill` - Whether to use an even-odd rule. Defaults to `false`.
+/// * `antialiased` - Enable/disable antialiasing on the shape's edges. Defaults to `true`.
+extension FillStyle: Decodable {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.init(
+            eoFill: try container.decode(Bool.self, forKey: .eoFill),
+            antialiased: try container.decode(Bool.self, forKey: .antialiased)
+        )
+    }
+    
+    enum CodingKeys: CodingKey {
+        case eoFill
+        case antialiased
+    }
+}

--- a/Sources/LiveViewNative/Utils/ShapeStyle/AnyShapeStyle.swift
+++ b/Sources/LiveViewNative/Utils/ShapeStyle/AnyShapeStyle.swift
@@ -171,7 +171,7 @@ import LiveViewNativeCore
 #if swift(>=5.8)
 @_documentation(visibility: public)
 #endif
-extension AnyShapeStyle: Decodable, AttributeDecodable {
+extension AnyShapeStyle: Decodable {
     public init(from attribute: LiveViewNativeCore.Attribute?) throws {
         guard let string = attribute?.value
         else { throw AttributeDecodingError.missingAttribute(Self.self) }

--- a/Sources/LiveViewNative/Utils/ShapeStyle/AnyShapeStyle.swift
+++ b/Sources/LiveViewNative/Utils/ShapeStyle/AnyShapeStyle.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import LiveViewNativeCore
 
 /// A color, gradient, or other style.
 ///
@@ -162,7 +163,13 @@ import SwiftUI
 #if swift(>=5.8)
 @_documentation(visibility: public)
 #endif
-extension AnyShapeStyle: Decodable {
+extension AnyShapeStyle: Decodable, AttributeDecodable {
+    public init(from attribute: LiveViewNativeCore.Attribute?) throws {
+        guard let string = attribute?.value
+        else { throw AttributeDecodingError.missingAttribute(Self.self) }
+        self = try makeJSONDecoder().decode(Self.self, from: Data(string.utf8))
+    }
+    
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         

--- a/Sources/LiveViewNative/Utils/ShapeStyle/AnyShapeStyle.swift
+++ b/Sources/LiveViewNative/Utils/ShapeStyle/AnyShapeStyle.swift
@@ -30,6 +30,14 @@ import LiveViewNativeCore
 /// ```elixir
 /// {:color, :blue}
 /// ```
+/// 
+/// ### :gradient
+/// Creates a gradient from a single color.
+/// See ``LiveViewNative/SwiftUI/Color/init(from:)`` for a list of possible color values.
+/// 
+/// ```elixir
+/// {:gradient, :blue}
+/// ```
 ///
 /// ### :angular_gradient
 /// See ``LiveViewNative/SwiftUI/AngularGradient`` for details on creating this style.
@@ -176,6 +184,8 @@ extension AnyShapeStyle: Decodable, AttributeDecodable {
         switch try container.decode(ConcreteStyle.self, forKey: .concreteStyle) {
         case .color:
             self = Self(try container.decode(SwiftUI.Color.self, forKey: .style))
+        case .gradient:
+            self = Self(try container.decode(SwiftUI.Color.self, forKey: .style).gradient)
         case .angularGradient:
             self = Self(try container.decode(AngularGradient.self, forKey: .style))
         case .ellipticalGradient:
@@ -234,6 +244,7 @@ extension AnyShapeStyle: Decodable, AttributeDecodable {
     
     enum ConcreteStyle: String, Decodable {
         case color
+        case gradient
         case angularGradient = "angular_gradient"
         case ellipticalGradient = "elliptical_gradient"
         case linearGradient = "linear_gradient"

--- a/Sources/LiveViewNative/Utils/StrokeStyle.swift
+++ b/Sources/LiveViewNative/Utils/StrokeStyle.swift
@@ -1,0 +1,82 @@
+//
+//  StrokeStyle.swift
+//  LiveViewNative
+//
+//  Created by Carson Katri on 5/11/23.
+//
+
+import SwiftUI
+
+/// Configuration for stroking a ``Shape``.
+///
+/// Create a map or keyword list to represent the style.
+///
+/// ```elixir
+/// [line_width: 10, dash: [10, 20], line_cap: :round]
+/// ```
+///
+/// ## Arguments
+/// * `line_width` - The thickness of the line. Defaults to `1`.
+/// * `line_cap` - The style of line endpoints. See ``LiveViewNative/SwiftUI/CGLineCap`` for a list of possible values. Defaults to `butt`.
+/// * `line_join` - The style of line junctions. See ``LiveViewNative/SwiftUI/CGLineJoin`` for a list of possible values. Defaults to `miter`.
+/// * `miter_limit` - Threshold that determines when to use a bevel instead of a miter. Defaults to `10`.
+/// * `dash` - A list of lengths for filled and empty segments of a dashed line. Defaults to `[]`
+/// * `dash_phase` - An offset for the dash pattern. Defaults to `0`
+extension StrokeStyle: Decodable {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.init(
+            lineWidth: try container.decode(CGFloat.self, forKey: .lineWidth),
+            lineCap: try container.decode(CGLineCap.self, forKey: .lineCap),
+            lineJoin: try container.decode(CGLineJoin.self, forKey: .lineJoin),
+            miterLimit: try container.decode(CGFloat.self, forKey: .miterLimit),
+            dash: try container.decode([CGFloat].self, forKey: .dash),
+            dashPhase: try container.decode(CGFloat.self, forKey: .dashPhase)
+        )
+    }
+    
+    enum CodingKeys: CodingKey {
+        case lineWidth
+        case lineCap
+        case lineJoin
+        case miterLimit
+        case dash
+        case dashPhase
+    }
+}
+
+/// Style for the endpoint of a stroke.
+///
+/// Possible values:
+/// * `butt`
+/// * `round`
+/// * `square`
+extension CGLineCap: Decodable {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        switch try container.decode(String.self) {
+        case "butt": self = .butt
+        case "round": self = .round
+        case "square": self = .square
+        case let `default`: throw DecodingError.dataCorrupted(.init(codingPath: container.codingPath, debugDescription: "Unknown line cap '\(`default`)'"))
+        }
+    }
+}
+
+/// Style for the stroke junctions.
+///
+/// Possible values:
+/// * `miter`
+/// * `round`
+/// * `bevel`
+extension CGLineJoin: Decodable {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        switch try container.decode(String.self) {
+        case "miter": self = .miter
+        case "round": self = .round
+        case "bevel": self = .bevel
+        case let `default`: throw DecodingError.dataCorrupted(.init(codingPath: container.codingPath, debugDescription: "Unknown line join '\(`default`)'"))
+        }
+    }
+}

--- a/Sources/LiveViewNative/ViewTree.swift
+++ b/Sources/LiveViewNative/ViewTree.swift
@@ -163,8 +163,8 @@ enum ModifierContainer<R: RootRegistry>: Decodable {
             } catch {
                 self = .error(ErrorModifier<R>(type: type.rawValue, error: error))
             }
-        } else if ShapeModifier.ModifierType(rawValue: type) != nil
-                    || FinalShapeModifier.ModifierType(rawValue: type) != nil
+        } else if ShapeModifierType(rawValue: type) != nil
+                    || FinalShapeModifierType(rawValue: type) != nil
         {
             self = .inert
         } else {

--- a/Sources/LiveViewNative/ViewTree.swift
+++ b/Sources/LiveViewNative/ViewTree.swift
@@ -146,6 +146,7 @@ enum ModifierContainer<R: RootRegistry>: Decodable {
     case builtin(BuiltinRegistry<R>.BuiltinModifier)
     case custom(R.CustomModifier)
     case error(ErrorModifier<R>)
+    case inert
     
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
@@ -162,6 +163,10 @@ enum ModifierContainer<R: RootRegistry>: Decodable {
             } catch {
                 self = .error(ErrorModifier<R>(type: type.rawValue, error: error))
             }
+        } else if ShapeModifier.ModifierType(rawValue: type) != nil
+                    || FinalShapeModifier.ModifierType(rawValue: type) != nil
+        {
+            self = .inert
         } else {
             self = .error(ErrorModifier<R>(type: type, error: ViewTreeBuilder<R>.Error.unknownModifierType))
         }
@@ -180,6 +185,8 @@ enum ModifierContainer<R: RootRegistry>: Decodable {
             modifier
         case let .error(modifier):
             modifier
+        case .inert:
+            EmptyModifier()
         }
     }
 }

--- a/Sources/LiveViewNative/Views/Shapes/Shape.swift
+++ b/Sources/LiveViewNative/Views/Shapes/Shape.swift
@@ -21,30 +21,30 @@ struct Shape<S: SwiftUI.Shape>: View {
     @ObservedElement private var element: ElementNode
     private let shape: S
 
-    /// The color the shape is filled with.
+    /// The ``LiveViewNative/SwiftUI/AnyShapeStyle`` the shape is filled with.
     ///
-    /// See ``LiveViewNative/SwiftUI/Color/init(fromNamedOrCSSHex:)``.
+    /// See ``LiveViewNative/SwiftUI/AnyShapeStyle`` for a list of possible values.
     #if swift(>=5.8)
     @_documentation(visibility: public)
     #endif
-    @Attribute("fill-color") private var fillColor: SwiftUI.Color? = nil
-    /// The color the shape stroke is drawn with.
+    @Attribute("fill") private var fill: SwiftUI.AnyShapeStyle? = nil
+    /// The ``LiveViewNative/SwiftUI/AnyShapeStyle`` the shape stroke is drawn with.
     ///
-    /// See ``LiveViewNative/SwiftUI/Color/init(fromNamedOrCSSHex:)``.
+    /// See ``LiveViewNative/SwiftUI/AnyShapeStyle`` for a list of possible values.
     #if swift(>=5.8)
     @_documentation(visibility: public)
     #endif
-    @Attribute("stroke-color") private var strokeColor: SwiftUI.Color? = nil
+    @Attribute("stroke") private var stroke: SwiftUI.AnyShapeStyle? = nil
     
     init(shape: S) {
         self.shape = shape
     }
     
     var body: some View {
-        if let fillColor {
-            shape.fill(fillColor)
-        } else if let strokeColor {
-            shape.stroke(strokeColor)
+        if let fill {
+            shape.fill(fill)
+        } else if let stroke {
+            shape.stroke(stroke)
         } else {
             shape
         }

--- a/Sources/LiveViewNative/Views/Shapes/Shape.swift
+++ b/Sources/LiveViewNative/Views/Shapes/Shape.swift
@@ -12,7 +12,7 @@ import LiveViewNativeCore
 ///
 /// This view isn't used directly as an element. Instead, use the shape itself (e.g., `<Rectangle>`).
 ///
-/// Attributes:
+/// ## Attributes
 /// - ``fillColor``
 /// - ``strokeColor``
 #if swift(>=5.8)

--- a/Tests/RenderingTests/Modifiers/ShapeModifiersTests.swift
+++ b/Tests/RenderingTests/Modifiers/ShapeModifiersTests.swift
@@ -14,12 +14,96 @@ final class ShapeModifiersTests: XCTestCase {
     func testFill() throws {
         try assertMatch(
             #"""
-            <Circle modifiers="[{&quot;content&quot;:{&quot;concrete_style&quot;:&quot;color&quot;,&quot;modifiers&quot;:[],&quot;style&quot;:{&quot;blue&quot;:null,&quot;brightness&quot;:null,&quot;green&quot;:null,&quot;hue&quot;:null,&quot;opacity&quot;:null,&quot;red&quot;:null,&quot;rgb_color_space&quot;:null,&quot;saturation&quot;:null,&quot;string&quot;:&quot;system-red&quot;,&quot;white&quot;:null}},&quot;style&quot;:null,&quot;type&quot;:&quot;fill&quot;}]" />
+            <Circle modifiers='[{"content":{"concrete_style":"color","modifiers":[],"style":{"blue":null,"brightness":null,"green":null,"hue":null,"opacity":null,"red":null,"rgb_color_space":null,"saturation":null,"string":"system-red","white":null}},"style":null,"type":"fill"}]' />
             """#,
             size: .init(width: 100, height: 100)
         ) {
             Circle()
                 .fill(.red)
+        }
+    }
+    
+    func testInset() throws {
+        try assertMatch(
+            #"""
+            <Circle modifiers='[{"amount":25.0,"type":"inset"}]' />
+            """#,
+            size: .init(width: 100, height: 100)
+        ) {
+            Circle()
+                .inset(by: 25)
+        }
+    }
+    
+    func testOffset() throws {
+        try assertMatch(
+            #"""
+            <Circle modifiers='[{"type":"offset_shape","x":10.0,"y":25.0}]' />
+            """#,
+            size: .init(width: 100, height: 100)
+        ) {
+            Circle()
+                .offset(x: 10, y: 25)
+        }
+    }
+    
+    func testRotation() throws {
+        try assertMatch(
+            #"""
+            <Rectangle modifiers='[{"anchor":null,"angle":0.7853981633974483,"type":"rotation"}]' />
+            """#,
+            size: .init(width: 100, height: 100)
+        ) {
+            Rectangle()
+                .rotation(.degrees(45))
+        }
+    }
+    
+    func testSize() throws {
+        try assertMatch(
+            #"""
+            <Rectangle modifiers='[{"height":75.0,"type":"size","width":50.0}]' />
+            """#,
+            size: .init(width: 100, height: 100)
+        ) {
+            Rectangle()
+                .size(width: 50, height: 75)
+        }
+    }
+    
+    func testStroke() throws {
+        try assertMatch(
+            #"""
+            <Circle modifiers='[{"content":{"concrete_style":"color","modifiers":[],"style":{"blue":null,"brightness":null,"green":null,"hue":null,"opacity":null,"red":null,"rgb_color_space":null,"saturation":null,"string":"system-red","white":null}},"style":{"dash":[],"dash_phase":0,"line_cap":"butt","line_join":"miter","line_width":10,"miter_limit":10},"type":"stroke"}]' />
+            """#,
+            size: .init(width: 100, height: 100)
+        ) {
+            Circle()
+                .stroke(.red, style: .init(lineWidth: 10))
+        }
+    }
+    
+    func testStrokeBorder() throws {
+        try assertMatch(
+            #"""
+            <Circle modifiers='[{"antialiased":true,"content":{"concrete_style":"color","modifiers":[],"style":{"blue":null,"brightness":null,"green":null,"hue":null,"opacity":null,"red":null,"rgb_color_space":null,"saturation":null,"string":"system-red","white":null}},"style":{"dash":[],"dash_phase":0,"line_cap":"butt","line_join":"miter","line_width":10,"miter_limit":10},"type":"stroke_border"}]' />
+            """#,
+            size: .init(width: 100, height: 100)
+        ) {
+            Circle()
+                .strokeBorder(.red, style: .init(lineWidth: 10))
+        }
+    }
+    
+    func testTrim() throws {
+        try assertMatch(
+            #"""
+            <Circle modifiers='[{"end_fraction":1.0,"start_fraction":0.5,"type":"trim"}]' />
+            """#,
+            size: .init(width: 100, height: 100)
+        ) {
+            Circle()
+                .trim(from: 0.5, to: 1)
         }
     }
 }

--- a/Tests/RenderingTests/Modifiers/ShapeModifiersTests.swift
+++ b/Tests/RenderingTests/Modifiers/ShapeModifiersTests.swift
@@ -1,0 +1,25 @@
+//
+//  ShapeModifiersTests.swift
+//
+//
+//  Created by Carson Katri on 5/11/23.
+//
+
+import XCTest
+import SwiftUI
+import LiveViewNative
+
+@MainActor
+final class ShapeModifiersTests: XCTestCase {
+    func testFill() throws {
+        try assertMatch(
+            #"""
+            <Circle modifiers="[{&quot;content&quot;:{&quot;concrete_style&quot;:&quot;color&quot;,&quot;modifiers&quot;:[],&quot;style&quot;:{&quot;blue&quot;:null,&quot;brightness&quot;:null,&quot;green&quot;:null,&quot;hue&quot;:null,&quot;opacity&quot;:null,&quot;red&quot;:null,&quot;rgb_color_space&quot;:null,&quot;saturation&quot;:null,&quot;string&quot;:&quot;system-red&quot;,&quot;white&quot;:null}},&quot;style&quot;:null,&quot;type&quot;:&quot;fill&quot;}]" />
+            """#,
+            size: .init(width: 100, height: 100)
+        ) {
+            Circle()
+                .fill(.red)
+        }
+    }
+}

--- a/lib/live_view_native_swift_ui/modifiers/shape/fill.ex
+++ b/lib/live_view_native_swift_ui/modifiers/shape/fill.ex
@@ -1,0 +1,9 @@
+defmodule LiveViewNativeSwiftUi.Modifiers.Fill do
+  use LiveViewNativePlatform.Modifier
+
+  alias LiveViewNativeSwiftUi.Types.ShapeStyle
+
+  modifier_schema "fill" do
+    field :style, ShapeStyle
+  end
+end

--- a/lib/live_view_native_swift_ui/modifiers/shape/fill.ex
+++ b/lib/live_view_native_swift_ui/modifiers/shape/fill.ex
@@ -1,9 +1,10 @@
 defmodule LiveViewNativeSwiftUi.Modifiers.Fill do
   use LiveViewNativePlatform.Modifier
 
-  alias LiveViewNativeSwiftUi.Types.ShapeStyle
+  alias LiveViewNativeSwiftUi.Types.{ShapeStyle, FillStyle}
 
   modifier_schema "fill" do
-    field :style, ShapeStyle
+    field :content, ShapeStyle
+    field :style, FillStyle
   end
 end

--- a/lib/live_view_native_swift_ui/modifiers/shape/inset.ex
+++ b/lib/live_view_native_swift_ui/modifiers/shape/inset.ex
@@ -1,0 +1,7 @@
+defmodule LiveViewNativeSwiftUi.Modifiers.Inset do
+  use LiveViewNativePlatform.Modifier
+
+  modifier_schema "inset" do
+    field :amount, :float
+  end
+end

--- a/lib/live_view_native_swift_ui/modifiers/shape/offset_shape.ex
+++ b/lib/live_view_native_swift_ui/modifiers/shape/offset_shape.ex
@@ -1,0 +1,8 @@
+defmodule LiveViewNativeSwiftUi.Modifiers.OffsetShape do
+  use LiveViewNativePlatform.Modifier
+
+  modifier_schema "offset_shape" do
+    field :x, :float, default: 0.0
+    field :y, :float, default: 0.0
+  end
+end

--- a/lib/live_view_native_swift_ui/modifiers/shape/rotation.ex
+++ b/lib/live_view_native_swift_ui/modifiers/shape/rotation.ex
@@ -1,0 +1,10 @@
+defmodule LiveViewNativeSwiftUi.Modifiers.Rotation do
+  use LiveViewNativePlatform.Modifier
+
+  alias LiveViewNativeSwiftUi.Types.{Angle, UnitPoint}
+
+  modifier_schema "rotation" do
+    field :angle, Angle
+    field :anchor, UnitPoint
+  end
+end

--- a/lib/live_view_native_swift_ui/modifiers/shape/size.ex
+++ b/lib/live_view_native_swift_ui/modifiers/shape/size.ex
@@ -1,0 +1,8 @@
+defmodule LiveViewNativeSwiftUi.Modifiers.Size do
+  use LiveViewNativePlatform.Modifier
+
+  modifier_schema "size" do
+    field :width, :float, default: 0.0
+    field :height, :float, default: 0.0
+  end
+end

--- a/lib/live_view_native_swift_ui/modifiers/shape/stroke.ex
+++ b/lib/live_view_native_swift_ui/modifiers/shape/stroke.ex
@@ -1,0 +1,10 @@
+defmodule LiveViewNativeSwiftUi.Modifiers.Stroke do
+  use LiveViewNativePlatform.Modifier
+
+  alias LiveViewNativeSwiftUi.Types.{ShapeStyle, StrokeStyle}
+
+  modifier_schema "stroke" do
+    field :content, ShapeStyle
+    field :style, StrokeStyle
+  end
+end

--- a/lib/live_view_native_swift_ui/modifiers/shape/stroke_border.ex
+++ b/lib/live_view_native_swift_ui/modifiers/shape/stroke_border.ex
@@ -1,0 +1,11 @@
+defmodule LiveViewNativeSwiftUi.Modifiers.StrokeBorder do
+  use LiveViewNativePlatform.Modifier
+
+  alias LiveViewNativeSwiftUi.Types.{ShapeStyle, StrokeStyle}
+
+  modifier_schema "stroke_border" do
+    field :content, ShapeStyle
+    field :style, StrokeStyle
+    field :antialiased, :boolean, default: true
+  end
+end

--- a/lib/live_view_native_swift_ui/modifiers/shape/trim.ex
+++ b/lib/live_view_native_swift_ui/modifiers/shape/trim.ex
@@ -1,0 +1,8 @@
+defmodule LiveViewNativeSwiftUi.Modifiers.Trim do
+  use LiveViewNativePlatform.Modifier
+
+  modifier_schema "trim" do
+    field :start_fraction, :float, default: 0.0
+    field :end_fraction, :float, default: 1.0
+  end
+end

--- a/lib/live_view_native_swift_ui/types/fill_style.ex
+++ b/lib/live_view_native_swift_ui/types/fill_style.ex
@@ -1,0 +1,14 @@
+defmodule LiveViewNativeSwiftUi.Types.FillStyle do
+  @derive Jason.Encoder
+  defstruct [eo_fill: false, antialiased: true]
+
+  use LiveViewNativePlatform.Modifier.Type
+  def type, do: :map
+
+  def cast(nil), do: {:ok, nil}
+  def cast(value) when is_map(value) or is_list(value) do
+    {:ok, struct(__MODULE__, value)}
+  end
+
+  def cast(_), do: :error
+end

--- a/lib/live_view_native_swift_ui/types/shape_style/shape_style.ex
+++ b/lib/live_view_native_swift_ui/types/shape_style/shape_style.ex
@@ -41,6 +41,7 @@ defmodule LiveViewNativeSwiftUi.Types.ShapeStyle do
   ###
 
   defp cast_style({:color, value}), do: Color.cast(value)
+  defp cast_style({:gradient, value}), do: Color.cast(value)
   defp cast_style({:angular_gradient, value}), do: AngularGradient.cast(value)
   defp cast_style({:elliptical_gradient, value}), do: EllipticalGradient.cast(value)
   defp cast_style({:linear_gradient, value}), do: LinearGradient.cast(value)
@@ -56,13 +57,6 @@ defmodule LiveViewNativeSwiftUi.Types.ShapeStyle do
     end
   end
   defp cast_modifier({type, properties}), do: %{ "type" => type, "properties" => properties }
-
-  def cast!(value) do
-    case cast(value) do
-      {:ok, result} -> result
-      :error -> raise "failed to cast #{value} to `ShapeStyle`"
-    end
-  end
 
   defimpl Phoenix.HTML.Safe do
     def to_iodata(data) do

--- a/lib/live_view_native_swift_ui/types/shape_style/shape_style.ex
+++ b/lib/live_view_native_swift_ui/types/shape_style/shape_style.ex
@@ -56,4 +56,20 @@ defmodule LiveViewNativeSwiftUi.Types.ShapeStyle do
     end
   end
   defp cast_modifier({type, properties}), do: %{ "type" => type, "properties" => properties }
+
+  def cast!(value) do
+    case cast(value) do
+      {:ok, result} -> result
+      :error -> raise "failed to cast #{value} to `ShapeStyle`"
+    end
+  end
+
+  defimpl Phoenix.HTML.Safe do
+    def to_iodata(data) do
+      data
+        |> Map.from_struct()
+        |> Jason.encode!()
+        |> Phoenix.HTML.Engine.html_escape()
+    end
+  end
 end

--- a/lib/live_view_native_swift_ui/types/stroke_style.ex
+++ b/lib/live_view_native_swift_ui/types/stroke_style.ex
@@ -1,0 +1,21 @@
+defmodule LiveViewNativeSwiftUi.Types.StrokeStyle do
+  @derive Jason.Encoder
+  defstruct [
+    line_width: 1,
+    line_cap: :butt,
+    line_join: :miter,
+    miter_limit: 10,
+    dash: [],
+    dash_phase: 0
+  ]
+
+  use LiveViewNativePlatform.Modifier.Type
+  def type, do: :map
+
+  def cast(nil), do: {:ok, nil}
+  def cast(value) when is_map(value) or is_list(value) do
+    {:ok, struct(__MODULE__, value)}
+  end
+
+  def cast(_), do: :error
+end


### PR DESCRIPTION
This adds support for new modifiers that only apply to shapes. This can be used to apply `ShapeStyle` fills and strokes. It also adds support for other Shape modifiers like `trim` and `size`.

This requires handling modifiers within `Shape`. Here's an example of mixing modifiers together:

```heex
<Circle modifiers={
  @native
    |> trim(start_fraction: 0.5)
    |> offset_shape(x: 50, y: 50)
    |> size(width: 50, height: 50)
    |> fill(style: {:color, :purple})
    |> gesture(gesture: :tap, action: "tap")
} />
```

The modifiers would be applied as:

1. `trim` - handled internally by `Shape`
2. `offset_shape` - handled internally by `Shape`
3. `size` - handled internally by `Shape`
4. `fill` - handled internally by `Shape`, treated as the "final modifier" since it returns a `_ShapeView` not a `Shape`
5. `gesture` - handled by the `ModifierApplicator`

Shape modifiers are applied as an `EmptyModifier` in the `ModifierApplicator`.

`fill-color` and `stroke-color` can still be used, but the `fill` and `stroke` modifiers take precedence.

Now we can create graphics like this using shapes:
<img width="242" alt="Screenshot 2023-05-11 at 11 39 20 AM" src="https://github.com/liveview-native/liveview-client-swiftui/assets/13581484/041f5490-6fd3-4667-b0d3-7dec94f1e12d">
<details>
<summary>
Template
</summary>

```heex
<ZStack modifiers={@native |> frame(width: 200, height: 200)}>
  <Circle modifiers={
    @native
      |> inset(amount: @thickness / 2)
      |> stroke(content: {:gradient, :red, [{:opacity, 0.2}]}, style: [line_width: @thickness, line_cap: :round])
  } />
  <Circle modifiers={
    @native
      |> inset(amount: @thickness * 1.5)
      |> stroke(content: {:gradient, :green, [{:opacity, 0.2}]}, style: [line_width: @thickness, line_cap: :round])
  } />
  <Circle modifiers={
    @native
      |> inset(amount: @thickness * 2.5)
      |> stroke(content: {:gradient, :blue, [{:opacity, 0.2}]}, style: [line_width: @thickness, line_cap: :round])
  } />
  <ZStack alignment="top">
    <Circle modifiers={
      @native
        |> rotation(angle: {:degrees, -90})
        |> inset(amount: @thickness / 2)
        |> trim(start_fraction: 0, end_fraction: 0.5)
        |> stroke(content: {:gradient, :red}, style: [line_width: @thickness, line_cap: :round])
    } />
    <Image system-name="arrow.right" modifiers={@native |> foreground_style(primary: {:color, :black}) |> font(font: {:system, :headline}) |> frame(height: @thickness)} />
  </ZStack>
  <ZStack alignment="top" modifiers={padding(@native, length: @thickness)}>
    <Circle modifiers={
      @native
        |> rotation(angle: {:degrees, -90})
        |> inset(amount: @thickness / 2)
        |> trim(start_fraction: 0, end_fraction: 0.75)
        |> stroke(content: {:gradient, :green}, style: [line_width: @thickness, line_cap: :round])
    } />
    <Image system-name="arrow.right.to.line" modifiers={@native |> foreground_style(primary: {:color, :black}) |> font(font: {:system, :headline}) |> frame(height: @thickness)} />
  </ZStack>
  <ZStack alignment="top" modifiers={padding(@native, length: @thickness * 2)}>
    <Circle modifiers={
      @native
        |> rotation(angle: {:degrees, -90})
        |> inset(amount: @thickness / 2)
        |> trim(start_fraction: 0, end_fraction: 0.8)
        |> stroke(content: {:gradient, :blue}, style: [line_width: @thickness, line_cap: :round])
    } />
    <Image system-name="arrow.up" modifiers={@native |> foreground_style(primary: {:color, :black}) |> font(font: {:system, :headline}) |> frame(height: @thickness)} />
  </ZStack>
</ZStack>
```

</details>