### PR TITLE
Add `ScaledMetric`

### DIFF
--- a/Sources/LiveViewNative/Utils/Font.swift
+++ b/Sources/LiveViewNative/Utils/Font.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import LiveViewNativeCore
 
 /// A font value.
 ///
@@ -311,11 +312,21 @@ extension Font.Design: Decodable {
 #if swift(>=5.8)
 @_documentation(visibility: public)
 #endif
-extension Font.TextStyle: Decodable {
+extension Font.TextStyle: Decodable, AttributeDecodable {
+    public init(from attribute: LiveViewNativeCore.Attribute?) throws {
+        guard let value = attribute?.value
+        else { throw AttributeDecodingError.missingAttribute(Self.self) }
+        try self.init(from: value)
+    }
+    
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
-        switch try container.decode(String.self) {
-        case "large_title": self = .largeTitle
+        try self.init(from: try container.decode(String.self))
+    }
+    
+    public init(from string: String) throws {
+        switch string {
+        case "large_title", "large-title": self = .largeTitle
         case "title": self = .title
         case "title2": self = .title2
         case "title3": self = .title3

--- a/Sources/LiveViewNative/Views/Accessibility/ScaledMetric.swift
+++ b/Sources/LiveViewNative/Views/Accessibility/ScaledMetric.swift
@@ -7,7 +7,33 @@
 
 import SwiftUI
 
+/// Updates a binding based on the dynamic type size in the current context.
 ///
+/// Use this element to scale a value with the accessibility dynamic type size.
+///
+/// ```html
+/// <ScaledMetric scaled-value-binding={:scaled_value} value={100} relative-to="large-title">
+///   <Image system-name="heart" resizable modifiers={frame(@native, width: @scaled_value, height: @scaled_value)}>
+/// </ScaledMetric>
+/// ```
+///
+/// ```elixir
+/// defmodule MyAppWeb.AccessibilityLive do
+///   native_binding :scaled_value, Float, 100.0
+/// end
+/// ```
+///
+/// The initial ``value`` of `100` will be used when dynamic type is disabled.
+/// If the dynamic type size is changed, the binding referenced by ``scaledValue`` will be updated with a scaled version of ``value``.
+///
+/// Optionally provide a ``LiveViewNative/SwiftUI/Font/TextStyle`` to scale relative to with the ``relativeStyle`` attribute.
+///
+/// ## Attributes
+/// * ``value``
+/// * ``relativeStyle``
+///
+/// ## Bindings
+/// * ``scaledValue``
 #if swift(>=5.8)
 @_documentation(visibility: public)
 #endif
@@ -15,13 +41,23 @@ struct ScaledMetric<R: RootRegistry>: View {
     @ObservedElement private var element: ElementNode
     @LiveContext<R> private var context
     
+    /// The binding to update with the scaled ``value``.
     #if swift(>=5.8)
     @_documentation(visibility: public)
     #endif
     @LiveBinding(attribute: "scaled-value-binding") private var scaledValue: Double
     
+    /// The initial value to scale.
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
     @Attribute("value") private var value: Double
     
+    /// The ``LiveViewNative/SwiftUI/Font/TextStyle`` to scale with.
+    /// Defaults to `body`.
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
     @Attribute("relative-to") private var relativeStyle: Font.TextStyle = .body
     
     var body: some View {

--- a/Sources/LiveViewNative/Views/Accessibility/ScaledMetric.swift
+++ b/Sources/LiveViewNative/Views/Accessibility/ScaledMetric.swift
@@ -1,0 +1,47 @@
+//
+//  ScaledMetric.swift
+//  LiveViewNative
+//
+//  Created by Carson Katri on 5/30/23.
+//
+
+import SwiftUI
+
+///
+#if swift(>=5.8)
+@_documentation(visibility: public)
+#endif
+struct ScaledMetric<R: RootRegistry>: View {
+    @ObservedElement private var element: ElementNode
+    @LiveContext<R> private var context
+    
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
+    @LiveBinding(attribute: "scaled-value-binding") private var scaledValue: Double
+    
+    @Attribute("value") private var value: Double
+    
+    @Attribute("relative-to") private var relativeStyle: Font.TextStyle = .body
+    
+    var body: some View {
+        ScaledMetricObserver(
+            scaledMetric: .init(wrappedValue: value, relativeTo: relativeStyle),
+            value: $scaledValue,
+            content: context.buildChildren(of: element)
+        )
+    }
+    
+    private struct ScaledMetricObserver<Content: View>: View {
+        let scaledMetric: SwiftUI.ScaledMetric<Double>
+        @Binding var value: Double
+        let content: Content
+        
+        var body: some View {
+            content
+                .task(id: scaledMetric.wrappedValue) {
+                    value = scaledMetric.wrappedValue
+                }
+        }
+    }
+}


### PR DESCRIPTION
Closes #242 

This is a property wrapper in SwiftUI, but I implemented it as a View here (similar to how the `NamespaceContext` view is implemented). The `@ScaledMetric` wrapper is used on the View and updates a `@LiveBinding` with the scaled value.