### PR TITLE
Bump mix.exs version to `0.0.8-rc.0`

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule LiveViewNativeSwiftUi.MixProject do
   def project do
     [
       app: :live_view_native_swift_ui,
-      version: "0.0.7",
+      version: "0.0.8-rc.0",
       elixir: "~> 1.13",
       description: "LiveView Native platform for SwiftUI",
       package: package(),


### PR DESCRIPTION
Bumping to 0.0.8-rc.0 to test support for upcoming releases of [live_view_native](https://github.com/liveview-native/live_view_native) and [live_view_native_platform](https://github.com/liveview-native/live_view_native_platform):

https://hex.pm/packages/live_view_native/0.0.8-rc.0
https://hex.pm/packages/live_view_native_platform/0.0.7-rc.0