### PR TITLE
Test View hierarchies

### DIFF
--- a/Sources/LiveViewNative/ViewModel.swift
+++ b/Sources/LiveViewNative/ViewModel.swift
@@ -20,6 +20,12 @@ public class LiveViewModel: ObservableObject {
     let bindingUpdatedByServer = PassthroughSubject<(String, Any), Never>()
     let bindingUpdatedByClient = PassthroughSubject<(String, Any), Never>()
     
+    init(forms: [String : FormModel] = [String: FormModel](), cachedNavigationTitle: NavigationTitleModifier? = nil, bindingValues: [String : Any] = [String: Any]()) {
+        self.forms = forms
+        self.cachedNavigationTitle = cachedNavigationTitle
+        self.bindingValues = bindingValues
+    }
+    
     /// Get or create a ``FormModel`` for the given `<live-form>`.
     ///
     /// - Important: The element parameter must be the form element. To get the form model for an element within a form, use the ``LiveContext`` or the `\.formModel` environment value.

--- a/Tests/RenderingTests/Modifiers/DrawingAndGraphicsModifiersTests.swift
+++ b/Tests/RenderingTests/Modifiers/DrawingAndGraphicsModifiersTests.swift
@@ -1,6 +1,6 @@
 //
 //  DrawingAndGraphicsModifiersTests.swift
-//  
+//
 //
 //  Created by Carson Katri on 5/3/23.
 //

--- a/Tests/RenderingTests/Modifiers/ModalPresentationsModifiersTests.swift
+++ b/Tests/RenderingTests/Modifiers/ModalPresentationsModifiersTests.swift
@@ -1,0 +1,72 @@
+//
+//  ModalPresentationsModifiersTests.swift
+//  
+//
+//  Created by Carson Katri on 5/18/23.
+//
+
+import XCTest
+import SwiftUI
+@testable import LiveViewNative
+
+@MainActor
+final class ModalPresentationsModifiersTests: XCTestCase {
+    func testSheet() throws {
+        try assertHierarchy(
+            #"""
+            <Rectangle fill-color="system-blue" modifiers='[{"content":"my_content","is_presented":"show","on_dismiss":null,"type":"sheet"}]'>
+                <Rectangle fill-color="system-red" template="my_content" />
+            </Rectangle>
+            """#,
+            outerView: {
+                $0
+                    .environmentObject(LiveViewModel(
+                        forms: [:],
+                        cachedNavigationTitle: nil,
+                        bindingValues: ["show": true]
+                    ))
+            }
+        ) {
+            AnyShape(Rectangle())
+                .fill(.blue)
+                .sheet(isPresented: .constant(true)) {
+                    AnyShape(Rectangle())
+                        .fill(.red)
+                }
+        }
+    }
+    
+    func testAlert() throws {
+        try assertHierarchy(
+            #"""
+            <Rectangle fill-color="system-blue" modifiers='[{"actions":"actions","is_presented":"show","message":"message","title":"My Alert","type":"alert"}]'>
+                <Text template="message">Message</Text>
+                <Group template="actions">
+                    <Button>Option #1</Button>
+                    <Button>Option #2</Button>
+                </Group>
+            </Rectangle>
+            """#,
+            outerView: {
+                $0
+                    .environmentObject(LiveViewModel(
+                        forms: [:],
+                        cachedNavigationTitle: nil,
+                        bindingValues: ["show": true]
+                    ))
+            }
+        ) {
+            AnyShape(Rectangle())
+                .fill(.blue)
+                .alert("My Alert", isPresented: .constant(true)) {
+                    Button("Option #1") {}
+                    Button("Option #2") {}
+                } message: {
+                    // Note: In some cases, wrapping content in an `if` provides a different hierarchy that matches LVN.
+                    if true {
+                        Text("Message")
+                    }
+                }
+        }
+    }
+}

--- a/Tests/RenderingTests/assertHierarchy.swift
+++ b/Tests/RenderingTests/assertHierarchy.swift
@@ -1,0 +1,269 @@
+//
+//  assertHierarchy.swift
+//  
+//
+//  Created by Carson Katri on 1/10/23.
+//
+
+import XCTest
+import SwiftUI
+import Foundation
+@testable import LiveViewNative
+import LiveViewNativeCore
+import RegexBuilder
+
+extension XCTestCase {
+    /// Tests if a View hierarchy markup matches an expected hierarchy.
+    ///
+    /// - Note: Only View types are compared, not the content of the hierarchy.
+    /// Use ``assertMatch`` to compare rendered content.
+    @MainActor
+    func assertHierarchy(
+        _ markup: String,
+        _ file: String = #file,
+        _ line: Int = #line,
+        _ function: StaticString = #function,
+        environment: @escaping (inout EnvironmentValues) -> () = { _ in },
+        @ViewBuilder outerView: @escaping (AnyView) -> some View = { $0 },
+        @ViewBuilder _ view: @escaping () -> some View
+    ) throws {
+        try assertHierarchy(name: "\(URL(filePath: file).lastPathComponent)-\(line)-\(function)", markup, environment: environment, outerView: outerView, view)
+    }
+    
+    @MainActor
+    func assertHierarchy(
+        name: String,
+        _ markup: String,
+        environment: @escaping (inout EnvironmentValues) -> () = { _ in },
+        @ViewBuilder outerView: @escaping (AnyView) -> some View = { $0 },
+        @ViewBuilder _ view: @escaping () -> some View
+    ) throws {
+        let session = LiveSessionCoordinator(URL(string: "http://localhost")!)
+        let document = try LiveViewNativeCore.Document.parse(markup)
+        let markupView = session.rootCoordinator.builder.fromNodes(
+            document[document.root()].children(),
+            coordinator: session.rootCoordinator,
+            url: session.url
+        ).environment(\.coordinatorEnvironment, CoordinatorEnvironment(session.rootCoordinator, document: document))
+        
+        let markupExpectation = XCTestExpectation()
+        var markupHierarchy: [RenderedViewHierarchy]!
+        ViewHierarchyHost(rootView: outerView(AnyView(markupView.transformEnvironment(\.self, transform: environment)))) {
+            markupHierarchy = $0
+            markupExpectation.fulfill()
+        }
+            .present()
+        wait(for: [markupExpectation])
+        
+        let viewExpectation = XCTestExpectation()
+        var viewHierarchy: [RenderedViewHierarchy]!
+        // Note: In some cases, wrapping content in an `if` provides a different hierarchy that matches LVN.
+        @ViewBuilder
+        var conditionalView: some View {
+            if true {
+                view()
+            }
+        }
+        ViewHierarchyHost(rootView: outerView(AnyView(conditionalView.transformEnvironment(\.self, transform: environment)))) {
+            viewHierarchy = $0
+            viewExpectation.fulfill()
+        }
+            .present()
+        wait(for: [viewExpectation])
+        
+        XCTAssertEqual(
+            markupHierarchy!,
+            viewHierarchy!,
+            zip(
+                markupHierarchy!.debugDescription.split(separator: "\n"),
+                viewHierarchy!.debugDescription.split(separator: "\n")
+            )
+                .filter { $0 != $1 }
+                .map { "Markup: \($0.0.trimmingCharacters(in: .whitespacesAndNewlines))\nView: \($0.1.trimmingCharacters(in: .whitespacesAndNewlines))" }
+                .joined(separator: "\n\n")
+        )
+    }
+}
+
+private let describeDenyList: Set<String> = ["SwiftUI.AccessibilityAttachmentModifier", "SwiftUI.ResolvedUIKitButtonBody", "SwiftUI.UIKitButtonAdaptor", "SwiftUI.ViewLeafView"]
+private func describe(_ value: Any) -> String {
+    let unknownContext = Regex {
+        "(unknown context at $"
+        OneOrMore(CharacterClass(.digit, "a"..."z"))
+        ")."
+    }
+    let typeName = String(reflecting: Swift.type(of: value))
+        .replacing(unknownContext, with: "")
+    if describeDenyList.contains(String(typeName.split(separator: "<")[0])) {
+        return "\(typeName)(...)"
+    }
+    if let convertible = value as? CustomStringConvertible {
+        return convertible.description
+    }
+    let mirror = (value as? CustomReflectable)?.customMirror ?? Mirror(reflecting: value)
+    if mirror.children.isEmpty {
+        return String(reflecting: value)
+    } else {
+        return """
+        \(typeName.split(separator: "<")[0])(\(mirror.children
+            .filter { ($0.value as? any View) == nil }
+            .map { "\($0.label ?? "_"): \(describe($0.value))" }
+            .joined(separator: ", ")
+        ))
+        """
+    }
+}
+
+struct RenderedViewHierarchy: CustomDebugStringConvertible, Equatable {
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        return lhs.debugDescription == rhs.debugDescription
+    }
+    
+    let type: Any.Type
+    let children: [Self]
+    
+    init(data: _ViewDebug.Data) {
+        self.type = data.data[.type]! as! Any.Type
+        self.children = data.childData.map(Self.init(data:))
+    }
+    
+    private var typeName: String {
+        String(reflecting: self.type)
+            .replacing(Regex {
+                "(unknown context at $"
+                OneOrMore {
+                    ChoiceOf {
+                        CharacterClass.digit
+                        "a"..."z"
+                    }
+                }
+                ")."
+            }, with: "")
+    }
+    
+    private var isModule: Bool {
+        !typeName.starts(with: "SwiftUI.")
+    }
+    private var isModifiedContent: Bool {
+        typeName.starts(with: "SwiftUI.ModifiedContent")
+    }
+    private var isAnyView: Bool {
+        typeName.starts(with: "SwiftUI.AnyView")
+    }
+    private var isEnvironmentKeyWritingModifier: Bool {
+        typeName.starts(with: "SwiftUI._EnvironmentKeyWritingModifier")
+    }
+    private var isConditionalContent: Bool {
+        typeName.starts(with: "SwiftUI._ConditionalContent")
+    }
+    private var isPreferenceWritingModifier: Bool {
+        typeName.starts(with: "SwiftUI._PreferenceWritingModifier")
+    }
+    private var isOpacityRendererEffect: Bool {
+        typeName.starts(with: "SwiftUI.OpacityRendererEffect")
+    }
+    private var isStaticIf: Bool {
+        typeName.starts(with: "SwiftUI.StaticIf")
+    }
+    private var isEmptyModifier: Bool {
+        typeName.starts(with: "SwiftUI.EmptyModifier")
+    }
+    private var isStaticSourceWriter: Bool {
+        typeName.starts(with: "SwiftUI.StaticSourceWriter")
+    }
+    private var isTupleView: Bool {
+        typeName.starts(with: "SwiftUI.TupleView")
+    }
+    
+    var debugDescription: String {
+        if isModule || isModifiedContent || isAnyView || isEnvironmentKeyWritingModifier || isConditionalContent || isPreferenceWritingModifier || isOpacityRendererEffect || isStaticIf || isEmptyModifier || isStaticSourceWriter || isTupleView {
+            return children.map(\.debugDescription).joined(separator: "\n")
+        } else {
+            let childItems = children
+                .map(\.debugDescription)
+                .flatMap { $0.split(separator: "\n") }
+            return """
+            \(typeName.split(separator: "<").first!)\(childItems.isEmpty ? "" : "\n | " + childItems.joined(separator: "\n  "))
+            """
+        }
+    }
+}
+
+extension _ViewDebug.Data {
+    var data: [_ViewDebug.Property:Any] {
+        Mirror(reflecting: self).descendant("data") as! [_ViewDebug.Property:Any]
+    }
+    var childData: [Self] {
+        Mirror(reflecting: self).descendant("childData") as! [Self]
+    }
+}
+
+struct DisplayList {
+    let value: Any
+    
+    init(from value: Any) {
+        self.value = value
+    }
+}
+
+struct RootMarker<Content: View>: View {
+    let content: Content
+    
+    var body: some View {
+        content
+    }
+}
+
+class ViewHierarchyHost<Content: View>: UIHostingController<RootMarker<Content>> {
+    var onHierarchy: (([RenderedViewHierarchy]) -> ())!
+    var didLayout = false
+    
+    init(rootView: Content, onHierarchy: @escaping ([RenderedViewHierarchy]) -> ()) {
+        super.init(rootView: RootMarker(content: rootView))
+        self.onHierarchy = onHierarchy
+    }
+    
+    @MainActor required dynamic init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func viewDidLayoutSubviews() {
+        guard !didLayout else { return }
+        didLayout = true
+        Task {
+            await MainActor.run { [weak self] in
+                guard let self else { return }
+                if let presented = self.presentedViewController?.view._test_viewDebugData() {
+                    onHierarchy(self.view._test_viewDebugData() + presented)
+                } else {
+                    onHierarchy(self.view._test_viewDebugData())
+                }
+            }
+        }
+    }
+    
+    func present() {
+        let window = UIWindow()
+        window.rootViewController = self
+        window.makeKeyAndVisible()
+    }
+}
+
+protocol HostingViewProtocol {
+    func _test_viewDebugData() -> [_ViewDebug.Data]
+}
+
+extension _UIHostingView: HostingViewProtocol {
+    func _test_viewDebugData() -> [_ViewDebug.Data] {
+        self._viewDebugData()
+    }
+}
+
+extension UIView {
+    func _test_viewDebugData() -> [RenderedViewHierarchy] {
+        let subviewData = self.subviews.flatMap({ $0._test_viewDebugData() })
+        guard let debugData = (self as? HostingViewProtocol)?._test_viewDebugData().first
+        else { return subviewData }
+        return [RenderedViewHierarchy(data: debugData)] + subviewData
+    }
+}

--- a/Tests/RenderingTests/assertMatch.swift
+++ b/Tests/RenderingTests/assertMatch.swift
@@ -1,6 +1,6 @@
 //
 //  assertMatch.swift
-//  
+//
 //
 //  Created by Carson Katri on 1/10/23.
 //


### PR DESCRIPTION
This adds a method for comparing evaluated View hierarchies by their types instead of a rendered image.

The content of the Views is not compared, but the structure is. This allows presentation modifiers and other non-visual modifiers to be tested.

> **Note**
> It's possible this method could break as SwiftUI changes since it uses underscored methods.