### PR TITLE
Add `clip_shape` modifier

### DIFF
--- a/Sources/LiveViewNative/Modifiers/Drawing and Graphics Modifiers/ClipShapeModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Drawing and Graphics Modifiers/ClipShapeModifier.swift
@@ -1,0 +1,76 @@
+//
+//  ClipShapeModifier.swift
+//  LiveViewNative
+//
+//  Created by Carson Katri on 5/16/2023.
+//
+
+import SwiftUI
+
+/// Masks an element with a given shape.
+///
+/// Provide a ``ShapeReference`` to clip the element with.
+///
+/// ```html
+/// <Text modifiers={clip_shape(@native, shape: :circle)}>
+///     Hello,
+///     world!
+/// </Text>
+/// ```
+///
+/// If the shape is not predefined, provide a ``Shape`` element with a `template` attribute.
+/// This lets you apply modifiers to the clip shape.
+///
+/// ```html
+/// <Text modifiers={clip_shape(@native, shape: :my_shape)}>
+///     Hello,
+///     world!
+///     <Rectangle template={:my_shape} modifiers={@native |> rotation(angle: {:degrees, 45})} />
+/// </Text>
+/// ```
+///
+/// ## Arguments
+/// * ``shape``
+/// * ``style``
+#if swift(>=5.8)
+@_documentation(visibility: public)
+#endif
+struct ClipShapeModifier<R: RootRegistry>: ViewModifier, Decodable {
+    /// The shape to use as a mask.
+    ///
+    /// See ``ShapeReference`` for more details on creating shape arguments.
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
+    private let shape: ShapeReference
+
+    /// The style to use when filling the ``shape`` for the mask.
+    ///
+    /// See ``LiveViewNative/SwiftUI/FillStyle`` for more details.
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
+    private let style: FillStyle
+    
+    @ObservedElement private var element
+    @LiveContext<R> private var context
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        self.shape = try container.decode(ShapeReference.self, forKey: .shape)
+        self.style = try container.decodeIfPresent(FillStyle.self, forKey: .style) ?? .init()
+    }
+
+    func body(content: Content) -> some View {
+        content.clipShape(
+            shape.resolve(on: element, in: context),
+            style: style
+        )
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case shape
+        case style
+    }
+}

--- a/Sources/LiveViewNative/Utils/ShapeReference.swift
+++ b/Sources/LiveViewNative/Utils/ShapeReference.swift
@@ -1,0 +1,145 @@
+//
+//  ShapeReference.swift
+//  LiveViewNative
+//
+//  Created by Carson Katri on 5/16/2023.
+//
+
+import SwiftUI
+
+/// A type that provides a shape argument.
+/// 
+/// There are two main types of shape reference: system shapes and template shapes.
+/// 
+/// ## System Shapes
+/// Use an atom to reference a system shape.
+/// If the shape has any properties, provide them as a keyword list in a tuple.
+/// 
+/// ```elixir
+/// :rectangle
+/// {:capsule, [style: :continuous]}
+/// ```
+/// 
+/// Possible values:
+/// * `:capsule`
+/// * `:circle`
+/// * `:container_relative_shape`
+/// * `:ellipse`
+/// * `:rectangle`
+/// * `:rounded_rectangle`
+/// 
+/// ### :capsule
+/// Arguments:
+/// * `style` - the corner style, see ``LiveViewNative/SwiftUI/RoundedCornerStyle`` for a list of possible values.
+/// 
+/// ```elixir
+/// {:capsule, [style: :continuous]}
+/// ```
+/// 
+/// ### :rounded_rectangle
+/// Arguments:
+/// * `radius` - takes precedence over `width`/`height`.
+/// * `width` - the width of the corners, requires `height` to be provided
+/// * `height` - the height of the corners, requires `width` to be provided
+/// * `style` - the corner style, see ``LiveViewNative/SwiftUI/RoundedCornerStyle`` for a list of possible values.
+/// 
+/// ```elixir
+/// {:rounded_rectangle, [radius: 10, style: :continuous]}
+/// ```
+/// 
+/// ## Template Shapes
+/// Use an atom to reference a ``Shape`` element with a `template` attribute.
+/// 
+/// Shape modifiers can be used to customize the appearance of the shape.
+/// 
+/// ```elixir
+/// :my_shape
+/// ```
+/// ```html
+/// <Rectangle template={:my_shape} modifiers={rotation(@native, angle: {:degrees, 45})} />
+/// ```
+#if swift(>=5.8)
+@_documentation(visibility: public)
+#endif
+enum ShapeReference: Decodable {
+    case `static`(AnyShape)
+    case key(String)
+    
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        if let key = try container.decodeIfPresent(String.self, forKey: .key) {
+            self = .key(key)
+        } else {
+            let staticContainer = try container.nestedContainer(keyedBy: CodingKeys.PropertiesKeys.self, forKey: .properties)
+            switch try container.decode(StaticShape.self, forKey: .static) {
+            case .capsule: self = .static(AnyShape(
+                Capsule(style: try staticContainer.decodeIfPresent(RoundedCornerStyle.self, forKey: .style) ?? .circular)
+            ))
+            case .circle: self = .static(AnyShape(Circle()))
+            case .containerRelativeShape: self = .static(AnyShape(ContainerRelativeShape()))
+            case .ellipse: self = .static(AnyShape(Ellipse()))
+            case .rectangle: self = .static(AnyShape(Rectangle()))
+            case .roundedRectangle:
+                let style = try staticContainer.decodeIfPresent(RoundedCornerStyle.self, forKey: .style) ?? .circular
+                if let radius = try staticContainer.decodeIfPresent(CGFloat.self, forKey: .radius) {
+                    self = .static(AnyShape(RoundedRectangle(
+                        cornerRadius: radius,
+                        style: style
+                    )))
+                } else {
+                    self = .static(AnyShape(RoundedRectangle(
+                        cornerSize: .init(
+                            width: try staticContainer.decode(CGFloat.self, forKey: .width),
+                            height: try staticContainer.decode(CGFloat.self, forKey: .height)
+                        ),
+                        style: style
+                    )))
+                }
+            }
+        }
+    }
+    
+    enum StaticShape: String, Decodable {
+        case capsule
+        case circle
+        case containerRelativeShape = "container_relative_shape"
+        case ellipse
+        case rectangle
+        case roundedRectangle = "rounded_rectangle"
+    }
+    
+    enum CodingKeys: String, CodingKey {
+        case `static`
+        case key
+        case properties
+        
+        enum PropertiesKeys: String, CodingKey {
+            case style
+            
+            case radius
+            
+            case width
+            case height
+        }
+    }
+    
+    func resolve<R: RootRegistry>(on element: ElementNode, in context: LiveContext<R>) -> AnyShape {
+        switch self {
+        case let .static(anyShape):
+            return anyShape
+        case let .key(keyName):
+            return context.children(of: element, forTemplate: keyName)
+                .compactMap { $0.asElement() }
+                .compactMap {
+                    let shape = Shape<Rectangle>.shapeTypes[$0.tag]!($0)
+                    if let modifiers = try? ShapeModifierStack(from: $0.attribute(named: "modifiers")) {
+                        return modifiers.stack.reduce(EitherAnyShape.insettable(shape)) { shape, modifier in
+                            modifier.apply(to: shape)
+                        }.eraseToAnyShape()
+                    } else {
+                        return AnyShape(shape)
+                    }
+                }.first!
+        }
+    } 
+}

--- a/Sources/LiveViewNative/Utils/ShapeReference.swift
+++ b/Sources/LiveViewNative/Utils/ShapeReference.swift
@@ -131,7 +131,23 @@ enum ShapeReference: Decodable {
             return context.children(of: element, forTemplate: keyName)
                 .compactMap { $0.asElement() }
                 .compactMap {
-                    let shape = Shape<Rectangle>.shapeTypes[$0.tag]!($0)
+                    let shape: any InsettableShape
+                    switch $0.tag {
+                    case "Capsule":
+                        shape = Capsule(from: $0)
+                    case "Circle":
+                        shape = Circle()
+                    case "ContainerRelativeShape":
+                        shape = ContainerRelativeShape()
+                    case "Ellipse":
+                        shape = Ellipse()
+                    case "Rectangle":
+                        shape = Rectangle()
+                    case "RoundedRectangle":
+                        shape = RoundedRectangle(from: $0)
+                    default:
+                        shape = Rectangle()
+                    }
                     if let modifiers = try? ShapeModifierStack(from: $0.attribute(named: "modifiers")) {
                         return modifiers.stack.reduce(EitherAnyShape.insettable(shape)) { shape, modifier in
                             modifier.apply(to: shape)
@@ -139,7 +155,7 @@ enum ShapeReference: Decodable {
                     } else {
                         return AnyShape(shape)
                     }
-                }.first!
+                }.first ?? AnyShape(Rectangle())
         }
-    } 
+    }
 }

--- a/Sources/LiveViewNative/Views/Shapes/Shape.swift
+++ b/Sources/LiveViewNative/Views/Shapes/Shape.swift
@@ -84,7 +84,7 @@ extension RoundedRectangle {
                 height: element.attributeValue(for: "corner-height").flatMap(Double.init) ?? radius
             ),
             style: (element.attributeValue(for: "style").flatMap({
-                try? JSONDecoder().decode(RoundedCornerStyle.self, from: Data($0.utf8))
+                try? makeJSONDecoder().decode(RoundedCornerStyle.self, from: Data($0.utf8))
             }) ?? .circular)
         )
     }
@@ -103,7 +103,7 @@ extension Capsule {
     init(from element: ElementNode) {
         self.init(
             style: (element.attributeValue(for: "style").flatMap({
-                try? JSONDecoder().decode(RoundedCornerStyle.self, from: Data($0.utf8))
+                try? makeJSONDecoder().decode(RoundedCornerStyle.self, from: Data($0.utf8))
             }) ?? .circular)
         )
     }

--- a/Sources/LiveViewNative/Views/Shapes/Shape.swift
+++ b/Sources/LiveViewNative/Views/Shapes/Shape.swift
@@ -57,28 +57,6 @@ struct Shape<S: SwiftUI.InsettableShape>: View {
             shape.eraseToAnyShape()
         }
     }
-    
-    static var shapeTypes: [String:(ElementNode) -> any SwiftUI.InsettableShape] {
-        [
-            "Capsule": Capsule.init(from:),
-            "Circle": { _ in Circle() },
-            "ContainerRelativeShape": { _ in ContainerRelativeShape() },
-            "Ellipse": { _ in Ellipse() },
-            "Rectangle": { _ in Rectangle() },
-            "RoundedRectangle": RoundedRectangle.init(from:),
-        ]
-    }
-    
-    static var atomShapes: [String:any SwiftUI.InsettableShape] {
-        [
-            "capsule": Capsule(),
-            "circle": Circle(),
-            "container_relative_shape": ContainerRelativeShape(),
-            "ellipse": Ellipse(),
-            "rectangle": Rectangle(),
-            "rounded_rectangle": RoundedRectangle(cornerRadius: 0)
-        ]
-    }
 }
 
 /// A rounded rectangle shape.

--- a/Tests/RenderingTests/Modifiers/DrawingAndGraphicsModifiersTests.swift
+++ b/Tests/RenderingTests/Modifiers/DrawingAndGraphicsModifiersTests.swift
@@ -34,4 +34,41 @@ final class DrawingAndGraphicsModifiersTests: XCTestCase {
                 .tint(.red)
         }
     }
+    
+    func testClipShape() throws {
+        try assertMatch(
+            #"""
+            <Text modifiers='[{"shape":{"key":null,"properties":{},"static":"circle"},"style":null,"type":"clip_shape"}]'>
+            Hello,
+            world!
+            </Text>
+            """#
+        ) {
+            Text("Hello,\nworld!")
+                .clipShape(Circle())
+        }
+        
+        try assertMatch(
+            #"""
+            <Text modifiers='[{"shape":{"key":null,"properties":{"radius":10},"static":"rounded_rectangle"},"style":null,"type":"clip_shape"}]'>
+                Hello, world!
+            </Text>
+            """#
+        ) {
+            Text("Hello, world!")
+                .clipShape(RoundedRectangle(cornerRadius: 10))
+        }
+        
+        try assertMatch(
+            #"""
+            <Text modifiers='[{"shape":{"key":"my_shape","properties":{},"static":null},"style":null,"type":"clip_shape"}]'>
+                Hello, world!
+                <Rectangle template="my_shape" modifiers='[{"anchor":null,"angle":0.7853981633974483,"type":"rotation"}]' />
+            </Text>
+            """#
+        ) {
+            Text("Hello, world!")
+                .clipShape(Rectangle().rotation(.degrees(45)))
+        }
+    }
 }

--- a/lib/live_view_native_swift_ui/modifiers/drawing_and_graphics/clip_shape.ex
+++ b/lib/live_view_native_swift_ui/modifiers/drawing_and_graphics/clip_shape.ex
@@ -1,0 +1,10 @@
+defmodule LiveViewNativeSwiftUi.Modifiers.ClipShape do
+  use LiveViewNativePlatform.Modifier
+
+  alias LiveViewNativeSwiftUi.Types.{Shape, FillStyle}
+
+  modifier_schema "clip_shape" do
+    field :shape, Shape
+    field :style, FillStyle
+  end
+end

--- a/lib/live_view_native_swift_ui/types/shape.ex
+++ b/lib/live_view_native_swift_ui/types/shape.ex
@@ -1,0 +1,33 @@
+defmodule LiveViewNativeSwiftUi.Types.Shape do
+  @derive Jason.Encoder
+  defstruct [
+    static: nil,
+    properties: %{},
+    key: nil
+  ]
+
+  use LiveViewNativePlatform.Modifier.Type
+  def type, do: :map
+
+  def cast(nil), do: nil
+
+  @static_shapes [
+    :capsule,
+    :circle,
+    :container_relative_shape,
+    :ellipse,
+    :rectangle
+  ]
+
+  # Static shape
+  def cast(value) when value in @static_shapes, do: cast({value, []})
+
+  def cast({type, opts}) when is_atom(type) and (is_list(opts) or is_map(opts)),
+    do: {:ok, %__MODULE__{ static: type, properties: Enum.into(opts, %{}) }}
+
+  # KeyName equivalent
+  def cast(value) when is_atom(value) and not is_boolean(value),
+    do: {:ok, %__MODULE__{ key: Atom.to_string(value) }}
+
+  def cast(_), do: :error
+end


### PR DESCRIPTION
This also adds a new `ShapeReference` type that can be used to pass a shape as a parameter to a modifier.

It supports the system shapes (with any arguments), as well as shapes with modifiers via an element with the `template` attribute.

```html
<Text modifiers={@native |> clip_shape(shape: :circle)}>
      Hello,
      world!
</Text>
<Text modifiers={@native |> clip_shape(shape: :my_shape)}>
      Hello, world!
      <Rectangle template={:my_shape} modifiers={@native |> rotation(angle: {:degrees, 45})} />
</Text>
```