### PR TITLE
Move Text/Image attributes to modifiers

### DIFF
--- a/Sources/LiveViewNative/Image Modifiers/AntialiasedModifier.swift
+++ b/Sources/LiveViewNative/Image Modifiers/AntialiasedModifier.swift
@@ -1,0 +1,31 @@
+//
+//  AntialiasedModifier.swift
+//  LiveViewNative
+//
+//  Created by Carson Katri on 6/1/23.
+//
+
+import SwiftUI
+
+/// Enables/disables antialiasing.
+///
+/// ```html
+/// <Image system-name="heart.fill" modifiers={antialiased(@native, is_active: true)} />
+/// ```
+///
+/// ## Arguments
+/// * ``isActive``
+#if swift(>=5.8)
+@_documentation(visibility: public)
+#endif
+struct AntialiasedModifier: ImageModifier, Decodable {
+    /// Specifies if antialiasing is enabled.
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
+    private let isActive: Bool
+    
+    func apply(to image: SwiftUI.Image) -> SwiftUI.Image {
+        image.antialiased(isActive)
+    }
+}

--- a/Sources/LiveViewNative/Image Modifiers/ImageModifier.swift
+++ b/Sources/LiveViewNative/Image Modifiers/ImageModifier.swift
@@ -1,0 +1,79 @@
+//
+//  ImageModifier.swift
+//  LiveViewNative
+//
+//  Created by Carson Katri on 6/1/23.
+//
+
+import SwiftUI
+import LiveViewNativeCore
+
+enum ImageModifierType: String, Decodable {
+    case resizable
+    case antialiased
+    case renderingMode = "rendering_mode"
+    case interpolation
+    
+    func decode(from decoder: Decoder) throws -> any ImageModifier {
+        switch self {
+        case .resizable:
+            return try ResizableModifier(from: decoder)
+        case .antialiased:
+            return try AntialiasedModifier(from: decoder)
+        case .renderingMode:
+            return try RenderingModeModifier(from: decoder)
+        case .interpolation:
+            return try InterpolationModifier(from: decoder)
+        }
+    }
+}
+
+/// A modifier that applies to an ``Image``.
+protocol ImageModifier {
+    /// Modify the `Image` and return the new `Image` type.
+    func apply(to image: SwiftUI.Image) -> SwiftUI.Image
+}
+
+struct ImageModifierStack: Decodable, AttributeDecodable {
+    var stack: [any ImageModifier]
+    
+    init(_ stack: [any ImageModifier]) {
+        self.stack = stack
+    }
+    
+    init(from attribute: LiveViewNativeCore.Attribute?) throws {
+        guard let value = attribute?.value else { throw AttributeDecodingError.missingAttribute(Self.self) }
+        self = try makeJSONDecoder().decode(Self.self, from: Data(value.utf8))
+    }
+    
+    enum ImageModifierContainer: Decodable {
+        case modifier(any ImageModifier)
+        case end
+        
+        init(from decoder: Decoder) throws {
+            let type = try decoder.container(keyedBy: CodingKeys.self).decode(String.self, forKey: .type)
+            if let modifierType = ImageModifierType(rawValue: type) {
+                self = .modifier(try modifierType.decode(from: decoder))
+            } else {
+                self = .end
+            }
+        }
+        
+        enum CodingKeys: CodingKey {
+            case type
+        }
+    }
+    
+    init(from decoder: Decoder) throws {
+        var container = try decoder.unkeyedContainer()
+        self.stack = []
+        while !container.isAtEnd {
+            switch try container.decode(ImageModifierContainer.self) {
+            case let .modifier(modifier):
+                self.stack.append(modifier)
+            case .end:
+                return
+            }
+        }
+    }
+}

--- a/Sources/LiveViewNative/Image Modifiers/ImageModifier.swift
+++ b/Sources/LiveViewNative/Image Modifiers/ImageModifier.swift
@@ -11,6 +11,7 @@ import LiveViewNativeCore
 enum ImageModifierType: String, Decodable {
     case resizable
     case antialiased
+    case symbolRenderingMode = "symbol_rendering_mode"
     case renderingMode = "rendering_mode"
     case interpolation
     
@@ -20,6 +21,8 @@ enum ImageModifierType: String, Decodable {
             return try ResizableModifier(from: decoder)
         case .antialiased:
             return try AntialiasedModifier(from: decoder)
+        case .symbolRenderingMode:
+            return try SymbolRenderingModeModifier(from: decoder)
         case .renderingMode:
             return try RenderingModeModifier(from: decoder)
         case .interpolation:

--- a/Sources/LiveViewNative/Image Modifiers/InterpolationModifier.swift
+++ b/Sources/LiveViewNative/Image Modifiers/InterpolationModifier.swift
@@ -1,0 +1,70 @@
+//
+//  InterpolationModifier.swift
+//  
+//
+//  Created by Carson.Katri on 6/1/23.
+//
+
+import SwiftUI
+
+/// Set the quality level for an ``Image`` that requires interpolation.
+///
+/// When an image is resized (such as with the ``ResizableModifier`` modifier), it is interpolated.
+/// Use this modifier to set the quality of interpolation.
+///
+/// ```html
+/// <Image
+///   name="dot_green"
+///   modifiers={@native |> resizable() |> interpolation(interpolation: :none)}
+/// />
+/// <Image
+///   name="dot_green"
+///   modifiers={@native |> resizable() |> interpolation(interpolation: :medium)}
+/// />
+/// ```
+///
+/// ## Arguments
+/// * ``interpolation``
+#if swift(>=5.8)
+@_documentation(visibility: public)
+#endif
+struct InterpolationModifier: ImageModifier, Decodable {
+    /// The interpolation quality.
+    ///
+    /// See ``LiveViewNative/SwiftUI/Image/Interpolation`` for a list of possible values.
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
+    private let interpolation: SwiftUI.Image.Interpolation
+    
+    func apply(to image: SwiftUI.Image) -> SwiftUI.Image {
+        image.interpolation(interpolation)
+    }
+}
+
+/// The quality level used to render an interpolated ``Image``.
+///
+/// Possible values:
+/// * `low`
+/// * `medium`
+/// * `high`
+/// * `none`
+#if swift(>=5.8)
+@_documentation(visibility: public)
+#endif
+extension SwiftUI.Image.Interpolation: Decodable {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        switch try container.decode(String.self) {
+        case "low":
+            self = .low
+        case "medium":
+            self = .medium
+        case "high":
+            self = .high
+        case "none":
+            self = .none
+        case let `default`: throw DecodingError.dataCorrupted(.init(codingPath: container.codingPath, debugDescription: "Unknown interpolation '\(`default`)'"))
+        }
+    }
+}

--- a/Sources/LiveViewNative/Image Modifiers/RenderingModeModifier.swift
+++ b/Sources/LiveViewNative/Image Modifiers/RenderingModeModifier.swift
@@ -1,0 +1,68 @@
+//
+//  RenderingModeModifier.swift
+//  LiveViewNative
+//
+//  Created by Carson Katri on 6/1/23.
+//
+
+import SwiftUI
+
+/// Specifies how ``Image`` elements are rendered.
+///
+/// The `original` mode renders pixels as they appear in the original image.
+/// The `template` mode renders nontransparent pixels as the foreground color.
+///
+/// ```html
+/// <Image name="dot_green" modifiers={rendering_mode(@native, mode: :original)} />
+/// <Image name="dot_green" modifiers={rendering_mode(@native, mode: :template)} />
+/// ```
+///
+/// This modifier can also be used to render multicolor SF Symbols.
+/// The `original` mode allows the symbol to use its predefined colors.
+///
+/// ```html
+/// <Image
+///   system-name="person.crop.circle.badge.plus"
+///   modifiers={rendering_mode(@native, mode: :original)}
+/// />
+/// ```
+///
+/// ## Arguments
+/// * ``mode``
+#if swift(>=5.8)
+@_documentation(visibility: public)
+#endif
+struct RenderingModeModifier: ImageModifier, Decodable {
+    /// The rendering mode to use.
+    ///
+    /// See ``LiveViewNative/SwiftUI/Image/TemplateRenderingMode`` for a list of possible values.
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
+    private let mode: SwiftUI.Image.TemplateRenderingMode
+    
+    func apply(to image: SwiftUI.Image) -> SwiftUI.Image {
+        image.renderingMode(mode)
+    }
+}
+
+/// The mode used to render an ``Image``.
+///
+/// Possible values:
+/// * `original`
+/// * `template`
+#if swift(>=5.8)
+@_documentation(visibility: public)
+#endif
+extension SwiftUI.Image.TemplateRenderingMode: Decodable {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        switch try container.decode(String.self) {
+        case "original":
+            self = .original
+        case "template":
+            self = .template
+        case let `default`: throw DecodingError.dataCorrupted(.init(codingPath: container.codingPath, debugDescription: "Unknown rendering mode '\(`default`)'"))
+        }
+    }
+}

--- a/Sources/LiveViewNative/Image Modifiers/ResizableModifier.swift
+++ b/Sources/LiveViewNative/Image Modifiers/ResizableModifier.swift
@@ -1,0 +1,64 @@
+//
+//  ResizableModifier.swift
+//  LiveViewNative
+//
+//  Created by Carson Katri on 6/1/23.
+//
+
+import SwiftUI
+
+/// Enables an image to fill the available space.
+///
+/// ```html
+/// <Image system-name="heart.fill" modifiers={resizable(@native)} />
+/// <Image system-name="heart.fill" modifiers={resizable(@native, resizing_mode: :tile)} />
+/// ```
+///
+/// ## Arguments
+/// * ``capInsets``
+/// * ``resizingMode``
+#if swift(>=5.8)
+@_documentation(visibility: public)
+#endif
+struct ResizableModifier: ImageModifier, Decodable {
+    /// Marks an inset that is not resized.
+    ///
+    /// See ``LiveViewNative/SwiftUI/EdgeInsets`` for more details.
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
+    private let capInsets: EdgeInsets?
+    
+    /// The mode for resizing.
+    ///
+    /// See ``LiveViewNative/SwiftUI/Image/ResizingMode`` for a list of possible values.
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
+    private let resizingMode: SwiftUI.Image.ResizingMode
+    
+    func apply(to image: SwiftUI.Image) -> SwiftUI.Image {
+        image.resizable(capInsets: capInsets ?? .init(), resizingMode: resizingMode)
+    }
+}
+
+/// The mode used to resize an ``Image``.
+///
+/// Possible values:
+/// * `stretch`
+/// * `tile`
+#if swift(>=5.8)
+@_documentation(visibility: public)
+#endif
+extension SwiftUI.Image.ResizingMode: Decodable {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        switch try container.decode(String.self) {
+        case "stretch":
+            self = .stretch
+        case "tile":
+            self = .tile
+        case let `default`: throw DecodingError.dataCorrupted(.init(codingPath: container.codingPath, debugDescription: "Unknown resizing mode '\(`default`)'"))
+        }
+    }
+}

--- a/Sources/LiveViewNative/Modifiers/Drawing and Graphics Modifiers/ForegroundColorModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Drawing and Graphics Modifiers/ForegroundColorModifier.swift
@@ -19,7 +19,7 @@ import SwiftUI
 #if swift(>=5.8)
 @_documentation(visibility: public)
 #endif
-struct ForegroundColorModifier: ViewModifier, Decodable {
+struct ForegroundColorModifier: ViewModifier, Decodable, TextModifier {
     /// The foreground color to use when rendering the view.
     #if swift(>=5.8)
     @_documentation(visibility: public)
@@ -28,5 +28,9 @@ struct ForegroundColorModifier: ViewModifier, Decodable {
 
     func body(content: Content) -> some View {
         content.foregroundColor(color)
+    }
+    
+    func apply(to text: SwiftUI.Text) -> SwiftUI.Text {
+        text.foregroundColor(color)
     }
 }

--- a/Sources/LiveViewNative/Modifiers/Images Modifiers/SymbolRenderingModeModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Images Modifiers/SymbolRenderingModeModifier.swift
@@ -20,7 +20,7 @@ import SwiftUI
 #if swift(>=5.8)
 @_documentation(visibility: public)
 #endif
-struct SymbolRenderingModeModifier: ViewModifier, Decodable {
+struct SymbolRenderingModeModifier: ViewModifier, Decodable, ImageModifier {
     /// A symbol rendering mode.
     #if swift(>=5.8)
     @_documentation(visibility: public)
@@ -46,6 +46,10 @@ struct SymbolRenderingModeModifier: ViewModifier, Decodable {
 
     func body(content: Content) -> some View {
         content.symbolRenderingMode(mode)
+    }
+    
+    func apply(to image: SwiftUI.Image) -> SwiftUI.Image {
+        image.symbolRenderingMode(mode)
     }
     
     enum CodingKeys: String, CodingKey {

--- a/Sources/LiveViewNative/Modifiers/Layout Adjustments Modifiers/SafeAreaInsetModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Layout Adjustments Modifiers/SafeAreaInsetModifier.swift
@@ -19,7 +19,7 @@ import SwiftUI
 ///     ...
 ///     <GroupBox template={:bottom_bar} id="bottom_bar">
 ///         <HStack template={:label}>
-///             <Text font-weight="bold" font="title2">Bottom Bar</Text>
+///             <Text>Bottom Bar</Text>
 ///             <Spacer />
 ///         </HStack>
 ///         <Text>This will allow the list to scroll further up so no rows are covered.</Text>

--- a/Sources/LiveViewNative/Modifiers/Lists Modifiers/BadgeModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Lists Modifiers/BadgeModifier.swift
@@ -86,7 +86,7 @@ struct BadgeModifier<R: RootRegistry>: ViewModifier, Decodable {
         #if os(iOS) || os(macOS)
         if let reference = self.content {
             content
-                .badge(context.children(of: element, forTemplate: reference).first?.asElement().flatMap(Text<R>.init(overrideElement:))?.body)
+                .badge(context.children(of: element, forTemplate: reference).first?.asElement().flatMap(Text<R>.init(element:))?.body)
         } else if let label {
             content.badge(label)
         } else if let count {

--- a/Sources/LiveViewNative/Modifiers/Lists Modifiers/BadgeModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Lists Modifiers/BadgeModifier.swift
@@ -39,7 +39,7 @@ import SwiftUI
 /// <List>
 ///   <Text id="a" modifiers={@native |> badge(content: :error)}>
 ///     Server A
-///     <Text template={:error} modifiers={foreground_color(@native, color: :red)}>
+///     <Text template={:error} modifiers={foreground_color(:red)}>
 ///       Down
 ///     </Text>
 ///   </Text>

--- a/Sources/LiveViewNative/Modifiers/Lists Modifiers/BadgeModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Lists Modifiers/BadgeModifier.swift
@@ -39,7 +39,7 @@ import SwiftUI
 /// <List>
 ///   <Text id="a" modifiers={@native |> badge(content: :error)}>
 ///     Server A
-///     <Text template={:error} color="system-red">
+///     <Text template={:error} modifiers={foreground_color(@native, color: :red)}>
 ///       Down
 ///     </Text>
 ///   </Text>

--- a/Sources/LiveViewNative/Modifiers/Text Input and Output Modifiers/BaselineOffsetModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Text Input and Output Modifiers/BaselineOffsetModifier.swift
@@ -20,7 +20,7 @@ import SwiftUI
 #if swift(>=5.8)
 @_documentation(visibility: public)
 #endif
-struct BaselineOffsetModifier: ViewModifier, Decodable {
+struct BaselineOffsetModifier: ViewModifier, Decodable, TextModifier {
     /// The vertical offset to apply.
     #if swift(>=5.8)
     @_documentation(visibility: public)
@@ -29,6 +29,10 @@ struct BaselineOffsetModifier: ViewModifier, Decodable {
 
     func body(content: Content) -> some View {
         content.baselineOffset(offset)
+    }
+    
+    func apply(to text: SwiftUI.Text) -> SwiftUI.Text {
+        text.baselineOffset(offset)
     }
 }
 

--- a/Sources/LiveViewNative/Modifiers/Text Input and Output Modifiers/BoldModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Text Input and Output Modifiers/BoldModifier.swift
@@ -18,7 +18,7 @@ import SwiftUI
 #if swift(>=5.8)
 @_documentation(visibility: public)
 #endif
-struct BoldModifier: ViewModifier, Decodable {
+struct BoldModifier: ViewModifier, Decodable, TextModifier {
     /// Enables/disables the bold effect.
     #if swift(>=5.8)
     @_documentation(visibility: public)
@@ -27,5 +27,9 @@ struct BoldModifier: ViewModifier, Decodable {
     
     func body(content: Content) -> some View {
         content.bold(isActive)
+    }
+    
+    func apply(to text: SwiftUI.Text) -> SwiftUI.Text {
+        text.bold(isActive)
     }
 }

--- a/Sources/LiveViewNative/Modifiers/Text Input and Output Modifiers/FontDesignModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Text Input and Output Modifiers/FontDesignModifier.swift
@@ -22,36 +22,18 @@ import SwiftUI
 @_documentation(visibility: public)
 #endif
 @available(iOS 16.1, watchOS 9.1, *)
-struct FontDesignModifier: ViewModifier, Decodable {
+struct FontDesignModifier: ViewModifier, Decodable, TextModifier {
     /// The font design to apply to the view.
     #if swift(>=5.8)
     @_documentation(visibility: public)
     #endif
     private var design: Font.Design
-    
-    init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        let designString = try container.decode(String.self, forKey: .design)
-
-        switch designString {
-        case "default":
-            design = .default
-        case "monospaced":
-            design = .monospaced
-        case "rounded":
-            design = .rounded
-        case "serif":
-            design = .serif
-        default:
-            throw DecodingError.dataCorruptedError(forKey: .design, in: container, debugDescription: "expected valid value for Font.Design");
-        }
-    }
 
     func body(content: Content) -> some View {
         content.fontDesign(design)
     }
     
-    enum CodingKeys: String, CodingKey {
-        case design
+    func apply(to text: SwiftUI.Text) -> SwiftUI.Text {
+        text.fontDesign(design)
     }
 }

--- a/Sources/LiveViewNative/Modifiers/Text Input and Output Modifiers/FontModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Text Input and Output Modifiers/FontModifier.swift
@@ -24,7 +24,7 @@ import SwiftUI
 #if swift(>=5.8)
 @_documentation(visibility: public)
 #endif
-struct FontModifier: ViewModifier, Decodable {
+struct FontModifier: ViewModifier, Decodable, TextModifier {
     /// The font to use for child elements.
     ///
     /// See ``LiveViewNative/SwiftUI/Font`` for more details on creating fonts.
@@ -35,5 +35,9 @@ struct FontModifier: ViewModifier, Decodable {
 
     func body(content: Content) -> some View {
         content.font(font)
+    }
+    
+    func apply(to text: SwiftUI.Text) -> SwiftUI.Text {
+        text.font(font)
     }
 }

--- a/Sources/LiveViewNative/Modifiers/Text Input and Output Modifiers/FontWeightModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Text Input and Output Modifiers/FontWeightModifier.swift
@@ -24,7 +24,7 @@ import SwiftUI
 #if swift(>=5.8)
 @_documentation(visibility: public)
 #endif
-struct FontWeightModifier: ViewModifier, Decodable, Equatable {
+struct FontWeightModifier: ViewModifier, Decodable, Equatable, TextModifier {
     /// The font weight to use for child elements.
     ///
     /// See ``LiveViewNative/SwiftUI/Font/Weight`` for more details on creating font weights.
@@ -35,5 +35,9 @@ struct FontWeightModifier: ViewModifier, Decodable, Equatable {
 
     func body(content: Content) -> some View {
         content.fontWeight(weight)
+    }
+    
+    func apply(to text: SwiftUI.Text) -> SwiftUI.Text {
+        text.fontWeight(weight)
     }
 }

--- a/Sources/LiveViewNative/Modifiers/Text Input and Output Modifiers/FontWidthModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Text Input and Output Modifiers/FontWidthModifier.swift
@@ -24,7 +24,7 @@ import SwiftUI
 #if swift(>=5.8)
 @_documentation(visibility: public)
 #endif
-struct FontWidthModifier: ViewModifier, Decodable {
+struct FontWidthModifier: ViewModifier, Decodable, TextModifier {
     /// The font width to use for child elements.
     ///
     /// See ``LiveViewNative/SwiftUI/Font/Width`` for more details on creating font widths.
@@ -43,6 +43,10 @@ struct FontWidthModifier: ViewModifier, Decodable {
 
     func body(content: Content) -> some View {
         content.fontWidth(width)
+    }
+    
+    func apply(to text: SwiftUI.Text) -> SwiftUI.Text {
+        text.fontWidth(width)
     }
 
     enum CodingKeys: String, CodingKey {

--- a/Sources/LiveViewNative/Modifiers/Text Input and Output Modifiers/ItalicModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Text Input and Output Modifiers/ItalicModifier.swift
@@ -18,7 +18,7 @@ import SwiftUI
 #if swift(>=5.8)
 @_documentation(visibility: public)
 #endif
-struct ItalicModifier: ViewModifier, Decodable {
+struct ItalicModifier: ViewModifier, Decodable, TextModifier {
     /// Enables/disables the italic effect.
     #if swift(>=5.8)
     @_documentation(visibility: public)
@@ -27,5 +27,9 @@ struct ItalicModifier: ViewModifier, Decodable {
     
     func body(content: Content) -> some View {
         content.italic(isActive)
+    }
+    
+    func apply(to text: SwiftUI.Text) -> SwiftUI.Text {
+        text.italic(isActive)
     }
 }

--- a/Sources/LiveViewNative/Modifiers/Text Input and Output Modifiers/KerningModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Text Input and Output Modifiers/KerningModifier.swift
@@ -20,7 +20,7 @@ import SwiftUI
 #if swift(>=5.8)
 @_documentation(visibility: public)
 #endif
-struct KerningModifier: ViewModifier, Decodable {
+struct KerningModifier: ViewModifier, Decodable, TextModifier {
     #if swift(>=5.8)
     @_documentation(visibility: public)
     #endif
@@ -28,5 +28,9 @@ struct KerningModifier: ViewModifier, Decodable {
 
     func body(content: Content) -> some View {
         content.kerning(kerning)
+    }
+    
+    func apply(to text: SwiftUI.Text) -> SwiftUI.Text {
+        text.kerning(kerning)
     }
 }

--- a/Sources/LiveViewNative/Modifiers/Text Input and Output Modifiers/MonospacedDigitModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Text Input and Output Modifiers/MonospacedDigitModifier.swift
@@ -22,11 +22,15 @@ import SwiftUI
 #if swift(>=5.8)
 @_documentation(visibility: public)
 #endif
-struct MonospacedDigitModifier: ViewModifier, Decodable, Equatable {
+struct MonospacedDigitModifier: ViewModifier, Decodable, Equatable, TextModifier {
     init(from decoder: Decoder) throws {
     }
 
     func body(content: Content) -> some View {
         return content.monospacedDigit()
+    }
+    
+    func apply(to text: SwiftUI.Text) -> SwiftUI.Text {
+        text.monospacedDigit()
     }
 }

--- a/Sources/LiveViewNative/Modifiers/Text Input and Output Modifiers/MonospacedModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Text Input and Output Modifiers/MonospacedModifier.swift
@@ -25,7 +25,7 @@ import SwiftUI
 #if swift(>=5.8)
 @_documentation(visibility: public)
 #endif
-struct MonospacedModifier: ViewModifier, Decodable, Equatable {
+struct MonospacedModifier: ViewModifier, Decodable, Equatable, TextModifier {
     /// A boolean that indicates whether the monospaced font should be used.
     #if swift(>=5.8)
     @_documentation(visibility: public)
@@ -34,5 +34,13 @@ struct MonospacedModifier: ViewModifier, Decodable, Equatable {
 
     func body(content: Content) -> some View {
         return content.monospaced(isActive)
+    }
+    
+    func apply(to text: SwiftUI.Text) -> SwiftUI.Text {
+        if #available(iOS 16.4, macOS 13.3, tvOS 16.4, watchOS 9.4, *) {
+            return text.monospaced(isActive)
+        } else {
+            return text
+        }
     }
 }

--- a/Sources/LiveViewNative/Modifiers/Text Input and Output Modifiers/StrikethroughModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Text Input and Output Modifiers/StrikethroughModifier.swift
@@ -24,7 +24,7 @@ import SwiftUI
 #if swift(>=5.8)
 @_documentation(visibility: public)
 #endif
-struct StrikethroughModifier: ViewModifier, Decodable {
+struct StrikethroughModifier: ViewModifier, Decodable, TextModifier {
     /// `is_active`, enables/disables the effect.
     #if swift(>=5.8)
     @_documentation(visibility: public)
@@ -49,5 +49,9 @@ struct StrikethroughModifier: ViewModifier, Decodable {
 
     func body(content: Content) -> some View {
         content.strikethrough(isActive, pattern: pattern, color: color)
+    }
+    
+    func apply(to text: SwiftUI.Text) -> SwiftUI.Text {
+        text.strikethrough(isActive, pattern: pattern, color: color)
     }
 }

--- a/Sources/LiveViewNative/Modifiers/Text Input and Output Modifiers/TrackingModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Text Input and Output Modifiers/TrackingModifier.swift
@@ -20,7 +20,7 @@ import SwiftUI
 #if swift(>=5.8)
 @_documentation(visibility: public)
 #endif
-struct TrackingModifier: ViewModifier, Decodable, Equatable {
+struct TrackingModifier: ViewModifier, Decodable, Equatable, TextModifier {
     #if swift(>=5.8)
     @_documentation(visibility: public)
     #endif
@@ -28,5 +28,9 @@ struct TrackingModifier: ViewModifier, Decodable, Equatable {
     
     func body(content: Content) -> some View {
         content.tracking(tracking)
+    }
+    
+    func apply(to text: SwiftUI.Text) -> SwiftUI.Text {
+        text.tracking(tracking)
     }
 }

--- a/Sources/LiveViewNative/Modifiers/Text Input and Output Modifiers/UnderlineModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Text Input and Output Modifiers/UnderlineModifier.swift
@@ -24,7 +24,7 @@ import SwiftUI
 #if swift(>=5.8)
 @_documentation(visibility: public)
 #endif
-struct UnderlineModifier: ViewModifier, Decodable {
+struct UnderlineModifier: ViewModifier, Decodable, TextModifier {
     /// `is_active`, enables/disables the effect. Defaults to `true`.
     #if swift(>=5.8)
     @_documentation(visibility: public)
@@ -49,5 +49,9 @@ struct UnderlineModifier: ViewModifier, Decodable {
 
     func body(content: Content) -> some View {
         content.underline(isActive, pattern: pattern, color: color)
+    }
+    
+    func apply(to text: SwiftUI.Text) -> SwiftUI.Text {
+        text.underline(isActive, pattern: pattern, color: color)
     }
 }

--- a/Sources/LiveViewNative/Property Wrappers/ObservedElement.swift
+++ b/Sources/LiveViewNative/Property Wrappers/ObservedElement.swift
@@ -51,29 +51,34 @@ import Combine
 /// ```
 @propertyWrapper
 public struct ObservedElement {
-    @Environment(\.element.nodeRef) private var environmentNodeRef: NodeRef?
+    @Environment(\.element.nodeRef) private var nodeRef: NodeRef?
     @Environment(\.coordinatorEnvironment) private var coordinator: CoordinatorEnvironment?
     @StateObject private var observer: Observer
     
-    private let overrideNodeRef: NodeRef?
-    
-    private var nodeRef: NodeRef? {
-        overrideNodeRef ?? environmentNodeRef
-    }
+    private let overrideElement: ElementNode?
     
     /// Creates an `ObservedElement` that observes changes to the view's element.
     public init(observeChildren: Bool = false) {
-        self.overrideNodeRef = nil
+        self.overrideElement = nil
         self._observer = .init(wrappedValue: .init(observeChildren: observeChildren))
     }
     
     public init(element: ElementNode, observeChildren: Bool = false) {
-        self.overrideNodeRef = element.node.id
+        self.overrideElement = element
         self._observer = .init(wrappedValue: .init(observeChildren: observeChildren))
+    }
+    
+    public init() {
+        self.overrideElement = nil
+        self._observer = .init(wrappedValue: .init(observeChildren: false))
     }
     
     /// The observed element in the document, with all current data.
     public var wrappedValue: ElementNode {
+        if let overrideElement {
+            return overrideElement
+        }
+        
         guard let nodeRef,
               let coordinator else {
             fatalError("Cannot use @ObservedElement on view that does not have an element and coordinator in the environment")

--- a/Sources/LiveViewNative/Utils/ShapeReference.swift
+++ b/Sources/LiveViewNative/Utils/ShapeReference.swift
@@ -202,14 +202,14 @@ enum ShapeReference: Decodable {
     }
     
     struct AnyInsettableShape: InsettableShape {
-        let _path: (CGRect) -> Path
-        let _inset: (CGFloat) -> any InsettableShape
-        let _sizeThatFits: (ProposedViewSize) -> CGSize
+        let _path: @Sendable (CGRect) -> Path
+        let _inset: @Sendable (CGFloat) -> any InsettableShape
+        let _sizeThatFits: @Sendable (ProposedViewSize) -> CGSize
         
         init(_ shape: some InsettableShape) {
-            self._path = shape.path(in:)
-            self._inset = shape.inset(by:)
-            self._sizeThatFits = shape.sizeThatFits(_:)
+            self._path = { shape.path(in: $0) }
+            self._inset = { shape.inset(by: $0) }
+            self._sizeThatFits = { shape.sizeThatFits($0) }
         }
         
         typealias InsetShape = Self

--- a/Sources/LiveViewNative/ViewTree.swift
+++ b/Sources/LiveViewNative/ViewTree.swift
@@ -169,6 +169,8 @@ enum ModifierContainer<R: RootRegistry>: Decodable {
             }
         } else if ShapeModifierType(rawValue: type) != nil
                     || FinalShapeModifierType(rawValue: type) != nil
+                    || TextModifierType(rawValue: type) != nil
+                    || ImageModifierType(rawValue: type) != nil
         {
             self = .inert
         } else {

--- a/Sources/LiveViewNative/Views/Controls and Indicators/Links/Link.swift
+++ b/Sources/LiveViewNative/Views/Controls and Indicators/Links/Link.swift
@@ -13,7 +13,7 @@ import SwiftUI
 ///
 /// ```html
 /// <Link destination="https://native.live">
-///     Go to <Text modifiers={font_weight(@native, weight: :bold)}>LiveView Native</Text>
+///     Go to <Text modifiers={font_weight(:bold)}>LiveView Native</Text>
 /// </Link>
 /// ```
 ///

--- a/Sources/LiveViewNative/Views/Controls and Indicators/Links/Link.swift
+++ b/Sources/LiveViewNative/Views/Controls and Indicators/Links/Link.swift
@@ -13,7 +13,7 @@ import SwiftUI
 ///
 /// ```html
 /// <Link destination="https://native.live">
-///     Go to <Text font="body" font-weight="bold">LiveView Native</Text>
+///     Go to <Text modifiers={font_weight(@native, weight: :bold)}>LiveView Native</Text>
 /// </Link>
 /// ```
 ///

--- a/Sources/LiveViewNative/Views/Controls and Indicators/Links/ShareLink.swift
+++ b/Sources/LiveViewNative/Views/Controls and Indicators/Links/ShareLink.swift
@@ -343,10 +343,10 @@ struct ShareLink<R: RootRegistry>: View {
                 let title = element.attributeValue(for: "title") ?? ""
                 let image = element.elementChildren()
                     .first(where: { $0.attributeValue(for: "template") == "image" })
-                    .flatMap({ Image(overrideElement: $0).image })
+                    .flatMap({ Image<R>(element: $0).body })
                 let icon = element.elementChildren()
                     .first(where: { $0.attributeValue(for: "template") == "icon" })
-                    .flatMap({ Image(overrideElement: $0).image })
+                    .flatMap({ Image<R>(element: $0).body })
                 
                 let data = PreviewData(
                     title: title,

--- a/Sources/LiveViewNative/Views/Images/Image.swift
+++ b/Sources/LiveViewNative/Views/Images/Image.swift
@@ -27,87 +27,84 @@ import SwiftUI
 #if swift(>=5.8)
 @_documentation(visibility: public)
 #endif
-struct Image: View {
-    /// When enabled, resizes the Image to fill all available space
+struct Image<R: RootRegistry>: View {
+    @ObservedElement private var element
+    @LiveContext<R> private var context
+    
+    ///
     #if swift(>=5.8)
     @_documentation(visibility: public)
     #endif
-    @Attribute("resizable") private var resizable: Bool
-    @ObservedElement private var observedElement: ElementNode
-    private let overrideElement: ElementNode?
-    private var element: ElementNode {
-        overrideElement ?? observedElement
+    @Attribute("system-name") private var systemName: String?
+    ///
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
+    @Attribute("variable-value") private var variableValue: Double?
+    
+    ///
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
+    @Attribute("name") private var name: String?
+    
+    @Attribute("modifiers") private var modifiers: ImageModifierStack?
+    
+    init() {}
+    
+    init(element: ElementNode) {
+        self._element = .init(element: element)
+        self._systemName = .init("system-name", element: element)
+        self._variableValue = .init("variable-value", element: element)
+        self._name = .init("name", element: element)
+        self._modifiers = .init("modifiers", element: element)
     }
     
-    init(overrideElement: ElementNode? = nil) {
-        self.overrideElement = overrideElement
-    }
-    
-    public var body: some View {
-        image?
-            // todo: this probably only works for symbols
-            .resizableIfPresent(resizable: resizable)
-            .scaledIfPresent(scale: symbolScale)
-            .foregroundColorIfPresent(color: symbolColor)
-    }
-    
-    var image: SwiftUI.Image? {
-        switch mode {
-        case .symbol(let name):
-            return SwiftUI.Image(systemName: name)
-        case .asset(let name):
-            return SwiftUI.Image(name)
-        default:
-            return nil
-        }
-    }
-    
-    private var mode: Mode? {
-        if let systemName = element.attributeValue(for: "system-name") {
-            return .symbol(systemName)
-        } else if let name = element.attributeValue(for: "name") {
-            return .asset(name)
+    public var body: SwiftUI.Image? {
+        if let image {
+            var result = image
+            for modifier in modifiers?.stack ?? [] {
+                result = modifier.apply(to: result)
+            }
+            return result
         } else {
             return nil
         }
     }
     
-    /// The foreground color of the symbol.
-    ///
-    /// If no color is provided, the symbol will use a color appropriate for the environment.
-    ///
-    /// See ``LiveViewNative/SwiftUI/Color/init(fromNamedOrCSSHex:)``.
-    #if swift(>=5.8)
-    @_documentation(visibility: public)
-    #endif
-    private var symbolColor: SwiftUI.Color? {
-        if let attr = element.attributeValue(for: "symbol-color") {
-            return SwiftUI.Color(fromNamedOrCSSHex: attr)
+    private var image: SwiftUI.Image? {
+        if let systemName {
+            return SwiftUI.Image(systemName: systemName, variableValue: variableValue)
+        } else if let name {
+            if let variableValue {
+                if let label {
+                    return SwiftUI.Image(name, variableValue: variableValue, label: label)
+                } else {
+                    return SwiftUI.Image(name, variableValue: variableValue)
+                }
+            } else {
+                if let label {
+                    return SwiftUI.Image(name, label: label)
+                } else {
+                    return SwiftUI.Image(name)
+                }
+            }
         } else {
             return nil
         }
     }
     
-    /// The display scale of the symbol.
-    ///
-    /// Possible values:
-    /// - `small`
-    /// - `medium`
-    /// - `large`
-    #if swift(>=5.8)
-    @_documentation(visibility: public)
-    #endif
-    private var symbolScale: SwiftUI.Image.Scale? {
-        switch element.attributeValue(for: "symbol-scale") {
-        case nil:
-            return nil
-        case "small":
-            return .small
-        case "medium":
-            return .medium
-        case "large":
-            return .large
-        default:
+    var label: SwiftUI.Text? {
+        if let labelNode = element.children().first {
+            switch labelNode.data {
+            case let .element(element):
+                return Text<R>(element: ElementNode(node: labelNode, data: element)).body
+            case let .leaf(label):
+                return .init(label)
+            case .root:
+                return nil
+            }
+        } else {
             return nil
         }
     }
@@ -117,35 +114,5 @@ extension Image {
     enum Mode {
         case symbol(String)
         case asset(String)
-    }
-}
-
-fileprivate extension SwiftUI.Image {
-    func resizableIfPresent(resizable: Bool) -> SwiftUI.Image {
-        if resizable {
-            return self.resizable()
-        } else {
-            return self
-        }
-    }
-
-    @ViewBuilder
-    func scaledIfPresent(scale: SwiftUI.Image.Scale?) -> some View {
-        if let scale = scale {
-            self.imageScale(scale)
-        } else {
-            self
-        }
-    }
-}
-
-fileprivate extension View {
-    @ViewBuilder
-    func foregroundColorIfPresent(color: SwiftUI.Color?) -> some View {
-        if let color = color {
-            self.foregroundColor(color)
-        } else {
-            self
-        }
     }
 }

--- a/Sources/LiveViewNative/Views/Images/Image.swift
+++ b/Sources/LiveViewNative/Views/Images/Image.swift
@@ -15,15 +15,48 @@ import SwiftUI
 /// The platform provides a wide variety of symbol images which are specified with the `system-name` attribute.
 /// See [Apple's documentation](https://developer.apple.com/sf-symbols/) for more information.
 ///
-/// The [`symbol-color`](doc:Image/symbolColor) and [`symbol-scale`](doc:Image/symbolScale) attributes may also be provided.
-/// ```html
-/// <Image system-name="cloud.sun.rain" symbol-color="#ff0000" symbol-scale="large" />
-/// ```
 /// ### Asset Catalog
 /// Specify the `name` attribute to use a named image from the app's asset catalog.
 /// ```html
 /// <Image name="MyCustomImage" />
 /// ```
+///
+/// ### Variable Value
+/// Some symbols and asset images support a value input. Use the ``variableValue`` attribute to set this value.
+///
+/// ```html
+/// <Image system-name="chart.bar.fill" variable-value={0.3} />
+/// <Image system-name="chart.bar.fill" variable-value={0.6} />
+/// <Image system-name="chart.bar.fill" variable-value={1.0} />
+/// ```
+///
+/// ### Image Labels
+/// Text content within the image will be used as the accessibility label.
+///
+/// ```html
+/// <Image name="landscape">
+///   Mountain landscape with a lake in the foreground
+/// </Image>
+/// ```
+///
+/// ### Modifying Images
+/// Use image modifiers to customize the appearance of an image.
+///
+/// ```html
+/// <Image system-name="heart.fill" modifiers={@native |> resizable() |> symbol_rendering_mode(mode: :multicolor)} />
+/// ```
+///
+/// These modifiers can be used on ``Image`` elements:
+/// * ``ResizableModifier``
+/// * ``AntialiasedModifier``
+/// * ``SymbolRenderingModeModifier``
+/// * ``RenderingModeModifier``
+/// * ``InterpolationModifier``
+///
+/// ## Attributes
+/// * ``systemName``
+/// * ``name``
+/// * ``variableValue``
 #if swift(>=5.8)
 @_documentation(visibility: public)
 #endif
@@ -31,22 +64,24 @@ struct Image<R: RootRegistry>: View {
     @ObservedElement private var element
     @LiveContext<R> private var context
     
+    /// The name of the system image (SF Symbol) to display.
     ///
+    /// See [Apple's documentation](https://developer.apple.com/sf-symbols/) for more information.
     #if swift(>=5.8)
     @_documentation(visibility: public)
     #endif
     @Attribute("system-name") private var systemName: String?
-    ///
-    #if swift(>=5.8)
-    @_documentation(visibility: public)
-    #endif
-    @Attribute("variable-value") private var variableValue: Double?
-    
-    ///
+    /// The name of an image in the app's asset catalog.
     #if swift(>=5.8)
     @_documentation(visibility: public)
     #endif
     @Attribute("name") private var name: String?
+    
+    /// The value represented by this image, in the range `0.0` to `1.0`.
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
+    @Attribute("variable-value") private var variableValue: Double?
     
     @Attribute("modifiers") private var modifiers: ImageModifierStack?
     

--- a/Sources/LiveViewNative/Views/Text Input and Output/Text.swift
+++ b/Sources/LiveViewNative/Views/Text Input and Output/Text.swift
@@ -468,7 +468,7 @@ enum TextModifierType: String, Decodable {
         case .baselineOffset:
             return try BaselineOffsetModifier(from: decoder)
         case .fontDesign:
-            if #available(iOS 16.1, *) {
+            if #available(iOS 16.1, macOS 13.0, tvOS 16.1, watchOS 9.1, *) {
                 return try FontDesignModifier(from: decoder)
             } else {
                 return EmptyTextModifier()

--- a/Sources/LiveViewNative/Views/Text Input and Output/Text.swift
+++ b/Sources/LiveViewNative/Views/Text Input and Output/Text.swift
@@ -342,7 +342,7 @@ struct Text<R: RootRegistry>: View {
                             .init("[\(element.innerText())](\(element.attributeValue(for: "destination")!))")
                         )
                     case "Image":
-                        if let image = Image(overrideElement: element).image {
+                        if let image = Image<R>(element: element).body {
                             prev = prev + SwiftUI.Text(image)
                         }
                     default:

--- a/Sources/LiveViewNative/Views/Text Input and Output/Text.swift
+++ b/Sources/LiveViewNative/Views/Text Input and Output/Text.swift
@@ -61,7 +61,7 @@ import LiveViewNativeCore
 /// </Text>
 /// ```
 ///
-/// These modifiers can be used on ``Text`` elements.
+/// These modifiers can be used on ``Text`` elements:
 /// * ``FontModifier``
 /// * ``FontWeightModifier``
 /// * ``ForegroundColorModifier``

--- a/Sources/LiveViewNative/Views/Text Input and Output/Text.swift
+++ b/Sources/LiveViewNative/Views/Text Input and Output/Text.swift
@@ -19,14 +19,14 @@ import LiveViewNativeCore
 /// <Text verbatim="Hello"/>
 /// ```
 /// ### Dates
-/// Provide an ISO 8601 date (with optional time) in the `date` attribute, and optionally a `Text.DateStyle` in the `date-style` attribute.
+/// Provide an ISO 8601 date (with optional time) in the ``date`` attribute, and optionally a ``LiveViewNative/SwiftUI/Text/DateStyle`` in the ``dateStyle`` attribute.
 /// Valid date styles are `date` (default), `time`, `relative`, `offset`, and `timer`.
 /// The displayed date is formatted with the user's locale.
 /// ```html
 /// <Text date="2023-03-14T15:19:00.000Z" date-style="date"/>
 /// ```
 /// ### Date Ranges
-/// Displays a localized date range between the given ISO 8601-formatted `date-start` and `date-end`.
+/// Displays a localized date range between the given ISO 8601-formatted ``dateStart`` and ``dateEnd``.
 /// ```html
 /// <Text date-start="2023-01-01" date-end="2024-01-01"/>
 /// ```
@@ -96,6 +96,14 @@ import LiveViewNativeCore
 /// ## Attributes
 /// * ``verbatim``
 /// * ``markdown``
+/// * ``date``
+/// * ``dateStart``
+/// * ``dateEnd``
+/// * ``value``
+/// * ``format``
+/// * ``currencyCode``
+/// * ``nameStyle``
+/// * ``dateStyle``
 #if swift(>=5.8)
 @_documentation(visibility: public)
 #endif
@@ -104,18 +112,111 @@ struct Text<R: RootRegistry>: View {
     
     @ObservedElement private var element: ElementNode
     
+    /// A string value to use as the text content without modification.
+    ///
+    /// In some cases, whitespaces and newlines in the text content are trimmed.
+    /// Use this attribute to avoid trimming.
+    ///
+    /// ```html
+    /// <Text verbatim=" Hello, world! " />
+    /// <Text verbatim={"\n"} />
+    /// ```
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
     @Attribute("verbatim") private var verbatim: String?
     
+    /// The value of this attribute is parsed as markdown.
+    ///
+    /// - Note: Only inline markdown is rendered.
+    ///
+    /// ```html
+    /// <Text markdown="Hello, *world*!" />
+    /// ```
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
     @Attribute("markdown") private var markdown: String?
     
+    /// Render an Elixir date.
+    ///
+    /// Use the ``dateStyle`` attribute to customize how the date is drawn.
+    ///
+    /// - Note: The value is expected to be in ISO 8601 format (with optional time)
+    ///
+    /// ```html
+    /// <Text date={DateTime.utc_now()} date-style="date" />
+    /// ```
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
     @Attribute("date", transform: Self.formatDate(_:)) private var date: Date?
+    /// The lower bound of a date range.
+    ///
+    /// Use this attribute with the ``dateEnd`` attribute to display a date range.
+    ///
+    /// - Note: The value is expected to be in ISO 8601 format (with optional time)
+    ///
+    /// ```html
+    /// <Text date-start={DateTime.utc_now()} date-end={DateTime.add(DateTime.utc_now(), 3, :day)} />
+    /// ```
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
     @Attribute("date-start", transform: Self.formatDate(_:)) private var dateStart: Date?
+    /// The upper bound of a date range.
+    ///
+    /// Use this attribute with the ``dateStart`` attribute to display a date range.
+    ///
+    /// - Note: The value is expected to be in ISO 8601 format (with optional time)
+    ///
+    /// ```html
+    /// <Text date-start={DateTime.utc_now()} date-end={DateTime.add(DateTime.utc_now(), 3, :day)} />
+    /// ```
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
     @Attribute("date-end", transform: Self.formatDate(_:)) private var dateEnd: Date?
     
+    /// A value to format.
+    ///
+    /// Use the ``format`` attribute to choose how this value should be formatted.
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
     @Attribute("value") private var value: String?
+    /// The format of ``value``.
+    ///
+    /// Possible values:
+    /// - `date-time`: The ``value`` is an ISO 8601 date (with optional time).
+    /// - `url`: The value is a URL.
+    /// - `iso8601`: The ``value`` is an ISO 8601 date (with optional time).
+    /// - `number`: The value is a `Double`. Shown in a localized number format.
+    /// - `percent`: The value is a `Double`.
+    /// - `currency`: The value is a `Double` and is shown as a localized currency value using the currency specified in the ``currencyCode`` attribute.
+    /// - `name`: The value is a string interpreted as a person's name. The ``nameStyle`` attribute determines the format of the name and may be `short`, `medium` (default), `long`, or `abbreviated`.
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
     @Attribute("format") private var format: String?
+    /// The currency code to use with the `currency` format.
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
     @Attribute("currency-code") private var currencyCode: String?
+    /// The style for a `name` format.
+    ///
+    /// See ``LiveViewNative/Foundation/PersonNameComponents/FormatStyle/Style`` for a list of possible values.
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
     @Attribute("name-style") private var nameStyle: PersonNameComponents.FormatStyle.Style = .medium
+    /// The style for a ``date`` value.
+    ///
+    /// See ``LiveViewNative/SwiftUI/Text/DateStyle`` for a list of possible values.
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
     @Attribute("date-style") private var dateStyle: SwiftUI.Text.DateStyle = .date
     
     @Attribute("modifiers") private var modifiers: TextModifierStack?
@@ -255,6 +356,17 @@ struct Text<R: RootRegistry>: View {
     }
 }
 
+/// A style for formatting a date.
+///
+/// Possible values:
+/// * `time`
+/// * `date`
+/// * `relative`
+/// * `offset`
+/// * `timer`
+#if swift(>=5.8)
+@_documentation(visibility: public)
+#endif
 extension SwiftUI.Text.DateStyle: AttributeDecodable {
     public init(from attribute: LiveViewNativeCore.Attribute?) throws {
         guard let value = attribute?.value else {
@@ -277,6 +389,16 @@ extension SwiftUI.Text.DateStyle: AttributeDecodable {
     }
 }
 
+/// A style for formatting a person's name.
+///
+/// Possible values:
+/// * `short`
+/// * `medium`
+/// * `long`
+/// * `abbreviated`
+#if swift(>=5.8)
+@_documentation(visibility: public)
+#endif
 extension PersonNameComponents.FormatStyle.Style: AttributeDecodable {
     public init(from attribute: LiveViewNativeCore.Attribute?) throws {
         guard let value = attribute?.value else {

--- a/Sources/LiveViewNative/Views/Text Input and Output/Text.swift
+++ b/Sources/LiveViewNative/Views/Text Input and Output/Text.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import LiveViewNativeCore
 
 /// Displays text.
 ///
@@ -22,7 +23,7 @@ import SwiftUI
 /// Valid date styles are `date` (default), `time`, `relative`, `offset`, and `timer`.
 /// The displayed date is formatted with the user's locale.
 /// ```html
-/// <Text date="2023-03-14T15:19.000Z" date-style="date"/>
+/// <Text date="2023-03-14T15:19:00.000Z" date-style="date"/>
 /// ```
 /// ### Date Ranges
 /// Displays a localized date range between the given ISO 8601-formatted `date-start` and `date-end`.
@@ -30,7 +31,12 @@ import SwiftUI
 /// <Text date-start="2023-01-01" date-end="2024-01-01"/>
 /// ```
 /// ### Markdown
-/// The value of the `markdown` attribute is parsed as Markdown and displayed. Only inline Markdown formatting is shown.
+/// The value of the ``markdown`` attribute is parsed as Markdown and displayed. Only inline Markdown formatting is shown.
+///
+/// ```html
+/// <Text markdown="Hello, *world*!" />
+/// ```
+///
 /// ### Formatted Values
 /// A value should provided in the `value` attribute, or in the inner text of the element. The value is formatted according to the `format` attribute:
 /// - `date-time`: The `value` is an ISO 8601 date (with optional time).
@@ -41,67 +47,143 @@ import SwiftUI
 /// - `currency`: The value is a `Double` and is shown as a localized currency value using the currency specified in the `currency-code` attribute.
 /// - `name`: The value is a string interpreted as a person's name. The `name-style` attribute determines the format of the name and may be `short`, `medium` (default), `long`, or `abbreviated`.
 ///
+/// ```html
+/// <Text value={15.99} format="currency" currency-code="usd" />
+/// <Text value="Doe John" format="name" name-style="short" />
+/// ```
+///
+/// ## Formatting Text
+/// Use text modifiers to customize the appearance of text.
+///
+/// ```html
+/// <Text modifiers={@native |> font(font: {:system, :large_title}) |> bold()}>
+///     Hello, world!
+/// </Text>
+/// ```
+///
+/// These modifiers can be used on ``Text`` elements.
+/// * ``FontModifier``
+/// * ``FontWeightModifier``
+/// * ``ForegroundColorModifier``
+/// * ``BoldModifier``
+/// * ``ItalicModifier``
+/// * ``StrikethroughModifier``
+/// * ``UnderlineModifier``
+/// * ``MonospacedDigitModifier``
+/// * ``KerningModifier``
+/// * ``TrackingModifier``
+/// * ``BaselineOffsetModifier``
+/// * ``FontDesignModifier``
+/// * ``FontWidthModifier``
+/// * ``MonospacedModifier``
+///
 /// ## Nesting Elements
-/// Certain elements may be nested within a `Text`.
+/// Certain elements may be nested within a ``Text``.
 /// - ``Text``: Text elements can be nested to adjust the formatting for only particular parts of the text.
 /// - ``Link``: Allows tappable links to be included in text.
 /// - ``Image``: Embeds images in the text.
 ///
-/// ## Formatting Attributes
-/// - [`font`](doc:Text/font)
-/// - [`font-weight`](doc:Text/fontWeight)
-/// - [`color`](doc:Text/textColor)
+/// - Note: Text modifiers can be used on nested ``Text`` elements, but other modifiers cannot.
 ///
+/// ```html
+/// <Text>
+///     <Image system-name="person.crop.circle.fill" /><Text value="Doe John" format="name" modifiers={@native |> foreground_color(color: :blue) |> bold()} />
+///     <Text verbatim={"\n"} />
+///     Check out this thing I made: <Link destination="mysite.com">mysite.com</Link>
+/// </Text>
+/// ```
+///
+/// ## Attributes
+/// * ``verbatim``
+/// * ``markdown``
 #if swift(>=5.8)
 @_documentation(visibility: public)
 #endif
 struct Text<R: RootRegistry>: View {
     @LiveContext<R> private var context
     
-    // The view that's in the SwiftUI view tree needs to observe an element to respond to DOM changes,
-    // but we also need to construct a Text view with a specific element to handle nested <Text>s.
-    // The `element` property returns the effective one, avoiding accessing the @ObservedElement when not
-    // installed in a view.
-    @ObservedElement private var observedElement: ElementNode
-    private var overrideElement: ElementNode?
-    private var element: ElementNode {
-        overrideElement ?? observedElement
-    }
+    @ObservedElement private var element: ElementNode
     
-    init(overrideElement: ElementNode? = nil) {
-        self.overrideElement = overrideElement
+    @Attribute("verbatim") private var verbatim: String?
+    
+    @Attribute("markdown") private var markdown: String?
+    
+    @Attribute("date", transform: Self.formatDate(_:)) private var date: Date?
+    @Attribute("date-start", transform: Self.formatDate(_:)) private var dateStart: Date?
+    @Attribute("date-end", transform: Self.formatDate(_:)) private var dateEnd: Date?
+    
+    @Attribute("value") private var value: String?
+    @Attribute("format") private var format: String?
+    @Attribute("currency-code") private var currencyCode: String?
+    @Attribute("name-style") private var nameStyle: PersonNameComponents.FormatStyle.Style = .medium
+    @Attribute("date-style") private var dateStyle: SwiftUI.Text.DateStyle = .date
+    
+    @Attribute("modifiers") private var modifiers: TextModifierStack?
+    
+    init() {}
+    
+    init(element: ElementNode) {
+        self._element = .init(element: element)
+        self._modifiers = .init(wrappedValue: nil, "modifiers", element: element)
+        self._verbatim = .init(wrappedValue: nil, "verbatim", element: element)
+        self._date = .init(
+            wrappedValue: nil,
+            "date",
+            transform: Self.formatDate(_:),
+            element: element
+        )
+        self._dateStart = .init(
+            wrappedValue: nil,
+            "date-start",
+            transform: Self.formatDate(_:),
+            element: element
+        )
+        self._dateEnd = .init(
+            wrappedValue: nil,
+            "date-end",
+            transform: Self.formatDate(_:),
+            element: element
+        )
+        self._markdown = .init(wrappedValue: nil, "markdown", element: element)
+        self._format = .init(wrappedValue: nil, "format", element: element)
+        self._value = .init(wrappedValue: nil, "value", element: element)
+        self._currencyCode = .init(wrappedValue: nil, "currency-code", element: element)
+        self._nameStyle = .init(wrappedValue: .medium, "name-style", element: element)
+        self._dateStyle = .init(wrappedValue: .date, "date-style", element: element)
     }
     
     public var body: SwiftUI.Text {
         var result = text
-        if let effectiveFont {
-            result = result.font(effectiveFont)
-        }
-        if let textColor {
-            result = result.foregroundColor(textColor)
+        for modifier in modifiers?.stack ?? [] {
+            result = modifier.apply(to: result)
         }
         return result
     }
     
-    private func formatDate(_ date: String) -> Date? {
-        try? Date(date, strategy: .elixirDateTimeOrDate)
+    private static func formatDate(_ value: LiveViewNativeCore.Attribute?) throws -> Date? {
+        try value.flatMap(\.value).flatMap(formatDate(_:))
+    }
+    
+    private static func formatDate(_ value: String) throws -> Date {
+        try Date(value, strategy: .elixirDateTimeOrDate)
     }
     
     private var text: SwiftUI.Text {
-        if let verbatim = element.attributeValue(for: "verbatim") {
+        if let verbatim {
             return SwiftUI.Text(verbatim: verbatim)
-        } else if let date = element.attributeValue(for: "date").flatMap(formatDate) {
+        } else if let date {
             return SwiftUI.Text(date, style: dateStyle)
-        } else if let dateStart = element.attributeValue(for: "date-start").flatMap(formatDate),
-                  let dateEnd = element.attributeValue(for: "date-end").flatMap(formatDate) {
+        } else if let dateStart,
+                  let dateEnd
+        {
             return SwiftUI.Text(dateStart...dateEnd)
-        } else if let markdown = element.attributeValue(for: "markdown") {
+        } else if let markdown {
             return SwiftUI.Text(.init(markdown))
-        } else if let format = element.attributeValue(for: "format") {
-            let innerText = element.attributeValue(for: "value") ?? element.innerText()
+        } else if let format {
+            let innerText = value ?? element.innerText()
             switch format {
             case "date-time":
-                if let date = formatDate(innerText) {
+                if let date = try? Self.formatDate(innerText) {
                     return SwiftUI.Text(date, format: .dateTime)
                 } else {
                     return SwiftUI.Text(innerText)
@@ -113,7 +195,7 @@ struct Text<R: RootRegistry>: View {
                     return SwiftUI.Text(innerText)
                 }
             case "iso8601":
-                if let date = formatDate(innerText) {
+                if let date = try? Self.formatDate(innerText) {
                     return SwiftUI.Text(date, format: .iso8601)
                 } else {
                     return SwiftUI.Text(innerText)
@@ -131,29 +213,14 @@ struct Text<R: RootRegistry>: View {
                     return SwiftUI.Text("")
                 }
             case "currency":
-                if let code = element.attributeValue(for: "currency-code"),
+                if let code = currencyCode,
                    let number = Double(innerText) {
                     return SwiftUI.Text(number, format: .currency(code: code))
                 } else {
                     return SwiftUI.Text(innerText)
                 }
             case "name":
-                if let style = element.attributeValue(for: "name-style"),
-                   let nameComponents = try? PersonNameComponents(innerText) {
-                    var nameStyle: PersonNameComponents.FormatStyle.Style {
-                        switch style {
-                        case "short":
-                            return .short
-                        case "medium":
-                            return .medium
-                        case "long":
-                            return .long
-                        case "abbreviated":
-                            return .abbreviated
-                        default:
-                            return .medium
-                        }
-                    }
+                if let nameComponents = try? PersonNameComponents(innerText) {
                     return SwiftUI.Text(nameComponents, format: .name(style: nameStyle))
                 } else {
                     return SwiftUI.Text(innerText)
@@ -168,7 +235,7 @@ struct Text<R: RootRegistry>: View {
                     else { return }
                     switch element.tag {
                     case "Text":
-                        prev = prev + Self(overrideElement: element).body
+                        prev = prev + Self(element: element).body
                     case "Link":
                         prev = prev + SwiftUI.Text(
                             .init("[\(element.innerText())](\(element.attributeValue(for: "destination")!))")
@@ -186,129 +253,158 @@ struct Text<R: RootRegistry>: View {
             }
         }
     }
-    
-    private var dateStyle: SwiftUI.Text.DateStyle {
-        switch element.attributeValue(for: "date-style") {
-        case "time":
-            return .time
-        case "date":
-            return .date
-        case "relative":
-            return .relative
-        case "offset":
-            return .offset
-        case "timer":
-            return .timer
-        default:
-            return .date
-        }
-    }
-    
-    private var effectiveFont: Font? {
-        font?.weight(fontWeight)
-    }
-    
-    /// The font in which to display this text.
-    ///
-    /// Possible fonts:
-    /// - `largetitle`
-    /// - `title`
-    /// - `title2`
-    /// - `title3`
-    /// - `headline`
-    /// - `subheadline`
-    /// - `body`
-    /// - `callout`
-    /// - `caption`
-    /// - `caption2`
-    /// - `footnote`
-    #if swift(>=5.8)
-    @_documentation(visibility: public)
-    #endif
-    private var font: Font? {
-        let font: Font?
-        switch element.attributeValue(for: "font")?.lowercased() {
-        case "largetitle":
-            font = .largeTitle
-        case "title":
-            font = .title
-        case "title2":
-            font = .title2
-        case "title3":
-            font = .title3
-        case "headline":
-            font = .headline
-        case "subheadline":
-            font = .subheadline
-        case "body":
-            font = .body
-        case "callout":
-            font = .callout
-        case "caption":
-            font = .caption
-        case "caption2":
-            font = .caption2
-        case "footnote":
-            font = .footnote
-        default:
-            font = nil
-        }
-        return font?.weight(fontWeight)
-    }
-    
-    
-    /// The font weight in which to display this text. ``font`` must also be specified for this attribute to take effect.
-    ///
-    /// Possible values:
-    /// - `black`
-    /// - `bold`
-    /// - `heavy`
-    /// - `light`
-    /// - `regular`
-    /// - `medium`
-    /// - `semibold`
-    /// - `thin`
-    /// - `ultralight`
-    #if swift(>=5.8)
-    @_documentation(visibility: public)
-    #endif
-    private var fontWeight: Font.Weight {
-        switch element.attributeValue(for: "font-weight")?.lowercased() {
-        case "black":
-            return Font.Weight.black
-        case "bold":
-            return Font.Weight.bold
-        case "heavy":
-            return Font.Weight.heavy
-        case "light":
-            return Font.Weight.light
-        case "regular":
-            return Font.Weight.regular
-        case "medium":
-            return Font.Weight.medium
-        case "semibold":
-            return Font.Weight.semibold
-        case "thin":
-            return Font.Weight.thin
-        case "ultralight":
-            return Font.Weight.ultraLight
-        default:
-            return Font.Weight.regular
-        }
-    }
+}
 
-    /// The color in which to display this text.
-    ///
-    /// Encoded as a named color or CSS hex color. See ``LiveViewNative/SwiftUI/Color/init(fromNamedOrCSSHex:)``.
-    #if swift(>=5.8)
-    @_documentation(visibility: public)
-    #endif
-    private var textColor: SwiftUI.Color? {
-        if let attr = element.attributeValue(for: "color"),
-           let color = SwiftUI.Color(fromNamedOrCSSHex: attr) {
-            return color
-        } else {
-            return nil
+extension SwiftUI.Text.DateStyle: AttributeDecodable {
+    public init(from attribute: LiveViewNativeCore.Attribute?) throws {
+        guard let value = attribute?.value else {
+            throw AttributeDecodingError.missingAttribute(Self.self)
+        }
+        switch value {
+        case "time":
+            self = .time
+        case "date":
+            self = .date
+        case "relative":
+            self = .relative
+        case "offset":
+            self = .offset
+        case "timer":
+            self = .timer
+        default:
+            throw AttributeDecodingError.badValue(Self.self)
+        }
+    }
+}
+
+extension PersonNameComponents.FormatStyle.Style: AttributeDecodable {
+    public init(from attribute: LiveViewNativeCore.Attribute?) throws {
+        guard let value = attribute?.value else {
+            throw AttributeDecodingError.missingAttribute(Self.self)
+        }
+        switch value {
+        case "short":
+            self = .short
+        case "medium":
+            self = .medium
+        case "long":
+            self = .long
+        case "abbreviated":
+            self = .abbreviated
+        default:
+            throw AttributeDecodingError.badValue(Self.self)
+        }
+    }
+}
+
+struct EmptyTextModifier: TextModifier {
+    func apply(to text: SwiftUI.Text) -> SwiftUI.Text {
+        text
+    }
+}
+
+enum TextModifierType: String, Decodable {
+    case font
+    case fontWeight = "font_weight"
+    case foregroundColor = "foreground_color"
+    case bold
+    case italic
+    case strikethrough
+    case underline
+    case monospacedDigit = "monospaced_digit"
+    case kerning
+    case tracking
+    case baselineOffset = "baseline_offset"
+    @available(iOS 16.1, macOS 13.0, tvOS 16.1, watchOS 9.1, *)
+    case fontDesign = "font_design"
+    case fontWidth = "font_width"
+    @available(iOS 16.4, macOS 13.3, tvOS 16.4, watchOS 9.4, *)
+    case monospaced
+    
+    func decode(from decoder: Decoder) throws -> any TextModifier {
+        switch self {
+        case .font:
+            return try FontModifier(from: decoder)
+        case .fontWeight:
+            return try FontWeightModifier(from: decoder)
+        case .foregroundColor:
+            return try ForegroundColorModifier(from: decoder)
+        case .bold:
+            return try BoldModifier(from: decoder)
+        case .italic:
+            return try ItalicModifier(from: decoder)
+        case .strikethrough:
+            return try StrikethroughModifier(from: decoder)
+        case .underline:
+            return try UnderlineModifier(from: decoder)
+        case .monospacedDigit:
+            return try MonospacedDigitModifier(from: decoder)
+        case .kerning:
+            return try KerningModifier(from: decoder)
+        case .tracking:
+            return try TrackingModifier(from: decoder)
+        case .baselineOffset:
+            return try BaselineOffsetModifier(from: decoder)
+        case .fontDesign:
+            if #available(iOS 16.1, *) {
+                return try FontDesignModifier(from: decoder)
+            } else {
+                return EmptyTextModifier()
+            }
+        case .fontWidth:
+            return try FontWidthModifier(from: decoder)
+        case .monospaced:
+            return try MonospacedModifier(from: decoder)
+        }
+    }
+}
+
+/// A modifier that applies to ``Text``.
+protocol TextModifier {
+    /// Modify the `Text` and return the new `Text` type.
+    func apply(to text: SwiftUI.Text) -> SwiftUI.Text
+}
+
+struct TextModifierStack: Decodable, AttributeDecodable {
+    var stack: [any TextModifier]
+    
+    init(_ stack: [any TextModifier]) {
+        self.stack = stack
+    }
+    
+    init(from attribute: LiveViewNativeCore.Attribute?) throws {
+        guard let value = attribute?.value else { throw AttributeDecodingError.missingAttribute(Self.self) }
+        self = try makeJSONDecoder().decode(Self.self, from: Data(value.utf8))
+    }
+    
+    enum TextModifierContainer: Decodable {
+        case modifier(any TextModifier)
+        case end
+        
+        init(from decoder: Decoder) throws {
+            let type = try decoder.container(keyedBy: CodingKeys.self).decode(String.self, forKey: .type)
+            if let modifierType = TextModifierType(rawValue: type) {
+                self = .modifier(try modifierType.decode(from: decoder))
+            } else {
+                self = .end
+            }
+        }
+        
+        enum CodingKeys: CodingKey {
+            case type
+        }
+    }
+    
+    init(from decoder: Decoder) throws {
+        var container = try decoder.unkeyedContainer()
+        self.stack = []
+        while !container.isAtEnd {
+            switch try container.decode(TextModifierContainer.self) {
+            case let .modifier(modifier):
+                self.stack.append(modifier)
+            case .end:
+                return
+            }
         }
     }
 }

--- a/Tests/RenderingTests/Modifiers/LayoutFundamentalsModifiersTests.swift
+++ b/Tests/RenderingTests/Modifiers/LayoutFundamentalsModifiersTests.swift
@@ -175,14 +175,13 @@ final class LayoutFundamentalsModifiersTests: XCTestCase {
             #"""
             <Text modifiers='[{"alignment":"bottom","content":"bg","fill_style":null,"ignores_safe_area_edges":null,"shape":null,"style":null,"type":"overlay"}]'>
                 Hello, world!
-                <Text template="bg" font="caption">Above</Text>
+                <Text template="bg">Above</Text>
             </Text>
             """#
         ) {
             Text("Hello, world!")
                 .overlay(alignment: .bottom) {
                     Text("Above")
-                        .font(.caption)
                 }
         }
         try assertMatch(

--- a/Tests/RenderingTests/Modifiers/LayoutFundamentalsModifiersTests.swift
+++ b/Tests/RenderingTests/Modifiers/LayoutFundamentalsModifiersTests.swift
@@ -139,14 +139,13 @@ final class LayoutFundamentalsModifiersTests: XCTestCase {
             #"""
             <Text modifiers='[{"alignment":"bottom","content":"bg","fill_style":null,"ignores_safe_area_edges":null,"shape":null,"style":null,"type":"background"}]'>
                 Hello, world!
-                <Text template="bg" font="caption">Behind</Text>
+                <Text template="bg">Behind</Text>
             </Text>
             """#
         ) {
             Text("Hello, world!")
                 .background(alignment: .bottom) {
                     Text("Behind")
-                        .font(.caption)
                 }
         }
         try assertMatch(

--- a/Tests/RenderingTests/Modifiers/ListModifiersTests.swift
+++ b/Tests/RenderingTests/Modifiers/ListModifiersTests.swift
@@ -321,7 +321,7 @@ final class ListsModifiersTests: XCTestCase {
             <List modifiers='[{"style":"plain","type":"list_style"}]'>
                 <Text id="0" modifiers='[{"content":"content","count":null,"label":null,"type":"badge"}]'>
                     Hello
-                    <Text template="content" color="system-red">World</Text>
+                    <Text template="content" modifiers='[{"color":{"blue":null,"brightness":null,"green":null,"hue":null,"opacity":null,"red":null,"rgb_color_space":null,"saturation":null,"string":"system-red","white":null},"type":"foreground_color"}]'>World</Text>
                 </Text>
             </List>
             """#,

--- a/Tests/RenderingTests/TextTests.swift
+++ b/Tests/RenderingTests/TextTests.swift
@@ -17,48 +17,13 @@ final class TextTests: XCTestCase {
             Text("Hello, world!")
         }
     }
-
-    func testTextStyles() throws {
-        for style in Font.TextStyle.allCases {
-            try assertMatch(#"<Text font="\#(style)">Hello, world!</Text>"#) {
-                Text("Hello, world!").font(.system(style, weight: .regular))
-            }
-        }
-    }
-
-    func testTextWeights() throws {
-        let allWeights: [String:Font.Weight] = [
-            "ultraLight": .ultraLight,
-            "thin": .thin,
-            "light": .light,
-            "regular": .regular,
-            "medium": .medium,
-            "semibold": .semibold,
-            "bold": .bold,
-            "heavy": .heavy,
-            "black": .black,
-        ]
-        for (name, weight) in allWeights {
-            try assertMatch(name: "weight-\(name)", #"<Text font="body" font-weight="\#(name)">Hello, world!</Text>"#) {
-                Text("Hello, world!").font(.system(.body, weight: weight))
-            }
-        }
-    }
-
-    func testTextColor() throws {
-        for color in [Color.primary, Color.red, Color.blue] {
-            try assertMatch(#"<Text color="system-\#(color)">Hello, world!</Text>"#) {
-                Text("Hello, world!").foregroundColor(color)
-            }
-        }
-    }
     
     func testTextNesting() throws {
         try assertMatch(#"""
 <Text>
     <Image system-name="person.crop.circle.fill" />
     <Text verbatim=" " />
-    <Text color="system-secondary">John Doe</Text>
+    <Text modifiers='[{"color":{"blue":null,"brightness":null,"green":null,"hue":null,"opacity":null,"red":null,"rgb_color_space":null,"saturation":null,"string":"system-secondary","white":null},"type":"foreground_color"}]'>John Doe</Text>
     <Text verbatim="
 " />
     Plain text<Text verbatim=" " />

--- a/lib/live_view_native_swift_ui/modifiers/images/antialiased.ex
+++ b/lib/live_view_native_swift_ui/modifiers/images/antialiased.ex
@@ -1,0 +1,7 @@
+defmodule LiveViewNativeSwiftUi.Modifiers.Antialiased do
+  use LiveViewNativePlatform.Modifier
+
+  modifier_schema "antialiased" do
+    field :is_active, :boolean, default: true
+  end
+end

--- a/lib/live_view_native_swift_ui/modifiers/images/interpolation.ex
+++ b/lib/live_view_native_swift_ui/modifiers/images/interpolation.ex
@@ -1,0 +1,7 @@
+defmodule LiveViewNativeSwiftUi.Modifiers.Interpolation do
+  use LiveViewNativePlatform.Modifier
+
+  modifier_schema "interpolation" do
+    field :interpolation, Ecto.Enum, values: ~w(low medium high none)a
+  end
+end

--- a/lib/live_view_native_swift_ui/modifiers/images/rendering_mode.ex
+++ b/lib/live_view_native_swift_ui/modifiers/images/rendering_mode.ex
@@ -1,0 +1,7 @@
+defmodule LiveViewNativeSwiftUi.Modifiers.RenderingMode do
+  use LiveViewNativePlatform.Modifier
+
+  modifier_schema "rendering_mode" do
+    field :mode, Ecto.Enum, values: ~w(original template)a
+  end
+end

--- a/lib/live_view_native_swift_ui/modifiers/images/resizable.ex
+++ b/lib/live_view_native_swift_ui/modifiers/images/resizable.ex
@@ -1,0 +1,10 @@
+defmodule LiveViewNativeSwiftUi.Modifiers.Resizable do
+  use LiveViewNativePlatform.Modifier
+
+  alias LiveViewNativeSwiftUi.Types.EdgeInsets
+
+  modifier_schema "resizable" do
+    field :cap_insets, EdgeInsets
+    field :resizing_mode, Ecto.Enum, values: ~w(stretch tile)a, default: :stretch
+  end
+end


### PR DESCRIPTION
This converts several `Text` and `Image` attributes into modifiers for more consistency and avoiding duplication of logic.

I also converted some manual `element.attributeValue(...)` calls into properties with `@Attribute` wrappers for better documentation and readability.

Here are some before/after examples.

<table>
<tr>
<th>Old</th>
<th>New</th>
</tr>
<tr>
<td>

```heex
<Text font="body" font-weight="heavy">Hello, world!</Text>
```

</td>
<td>

```heex
<Text modifiers={@native |> font(font: {:system, :body}) |> font_weight(weight: :heavy)}>Hello, world!</Text>
```

</td>
</tr>
</table>
<table>
<tr>
<th>Old</th>
<th>New</th>
</tr>
<tr>
<td>

```heex
<!-- How can I do tiling mode? -->
<Image system-name="heart.fill" resizable symbol-color="system-red" />
```

</td>
<td>

```heex
<Image system-name="heart.fill" modifiers={resizable(@native, resizing_mode: :tile) |> foreground_color(color: :red)} />
```

</td>
</tr>
</table>