### PR TITLE
Add symbol effect transitions

### DIFF
--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -1,13 +1,8 @@
-// swift-tools-version: 5.6
+// swift-tools-version: 5.9
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
-
-#if swift(>=5.8)
-let swiftSettings = [SwiftSetting.unsafeFlags(["-emit-extension-block-symbols"])]
-#else
-let swiftSettings = [SwiftSetting]()
-#endif
+import CompilerPluginSupport
 
 let package = Package(
     name: "LiveViewNative",
@@ -30,6 +25,8 @@ let package = Package(
         
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.2.2"),
         .package(url: "https://github.com/apple/swift-markdown.git", branch: "main"),
+        
+        .package(url: "https://github.com/apple/swift-syntax.git", from: "509.0.0-swift-5.9-DEVELOPMENT-SNAPSHOT-2023-04-25-b"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
@@ -40,8 +37,11 @@ let package = Package(
                 "SwiftSoup",
                 "SwiftPhoenixClient",
                 .product(name: "LiveViewNativeCore", package: "liveview-native-core-swift"),
+                "LiveViewNativeMacros"
             ],
-            swiftSettings: swiftSettings,
+            swiftSettings: [
+                SwiftSetting.unsafeFlags(["-emit-extension-block-symbols"])
+            ],
             plugins: [
                 .plugin(name: "BuiltinRegistryGeneratorPlugin")
             ]
@@ -112,5 +112,20 @@ let package = Package(
         //     ),
         //     dependencies: [.target(name: "TutorialRepoGenerator")]
         // )
+        
+        .macro(
+            name: "LiveViewNativeMacros",
+            dependencies: [
+                .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
+                .product(name: "SwiftCompilerPlugin", package: "swift-syntax")
+            ]
+        ),
+        .testTarget(
+            name: "LiveViewNativeMacrosTests",
+            dependencies: [
+                "LiveViewNativeMacros",
+                .product(name: "SwiftSyntaxMacrosTestSupport", package: "swift-syntax"),
+            ]
+        ),
     ]
 )

--- a/Sources/LiveViewNative/LiveView.swift
+++ b/Sources/LiveViewNative/LiveView.swift
@@ -57,11 +57,19 @@ public struct LiveView<R: RootRegistry>: View {
                             ErrorView<R>(html: trace)
                         } else {
                             if #available(iOS 17, macOS 14, tvOS 17, watchOS 10, *) {
+                                #if swift(>=5.9)
                                 SwiftUI.ContentUnavailableView {
                                     SwiftUI.Label("No Connection", systemImage: "network.slash")
                                 } description: {
                                     SwiftUI.Text("The app will reconnect when network connection is regained.")
                                 }
+                                #else
+                                SwiftUI.VStack {
+                                    SwiftUI.Text("Connection Failed")
+                                        .font(.subheadline)
+                                    SwiftUI.Text(error.localizedDescription)
+                                }
+                                #endif
                             } else {
                                 SwiftUI.VStack {
                                     SwiftUI.Text("Connection Failed")

--- a/Sources/LiveViewNative/LiveView.swift
+++ b/Sources/LiveViewNative/LiveView.swift
@@ -56,10 +56,18 @@ public struct LiveView<R: RootRegistry>: View {
                         {
                             ErrorView<R>(html: trace)
                         } else {
-                            SwiftUI.VStack {
-                                SwiftUI.Text("Connection Failed")
-                                    .font(.subheadline)
-                                SwiftUI.Text(error.localizedDescription)
+                            if #available(iOS 17, macOS 14, tvOS 17, watchOS 10, *) {
+                                SwiftUI.ContentUnavailableView {
+                                    SwiftUI.Label("No Connection", systemImage: "network.slash")
+                                } description: {
+                                    SwiftUI.Text("The app will reconnect when network connection is regained.")
+                                }
+                            } else {
+                                SwiftUI.VStack {
+                                    SwiftUI.Text("Connection Failed")
+                                        .font(.subheadline)
+                                    SwiftUI.Text(error.localizedDescription)
+                                }
                             }
                         }
                     }

--- a/Sources/LiveViewNative/Modifiers/Focus Modifiers/FocusScopeModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Focus Modifiers/FocusScopeModifier.swift
@@ -44,14 +44,16 @@ struct FocusScopeModifier: ViewModifier, Decodable {
     }
 
     func body(content: Content) -> some View {
+        #if !os(iOS)
         if let namespace = namespaces[namespace] {
             content
-                #if !os(iOS)
                 .focusScope(namespace)
-                #endif
         } else {
             content
         }
+        #else
+        content
+        #endif
     }
 
     enum CodingKeys: CodingKey {

--- a/Sources/LiveViewNative/Modifiers/Focus Modifiers/PrefersDefaultFocusModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Focus Modifiers/PrefersDefaultFocusModifier.swift
@@ -61,14 +61,16 @@ struct PrefersDefaultFocusModifier: ViewModifier, Decodable {
     }
 
     func body(content: Content) -> some View {
+        #if !os(iOS)
         if let namespace = namespaces[namespace] {
             content
-                #if !os(iOS)
                 .prefersDefaultFocus(prefersDefaultFocus, in: namespace)
-                #endif
         } else {
             content
         }
+        #else
+        content
+        #endif
     }
 
     enum CodingKeys: CodingKey {

--- a/Sources/LiveViewNative/Registries/AggregateRegistry.swift
+++ b/Sources/LiveViewNative/Registries/AggregateRegistry.swift
@@ -8,9 +8,37 @@
 import Foundation
 import SwiftUI
 
+#if swift(>=5.9)
+/// A macro that combines multiple registries together.
+///
+/// ```swift
+/// struct AppRegistries: AggregateRegistry {
+///     #Registries<
+///         MyRegistry,
+///         LiveFormsRegistry<Self>,
+///         AVKitRegistry<Self>
+///     >
+/// }
+/// ```
+@freestanding(declaration, names: named(Registries))
+public macro Registries() = #externalMacro(module: "LiveViewNativeMacros", type: "RegistriesMacro")
+#endif
+
 /// An aggregate registry combines multiple other registries together, allowing you to use tags/modifiers declared by any of them.
 ///
-/// To conform to this protocol, provide the `Registries` typealias, using the `Registry2`/`Registry3`/etc. types:
+/// In Swift 5.9, use the ``LiveViewNative/Registries`` macro to combine registries together.
+///
+/// ```swift
+/// struct AppRegistries: AggregateRegistry {
+///     #Registries<
+///         MyRegistry,
+///         LiveFormsRegistry<Self>,
+///         AVKitRegistry<Self>
+///     >
+/// }
+/// ```
+///
+/// When using a Swift version < 5.9, conform to this protocol manually, provide the `Registries` typealias using the `Registry2`/`Registry3`/etc. types:
 /// ```swift
 /// struct AppRegistries: AggregateRegistry {
 ///     typealias Registries = Registry2<

--- a/Sources/LiveViewNative/Registries/CustomRegistry.swift
+++ b/Sources/LiveViewNative/Registries/CustomRegistry.swift
@@ -40,7 +40,7 @@ import LiveViewNativeCore
 /// ### Supporting Types
 /// - ``EmptyRegistry``
 /// - ``ViewModifierBuilder``
-public protocol CustomRegistry {
+public protocol CustomRegistry<Root> {
     /// The root custom registry type that the live view coordinator and context use.
     ///
     /// Conform you registry type to ``RootRegistry``, which sets this type to `Self` automatically, if you intend to use your registry directly.

--- a/Sources/LiveViewNative/Shape Modifiers/StrokeBorderModifier.swift
+++ b/Sources/LiveViewNative/Shape Modifiers/StrokeBorderModifier.swift
@@ -56,6 +56,13 @@ struct StrokeBorderModifier: FinalShapeModifier, Decodable {
     }
     
     func apply(to shape: any InsettableShape) -> some View {
-        AnyView(shape.strokeBorder(content, style: style ?? .init(), antialiased: antialiased))
+        let modified = shape.strokeBorder(content, style: style ?? .init(), antialiased: antialiased)
+        return modified.eraseToAnyView()
+    }
+}
+
+private extension View {
+    func eraseToAnyView() -> AnyView {
+        AnyView(self)
     }
 }

--- a/Sources/LiveViewNative/Utils/ContentTransition.swift
+++ b/Sources/LiveViewNative/Utils/ContentTransition.swift
@@ -42,6 +42,18 @@ import SwiftUI
 /// Arguments:
 /// * `counts_down` - Whether the numbers the text represents count down. Defaults to `false`.
 ///
+/// ### :symbol_effect
+/// Arguments:
+/// * `effect` - The ``SymbolEffectContentTransition`` effect to apply. Defaults to `automatic`.
+/// * `options` - The ``LiveViewNative/SwiftUI/SymbolEffectOptions`` used to configure the transition.
+///
+/// ```elixir
+/// :symbol_effect
+/// {:symbol_effect, :replace}
+/// {:symbol_effect, [:replace, :off_up]}
+/// {:symbol_effect, [:replace, :off_up], [:repeating, {:speed, 0.2}]}
+/// ```
+///
 /// See [`SwiftUI.ContentTransition.numericText`](https://developer.apple.com/documentation/swiftui/contenttransition/numerictext(countsdown:)) for more details on this content transition.
 extension ContentTransition: Decodable {
     public init(from decoder: Decoder) throws {
@@ -56,6 +68,16 @@ extension ContentTransition: Decodable {
         case .numericText:
             let properties = try container.nestedContainer(keyedBy: CodingKeys.NumericText.self, forKey: .properties)
             self = .numericText(countsDown: try properties.decodeIfPresent(Bool.self, forKey: .countsDown) ?? false)
+        case .symbolEffect:
+            if #available(iOS 17, macOS 14, tvOS 17, watchOS 10, *) {
+                #if canImport(Symbols)
+                self = try container.decodeIfPresent(SymbolEffectContentTransition.self, forKey: .properties)?.transition ?? .symbolEffect
+                #else
+                self = .identity
+                #endif
+            } else {
+                self = .identity
+            }
         }
     }
     
@@ -64,6 +86,7 @@ extension ContentTransition: Decodable {
         case interpolate
         case opacity
         case numericText = "numeric_text"
+        case symbolEffect = "symbol_effect"
     }
     
     enum CodingKeys: String, CodingKey {
@@ -73,5 +96,79 @@ extension ContentTransition: Decodable {
         enum NumericText: String, CodingKey {
             case countsDown
         }
+        
+        enum SymbolEffect: CodingKey {
+            case symbolEffect
+        }
     }
 }
+
+#if canImport(Symbols)
+/// A content transition applied to a system image.
+///
+/// Possible values:
+/// * `automatic`
+/// * `replace` - Supports the options `down_up`, `up_up`, `off_up`, `by_layer`, and `whole_symbol`.
+///
+/// ```elixir
+/// :automatic
+/// :replace
+/// [:replace, :up_up, :by_layer]
+/// ```
+@_documentation(visibility: public)
+@available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+struct SymbolEffectContentTransition: Decodable {
+    let transition: ContentTransition
+    
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        
+        let effect: any (SymbolEffect & ContentTransitionSymbolEffect)
+        if var container = try? container.nestedUnkeyedContainer(forKey: .effect) {
+            let partialEffect = try container.decode(TransitionSymbolEffectType.self)
+            var options = [String]()
+            while !container.isAtEnd {
+                options.append(try container.decode(String.self))
+            }
+            effect = partialEffect.effect(options: options)
+        } else {
+            effect = try container.decode(TransitionSymbolEffectType.self, forKey: .effect).effect(options: [])
+        }
+        
+        self.transition = .symbolEffect(
+            effect,
+            options: try container.decode(SymbolEffectOptions.self, forKey: .options)
+        )
+    }
+    
+    enum CodingKeys: CodingKey {
+        case effect
+        case options
+    }
+    
+    enum TransitionSymbolEffectType: String, Decodable {
+        case automatic
+        case replace
+        
+        func effect(options: [String]) -> any (SymbolEffect & ContentTransitionSymbolEffect) {
+            switch self {
+            case .automatic:
+                return AutomaticSymbolEffect.automatic
+            case .replace:
+                var result = ReplaceSymbolEffect.replace
+                for option in options {
+                    switch option {
+                    case "down_up": result = result.downUp
+                    case "up_up": result = result.upUp
+                    case "off_up": result = result.offUp
+                    case "by_layer": result = result.byLayer
+                    case "whole_symbol": result = result.wholeSymbol
+                    default: continue
+                    }
+                }
+                return result
+            }
+        }
+    }
+}
+#endif

--- a/Sources/LiveViewNative/Utils/KeyEquivalent.swift
+++ b/Sources/LiveViewNative/Utils/KeyEquivalent.swift
@@ -51,7 +51,7 @@ extension KeyEquivalent: Decodable {
             self = .delete
         case "end":
             self = .end
-        case "escap":
+        case "escape":
             self = .escape
         case "home":
             self = .home

--- a/Sources/LiveViewNativeMacros/LiveViewNativeMacros.swift
+++ b/Sources/LiveViewNativeMacros/LiveViewNativeMacros.swift
@@ -1,0 +1,16 @@
+//
+//  LiveViewNativeMacros.swift
+//
+//
+//  Created by Carson Katri on 6/6/23.
+//
+
+import SwiftCompilerPlugin
+import SwiftSyntaxMacros
+
+@main
+struct LiveViewNativeMacrosPlugin: CompilerPlugin {
+    let providingMacros: [Macro.Type] = [
+        RegistriesMacro.self
+    ]
+}

--- a/Sources/LiveViewNativeMacros/RegistriesMacro.swift
+++ b/Sources/LiveViewNativeMacros/RegistriesMacro.swift
@@ -1,0 +1,77 @@
+//
+//  RegistriesMacro.swift
+//
+//
+//  Created by Carson Katri on 6/6/23.
+//
+
+import SwiftCompilerPlugin
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+
+/// Implementation of the `#AggregateRegistry` macro, which takes an expression
+/// of any type and produces a tuple containing the value of that expression
+/// and the source code that produced the value. For example
+///
+///     struct MyAppRegistry: RootRegistry {
+///         #Registries(
+///             AVKitRegistry.self,
+///             PhotoKitRegistry.self
+///         )
+///     }
+///
+///  will expand to
+///
+///     _MultiRegistry
+public enum RegistriesMacro {}
+
+extension RegistriesMacro: DeclarationMacro {
+    public static func expansion<Node, Context>(
+        of node: Node,
+        in context: Context
+    ) throws -> [DeclSyntax]
+        where Node: FreestandingMacroExpansionSyntax, Context: MacroExpansionContext
+    {
+        guard let registries = node.genericArguments?.arguments
+        else { throw RegistriesMacroError.missingArguments }
+        
+        switch registries.count {
+        case 0:
+            throw RegistriesMacroError.missingArguments
+        case 1:
+            return ["typealias Registries = \(registries.first!)"]
+        default:
+            func multiRegistry(_ registries: GenericArgumentListSyntax) -> SimpleTypeIdentifierSyntax {
+                switch registries.count {
+                case 2:
+                    return SimpleTypeIdentifierSyntax(
+                        name: "_MultiRegistry",
+                        genericArgumentClause: .init(arguments: registries)
+                    )
+                default:
+                    return SimpleTypeIdentifierSyntax(
+                        name: "_MultiRegistry",
+                        genericArgumentClause: .init(arguments: .init([
+                            registries.first!,
+                            .init(argumentType: multiRegistry(registries.removingFirst()))
+                        ]))
+                    )
+                }
+            }
+            
+            return ["typealias Registries = \(multiRegistry(registries))"]
+        }
+    }
+}
+
+enum RegistriesMacroError: CustomStringConvertible, Error {
+    case missingArguments
+    
+    var description: String {
+        switch self {
+        case .missingArguments:
+            return "No registry types provided as generic arguments."
+        }
+    }
+}

--- a/Sources/LiveViewNativeMacros/RegistriesMacro.swift
+++ b/Sources/LiveViewNativeMacros/RegistriesMacro.swift
@@ -10,20 +10,25 @@ import SwiftSyntax
 import SwiftSyntaxBuilder
 import SwiftSyntaxMacros
 
-/// Implementation of the `#AggregateRegistry` macro, which takes an expression
-/// of any type and produces a tuple containing the value of that expression
-/// and the source code that produced the value. For example
+/// Implementation of the `#Registries` macro, which creates the `Registries` typealias for an `AggregateRegistry`.
 ///
-///     struct MyAppRegistry: RootRegistry {
-///         #Registries(
-///             AVKitRegistry.self,
-///             PhotoKitRegistry.self
-///         )
-///     }
+/// For example
+///
+///     #Registries<
+///         MyAppRegistry,
+///         AVKitRegistry<Self>,
+///         PhotoKitRegistry<Self>
+///     >
 ///
 ///  will expand to
 ///
-///     _MultiRegistry
+///     _MultiRegistry<
+///         MyAppRegistry,
+///         _MultiRegistry<
+///             AVKitRegistry<Self>,
+///             PhotoKitRegistry<Self>
+///         >
+///     >
 public enum RegistriesMacro {}
 
 extension RegistriesMacro: DeclarationMacro {

--- a/Tests/LiveViewNativeMacrosTests/LiveViewNativeMacrosTests.swift
+++ b/Tests/LiveViewNativeMacrosTests/LiveViewNativeMacrosTests.swift
@@ -1,0 +1,40 @@
+//
+//  LiveViewNativeMacrosTests.swift
+//  
+//
+//  Created by Carson Katri on 6/6/23.
+//
+
+import SwiftSyntaxMacros
+import SwiftSyntaxMacrosTestSupport
+import XCTest
+import LiveViewNativeMacros
+
+let testMacros: [String: Macro.Type] = [
+    "Registries": RegistriesMacro.self,
+]
+
+final class LiveViewNativeMacrosTests: XCTestCase {
+    func testMacro() {
+        assertMacroExpansion(
+            """
+            struct AppRegistry: AggregateRegistry {
+                #Registries<
+                    AVKitRegistry<Self>,
+                    PhotoKitRegistry<Self>,
+                    LiveFormsRegistry<Self>
+                >
+            }
+            """,
+            expandedSource: """
+            struct AppRegistry: AggregateRegistry {
+                typealias Registries = _MultiRegistry<
+                        AVKitRegistry<Self>, _MultiRegistry<
+                        PhotoKitRegistry<Self>,
+                        LiveFormsRegistry<Self>>>
+            }
+            """,
+            macros: testMacros
+        )
+    }
+}

--- a/lib/live_view_native_swift_ui/types/content_transition.ex
+++ b/lib/live_view_native_swift_ui/types/content_transition.ex
@@ -5,9 +5,16 @@ defmodule LiveViewNativeSwiftUi.Types.ContentTransition do
   use LiveViewNativePlatform.Modifier.Type
   def type, do: :map
 
-  def cast(value) when is_atom(value), do: {:ok, %__MODULE__{ type: value, properties: %{} }}
-  def cast({value, [ {k, _} | _ ] = properties}) when is_atom(value) and is_atom(k) do
-    {:ok, %__MODULE__{ type: value, properties: Enum.into(properties, %{}) }}
+  def cast(type) when is_atom(type), do: {:ok, %__MODULE__{ type: type, properties: nil }}
+  def cast({:symbol_effect = type, effect}), do: cast({type, effect, []})
+  def cast({:symbol_effect = type, effect, options}) do
+    {:ok, %__MODULE__{
+      type: type,
+      properties: %{ effect: effect, options: Enum.map(options, &LiveViewNativeSwiftUi.Types.Transition.cast_symbol_effect_option/1) }
+    }}
+  end
+  def cast({type, [ {k, _} | _ ] = properties}) when is_atom(type) and is_atom(k) do
+    {:ok, %__MODULE__{ type: type, properties: Enum.into(properties, %{}) }}
   end
 
   def cast(_), do: :error


### PR DESCRIPTION
Symbol effects are available in iOS 17 and aligned releases. This extends our `transition` and `content_transition` modifiers to support the `symbol_effect` transition types.

```heex
<Image
  system-name={if @show, do: "eye.fill", else: "eye.slash.fill"}
  modifiers={
    @native
      |> content_transition(transition: :symbol_effect)
  }
/>
```

https://github.com/liveview-native/liveview-client-swiftui/assets/13581484/8b821b65-c16d-466c-93ab-c05fd2455942
