### PR TITLE
Add `@_spi(LiveViewNative)` for better addon library support

### DIFF
--- a/Sources/LiveViewNative/ErrorView.swift
+++ b/Sources/LiveViewNative/ErrorView.swift
@@ -12,20 +12,20 @@ enum ErrorSource {
     case error(Error)
 }
 
-struct ErrorView<R: RootRegistry>: View {
+@_spi(LiveViewNative) public struct ErrorView<R: RootRegistry>: View {
     let source: ErrorSource
     
-    init(html: String) {
+    @_spi(LiveViewNative) public init(html: String) {
         self.source = .html(html)
     }
     
-    init(_ error: Error) {
+    @_spi(LiveViewNative) public init(_ error: Error) {
         self.source = .error(error)
     }
     
     @State private var isPresented = false
     
-    var body: some View {
+    @_spi(LiveViewNative) public var body: some View {
         switch source {
         case let .html(html):
             WebErrorView(html: html)

--- a/Sources/LiveViewNative/JSONDecoder.swift
+++ b/Sources/LiveViewNative/JSONDecoder.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-func makeJSONDecoder() -> JSONDecoder {
+@_spi(LiveViewNative) public func makeJSONDecoder() -> JSONDecoder {
     snakeCaseDecoder
 }
 

--- a/Sources/LiveViewNative/Property Wrappers/LiveContext.swift
+++ b/Sources/LiveViewNative/Property Wrappers/LiveContext.swift
@@ -23,7 +23,7 @@ import LiveViewNativeCore
 @propertyWrapper
 public struct LiveContext<R: RootRegistry>: DynamicProperty {
     @Environment(\.anyLiveContextStorage) private var anyStorage
-    var storage: LiveContextStorage<R> {
+    @_spi(LiveViewNative) public var storage: LiveContextStorage<R> {
         anyStorage as! LiveContextStorage<R>
     }
     
@@ -143,7 +143,12 @@ public struct LiveContext<R: RootRegistry>: DynamicProperty {
     }
 }
 
-struct LiveContextStorage<R: RootRegistry> {
+@_spi(LiveViewNative) public struct LiveContextStorage<R: RootRegistry> {
     let coordinator: LiveViewCoordinator<R>
     let url: URL
+    
+    @_spi(LiveViewNative) public init(coordinator: LiveViewCoordinator<R>, url: URL) {
+        self.coordinator = coordinator
+        self.url = url
+    }
 }

--- a/Sources/LiveViewNative/Utils/DOM.swift
+++ b/Sources/LiveViewNative/Utils/DOM.swift
@@ -27,7 +27,7 @@ public struct ElementNode: Sendable {
     let node: Node
     let data: ElementData
     
-    init(node: Node, data: ElementData) {
+    @_spi(LiveViewNative) public init(node: Node, data: ElementData) {
         self.node = node
         self.data = data
     }

--- a/Sources/LiveViewNative/Utils/DOM.swift
+++ b/Sources/LiveViewNative/Utils/DOM.swift
@@ -23,7 +23,7 @@ import LiveViewNativeCore
 /// - ``depthFirstChildren()``
 /// - ``elementChildren()``
 /// - ``innerText()``
-public struct ElementNode: Sendable {
+public struct ElementNode {
     let node: Node
     let data: ElementData
     

--- a/Sources/LiveViewNative/Utils/ElixirDateFormats.swift
+++ b/Sources/LiveViewNative/Utils/ElixirDateFormats.swift
@@ -50,8 +50,8 @@ struct ElixirDateTimeFormat: ParseableFormatStyle {
     var parseStrategy = ElixirDateTimeOrDateParseStrategy()
 }
 
-struct ElixirDateTimeOrDateParseStrategy: ParseStrategy {
-    func parse(_ value: String) throws -> Date {
+@_spi(LiveViewNative) public struct ElixirDateTimeOrDateParseStrategy: ParseStrategy {
+    @_spi(LiveViewNative) public func parse(_ value: String) throws -> Date {
         guard let value = dateTimeFormatter.date(from: value) ?? dateFormatter.date(from: value)
         else { throw DateParseError.invalidDate }
         return value
@@ -70,8 +70,8 @@ extension FormatStyle where Self == ElixirDateFormat {
     static var elixirDate: ElixirDateFormat { .init() }
 }
 
-extension ParseStrategy where Self == ElixirDateTimeOrDateParseStrategy {
-    static var elixirDateTimeOrDate: ElixirDateTimeOrDateParseStrategy { .init() }
+@_spi(LiveViewNative) public extension ParseStrategy where Self == ElixirDateTimeOrDateParseStrategy {
+    @_spi(LiveViewNative) static var elixirDateTimeOrDate: ElixirDateTimeOrDateParseStrategy { .init() }
 }
 
 extension ParseStrategy where Self == ElixirDateParseStrategy {


### PR DESCRIPTION
Some add-on libraries (such as Swift Charts and MapKit) will require access to the types marked here.

In regular user code, these types will still be internal. However, addon libraries can mark imports like so:

```swift
@_spi(LiveViewNative) import LiveViewNative
```

This will give access to any of the types marked in this PR.