### PR TITLE
Refactor `.connect()` calls

### DIFF
--- a/Sources/LiveViewNative/Coordinators/LiveSessionCoordinator.swift
+++ b/Sources/LiveViewNative/Coordinators/LiveSessionCoordinator.swift
@@ -79,7 +79,6 @@ public class LiveSessionCoordinator<R: RootRegistry>: ObservableObject {
             }
         }.store(in: &cancellables)
         $navigationPath.scan(([LiveNavigationEntry<R>](), [LiveNavigationEntry<R>]()), { ($0.1, $1) }).sink { prev, next in
-            print(prev, next)
             if prev.count > next.count {
                 let last = next.last ?? .init(url: self.url, coordinator: self.rootCoordinator)
                 if last.coordinator.url != last.url {

--- a/Sources/LiveViewNative/NavStackEntryView.swift
+++ b/Sources/LiveViewNative/NavStackEntryView.swift
@@ -22,15 +22,6 @@ struct NavStackEntryView<R: RootRegistry>: View {
         let _ = Self._printChanges()
         elementTree
             .environmentObject(liveViewModel)
-            .task {
-                // If the coordinator is not connected to the right URL, update it.
-                if coordinator.url != entry.url {
-                    coordinator.url = entry.url
-                    await coordinator.reconnect()
-                } else {
-                    await coordinator.connect()
-                }
-            }
             .onReceive(coordinator.$document) { newDocument in
                 if let doc = newDocument {
                     // todo: doing this every time the DOM changes is probably not efficient


### PR DESCRIPTION
This fixes navigation on macOS by moving the coordinator `.connect()`/`.reconnect()` calls out of a task modifier and into the `LiveSessionCoordinator`.