### PR TITLE
Add strongly typed JSON values to replace Payload where possible

### DIFF
--- a/Sources/LiveViewNative/BuiltinRegistry+applyBinding.swift
+++ b/Sources/LiveViewNative/BuiltinRegistry+applyBinding.swift
@@ -13,7 +13,7 @@ extension BuiltinRegistry {
     static func applyBinding(
         _ binding: AttributeName,
         event: String,
-        value: Payload,
+        value: JSONValue,
         to view: some View,
         element: ElementNode
     ) -> some View {
@@ -71,9 +71,9 @@ fileprivate struct ScenePhaseObserver<Content: View>: View {
     let content: Content
     let target: ScenePhase
     let _event: Event
-    let value: Payload
+    let value: JSONValue
     
-    init(content: Content, target: ScenePhase, type: String, event: String, value: Payload) {
+    init(content: Content, target: ScenePhase, type: String, event: String, value: JSONValue) {
         self.content = content
         self.target = target
         self._event = .init(event: event, type: type)
@@ -95,9 +95,9 @@ fileprivate struct FocusObserver<Content: View>: View {
     let content: Content
     let target: Bool
     let _event: Event
-    let value: Payload
+    let value: JSONValue
     
-    init(content: Content, target: Bool, type: String, event: String, value: Payload) {
+    init(content: Content, target: Bool, type: String, event: String, value: JSONValue) {
         self.content = content
         self.target = target
         self._event = .init(event: event, type: type)
@@ -117,9 +117,9 @@ fileprivate struct FocusObserver<Content: View>: View {
 fileprivate struct TapGestureView<Content: View>: View {
     let content: Content
     let _event: Event
-    let value: Payload
+    let value: JSONValue
     
-    init(content: Content, type: String, event: String, value: Payload) {
+    init(content: Content, type: String, event: String, value: JSONValue) {
         self.content = content
         self._event = .init(event: event, type: type)
         self.value = value

--- a/Sources/LiveViewNative/Coordinators/LiveViewCoordinator.swift
+++ b/Sources/LiveViewNative/Coordinators/LiveViewCoordinator.swift
@@ -72,7 +72,7 @@ public class LiveViewCoordinator<R: RootRegistry>: ObservableObject {
     /// - Parameter value: The event value to provide to the backend event handler.
     /// - Parameter target: The value of the `phx-target` attribute.
     /// - Throws: ``LiveConnectionError/eventError(_:)`` if an error is encountered sending the event or processing it on the backend, `CancellationError` if the coordinator navigates to a different page while the event is being handled
-    public func pushEvent(type: String, event: String, value: some ToJSONValue, target: Int? = nil) async throws {
+    public func pushEvent(type: String, event: String, value: some JSONValueConvertible, target: Int? = nil) async throws {
         try await doPushEvent("event", payload: [
             "type": type,
             "event": event,
@@ -81,7 +81,7 @@ public class LiveViewCoordinator<R: RootRegistry>: ObservableObject {
         ])
     }
     
-    internal func doPushEvent(_ event: String, payload: [String: any ToJSONValue]) async throws {
+    internal func doPushEvent(_ event: String, payload: [String: any JSONValueConvertible]) async throws {
         guard let channel = channel else {
             return
         }
@@ -89,7 +89,7 @@ public class LiveViewCoordinator<R: RootRegistry>: ObservableObject {
         let token = self.currentConnectionToken
 
         let replyPayload = try await withCheckedThrowingContinuation({ [weak channel] continuation in
-            channel?.push(event, payload: payload.mapValues { $0.toJSONValue().toNSJSONSerializable() }, timeout: PUSH_TIMEOUT)
+            channel?.push(event, payload: payload.mapValues { $0.jsonValue.toNSJSONSerializable() }, timeout: PUSH_TIMEOUT)
                 .receive("ok") { reply in
                     continuation.resume(returning: reply.payload)
                 }

--- a/Sources/LiveViewNative/Environment.swift
+++ b/Sources/LiveViewNative/Environment.swift
@@ -24,7 +24,7 @@ private struct LiveContextStorageKey: EnvironmentKey {
 /// Provides access to ``LiveViewCoordinator`` properties via the environment.
 /// This exists to type-erase the coordinator, since environment properties can't be generic.
 struct CoordinatorEnvironment {
-    let pushEvent: @MainActor (String, String, Any, Int?) async throws -> Void
+    let pushEvent: @MainActor (String, String, JSONValue, Int?) async throws -> Void
     let elementChanged: AnyPublisher<NodeRef, Never>
     let document: Document
     

--- a/Sources/LiveViewNative/JSONValue.swift
+++ b/Sources/LiveViewNative/JSONValue.swift
@@ -1,0 +1,165 @@
+//
+//  JSONValue.swift
+//  LiveViewNative
+//
+//  Created by Shadowfacts on 5/19/23.
+//
+
+import Foundation
+
+/// A strongly typed JSON value.
+///
+/// In conjunction with the ``ToJSONValue`` protocol, complex JSON structures can be expressed in Swift directly as heterogenous collections.
+///
+/// ```swift
+/// let object: JSONValue = [
+///     "key1": nil as JSONValue,
+///     "key2": 3.14,
+///     "key3": "foo",
+///     "key4": [
+///         ["bar": false, "baz": 42],
+///         "qux",
+///     ],
+/// ]
+/// ```
+///
+/// ## Topics
+/// ### Supporting Types
+/// - ``ToJSONValue``
+public indirect enum JSONValue: Equatable {
+    case null
+    case integer(Int)
+    case double(Double)
+    case string(String)
+    case boolean(Bool)
+    case array([JSONValue])
+    case object([String: JSONValue])
+}
+
+extension JSONValue {
+    /// Converts a `JSONValue` to a form serializable by `JSONSerialization`
+    func toNSJSONSerializable() -> Any {
+        switch self {
+        case .null:
+            return nil as Any? as Any
+        case .integer(let i):
+            return i
+        case .double(let d):
+            return d
+        case .string(let s):
+            return s
+        case .boolean(let b):
+            return b
+        case .array(let a):
+            return a.map { $0.toNSJSONSerializable() }
+        case .object(let o):
+            return o.mapValues { $0.toNSJSONSerializable() }
+        }
+    }
+    
+    /// Returns the right value if the left one is ``JSONValue/null``, otherwise returns the left value.
+    public static func ?? (lhs: Self, rhs: @autoclosure () -> Self) -> Self {
+        if case .null = lhs {
+            return rhs()
+        } else {
+            return lhs
+        }
+    }
+}
+extension JSONValue: ExpressibleByNilLiteral {
+    public init(nilLiteral: ()) {
+        self = .null
+    }
+}
+extension JSONValue: ExpressibleByArrayLiteral {
+    public init(arrayLiteral elements: any ToJSONValue...) {
+        self = .array(elements.map { $0.toJSONValue() })
+    }
+}
+extension JSONValue: ExpressibleByDictionaryLiteral {
+    public typealias Key = String
+    public typealias Value = any ToJSONValue
+    public init(dictionaryLiteral elements: (Key, Value)...) {
+        self = .object(Dictionary(uniqueKeysWithValues: elements.map { ($0.0, $0.1.toJSONValue()) }))
+    }
+}
+extension JSONValue: Decodable {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if container.decodeNil() {
+            self = .null
+        } else if let i = try? container.decode(Int.self) {
+            self = .integer(i)
+        } else if let d = try? container.decode(Double.self) {
+            self = .double(d)
+        } else if let s = try? container.decode(String.self) {
+            self = .string(s)
+        } else if let b = try? container.decode(Bool.self) {
+            self = .boolean(b)
+        } else if let a = try? container.decode([JSONValue].self) {
+            self = .array(a)
+        } else if let o = try? container.decode([String: JSONValue].self) {
+            self = .object(o)
+        } else {
+            throw DecodingError.dataCorruptedError(in: container, debugDescription: "Expected JSONValue")
+        }
+    }
+}
+
+/// Types that can be converted to ``JSONValue`` conform to this protocol.
+///
+/// This protocol makes it easier to express complex, nested JSON structures by using heterogenous collections of `any ToJSONValue`.
+///
+/// For example, `[String: any ToJSONValue]` conforms to `ToJSONValue` and so may be used directly in another JSON object, without manually specifying the JSON object.
+public protocol ToJSONValue {
+    func toJSONValue() -> JSONValue
+}
+extension JSONValue: ToJSONValue {
+    public func toJSONValue() -> JSONValue {
+        self
+    }
+}
+extension Int: ToJSONValue {
+    public func toJSONValue() -> JSONValue {
+        .integer(self)
+    }
+}
+extension Double: ToJSONValue {
+    public func toJSONValue() -> JSONValue {
+        .double(self)
+    }
+}
+extension CGFloat: ToJSONValue {
+    public func toJSONValue() -> JSONValue {
+        .double(Double(self))
+    }
+}
+extension String: ToJSONValue {
+    public func toJSONValue() -> JSONValue {
+        .string(self)
+    }
+}
+extension Bool: ToJSONValue {
+    public func toJSONValue() -> JSONValue {
+        .boolean(self)
+    }
+}
+extension Array: ToJSONValue where Element == any ToJSONValue {
+    public func toJSONValue() -> JSONValue {
+        .array(self.map { $0.toJSONValue() })
+    }
+}
+extension Dictionary: ToJSONValue where Key == String, Value == any ToJSONValue {
+    public func toJSONValue() -> JSONValue {
+        .object(self.mapValues { $0.toJSONValue() })
+    }
+}
+extension Optional: ToJSONValue where Wrapped: ToJSONValue {
+    public func toJSONValue() -> JSONValue {
+        if let wrapped = self {
+            return wrapped.toJSONValue()
+        } else {
+            return .null
+        }
+    }
+}

--- a/Sources/LiveViewNative/LiveViewNative.docc/Resources/05-02-06-button.swift
+++ b/Sources/LiveViewNative/LiveViewNative.docc/Resources/05-02-06-button.swift
@@ -16,7 +16,7 @@ struct NavFavoriteModifier: ViewModifier, Decodable {
                 ToolbarItem(placement: .navigationBarTrailing) {
                     Button {
                         Task {
-                            try? await context.coordinator.pushEvent(type: "click", event: "toggle-favorite", value: [String:Any]())
+                            try? await context.coordinator.pushEvent(type: "click", event: "toggle-favorite", value: nil)
                         }
                     } label: {
                         Image(systemName: isFavorite ? "star.fill" : "star")

--- a/Sources/LiveViewNative/Modifiers/Documents Modifiers/RenameActionModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Documents Modifiers/RenameActionModifier.swift
@@ -55,7 +55,7 @@ struct RenameActionModifier: ViewModifier, Decodable {
         content
             .renameAction {
                 Task {
-                    try await coordinatorEnvironment?.pushEvent("click", event, [String:Any](), target)
+                    try await coordinatorEnvironment?.pushEvent("click", event, nil, target)
                 }
             }
     }

--- a/Sources/LiveViewNative/Modifiers/Gestures Modifiers/GestureModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Gestures Modifiers/GestureModifier.swift
@@ -49,7 +49,7 @@ struct GestureModifier<R: RootRegistry>: ViewModifier, Decodable {
     #if swift(>=5.8)
     @_documentation(visibility: public)
     #endif
-    private let gesture: AnyGesture<Any>
+    private let gesture: AnyGesture<JSONValue>
     
     /// The event to trigger when tapped.
     ///
@@ -78,7 +78,7 @@ struct GestureModifier<R: RootRegistry>: ViewModifier, Decodable {
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
-        self.gesture = try container.decode(AnyGesture<Any>.self, forKey: .gesture)
+        self.gesture = try container.decode(AnyGesture<JSONValue>.self, forKey: .gesture)
         self._action = try container.decode(Event.self, forKey: .action)
         self.priority = try container.decode(GesturePriority.self, forKey: .priority)
         self.mask = try container.decode(GestureMask.self, forKey: .mask)

--- a/Sources/LiveViewNative/Payload.swift
+++ b/Sources/LiveViewNative/Payload.swift
@@ -7,5 +7,4 @@
 
 import Foundation
 
-// todo: typed payloads
 public typealias Payload = [String: Any]

--- a/Sources/LiveViewNative/Property Wrappers/Event.swift
+++ b/Sources/LiveViewNative/Property Wrappers/Event.swift
@@ -260,14 +260,14 @@ public struct Event: DynamicProperty, Decodable {
     public struct EventHandler {
         let owner: Event
         
-        public func callAsFunction(value: some ToJSONValue = JSONValue.null, didSend: (() -> Void)? = nil) {
+        public func callAsFunction(value: some JSONValueConvertible = JSONValue.null, didSend: (() -> Void)? = nil) {
             Task {
                 try await self.callAsFunction(value: value)
                 didSend?()
             }
         }
         
-        public func callAsFunction(value: some ToJSONValue = JSONValue.null) async throws {
+        public func callAsFunction(value: some JSONValueConvertible = JSONValue.null) async throws {
             guard let event = owner.event ?? owner.name.flatMap(owner.element.attributeValue(for:)) else {
                 return
             }
@@ -275,7 +275,7 @@ public struct Event: DynamicProperty, Decodable {
                 owner.handler.currentEvent.send({
                     Task {
                         do {
-                            try await owner.coordinatorEnvironment?.pushEvent(owner.type, event, owner.params ?? value.toJSONValue(), owner.target ?? owner.element.attributeValue(for: "phx-target").flatMap(Int.init))
+                            try await owner.coordinatorEnvironment?.pushEvent(owner.type, event, owner.params ?? value.jsonValue, owner.target ?? owner.element.attributeValue(for: "phx-target").flatMap(Int.init))
                             continuation.resume()
                         } catch {
                             continuation.resume(with: .failure(error))

--- a/Sources/LiveViewNative/Property Wrappers/FormState.swift
+++ b/Sources/LiveViewNative/Property Wrappers/FormState.swift
@@ -202,7 +202,7 @@ public struct FormState<Value: FormValue> {
         let name = element.attributeValue(for: "name") ?? "value"
         let encoder = FragmentEncoder()
         try! wrappedValue.encode(to: encoder)
-        let value = encoder.unwrap() as Any
+        let value = encoder.unwrap()
         Task {
             try? await coordinator!.pushEvent("native-form", changeEvent, [name: value], nil)
         }

--- a/Sources/LiveViewNative/Property Wrappers/LiveBinding.swift
+++ b/Sources/LiveViewNative/Property Wrappers/LiveBinding.swift
@@ -181,7 +181,7 @@ public struct LiveBinding<Value: Codable> {
                 // todo: if encoding fails, what should happen?
                 try! newValue.encode(to: encoder)
                 data.skipNextUpdate = true
-                liveViewModel.setBinding(bindingName, to: encoder.unwrap() as Any)
+                liveViewModel.setBinding(bindingName, to: encoder.unwrap())
             }
         }
     }

--- a/Sources/LiveViewNative/Utils/DOM.swift
+++ b/Sources/LiveViewNative/Utils/DOM.swift
@@ -91,13 +91,13 @@ public struct ElementNode {
         .joined(separator: " ")
     }
     
-    internal func buildPhxValuePayload() -> Payload {
+    internal func buildPhxValuePayload() -> [String: JSONValue] {
         let prefix = "phx-value-"
         return attributes
             .filter { $0.name.namespace == nil && $0.name.name.starts(with: prefix) }
             .reduce(into: [:]) { partialResult, attr in
                 // TODO: for nil attribute values, what value should this use?
-                partialResult[String(attr.name.name.dropFirst(prefix.count))] = attr.value
+                partialResult[String(attr.name.name.dropFirst(prefix.count))] = attr.value.flatMap(JSONValue.string(_:))
             }
     }
 }

--- a/Sources/LiveViewNative/ViewTree.swift
+++ b/Sources/LiveViewNative/ViewTree.swift
@@ -241,7 +241,7 @@ private struct BindingApplicator<Parent: View, R: RootRegistry>: View {
         BuiltinRegistry<R>.applyBinding(
             binding.name,
             event: binding.value!,
-            value: element.buildPhxValuePayload(),
+            value: .object(element.buildPhxValuePayload()),
             to: parent,
             element: element
         )

--- a/Sources/LiveViewNative/Views/Controls and Indicators/Buttons/PasteButton.swift
+++ b/Sources/LiveViewNative/Views/Controls and Indicators/Buttons/PasteButton.swift
@@ -53,7 +53,7 @@ struct PasteButton<R: RootRegistry>: View {
     var body: some View {
         #if os(iOS) || os(macOS)
         SwiftUI.PasteButton(payloadType: String.self) { strings in
-            click(value: ["value": strings]) {}
+            click(value: ["value": JSONValue.array(strings.map(JSONValue.string(_:)))]) {}
         }
             .preference(key: ProvidedBindingsKey.self, value: ["phx-click"])
         #endif

--- a/Sources/LiveViewNative/Views/Layout Containers/Collection Containers/List.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Collection Containers/List.swift
@@ -197,7 +197,7 @@ struct List<R: RootRegistry>: View {
         return { indices in
             var meta = element.buildPhxValuePayload()
             // todo: what about multiple indicies?
-            meta["index"] = indices.first!
+            meta["index"] = .integer(indices.first!)
             delete(value: meta) {}
         }
     }
@@ -205,8 +205,8 @@ struct List<R: RootRegistry>: View {
     private var onMoveHandler: ((IndexSet, Int) -> Void)? {
         return { indices, index in
             var meta = element.buildPhxValuePayload()
-            meta["index"] = indices.first!
-            meta["destination"] = index
+            meta["index"] = .integer(indices.first!)
+            meta["destination"] = .integer(index)
             move(value: meta) {
                 Task {
 #if os(iOS) || os(tvOS)

--- a/Sources/LiveViewNative/Views/Text Input and Output/TextFieldProtocol.swift
+++ b/Sources/LiveViewNative/Views/Text Input and Output/TextFieldProtocol.swift
@@ -76,12 +76,12 @@ extension TextFieldProtocol {
         if isFocused {
             focusEvent(value:
                 element.buildPhxValuePayload()
-                    .merging(["value": textBinding.wrappedValue], uniquingKeysWith: { a, _ in a })
+                    .merging(["value": .string(textBinding.wrappedValue)], uniquingKeysWith: { a, _ in a })
             )
         } else {
             blurEvent(value:
                 element.buildPhxValuePayload()
-                    .merging(["value": textBinding.wrappedValue], uniquingKeysWith: { a, _ in a })
+                    .merging(["value": .string(textBinding.wrappedValue)], uniquingKeysWith: { a, _ in a })
             )
         }
     }

--- a/Tests/LiveViewNativeTests/FragmentEncoderTests.swift
+++ b/Tests/LiveViewNativeTests/FragmentEncoderTests.swift
@@ -41,7 +41,7 @@ final class FragmentEncoderTests: XCTestCase {
         let test = Test(b: false, s: "hello", d: 3.14, f: 1.0, i: -1, o: Nested(s: "foo"), a: [Nested(s: "bar")])
         let encoder = FragmentEncoder()
         try test.encode(to: encoder)
-        XCTAssertEqual(encoder.unwrap() as! [String: Any?] as NSDictionary, expected as NSDictionary)
+        XCTAssertEqual(encoder.toNSJSONSerializable() as! NSDictionary, expected as NSDictionary)
     }
     
 }

--- a/Tests/LiveViewNativeTests/JSONValueTests.swift
+++ b/Tests/LiveViewNativeTests/JSONValueTests.swift
@@ -30,6 +30,10 @@ final class JSONValueTests: XCTestCase {
                 .string("qux"),
             ])
         ]))
+        XCTAssertEqual(
+            try JSONSerialization.data(withJSONObject: object.toNSJSONSerializable(), options: .sortedKeys),
+            Data(#"{"key1":null,"key2":3.1400000000000001,"key3":"foo","key4":[{"bar":false,"baz":42},"qux"]}"#.utf8)
+        )
     }
     
 }

--- a/Tests/LiveViewNativeTests/JSONValueTests.swift
+++ b/Tests/LiveViewNativeTests/JSONValueTests.swift
@@ -1,0 +1,35 @@
+//
+//  JSONValueTests.swift
+//  
+//
+//  Created by Shadowfacts on 5/19/23.
+//
+
+import XCTest
+@testable import LiveViewNative
+
+final class JSONValueTests: XCTestCase {
+
+    func testHeterogenousCollections() {
+        let object: JSONValue = [
+            // todo: without the explicit cast, this nil can't be inferred as a JSONValue for some reason
+            "key1": nil as JSONValue,
+            "key2": 3.14,
+            "key3": "foo",
+            "key4": [
+                ["bar": false, "baz": 42],
+                "qux",
+            ],
+        ]
+        XCTAssertEqual(object, .object([
+            "key1": .null,
+            "key2": .double(3.14),
+            "key3": .string("foo"),
+            "key4": .array([
+                .object(["bar": .boolean(false), "baz": .integer(42)]),
+                .string("qux"),
+            ])
+        ]))
+    }
+    
+}


### PR DESCRIPTION
This adds a `JSONValue` type that's limited to JSON primitives, and a number of helpers for expressing JSON values in a more Swift-y way:

```swift
let object: JSONValue = [
	"key1": nil as JSONValue,
	"key2": 3.14,
	"key3": "foo",
	"key4": [
		["bar": false, "baz": 42],
		"qux",
	],
]
```

The goal is to replace `Payload` and `Any`, both for general type-safety and with the intent of providing a better foundation for Core-managed channels, since we'll need the ability to pass JSON across the FFI boundary, which means stronger types (one possibility switching out the `JSONValue` enum with a wrapper of whatever type Core provides, and keeping the `ToJSONValue` protocol to provide better expressibility in Swift).