### PR TITLE
Add `palette` picker style

### DIFF
--- a/Sources/LiveViewNative/Modifiers/Controls and Indicators Modifiers/PickerStyleModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Controls and Indicators Modifiers/PickerStyleModifier.swift
@@ -51,6 +51,14 @@ struct PickerStyleModifier: ViewModifier, Decodable {
 #if os(iOS) || os(watchOS)
             content.pickerStyle(.wheel)
 #endif
+        case .palette:
+            if #available(iOS 17, macOS 14, *) {
+#if swift(>=5.9) && (os(iOS) || os(macOS))
+                content.pickerStyle(.palette)
+#endif
+            } else {
+                content
+            }
         }
     }
 }
@@ -95,4 +103,9 @@ private enum PickerStyle: String, Decodable {
     #endif
     @available(iOS 16.0, watchOS 9.0, *)
     case wheel
+    #if swift(>=5.8)
+    @_documentation(visibility: public)
+    #endif
+    @available(iOS 17.0, macOS 14.0, *)
+    case palette
 }

--- a/Sources/LiveViewNative/Modifiers/View Fundamentals Modifiers/TagModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/View Fundamentals Modifiers/TagModifier.swift
@@ -16,9 +16,9 @@ import SwiftUI
 @_documentation(visibility: public)
 #endif
 struct TagModifier: ViewModifier, Decodable {
-    private let value: String?
+    private let tag: String?
     
     func body(content: Content) -> some View {
-        content.tag(value)
+        content.tag(tag)
     }
 }

--- a/Sources/LiveViewNative/Views/Controls and Indicators/Pickers/Picker.swift
+++ b/Sources/LiveViewNative/Views/Controls and Indicators/Pickers/Picker.swift
@@ -14,7 +14,7 @@ import SwiftUI
 /// Use the `content` children to specify the options for the picker, and the `label` children to provide a label.
 ///
 /// ```html
-/// <Picker value-binding="transport" picker-style="menu">
+/// <Picker value-binding="transport">
 ///     <Text template={:label}>Transportation</Text>
 ///     <Group template={:content}>
 ///         <Label system-image="car" modifiers={tag(@native, tag: "car")}>Car</Label>

--- a/lib/live_view_native_swift_ui/modifiers/controls_and_indicators/picker_style.ex
+++ b/lib/live_view_native_swift_ui/modifiers/controls_and_indicators/picker_style.ex
@@ -10,6 +10,7 @@ defmodule LiveViewNativeSwiftUi.Modifiers.PickerStyle do
       radio_group
       segmented
       wheel
+      palette
     )a)
   end
 end


### PR DESCRIPTION
The `palette` style is available on iOS 17 and aligned releases.

```heex
<Menu>
  <Text template={:label}>Message</Text>
  <Button>Reply...</Button>
  <Picker modifiers={@native |> picker_style(style: :palette)} value-binding="value">
    <Text template={:label}>React</Text>
    <Group template={:content}>
      <Label modifiers={tag(@native, tag: "thumbsup")} system-image="hand.thumbsup">Thumbs up</Label>
      <Label modifiers={tag(@native, tag: "thumbsdown")} system-image="hand.thumbsdown">Thumbs down</Label>
      <Label modifiers={tag(@native, tag: "like")} system-image="heart">Like</Label>
      <Label modifiers={tag(@native, tag: "question")} system-image="questionmark">Question mark</Label>
    </Group>
  </Picker>
</Menu>
```

https://github.com/liveview-native/liveview-client-swiftui/assets/13581484/d415c3e1-85b4-4993-ae9b-2625b348bf8e