### PR TITLE
HTML decode the output of `encode_modifiers`

### DIFF
--- a/util/encode_modifiers.exs
+++ b/util/encode_modifiers.exs
@@ -12,10 +12,10 @@ defmodule ModifierEncoder do
     platform_modifiers: @native.platform_modifiers
 
   defmacro quote_argv() do
-    Code.string_to_quoted!(
-      hd(System.argv())
-      |> String.replace(~r'///', "")
-    )
+    System.argv()
+    |> hd()
+    |> String.replace(~r'///', "")
+    |> Code.string_to_quoted!()
   end
 
   def encode() do

--- a/util/encode_modifiers.exs
+++ b/util/encode_modifiers.exs
@@ -20,9 +20,10 @@ defmodule ModifierEncoder do
 
   def encode() do
     IO.write(
-      Phoenix.HTML.Safe.to_iodata(quote_argv().modifiers)
-      |> IO.iodata_to_binary
-      |> HtmlEntities.decode
+      quote_argv().modifiers
+      |> Phoenix.HTML.Safe.to_iodata()
+      |> IO.iodata_to_binary()
+      |> HtmlEntities.decode()
     )
   end
 end

--- a/util/encode_modifiers.exs
+++ b/util/encode_modifiers.exs
@@ -1,6 +1,7 @@
 Mix.install([
   {:live_view_native_swift_ui, path: "."},
   {:live_view_native, git: "https://github.com/liveview-native/live_view_native", branch: "main"},
+  {:html_entities, "~> 0.5"}
 ])
 
 defmodule ModifierEncoder do
@@ -15,7 +16,11 @@ defmodule ModifierEncoder do
   end
 
   def encode() do
-    IO.write(Phoenix.HTML.Safe.to_iodata(quote_argv().modifiers) |> IO.iodata_to_binary)
+    IO.write(
+      Phoenix.HTML.Safe.to_iodata(quote_argv().modifiers)
+      |> IO.iodata_to_binary
+      |> HtmlEntities.decode
+    )
   end
 end
 

--- a/util/encode_modifiers.exs
+++ b/util/encode_modifiers.exs
@@ -12,7 +12,10 @@ defmodule ModifierEncoder do
     platform_modifiers: @native.platform_modifiers
 
   defmacro quote_argv() do
-    Code.string_to_quoted!(hd(System.argv()))
+    Code.string_to_quoted!(
+      hd(System.argv())
+      |> String.replace(~r'///', "")
+    )
   end
 
   def encode() do


### PR DESCRIPTION
@carson-katri Thanks for writing the utility. It was a big help.

Since we escape the entire input string in Swift, I thought it would make the tests easier to read and tweak if they weren't HTML encoded.

```
[{&quot;disable&quot;:true,&quot;type&quot;:&quot;autocorrection_disabled&quot;}]
[{&quot;font&quot;:{&quot;modifiers&quot;:[],&quot;properties&quot;:{&quot;design&quot;:&quot;serif&quot;,&quot;style&quot;:&quot;large_title&quot;},&quot;type&quot;:&quot;system&quot;},&quot;type&quot;:&quot;font&quot;}]
```

vs

```
[{"disable":true,"type":"autocorrection_disabled"}]
[{"font":{"modifiers":[],"properties":{"design":"serif","style":"large_title"},"type":"system"},"type":"font"}]
```

I also made the utility strip `///` so I could cut and paste multiline modifier chains from the doc comments.