### PR TITLE
Add Keyframe Animation

### DIFF
--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -1,13 +1,8 @@
-// swift-tools-version: 5.6
+// swift-tools-version: 5.9
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
-
-#if swift(>=5.8)
-let swiftSettings = [SwiftSetting.unsafeFlags(["-emit-extension-block-symbols"])]
-#else
-let swiftSettings = [SwiftSetting]()
-#endif
+import CompilerPluginSupport
 
 let package = Package(
     name: "LiveViewNative",
@@ -30,6 +25,8 @@ let package = Package(
         
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.2.2"),
         .package(url: "https://github.com/apple/swift-markdown.git", branch: "main"),
+        
+        .package(url: "https://github.com/apple/swift-syntax.git", from: "509.0.0-swift-5.9-DEVELOPMENT-SNAPSHOT-2023-04-25-b"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
@@ -40,8 +37,11 @@ let package = Package(
                 "SwiftSoup",
                 "SwiftPhoenixClient",
                 .product(name: "LiveViewNativeCore", package: "liveview-native-core-swift"),
+                "LiveViewNativeMacros"
             ],
-            swiftSettings: swiftSettings,
+            swiftSettings: [
+                SwiftSetting.unsafeFlags(["-emit-extension-block-symbols"])
+            ],
             plugins: [
                 .plugin(name: "BuiltinRegistryGeneratorPlugin")
             ]
@@ -112,5 +112,20 @@ let package = Package(
         //     ),
         //     dependencies: [.target(name: "TutorialRepoGenerator")]
         // )
+        
+        .macro(
+            name: "LiveViewNativeMacros",
+            dependencies: [
+                .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
+                .product(name: "SwiftCompilerPlugin", package: "swift-syntax")
+            ]
+        ),
+        .testTarget(
+            name: "LiveViewNativeMacrosTests",
+            dependencies: [
+                "LiveViewNativeMacros",
+                .product(name: "SwiftSyntaxMacrosTestSupport", package: "swift-syntax"),
+            ]
+        ),
     ]
 )

--- a/Sources/LiveViewNative/LiveView.swift
+++ b/Sources/LiveViewNative/LiveView.swift
@@ -57,11 +57,19 @@ public struct LiveView<R: RootRegistry>: View {
                             ErrorView<R>(html: trace)
                         } else {
                             if #available(iOS 17, macOS 14, tvOS 17, watchOS 10, *) {
+                                #if swift(>=5.9)
                                 SwiftUI.ContentUnavailableView {
                                     SwiftUI.Label("No Connection", systemImage: "network.slash")
                                 } description: {
                                     SwiftUI.Text("The app will reconnect when network connection is regained.")
                                 }
+                                #else
+                                SwiftUI.VStack {
+                                    SwiftUI.Text("Connection Failed")
+                                        .font(.subheadline)
+                                    SwiftUI.Text(error.localizedDescription)
+                                }
+                                #endif
                             } else {
                                 SwiftUI.VStack {
                                     SwiftUI.Text("Connection Failed")

--- a/Sources/LiveViewNative/LiveView.swift
+++ b/Sources/LiveViewNative/LiveView.swift
@@ -56,10 +56,18 @@ public struct LiveView<R: RootRegistry>: View {
                         {
                             ErrorView<R>(html: trace)
                         } else {
-                            SwiftUI.VStack {
-                                SwiftUI.Text("Connection Failed")
-                                    .font(.subheadline)
-                                SwiftUI.Text(error.localizedDescription)
+                            if #available(iOS 17, macOS 14, tvOS 17, watchOS 10, *) {
+                                SwiftUI.ContentUnavailableView {
+                                    SwiftUI.Label("No Connection", systemImage: "network.slash")
+                                } description: {
+                                    SwiftUI.Text("The app will reconnect when network connection is regained.")
+                                }
+                            } else {
+                                SwiftUI.VStack {
+                                    SwiftUI.Text("Connection Failed")
+                                        .font(.subheadline)
+                                    SwiftUI.Text(error.localizedDescription)
+                                }
                             }
                         }
                     }

--- a/Sources/LiveViewNative/Modifiers/Animations Modifiers/KeyframeAnimatorModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Animations Modifiers/KeyframeAnimatorModifier.swift
@@ -1,0 +1,150 @@
+//
+//  KeyframeAnimatorModifier.swift
+//  LiveViewNative
+//
+//  Created by Carson Katri on 6/7/2023.
+//
+
+import SwiftUI
+
+/// Use keyframes to animate specific modifiers.
+///
+/// There is no noticeable latency when using keyframe animations, as all values are calculated on-device.
+///
+/// The keyframe values will replace the listed ``properties`` of the modifiers.
+///
+/// - Note: Only numeric properties can be animated.
+///
+/// ```html
+/// <Image
+///   system-name="heart.fill"
+///   modifiers={
+///     @native |> keyframe_animator(
+///       initial_value: 1.0,
+///       trigger: "#{@liked}",
+///       keyframes: [
+///         {:linear, 1.0, [duration: 0.36]},
+///         {:spring, 1.5, [duration: 0.8, spring: :bouncy]},
+///         {:spring, 1.0, [spring: :bouncy]}
+///       ],
+///       modifiers: @native |> scale_effect(x: 1.0, y: 1.0),
+///       properties: [:x, :y]
+///     )
+///   }
+/// />
+/// ```
+///
+/// When the `@liked` assign changes, the image will scale up then back down.
+/// The `x` and `y` properties in the ``ScaleEffectModifier`` modifier passed to the ``modifiers`` argument will be replaced for each frame.
+///
+/// ## Arguments
+/// * ``initialValue``
+/// * ``trigger``
+/// * ``keyframes``
+/// * ``modifiers``
+/// * ``properties``
+#if swift(>=5.8)
+@_documentation(visibility: public)
+#endif
+@available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+struct KeyframeAnimatorModifier<R: RootRegistry>: ViewModifier, Decodable, Sendable {
+    /// The initial value of the animation.
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
+    private let initialValue: Double
+    
+    /// A string that, when changed, triggers the animation.
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
+    private let trigger: String
+    
+    /// A list of keyframes to animate with.
+    /// See ``LiveViewNative/KeyframeAnimation/Keyframe`` for more details.
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
+    private let keyframes: [KeyframeAnimation.Keyframe]
+    
+    /// The modifier stack to animate.
+    ///
+    /// The modifier stack is created with the `@native` assign and modifier functions.
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
+    private let modifiers: String
+    
+    /// A list of atoms with the names of the modifier's properties to animate.
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
+    private let properties: [String]
+    
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.initialValue = try container.decode(Double.self, forKey: .initialValue)
+        self.trigger = try container.decode(String.self, forKey: .trigger)
+        self.keyframes = try container.decode([KeyframeAnimation.Keyframe].self, forKey: .keyframes)
+        self.modifiers = try container.decode(String.self, forKey: .modifiers)
+        self.properties = try container.decode([String].self, forKey: .properties)
+    }
+    
+    func body(content: Content) -> some View {
+        content
+            #if swift(>=5.9)
+            .keyframeAnimator(
+                initialValue: initialValue,
+                trigger: trigger
+            ) { content, value in
+                if let applicator = try? Applicator(modifiers, value: value, properties: properties, content: content) {
+                    applicator
+                } else {
+                    content
+                }
+            } keyframes: { value in
+                KeyframeTrack(\.self) {
+                    KeyframeTrackContentBuilder.buildArray(keyframes.map(\.value))
+                }
+            }
+            #endif
+    }
+    
+    enum CodingKeys: CodingKey {
+        case initialValue
+        case trigger
+        case keyframes
+        case modifiers
+        case properties
+    }
+    
+    private struct Applicator<Content: View>: View {
+        let stack: [ModifierContainer<R>]
+        let content: Content
+        
+        @ObservedElement private var element
+        @LiveContext<R> private var context
+        
+        nonisolated init(_ modifiers: String, value: Double, properties: [String], content: Content) throws {
+            self.content = content
+            
+            let modified = NSArray(array: (try JSONSerialization.jsonObject(with: Data(modifiers.utf8)) as! [[NSString:Any]])
+                .map({
+                    Dictionary(uniqueKeysWithValues: $0.map({
+                        if properties.contains(String($0.key)) {
+                            return ($0.key, NSNumber(value: value) as Any)
+                        } else {
+                            return ($0.key, $0.value)
+                        }
+                    })) as NSDictionary
+                })) as NSArray
+            let encoded = try JSONSerialization.data(withJSONObject: modified, options: .sortedKeys)
+            self.stack = try makeJSONDecoder().decode([ModifierContainer<R>].self, from: encoded)
+        }
+        
+        var body: some View {
+            content
+                .applyModifiers(stack[...], element: element, context: context.storage)
+        }
+    }
+}

--- a/Sources/LiveViewNative/Modifiers/Animations Modifiers/KeyframeAnimatorModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Animations Modifiers/KeyframeAnimatorModifier.swift
@@ -5,6 +5,7 @@
 //  Created by Carson Katri on 6/7/2023.
 //
 
+#if swift(>=5.9)
 import SwiftUI
 
 /// Use keyframes to animate specific modifiers.
@@ -98,7 +99,6 @@ struct KeyframeAnimatorModifier<R: RootRegistry>: ViewModifier, Decodable {
     
     func body(content: Content) -> some View {
         content
-            #if swift(>=5.9)
             .keyframeAnimator(
                 initialValue: initialValue,
                 trigger: trigger
@@ -113,7 +113,6 @@ struct KeyframeAnimatorModifier<R: RootRegistry>: ViewModifier, Decodable {
                     KeyframeTrackContentBuilder.buildArray(keyframes.map(\.value))
                 }
             }
-            #endif
     }
     
     enum CodingKeys: CodingKey {
@@ -156,3 +155,4 @@ struct KeyframeAnimatorModifier<R: RootRegistry>: ViewModifier, Decodable {
         }
     }
 }
+#endif

--- a/Sources/LiveViewNative/Modifiers/Animations Modifiers/KeyframeAnimatorModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Animations Modifiers/KeyframeAnimatorModifier.swift
@@ -5,7 +5,6 @@
 //  Created by Carson Katri on 6/7/2023.
 //
 
-#if swift(>=5.9)
 import SwiftUI
 
 /// Use keyframes to animate specific modifiers.
@@ -68,6 +67,14 @@ struct KeyframeAnimatorModifier<R: RootRegistry>: ViewModifier, Decodable {
     #endif
     private let keyframes: [KeyframeAnimation.Keyframe]
     
+    #if !swift(>=5.9)
+    enum KeyframeAnimation {
+        struct Keyframe: Decodable {
+            init(from decoder: Decoder) throws {}
+        }
+    }
+    #endif
+    
     /// The modifier stack to animate.
     ///
     /// The modifier stack is created with the `@native` assign and modifier functions.
@@ -99,6 +106,7 @@ struct KeyframeAnimatorModifier<R: RootRegistry>: ViewModifier, Decodable {
     
     func body(content: Content) -> some View {
         content
+            #if swift(>=5.9)
             .keyframeAnimator(
                 initialValue: initialValue,
                 trigger: trigger
@@ -113,6 +121,7 @@ struct KeyframeAnimatorModifier<R: RootRegistry>: ViewModifier, Decodable {
                     KeyframeTrackContentBuilder.buildArray(keyframes.map(\.value))
                 }
             }
+            #endif
     }
     
     enum CodingKeys: CodingKey {
@@ -155,4 +164,3 @@ struct KeyframeAnimatorModifier<R: RootRegistry>: ViewModifier, Decodable {
         }
     }
 }
-#endif

--- a/Sources/LiveViewNative/Modifiers/Animations Modifiers/KeyframeAnimatorModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Animations Modifiers/KeyframeAnimatorModifier.swift
@@ -28,7 +28,7 @@ import SwiftUI
 ///         {:spring, 1.0, [spring: :bouncy]}
 ///       ],
 ///       modifiers: @native |> scale_effect(x: 1.0, y: 1.0),
-///       properties: [:x, :y]
+///       properties: [scale_effect: [:x, :y]]
 ///     )
 ///   }
 /// />

--- a/Sources/LiveViewNative/Modifiers/Drawing and Graphics Modifiers/ScaleEffectModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Drawing and Graphics Modifiers/ScaleEffectModifier.swift
@@ -17,24 +17,40 @@ import SwiftUI
 ///
 /// ## Arguments
 /// * ``scale``
+/// * ``x``
+/// * ``y``
 /// * ``anchor``
 #if swift(>=5.8)
 @_documentation(visibility: public)
 #endif
 struct ScaleEffectModifier: ViewModifier, Decodable {
     /// The horizontal and vertical amount to scale the view.
+    ///
+    /// Takes precedence over ``x`` and ``y``.
     #if swift(>=5.8)
     @_documentation(visibility: public)
     #endif
-    private let scale: CGSize
+    private let scale: CGSize?
+    
+    /// The horizontal amount to scale.
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
+    private let x: Double?
+    
+    /// The vertical amount to scale.
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
+    private let y: Double?
 
-    /// The ``LiveViewNative/SwiftUI/UnitPoint`` from which to apply the transformation.
+    /// The ``LiveViewNative/SwiftUI/UnitPoint`` from which to apply the transformation. Defaults to `center`.
     #if swift(>=5.8)
     @_documentation(visibility: public)
     #endif
-    private let anchor: UnitPoint
+    private let anchor: UnitPoint?
 
     func body(content: Content) -> some View {
-        content.scaleEffect(scale, anchor: anchor)
+        content.scaleEffect(scale ?? .init(width: x ?? 1, height: y ?? 1), anchor: anchor ?? .center)
     }
 }

--- a/Sources/LiveViewNative/Modifiers/Focus Modifiers/FocusScopeModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Focus Modifiers/FocusScopeModifier.swift
@@ -44,14 +44,16 @@ struct FocusScopeModifier: ViewModifier, Decodable {
     }
 
     func body(content: Content) -> some View {
+        #if !os(iOS)
         if let namespace = namespaces[namespace] {
             content
-                #if !os(iOS)
                 .focusScope(namespace)
-                #endif
         } else {
             content
         }
+        #else
+        content
+        #endif
     }
 
     enum CodingKeys: CodingKey {

--- a/Sources/LiveViewNative/Modifiers/Focus Modifiers/PrefersDefaultFocusModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Focus Modifiers/PrefersDefaultFocusModifier.swift
@@ -61,14 +61,16 @@ struct PrefersDefaultFocusModifier: ViewModifier, Decodable {
     }
 
     func body(content: Content) -> some View {
+        #if !os(iOS)
         if let namespace = namespaces[namespace] {
             content
-                #if !os(iOS)
                 .prefersDefaultFocus(prefersDefaultFocus, in: namespace)
-                #endif
         } else {
             content
         }
+        #else
+        content
+        #endif
     }
 
     enum CodingKeys: CodingKey {

--- a/Sources/LiveViewNative/Modifiers/Layout Adjustments Modifiers/OffsetModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Layout Adjustments Modifiers/OffsetModifier.swift
@@ -30,14 +30,14 @@ struct OffsetModifier: ViewModifier, Decodable, Equatable {
     #if swift(>=5.8)
     @_documentation(visibility: public)
     #endif
-    private let x: CGFloat
+    private let x: CGFloat?
     /// The offset to apply to the y axis.
     #if swift(>=5.8)
     @_documentation(visibility: public)
     #endif
-    private let y: CGFloat
+    private let y: CGFloat?
 
     func body(content: Content) -> some View {
-        content.offset(x: x, y: y)
+        content.offset(x: x ?? 0, y: y ?? 0)
     }
 }

--- a/Sources/LiveViewNative/Registries/AggregateRegistry.swift
+++ b/Sources/LiveViewNative/Registries/AggregateRegistry.swift
@@ -8,9 +8,37 @@
 import Foundation
 import SwiftUI
 
+#if swift(>=5.9)
+/// A macro that combines multiple registries together.
+///
+/// ```swift
+/// struct AppRegistries: AggregateRegistry {
+///     #Registries<
+///         MyRegistry,
+///         LiveFormsRegistry<Self>,
+///         AVKitRegistry<Self>
+///     >
+/// }
+/// ```
+@freestanding(declaration, names: named(Registries))
+public macro Registries() = #externalMacro(module: "LiveViewNativeMacros", type: "RegistriesMacro")
+#endif
+
 /// An aggregate registry combines multiple other registries together, allowing you to use tags/modifiers declared by any of them.
 ///
-/// To conform to this protocol, provide the `Registries` typealias, using the `Registry2`/`Registry3`/etc. types:
+/// In Swift 5.9, use the ``LiveViewNative/Registries`` macro to combine registries together.
+///
+/// ```swift
+/// struct AppRegistries: AggregateRegistry {
+///     #Registries<
+///         MyRegistry,
+///         LiveFormsRegistry<Self>,
+///         AVKitRegistry<Self>
+///     >
+/// }
+/// ```
+///
+/// When using a Swift version < 5.9, conform to this protocol manually, provide the `Registries` typealias using the `Registry2`/`Registry3`/etc. types:
 /// ```swift
 /// struct AppRegistries: AggregateRegistry {
 ///     typealias Registries = Registry2<

--- a/Sources/LiveViewNative/Registries/AggregateRegistry.swift
+++ b/Sources/LiveViewNative/Registries/AggregateRegistry.swift
@@ -105,6 +105,10 @@ extension AggregateRegistry {
     public static func loadingView(for url: URL, state: LiveSessionState) -> some View {
         return Registries.loadingView(for: url, state: state)
     }
+    
+    public static func errorView(for error: Error) -> some View {
+        return Registries.errorView(for: error)
+    }
 }
 
 /// A helper type that represents either one of two `RawRepresentable<String>` types.
@@ -160,6 +164,10 @@ public enum _EitherRawString<First: RawRepresentable<String>, Second: RawReprese
 
     public static func loadingView(for url: URL, state: LiveSessionState) -> some View {
         return First.loadingView(for: url, state: state)
+    }
+    
+    public static func errorView(for error: Error) -> some View {
+        return First.errorView(for: error)
     }
 }
 

--- a/Sources/LiveViewNative/Registries/CustomRegistry.swift
+++ b/Sources/LiveViewNative/Registries/CustomRegistry.swift
@@ -40,7 +40,7 @@ import LiveViewNativeCore
 /// ### Supporting Types
 /// - ``EmptyRegistry``
 /// - ``ViewModifierBuilder``
-public protocol CustomRegistry {
+public protocol CustomRegistry<Root> {
     /// The root custom registry type that the live view coordinator and context use.
     ///
     /// Conform you registry type to ``RootRegistry``, which sets this type to `Self` automatically, if you intend to use your registry directly.

--- a/Sources/LiveViewNative/Shape Modifiers/StrokeBorderModifier.swift
+++ b/Sources/LiveViewNative/Shape Modifiers/StrokeBorderModifier.swift
@@ -56,6 +56,13 @@ struct StrokeBorderModifier: FinalShapeModifier, Decodable {
     }
     
     func apply(to shape: any InsettableShape) -> some View {
-        AnyView(shape.strokeBorder(content, style: style ?? .init(), antialiased: antialiased))
+        let modified = shape.strokeBorder(content, style: style ?? .init(), antialiased: antialiased)
+        return modified.eraseToAnyView()
+    }
+}
+
+private extension View {
+    func eraseToAnyView() -> AnyView {
+        AnyView(self)
     }
 }

--- a/Sources/LiveViewNative/Utils/Animation.swift
+++ b/Sources/LiveViewNative/Utils/Animation.swift
@@ -218,7 +218,11 @@ extension Animation: Decodable {
             )
         case .keyframe:
             if #available(iOS 17, macOS 14, tvOS 17, watchOS 10, *) {
+                #if swift(>=5.9)
                 base = .init(try container.decode(KeyframeAnimation.self, forKey: .properties))
+                #else
+                base = .default
+                #endif
             } else {
                 base = .default
             }
@@ -311,6 +315,7 @@ extension Animation: Decodable {
     }
 }
 
+#if swift(>=5.9)
 /// An animation that plays a list of keyframes.
 ///
 /// ```elixir
@@ -325,7 +330,6 @@ extension Animation: Decodable {
 /// ```
 ///
 /// See ``LiveViewNative/KeyframeAnimation/Keyframe`` for more details.
-#if swift(>=5.9)
 @_documentation(visibility: public)
 @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
 struct KeyframeAnimation: CustomAnimation, Decodable {

--- a/Sources/LiveViewNative/Utils/Animation.swift
+++ b/Sources/LiveViewNative/Utils/Animation.swift
@@ -83,6 +83,16 @@ import SwiftUI
 ///
 /// See [`SwiftUI.Animation.interpolatingSpring`](https://developer.apple.com/documentation/swiftui/animation/interpolatingspring(mass:stiffness:damping:initialvelocity:)) for more details on this animation.
 ///
+/// #### :keyframe
+/// Pass a ``KeyframeAnimation`` as the second element in the tuple.
+/// ```elixir
+/// {:keyframe, [initial_value: 1.0, keyframes: [
+///   {:linear, 1.0, [duration: 0.36]},
+///   {:spring, 1.5, [duration: 0.8, spring: :bouncy]},
+///   {:spring, 1.0, [spring: :bouncy]}
+/// ]]}
+/// ```
+///
 /// ### Animation Modifiers
 /// Modifiers can be applied to any animation as the third tuple element.
 ///

--- a/Sources/LiveViewNative/Utils/DOM.swift
+++ b/Sources/LiveViewNative/Utils/DOM.swift
@@ -23,7 +23,7 @@ import LiveViewNativeCore
 /// - ``depthFirstChildren()``
 /// - ``elementChildren()``
 /// - ``innerText()``
-public struct ElementNode {
+public struct ElementNode: Sendable {
     let node: Node
     let data: ElementData
     

--- a/Sources/LiveViewNative/Utils/KeyEquivalent.swift
+++ b/Sources/LiveViewNative/Utils/KeyEquivalent.swift
@@ -51,7 +51,7 @@ extension KeyEquivalent: Decodable {
             self = .delete
         case "end":
             self = .end
-        case "escap":
+        case "escape":
             self = .escape
         case "home":
             self = .home

--- a/Sources/LiveViewNative/ViewTree.swift
+++ b/Sources/LiveViewNative/ViewTree.swift
@@ -142,6 +142,10 @@ extension ViewTreeBuilder {
     }
 }
 
+extension CodingUserInfoKey {
+    static var modifierAnimationScale: Self { .init(rawValue: "modifierAnimationScale")! }
+}
+
 enum ModifierContainer<R: RootRegistry>: Decodable {
     case builtin(BuiltinRegistry<R>.BuiltinModifier)
     case custom(R.CustomModifier)

--- a/Sources/LiveViewNativeMacros/LiveViewNativeMacros.swift
+++ b/Sources/LiveViewNativeMacros/LiveViewNativeMacros.swift
@@ -1,0 +1,16 @@
+//
+//  LiveViewNativeMacros.swift
+//
+//
+//  Created by Carson Katri on 6/6/23.
+//
+
+import SwiftCompilerPlugin
+import SwiftSyntaxMacros
+
+@main
+struct LiveViewNativeMacrosPlugin: CompilerPlugin {
+    let providingMacros: [Macro.Type] = [
+        RegistriesMacro.self
+    ]
+}

--- a/Sources/LiveViewNativeMacros/RegistriesMacro.swift
+++ b/Sources/LiveViewNativeMacros/RegistriesMacro.swift
@@ -1,0 +1,77 @@
+//
+//  RegistriesMacro.swift
+//
+//
+//  Created by Carson Katri on 6/6/23.
+//
+
+import SwiftCompilerPlugin
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+
+/// Implementation of the `#AggregateRegistry` macro, which takes an expression
+/// of any type and produces a tuple containing the value of that expression
+/// and the source code that produced the value. For example
+///
+///     struct MyAppRegistry: RootRegistry {
+///         #Registries(
+///             AVKitRegistry.self,
+///             PhotoKitRegistry.self
+///         )
+///     }
+///
+///  will expand to
+///
+///     _MultiRegistry
+public enum RegistriesMacro {}
+
+extension RegistriesMacro: DeclarationMacro {
+    public static func expansion<Node, Context>(
+        of node: Node,
+        in context: Context
+    ) throws -> [DeclSyntax]
+        where Node: FreestandingMacroExpansionSyntax, Context: MacroExpansionContext
+    {
+        guard let registries = node.genericArguments?.arguments
+        else { throw RegistriesMacroError.missingArguments }
+        
+        switch registries.count {
+        case 0:
+            throw RegistriesMacroError.missingArguments
+        case 1:
+            return ["typealias Registries = \(registries.first!)"]
+        default:
+            func multiRegistry(_ registries: GenericArgumentListSyntax) -> SimpleTypeIdentifierSyntax {
+                switch registries.count {
+                case 2:
+                    return SimpleTypeIdentifierSyntax(
+                        name: "_MultiRegistry",
+                        genericArgumentClause: .init(arguments: registries)
+                    )
+                default:
+                    return SimpleTypeIdentifierSyntax(
+                        name: "_MultiRegistry",
+                        genericArgumentClause: .init(arguments: .init([
+                            registries.first!,
+                            .init(argumentType: multiRegistry(registries.removingFirst()))
+                        ]))
+                    )
+                }
+            }
+            
+            return ["typealias Registries = \(multiRegistry(registries))"]
+        }
+    }
+}
+
+enum RegistriesMacroError: CustomStringConvertible, Error {
+    case missingArguments
+    
+    var description: String {
+        switch self {
+        case .missingArguments:
+            return "No registry types provided as generic arguments."
+        }
+    }
+}

--- a/Sources/LiveViewNativeMacros/RegistriesMacro.swift
+++ b/Sources/LiveViewNativeMacros/RegistriesMacro.swift
@@ -10,20 +10,25 @@ import SwiftSyntax
 import SwiftSyntaxBuilder
 import SwiftSyntaxMacros
 
-/// Implementation of the `#AggregateRegistry` macro, which takes an expression
-/// of any type and produces a tuple containing the value of that expression
-/// and the source code that produced the value. For example
+/// Implementation of the `#Registries` macro, which creates the `Registries` typealias for an `AggregateRegistry`.
 ///
-///     struct MyAppRegistry: RootRegistry {
-///         #Registries(
-///             AVKitRegistry.self,
-///             PhotoKitRegistry.self
-///         )
-///     }
+/// For example
+///
+///     #Registries<
+///         MyAppRegistry,
+///         AVKitRegistry<Self>,
+///         PhotoKitRegistry<Self>
+///     >
 ///
 ///  will expand to
 ///
-///     _MultiRegistry
+///     _MultiRegistry<
+///         MyAppRegistry,
+///         _MultiRegistry<
+///             AVKitRegistry<Self>,
+///             PhotoKitRegistry<Self>
+///         >
+///     >
 public enum RegistriesMacro {}
 
 extension RegistriesMacro: DeclarationMacro {

--- a/Tests/LiveViewNativeMacrosTests/LiveViewNativeMacrosTests.swift
+++ b/Tests/LiveViewNativeMacrosTests/LiveViewNativeMacrosTests.swift
@@ -1,0 +1,40 @@
+//
+//  LiveViewNativeMacrosTests.swift
+//  
+//
+//  Created by Carson Katri on 6/6/23.
+//
+
+import SwiftSyntaxMacros
+import SwiftSyntaxMacrosTestSupport
+import XCTest
+import LiveViewNativeMacros
+
+let testMacros: [String: Macro.Type] = [
+    "Registries": RegistriesMacro.self,
+]
+
+final class LiveViewNativeMacrosTests: XCTestCase {
+    func testMacro() {
+        assertMacroExpansion(
+            """
+            struct AppRegistry: AggregateRegistry {
+                #Registries<
+                    AVKitRegistry<Self>,
+                    PhotoKitRegistry<Self>,
+                    LiveFormsRegistry<Self>
+                >
+            }
+            """,
+            expandedSource: """
+            struct AppRegistry: AggregateRegistry {
+                typealias Registries = _MultiRegistry<
+                        AVKitRegistry<Self>, _MultiRegistry<
+                        PhotoKitRegistry<Self>,
+                        LiveFormsRegistry<Self>>>
+            }
+            """,
+            macros: testMacros
+        )
+    }
+}

--- a/lib/live_view_native_swift_ui/modifiers.ex
+++ b/lib/live_view_native_swift_ui/modifiers.ex
@@ -1,8 +1,8 @@
 defmodule LiveViewNativeSwiftUi.Modifiers do
   use LiveViewNativePlatform.Modifiers
 
-  defimpl Phoenix.HTML.Safe do
-    def to_iodata(%{stack: stack}) do
+  defimpl Jason.Encoder do
+    def encode(%{stack: stack}, opts) do
       modifiers =
         Enum.reduce(stack, [], fn %modifier_schema{} = modifier, acc ->
           key = apply(modifier_schema, :modifier_name, [])
@@ -24,12 +24,18 @@ defmodule LiveViewNativeSwiftUi.Modifiers do
 
       case modifiers do
         [] ->
-          ""
+          nil
 
         modifiers ->
-          Jason.encode!(modifiers)
-          |> Phoenix.HTML.Engine.html_escape()
+          Jason.Encode.list(modifiers, opts)
       end
+    end
+  end
+
+  defimpl Phoenix.HTML.Safe do
+    def to_iodata(struct) do
+      Jason.encode!(struct)
+        |> Phoenix.HTML.Engine.html_escape()
     end
   end
 end

--- a/lib/live_view_native_swift_ui/modifiers/animation/keyframe_animator.ex
+++ b/lib/live_view_native_swift_ui/modifiers/animation/keyframe_animator.ex
@@ -1,0 +1,15 @@
+defmodule LiveViewNativeSwiftUi.Modifiers.KeyframeAnimator do
+  use LiveViewNativePlatform.Modifier
+
+  alias LiveViewNativeSwiftUi.Types.EncodedModifierStack
+  alias LiveViewNativeSwiftUi.Types.Keyframe
+  alias LiveViewNativeSwiftUi.Types.KeyName
+
+  modifier_schema "keyframe_animator" do
+    field :initial_value, :float
+    field :trigger, :string
+    field :keyframes, {:array, Keyframe}
+    field :modifiers, EncodedModifierStack
+    field :properties, {:array, KeyName}
+  end
+end

--- a/lib/live_view_native_swift_ui/modifiers/animation/keyframe_animator.ex
+++ b/lib/live_view_native_swift_ui/modifiers/animation/keyframe_animator.ex
@@ -1,15 +1,13 @@
 defmodule LiveViewNativeSwiftUi.Modifiers.KeyframeAnimator do
   use LiveViewNativePlatform.Modifier
 
-  alias LiveViewNativeSwiftUi.Types.EncodedModifierStack
-  alias LiveViewNativeSwiftUi.Types.Keyframe
-  alias LiveViewNativeSwiftUi.Types.KeyName
+  alias LiveViewNativeSwiftUi.Types.{EncodedModifierStack, Keyframe, KeyframeProperties}
 
   modifier_schema "keyframe_animator" do
     field :initial_value, :float
     field :trigger, :string
     field :keyframes, {:array, Keyframe}
     field :modifiers, EncodedModifierStack
-    field :properties, {:array, KeyName}
+    field :properties, KeyframeProperties
   end
 end

--- a/lib/live_view_native_swift_ui/modifiers/drawing_and_graphics/scale_effect.ex
+++ b/lib/live_view_native_swift_ui/modifiers/drawing_and_graphics/scale_effect.ex
@@ -1,10 +1,12 @@
 defmodule LiveViewNativeSwiftUi.Modifiers.ScaleEffect do
   use LiveViewNativePlatform.Modifier
-  
+
   alias LiveViewNativeSwiftUi.Types.UnitPoint
-  
+
   modifier_schema "scale_effect" do
-    field :scale, {:array, :float}, default: [1.0, 1.0]
+    field :x, :float
+    field :y, :float
+    field :scale, {:array, :float}
     field :anchor, UnitPoint
   end
 end

--- a/lib/live_view_native_swift_ui/types/animation/animation.ex
+++ b/lib/live_view_native_swift_ui/types/animation/animation.ex
@@ -5,7 +5,21 @@ defmodule LiveViewNativeSwiftUi.Types.Animation do
   use LiveViewNativePlatform.Modifier.Type
   def type, do: :map
 
+  alias LiveViewNativeSwiftUi.Types.Keyframe
+
   def cast(type) when is_atom(type), do: {:ok, %__MODULE__{ type: type, properties: %{}, modifiers: [] }}
+  def cast({:keyframe = type, properties}) when is_atom(type), do: cast({type, properties, []})
+  def cast({:keyframe = type, properties, modifiers}) when is_atom(type) and is_list(modifiers) do
+    {
+      :ok,
+      %__MODULE__{
+        type: type,
+        properties: Enum.into(properties, %{})
+          |> Map.update(:keyframes, [], fn keyframes -> Enum.map(keyframes, fn k -> Keyframe.cast(k) |> elem(1) end) end),
+        modifiers: modifiers
+      }
+    }
+  end
   def cast({type, [ {k, _} | _ ] = properties}) when is_atom(type) and is_atom(k) do
     {:ok, %__MODULE__{ type: type, properties: Enum.into(properties, %{}), modifiers: [] }}
   end

--- a/lib/live_view_native_swift_ui/types/animation/keyframe.ex
+++ b/lib/live_view_native_swift_ui/types/animation/keyframe.ex
@@ -1,0 +1,20 @@
+defmodule LiveViewNativeSwiftUi.Types.Keyframe do
+  @derive Jason.Encoder
+  defstruct [:type, :value, :properties]
+
+  use LiveViewNativePlatform.Modifier.Type
+  def type, do: :map
+
+  def cast({:spring = type, value, properties}) when is_number(value) do
+    {:ok, %__MODULE__{ type: type, value: value, properties: Enum.into(properties, %{}) |> Map.replace_lazy(:spring, &cast_spring/1) }}
+  end
+  def cast({type, value, properties}) when is_atom(type) and is_number(value) do
+    {:ok, %__MODULE__{ type: type, value: value, properties: Enum.into(properties, %{}) }}
+  end
+
+  def cast(_), do: :error
+
+  defp cast_spring(type) when is_atom(type), do: %{ type: type }
+  defp cast_spring({type, properties}), do: Enum.into(properties, %{}) |> Map.put_new(:type, type)
+  defp cast_spring(properties), do: Enum.into(properties, %{})
+end

--- a/lib/live_view_native_swift_ui/types/animation/keyframe_properties.ex
+++ b/lib/live_view_native_swift_ui/types/animation/keyframe_properties.ex
@@ -1,0 +1,10 @@
+defmodule LiveViewNativeSwiftUi.Types.KeyframeProperties do
+  use LiveViewNativePlatform.Modifier.Type
+  def type, do: :map
+
+  def cast(value) when is_list(value) or is_map(value) do
+    {:ok, Enum.into(value, %{})}
+  end
+
+  def cast(_), do: :error
+end

--- a/lib/live_view_native_swift_ui/types/encoded_modifier_stack.ex
+++ b/lib/live_view_native_swift_ui/types/encoded_modifier_stack.ex
@@ -1,0 +1,9 @@
+defmodule LiveViewNativeSwiftUi.Types.EncodedModifierStack do
+  use LiveViewNativePlatform.Modifier.Type
+  def type, do: :string
+
+  def cast(value) when is_struct(value, LiveViewNativePlatform.Context) do
+    {:ok, Jason.encode!(value.modifiers)}
+  end
+  def cast(_), do: :error
+end


### PR DESCRIPTION
This adds support for keyframe animation to the `Animation` type, as well as a new `keyframe_animator` modifier.

It is available for iOS 17 and aligned releases.

```elixir
<Button phx-click="like">
  <Image
    modifiers={
      @native
        |> font(font: {:system, :large_title})
        |> foreground_style(primary: {:color, :red})
        # angle
        |> keyframe_animator(
          initial_value: 0.0,
          trigger: "#{@liked}",
          keyframes: [
            {:linear, 0.0, [duration: 0.5]},
            {:cubic, -15.0 * (:math.pi / 180.0), [duration: 0.1]},
            {:cubic, 15.0 * (:math.pi / 180.0), [duration: 0.1]},
            {:cubic, -15.0 * (:math.pi / 180.0), [duration: 0.1]},
            {:cubic, 15.0 * (:math.pi / 180.0), [duration: 0.1]},
            {:spring, 0.0, [duration: 0.3, spring: :bouncy]},
          ],
          modifiers: @native |> rotation_effect(angle: {:radians, 0.0}, anchor: :center),
          properties: [rotation_effect: [:angle]]
        )
        # scale
        |> keyframe_animator(
          initial_value: 1.0,
          trigger: "#{@liked}",
          keyframes: [
            {:linear, 1.0, [duration: 0.36]},
            {:spring, 1.5, [duration: 0.8, spring: :bouncy]},
            {:spring, 1.0, [spring: :bouncy]}
          ],
          modifiers: @native |> scale_effect(x: 1.0, y: 1.0),
          properties: [scale_effect: [:x, :y]]
        )
        # vertical stretch
        |> keyframe_animator(
          initial_value: 1.0,
          trigger: "#{@liked}",
          keyframes: [
            {:cubic, 1.0, [duration: 0.1]},
            {:cubic, 0.6, [duration: 0.15]},
            {:cubic, 1.5, [duration: 0.1]},
            {:cubic, 1.05, [duration: 0.15]},
            {:cubic, 1.0, [duration: 0.88]},
            {:cubic, 0.8, [duration: 0.1]},
            {:cubic, 1.04, [duration: 0.4]},
            {:cubic, 1.0, [duration: 0.22]},
          ],
          modifiers: @native |> scale_effect(y: 1.0),
          properties: [scale_effect: [:y]]
        )
        # vertical translation
        |> keyframe_animator(
          initial_value: 0.0,
          trigger: "#{@liked}",
          keyframes: [
            {:linear, 0.0, [duration: 0.1]},
            {:spring, 20.0, [duration: 0.15, spring: :bouncy]},
            {:spring, -60.0, [duration: 1.0, spring: :bouncy]},
            {:spring, 0.0, [spring: :bouncy]}
          ],
          modifiers: offset(@native),
          properties: [offset: [:y]]
        )
    }
    system-name={if @liked, do: "heart.fill", else: "heart"}
  />
</Button>
```

https://github.com/liveview-native/liveview-client-swiftui/assets/13581484/07866538-09e4-4fee-b527-73e515651dfd