### PR TITLE
Fix template elements and selection in `List`

### DIFF
--- a/Sources/LiveViewNative/Property Wrappers/Event.swift
+++ b/Sources/LiveViewNative/Property Wrappers/Event.swift
@@ -260,6 +260,10 @@ public struct Event: DynamicProperty, Decodable {
     public struct EventHandler {
         let owner: Event
         
+        var event: String? {
+            owner.event ?? owner.name.flatMap(owner.element.attributeValue(for:))
+        }
+        
         public func callAsFunction(value: Any = [String:String](), didSend: (() -> Void)? = nil) {
             Task {
                 try await self.callAsFunction(value: value)
@@ -268,7 +272,7 @@ public struct Event: DynamicProperty, Decodable {
         }
         
         public func callAsFunction(value: Any = [String:String]()) async throws {
-            guard let event = owner.event ?? owner.name.flatMap(owner.element.attributeValue(for:)) else {
+            guard let event else {
                 return
             }
             try await withCheckedThrowingContinuation { continuation in

--- a/Sources/LiveViewNative/Property Wrappers/LiveContext.swift
+++ b/Sources/LiveViewNative/Property Wrappers/LiveContext.swift
@@ -133,6 +133,14 @@ public struct LiveContext<R: RootRegistry>: DynamicProperty {
     ) -> [NodeChildrenSequence.Element] {
         element.children().filter(Self.isTemplateElement(template))
     }
+    
+    func children(
+        of element: ElementNode
+    ) -> [NodeChildrenSequence.Element] {
+        element.children().filter {
+            !($0.asElement()?.attributes.contains(where: { $0.name.rawValue == "template" }) ?? false)
+        }
+    }
 }
 
 struct LiveContextStorage<R: RootRegistry> {

--- a/Sources/LiveViewNative/Property Wrappers/LiveContext.swift
+++ b/Sources/LiveViewNative/Property Wrappers/LiveContext.swift
@@ -138,7 +138,7 @@ public struct LiveContext<R: RootRegistry>: DynamicProperty {
         of element: ElementNode
     ) -> [NodeChildrenSequence.Element] {
         element.children().filter {
-            !($0.asElement()?.attributes.contains(where: { $0.name.rawValue == "template" }) ?? false)
+            !$0.attributes.contains(where: { $0.name.rawValue == "template" })
         }
     }
 }

--- a/Sources/LiveViewNative/Utils/Selection.swift
+++ b/Sources/LiveViewNative/Utils/Selection.swift
@@ -7,6 +7,7 @@
 
 /// Selection of either a single value or set of values.
 enum Selection: Codable {
+    case none
     case single(String?)
     case multiple(Set<String>)
     
@@ -33,7 +34,7 @@ enum Selection: Codable {
     init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
         if container.decodeNil() {
-            self = .single(nil)
+            self = .none
         } else if let item = try? container.decode(String.self) {
             self = .single(item)
         } else {
@@ -44,6 +45,8 @@ enum Selection: Codable {
     func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
         switch self {
+        case .none:
+            try container.encodeNil()
         case .single(let selection):
             try container.encode(selection)
         case .multiple(let selection):

--- a/Sources/LiveViewNative/Views/Layout Containers/Collection Containers/List.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Collection Containers/List.swift
@@ -166,7 +166,7 @@ struct List<R: RootRegistry>: View {
     #if swift(>=5.8)
     @_documentation(visibility: public)
     #endif
-    @LiveBinding(attribute: "selection") private var selection = Selection.single(nil)
+    @LiveBinding(attribute: "selection") private var selection = Selection.none
     
     public var body: some View {
         #if os(watchOS)
@@ -175,6 +175,10 @@ struct List<R: RootRegistry>: View {
         }
         #else
         switch selection {
+        case .none:
+            SwiftUI.List {
+                content
+            }
         case .single:
             SwiftUI.List(selection: $selection.single) {
                 content
@@ -188,7 +192,7 @@ struct List<R: RootRegistry>: View {
     }
     
     private var content: some View {
-        forEach(nodes: element.children(), context: context.storage)
+        forEach(nodes: context.children(of: element), context: context.storage)
             .onDelete(perform: onDeleteHandler)
             .onMove(perform: onMoveHandler)
     }

--- a/Sources/LiveViewNative/Views/Layout Containers/Collection Containers/List.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Collection Containers/List.swift
@@ -198,6 +198,7 @@ struct List<R: RootRegistry>: View {
     }
     
     private var onDeleteHandler: ((IndexSet) -> Void)? {
+        guard delete.event != nil else { return nil }
         return { indices in
             var meta = element.buildPhxValuePayload()
             // todo: what about multiple indicies?
@@ -207,6 +208,7 @@ struct List<R: RootRegistry>: View {
     }
     
     private var onMoveHandler: ((IndexSet, Int) -> Void)? {
+        guard move.event != nil else { return nil }
         return { indices, index in
             var meta = element.buildPhxValuePayload()
             meta["index"] = indices.first!

--- a/Sources/LiveViewNative/Views/Layout Containers/Collection Containers/Table.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Collection Containers/Table.swift
@@ -130,7 +130,7 @@ struct Table<R: RootRegistry>: View {
     #if swift(>=5.8)
     @_documentation(visibility: public)
     #endif
-    @LiveBinding(attribute: "selection") private var selection = Selection.multiple([])
+    @LiveBinding(attribute: "selection") private var selection = Selection.none
     /// Synchronizes the columns to sort by with the server.
     ///
     /// The order is serialized as a list of maps with an `id` and `order` property.
@@ -330,6 +330,8 @@ fileprivate extension SwiftUI.Table where Value == TableRow, Rows == TableForEac
         @TableColumnBuilder<TableRow, TableColumnSort> columns: () -> Columns
     ) {
         switch selection.wrappedValue {
+        case .none:
+            self.init(rows, sortOrder: sortOrder, columns: columns)
         case .single(_):
             self.init(rows, selection: selection.single, sortOrder: sortOrder, columns: columns)
         case .multiple(_):


### PR DESCRIPTION
This fixes 3 bugs with `List`:
1. Elements with `template={...}` were rendered as list items and required an `id`. They are now ignored.
2. If no `selection` attribute was present, selection was still possible but not sent to the backend. Now selection is disabled if the attribute is not set to a binding (this applies to `Table` as well)
3. If no `phx-delete`/`phx-move` event was provided, delete/move actions were still enabled. Now they are disabled unless the event attribute is set.