### PR TITLE
Fix system font with size encoding

### DIFF
--- a/Sources/LiveViewNative/Utils/Font.swift
+++ b/Sources/LiveViewNative/Utils/Font.swift
@@ -32,6 +32,12 @@ import SwiftUI
 /// {:system, :subheadline, [design: :serif, weight: :bold]}
 /// ```
 ///
+/// Provide a size instead of a text style to use a custom size.
+/// ```elixir
+/// {:system, [size: 21]}
+/// {:system, [size: 21, weight: :bold]}
+/// ```
+///
 /// ### Custom Fonts
 /// Fonts can be created by name as well.
 ///

--- a/lib/live_view_native_swift_ui/types/font.ex
+++ b/lib/live_view_native_swift_ui/types/font.ex
@@ -12,7 +12,7 @@ defmodule LiveViewNativeSwiftUi.Types.Font do
   end
   def cast({:system, [{:size, _} | _] = properties}), do: cast({:system, properties, []})
   def cast({:system, [{:size, _} | _] = properties, modifiers}) do
-    {:ok, %__MODULE__{ type: :system, properties: properties, modifiers: Enum.map(modifiers, &cast_modifier/1) }}
+    {:ok, %__MODULE__{ type: :system, properties: Enum.into(properties, %{}), modifiers: Enum.map(modifiers, &cast_modifier/1) }}
   end
 
   def cast({:custom, name, [fixed_size: fixed_size]}), do: cast({:custom, name, [fixed_size: fixed_size], []})


### PR DESCRIPTION
This fixes a bug with the `Font` type encoding incorrectly when using a `{:system, [size: n]}` value.

I've also added documentation around this form.