### PR TITLE
Add more modifier constructors

### DIFF
--- a/lib/live_view_native_swift_ui/modifiers/animation/animation.ex
+++ b/lib/live_view_native_swift_ui/modifiers/animation/animation.ex
@@ -7,4 +7,7 @@ defmodule LiveViewNativeSwiftUi.Modifiers.Animation do
     field :animation, Animation
     field :value, :string
   end
+
+  def params(animation, [value: value]), do: [animation: animation, value: value]
+  def params(params), do: params
 end

--- a/lib/live_view_native_swift_ui/modifiers/animation/content_transition.ex
+++ b/lib/live_view_native_swift_ui/modifiers/animation/content_transition.ex
@@ -6,4 +6,13 @@ defmodule LiveViewNativeSwiftUi.Modifiers.ContentTransition do
   modifier_schema "content_transition" do
     field :transition, ContentTransition
   end
+
+  def params(params) do
+    with {:ok, _} <- ContentTransition.cast(params) do
+      [transition: params]
+    else
+      _ ->
+        params
+    end
+  end
 end

--- a/lib/live_view_native_swift_ui/modifiers/animation/transition.ex
+++ b/lib/live_view_native_swift_ui/modifiers/animation/transition.ex
@@ -6,4 +6,13 @@ defmodule LiveViewNativeSwiftUi.Modifiers.Transition do
   modifier_schema "transition" do
     field :transition, Transition
   end
+
+  def params(params) do
+    with {:ok, _} <- Transition.cast(params) do
+      [transition: params]
+    else
+      _ ->
+        params
+    end
+  end
 end

--- a/lib/live_view_native_swift_ui/modifiers/controls_and_indicators/button_style.ex
+++ b/lib/live_view_native_swift_ui/modifiers/controls_and_indicators/button_style.ex
@@ -10,4 +10,7 @@ defmodule LiveViewNativeSwiftUi.Modifiers.ButtonStyle do
       plain
     )a)
   end
+
+  def params(style) when is_atom(style), do: [style: style]
+  def params(params), do: params
 end

--- a/lib/live_view_native_swift_ui/modifiers/controls_and_indicators/button_style.ex
+++ b/lib/live_view_native_swift_ui/modifiers/controls_and_indicators/button_style.ex
@@ -11,6 +11,6 @@ defmodule LiveViewNativeSwiftUi.Modifiers.ButtonStyle do
     )a)
   end
 
-  def params(style) when is_atom(style), do: [style: style]
+  def params(style) when is_atom(style) and not is_boolean(style) and not is_nil(style), do: [style: style]
   def params(params), do: params
 end

--- a/lib/live_view_native_swift_ui/modifiers/controls_and_indicators/control_size.ex
+++ b/lib/live_view_native_swift_ui/modifiers/controls_and_indicators/control_size.ex
@@ -5,6 +5,6 @@ defmodule LiveViewNativeSwiftUi.Modifiers.ControlSize do
     field(:size, Ecto.Enum, values: ~w(mini small regular large)a)
   end
 
-  def params(size) when is_atom(size), do: [size: size]
+  def params(size) when is_atom(size) and not is_boolean(size) and not is_nil(size), do: [size: size]
   def params(params), do: params
 end

--- a/lib/live_view_native_swift_ui/modifiers/controls_and_indicators/control_size.ex
+++ b/lib/live_view_native_swift_ui/modifiers/controls_and_indicators/control_size.ex
@@ -4,4 +4,7 @@ defmodule LiveViewNativeSwiftUi.Modifiers.ControlSize do
   modifier_schema "control_size" do
     field(:size, Ecto.Enum, values: ~w(mini small regular large)a)
   end
+
+  def params(size) when is_atom(size), do: [size: size]
+  def params(params), do: params
 end

--- a/lib/live_view_native_swift_ui/modifiers/controls_and_indicators/date_picker_style.ex
+++ b/lib/live_view_native_swift_ui/modifiers/controls_and_indicators/date_picker_style.ex
@@ -11,4 +11,7 @@ defmodule LiveViewNativeSwiftUi.Modifiers.DatePickerStyle do
       stepper_field
     )a)
   end
+
+  def params(style) when is_atom(style), do: [style: style]
+  def params(params), do: params
 end

--- a/lib/live_view_native_swift_ui/modifiers/controls_and_indicators/date_picker_style.ex
+++ b/lib/live_view_native_swift_ui/modifiers/controls_and_indicators/date_picker_style.ex
@@ -12,6 +12,6 @@ defmodule LiveViewNativeSwiftUi.Modifiers.DatePickerStyle do
     )a)
   end
 
-  def params(style) when is_atom(style), do: [style: style]
+  def params(style) when is_atom(style) and not is_boolean(style) and not is_nil(style), do: [style: style]
   def params(params), do: params
 end

--- a/lib/live_view_native_swift_ui/modifiers/controls_and_indicators/default_wheel_picker_item_height.ex
+++ b/lib/live_view_native_swift_ui/modifiers/controls_and_indicators/default_wheel_picker_item_height.ex
@@ -4,4 +4,7 @@ defmodule LiveViewNativeSwiftUi.Modifiers.DefaultWheelPickerItemHeight do
   modifier_schema "default_wheel_picker_item_height" do
     field(:height, :float)
   end
+
+  def params(height) when is_number(height), do: [height: height]
+  def params(params), do: params
 end

--- a/lib/live_view_native_swift_ui/modifiers/controls_and_indicators/gauge_style.ex
+++ b/lib/live_view_native_swift_ui/modifiers/controls_and_indicators/gauge_style.ex
@@ -11,4 +11,7 @@ defmodule LiveViewNativeSwiftUi.Modifiers.GaugeStyle do
       accessory_linear
     )a)
   end
+
+  def params(style) when is_atom(style), do: [style: style]
+  def params(params), do: params
 end

--- a/lib/live_view_native_swift_ui/modifiers/controls_and_indicators/gauge_style.ex
+++ b/lib/live_view_native_swift_ui/modifiers/controls_and_indicators/gauge_style.ex
@@ -12,6 +12,6 @@ defmodule LiveViewNativeSwiftUi.Modifiers.GaugeStyle do
     )a)
   end
 
-  def params(style) when is_atom(style), do: [style: style]
+  def params(style) when is_atom(style) and not is_boolean(style) and not is_nil(style), do: [style: style]
   def params(params), do: params
 end

--- a/lib/live_view_native_swift_ui/modifiers/controls_and_indicators/picker_style.ex
+++ b/lib/live_view_native_swift_ui/modifiers/controls_and_indicators/picker_style.ex
@@ -13,4 +13,7 @@ defmodule LiveViewNativeSwiftUi.Modifiers.PickerStyle do
       palette
     )a)
   end
+
+  def params(style) when is_atom(style), do: [style: style]
+  def params(params), do: params
 end

--- a/lib/live_view_native_swift_ui/modifiers/controls_and_indicators/picker_style.ex
+++ b/lib/live_view_native_swift_ui/modifiers/controls_and_indicators/picker_style.ex
@@ -14,6 +14,6 @@ defmodule LiveViewNativeSwiftUi.Modifiers.PickerStyle do
     )a)
   end
 
-  def params(style) when is_atom(style), do: [style: style]
+  def params(style) when is_atom(style) and not is_boolean(style) and not is_nil(style), do: [style: style]
   def params(params), do: params
 end

--- a/lib/live_view_native_swift_ui/modifiers/controls_and_indicators/progress_view_style.ex
+++ b/lib/live_view_native_swift_ui/modifiers/controls_and_indicators/progress_view_style.ex
@@ -8,4 +8,7 @@ defmodule LiveViewNativeSwiftUi.Modifiers.ProgressViewStyle do
       circular
     )a)
   end
+
+  def params(style) when is_atom(style), do: [style: style]
+  def params(params), do: params
 end

--- a/lib/live_view_native_swift_ui/modifiers/controls_and_indicators/progress_view_style.ex
+++ b/lib/live_view_native_swift_ui/modifiers/controls_and_indicators/progress_view_style.ex
@@ -9,6 +9,6 @@ defmodule LiveViewNativeSwiftUi.Modifiers.ProgressViewStyle do
     )a)
   end
 
-  def params(style) when is_atom(style), do: [style: style]
+  def params(style) when is_atom(style) and not is_boolean(style) and not is_nil(style), do: [style: style]
   def params(params), do: params
 end

--- a/lib/live_view_native_swift_ui/modifiers/controls_and_indicators/toggle_style.ex
+++ b/lib/live_view_native_swift_ui/modifiers/controls_and_indicators/toggle_style.ex
@@ -10,6 +10,6 @@ defmodule LiveViewNativeSwiftUi.Modifiers.ToggleStyle do
     )a)
   end
 
-  def params(style) when is_atom(style), do: [style: style]
+  def params(style) when is_atom(style) and not is_boolean(style) and not is_nil(style), do: [style: style]
   def params(params), do: params
 end

--- a/lib/live_view_native_swift_ui/modifiers/controls_and_indicators/toggle_style.ex
+++ b/lib/live_view_native_swift_ui/modifiers/controls_and_indicators/toggle_style.ex
@@ -9,4 +9,7 @@ defmodule LiveViewNativeSwiftUi.Modifiers.ToggleStyle do
       checkbox
     )a)
   end
+
+  def params(style) when is_atom(style), do: [style: style]
+  def params(params), do: params
 end

--- a/lib/live_view_native_swift_ui/modifiers/layout_adjustments/layout_priority.ex
+++ b/lib/live_view_native_swift_ui/modifiers/layout_adjustments/layout_priority.ex
@@ -4,4 +4,7 @@ defmodule LiveViewNativeSwiftUi.Modifiers.LayoutPriority do
   modifier_schema "layout_priority" do
     field :value, :float
   end
+
+  def params(value) when is_number(value), do: [value: value]
+  def params(params), do: params
 end

--- a/lib/live_view_native_swift_ui/modifiers/layout_adjustments/padding.ex
+++ b/lib/live_view_native_swift_ui/modifiers/layout_adjustments/padding.ex
@@ -11,11 +11,14 @@ defmodule LiveViewNativeSwiftUi.Modifiers.Padding do
   end
 
   def params(), do: []
-  def params(length) when is_number(length), do: [length: length]
+
   def params(edges, length) when is_atom(edges) or is_list(edges), do: [edges: edges, length: length]
+
+  def params(length) when is_number(length), do: [length: length]
   def params(edges) when is_atom(edges), do: [edges: edges]
   def params([e | _] = edges) when is_atom(e), do: [edges: edges]
   def params([{k, v} | _] = insets) when is_atom(k) and is_number(v), do: [insets: insets]
   def params(insets) when is_map(insets), do: [insets: insets]
+
   def params(params), do: params
 end

--- a/lib/live_view_native_swift_ui/modifiers/layout_adjustments/padding.ex
+++ b/lib/live_view_native_swift_ui/modifiers/layout_adjustments/padding.ex
@@ -15,9 +15,9 @@ defmodule LiveViewNativeSwiftUi.Modifiers.Padding do
   def params(edges, length) when is_atom(edges) or is_list(edges), do: [edges: edges, length: length]
 
   def params(length) when is_number(length), do: [length: length]
-  def params(edges) when is_atom(edges), do: [edges: edges]
-  def params([e | _] = edges) when is_atom(e), do: [edges: edges]
-  def params([{k, v} | _] = insets) when is_atom(k) and is_number(v), do: [insets: insets]
+  def params(edges) when is_atom(edges) and not is_boolean(edges) and not is_nil(edges), do: [edges: edges]
+  def params([e | _] = edges) when is_atom(e) and not is_boolean(e) and not is_nil(e), do: [edges: edges]
+  def params([{k, v} | _] = insets) when is_atom(k) and not is_boolean(k) and not is_nil(k) and is_number(v), do: [insets: insets]
   def params(insets) when is_map(insets), do: [insets: insets]
 
   def params(params), do: params

--- a/lib/live_view_native_swift_ui/modifiers/layout_adjustments/padding.ex
+++ b/lib/live_view_native_swift_ui/modifiers/layout_adjustments/padding.ex
@@ -9,4 +9,13 @@ defmodule LiveViewNativeSwiftUi.Modifiers.Padding do
     field :edges, EdgeSet
     field :length, :float
   end
+
+  def params(), do: []
+  def params(length) when is_number(length), do: [length: length]
+  def params(edges, length) when is_atom(edges) or is_list(edges), do: [edges: edges, length: length]
+  def params(edges) when is_atom(edges), do: [edges: edges]
+  def params([e | _] = edges) when is_atom(e), do: [edges: edges]
+  def params([{k, v} | _] = insets) when is_atom(k) and is_number(v), do: [insets: insets]
+  def params(insets) when is_map(insets), do: [insets: insets]
+  def params(params), do: params
 end

--- a/lib/live_view_native_swift_ui/modifiers/layout_adjustments/scene_padding.ex
+++ b/lib/live_view_native_swift_ui/modifiers/layout_adjustments/scene_padding.ex
@@ -9,6 +9,6 @@ defmodule LiveViewNativeSwiftUi.Modifiers.ScenePadding do
   end
 
   def params(padding, [edges: edges]), do: [padding: padding, edges: edges]
-  def params(padding) when is_atom(padding), do: [padding: padding]
+  def params(padding) when is_atom(padding) and not is_boolean(padding) and not is_nil(padding), do: [padding: padding]
   def params(params), do: params
 end

--- a/lib/live_view_native_swift_ui/modifiers/layout_adjustments/scene_padding.ex
+++ b/lib/live_view_native_swift_ui/modifiers/layout_adjustments/scene_padding.ex
@@ -7,4 +7,8 @@ defmodule LiveViewNativeSwiftUi.Modifiers.ScenePadding do
     field :padding, Ecto.Enum, values: ~w(automatic minimum navigation_bar)a, default: :automatic
     field :edges, EdgeSet
   end
+
+  def params(padding, [edges: edges]), do: [padding: padding, edges: edges]
+  def params(padding) when is_atom(padding), do: [padding: padding]
+  def params(params), do: params
 end

--- a/lib/live_view_native_swift_ui/modifiers/layout_fundamentals/background.ex
+++ b/lib/live_view_native_swift_ui/modifiers/layout_fundamentals/background.ex
@@ -23,4 +23,12 @@ defmodule LiveViewNativeSwiftUi.Modifiers.Background do
     field :ignores_safe_area_edges, EdgeSet
     field :fill_style, FillStyle
   end
+
+  def params({type, _} = style, [in: shape, fill_style: fill_style]) when is_atom(type), do: [style: style, shape: shape, fill_style: fill_style]
+  def params({type, _} = style, [in: shape]) when is_atom(type), do: [style: style, shape: shape]
+  def params([in: shape, fill_style: fill_style]), do: [shape: shape, fill_style: fill_style]
+  def params([in: shape]), do: [shape: shape]
+  def params({type, _} = style, [ignores_safe_area_edges: edges]) when is_atom(type), do: [style: style, ignores_safe_area_edges: edges]
+  def params({type, _} = style) when is_atom(type), do: [style: style]
+  def params(params), do: params
 end

--- a/lib/live_view_native_swift_ui/modifiers/layout_fundamentals/background.ex
+++ b/lib/live_view_native_swift_ui/modifiers/layout_fundamentals/background.ex
@@ -24,11 +24,11 @@ defmodule LiveViewNativeSwiftUi.Modifiers.Background do
     field :fill_style, FillStyle
   end
 
-  def params({type, _} = style, [in: shape, fill_style: fill_style]) when is_atom(type), do: [style: style, shape: shape, fill_style: fill_style]
-  def params({type, _} = style, [in: shape]) when is_atom(type), do: [style: style, shape: shape]
-  def params({type, _} = style, [ignores_safe_area_edges: edges]) when is_atom(type), do: [style: style, ignores_safe_area_edges: edges]
+  def params({type, _} = style, [in: shape, fill_style: fill_style]) when is_atom(type) and not is_boolean(type) and not is_nil(type), do: [style: style, shape: shape, fill_style: fill_style]
+  def params({type, _} = style, [in: shape]) when is_atom(type) and not is_boolean(type) and not is_nil(type), do: [style: style, shape: shape]
+  def params({type, _} = style, [ignores_safe_area_edges: edges]) when is_atom(type) and not is_boolean(type) and not is_nil(type), do: [style: style, ignores_safe_area_edges: edges]
   def params([in: shape, fill_style: fill_style]), do: [shape: shape, fill_style: fill_style]
   def params([in: shape]), do: [shape: shape]
-  def params({type, _} = style) when is_atom(type), do: [style: style]
+  def params({type, _} = style) when is_atom(type) and not is_boolean(type) and not is_nil(type), do: [style: style]
   def params(params), do: params
 end

--- a/lib/live_view_native_swift_ui/modifiers/layout_fundamentals/background.ex
+++ b/lib/live_view_native_swift_ui/modifiers/layout_fundamentals/background.ex
@@ -26,9 +26,9 @@ defmodule LiveViewNativeSwiftUi.Modifiers.Background do
 
   def params({type, _} = style, [in: shape, fill_style: fill_style]) when is_atom(type), do: [style: style, shape: shape, fill_style: fill_style]
   def params({type, _} = style, [in: shape]) when is_atom(type), do: [style: style, shape: shape]
+  def params({type, _} = style, [ignores_safe_area_edges: edges]) when is_atom(type), do: [style: style, ignores_safe_area_edges: edges]
   def params([in: shape, fill_style: fill_style]), do: [shape: shape, fill_style: fill_style]
   def params([in: shape]), do: [shape: shape]
-  def params({type, _} = style, [ignores_safe_area_edges: edges]) when is_atom(type), do: [style: style, ignores_safe_area_edges: edges]
   def params({type, _} = style) when is_atom(type), do: [style: style]
   def params(params), do: params
 end

--- a/lib/live_view_native_swift_ui/modifiers/layout_fundamentals/grid_cell_anchor.ex
+++ b/lib/live_view_native_swift_ui/modifiers/layout_fundamentals/grid_cell_anchor.ex
@@ -1,7 +1,18 @@
 defmodule LiveViewNativeSwiftUi.Modifiers.GridCellAnchor do
   use LiveViewNativePlatform.Modifier
 
+  alias LiveViewNativeSwiftUi.Types.UnitPoint
+
   modifier_schema "grid_cell_anchor" do
-    field :anchor, LiveViewNativeSwiftUi.Types.UnitPoint
+    field :anchor, UnitPoint
+  end
+
+  def params(params) do
+    with {:ok, _} <- UnitPoint.cast(params) do
+      [anchor: params]
+    else
+      _ ->
+        params
+    end
   end
 end

--- a/lib/live_view_native_swift_ui/modifiers/layout_fundamentals/grid_cell_columns.ex
+++ b/lib/live_view_native_swift_ui/modifiers/layout_fundamentals/grid_cell_columns.ex
@@ -4,4 +4,7 @@ defmodule LiveViewNativeSwiftUi.Modifiers.GridCellColumns do
   modifier_schema "grid_cell_columns" do
     field :count, :integer
   end
+
+  def params(count) when is_number(count), do: [count: count]
+  def params(params), do: params
 end

--- a/lib/live_view_native_swift_ui/modifiers/layout_fundamentals/grid_cell_unsized_axes.ex
+++ b/lib/live_view_native_swift_ui/modifiers/layout_fundamentals/grid_cell_unsized_axes.ex
@@ -4,4 +4,7 @@ defmodule LiveViewNativeSwiftUi.Modifiers.GridCellUnsizedAxes do
   modifier_schema "grid_cell_unsized_axes" do
     field :axes, Ecto.Enum, values: [:horizontal, :vertical, :all]
   end
+
+  def params(axes) when is_atom(axes), do: [axes: axes]
+  def params(params), do: params
 end

--- a/lib/live_view_native_swift_ui/modifiers/layout_fundamentals/grid_cell_unsized_axes.ex
+++ b/lib/live_view_native_swift_ui/modifiers/layout_fundamentals/grid_cell_unsized_axes.ex
@@ -5,6 +5,6 @@ defmodule LiveViewNativeSwiftUi.Modifiers.GridCellUnsizedAxes do
     field :axes, Ecto.Enum, values: [:horizontal, :vertical, :all]
   end
 
-  def params(axes) when is_atom(axes), do: [axes: axes]
+  def params(axes) when is_atom(axes) and not is_boolean(axes) and not is_nil(axes), do: [axes: axes]
   def params(params), do: params
 end

--- a/lib/live_view_native_swift_ui/modifiers/layout_fundamentals/grid_column_alignment.ex
+++ b/lib/live_view_native_swift_ui/modifiers/layout_fundamentals/grid_column_alignment.ex
@@ -4,4 +4,7 @@ defmodule LiveViewNativeSwiftUi.Modifiers.GridColumnAlignment do
   modifier_schema "grid_column_alignment" do
     field :guide, Ecto.Enum, values: [:leading, :center, :trailing]
   end
+
+  def params(guide) when is_atom(guide), do: [guide: guide]
+  def params(params), do: params
 end

--- a/lib/live_view_native_swift_ui/modifiers/layout_fundamentals/grid_column_alignment.ex
+++ b/lib/live_view_native_swift_ui/modifiers/layout_fundamentals/grid_column_alignment.ex
@@ -5,6 +5,6 @@ defmodule LiveViewNativeSwiftUi.Modifiers.GridColumnAlignment do
     field :guide, Ecto.Enum, values: [:leading, :center, :trailing]
   end
 
-  def params(guide) when is_atom(guide), do: [guide: guide]
+  def params(guide) when is_atom(guide) and not is_boolean(guide) and not is_nil(guide), do: [guide: guide]
   def params(params), do: params
 end

--- a/lib/live_view_native_swift_ui/modifiers/layout_fundamentals/overlay.ex
+++ b/lib/live_view_native_swift_ui/modifiers/layout_fundamentals/overlay.ex
@@ -24,9 +24,9 @@ defmodule LiveViewNativeSwiftUi.Modifiers.Overlay do
     field :fill_style, FillStyle
   end
 
-  def params({type, _} = style, [in: shape, fill_style: fill_style]) when is_atom(type), do: [style: style, shape: shape, fill_style: fill_style]
-  def params({type, _} = style, [in: shape]) when is_atom(type), do: [style: style, shape: shape]
-  def params({type, _} = style, [ignores_safe_area_edges: edges]) when is_atom(type), do: [style: style, ignores_safe_area_edges: edges]
-  def params({type, _} = style) when is_atom(type), do: [style: style]
+  def params({type, _} = style, [in: shape, fill_style: fill_style]) when is_atom(type) and not is_boolean(type) and not is_nil(type), do: [style: style, shape: shape, fill_style: fill_style]
+  def params({type, _} = style, [in: shape]) when is_atom(type) and not is_boolean(type) and not is_nil(type), do: [style: style, shape: shape]
+  def params({type, _} = style, [ignores_safe_area_edges: edges]) when is_atom(type) and not is_boolean(type) and not is_nil(type), do: [style: style, ignores_safe_area_edges: edges]
+  def params({type, _} = style) when is_atom(type) and not is_boolean(type) and not is_nil(type), do: [style: style]
   def params(params), do: params
 end

--- a/lib/live_view_native_swift_ui/modifiers/layout_fundamentals/overlay.ex
+++ b/lib/live_view_native_swift_ui/modifiers/layout_fundamentals/overlay.ex
@@ -23,4 +23,10 @@ defmodule LiveViewNativeSwiftUi.Modifiers.Overlay do
     field :ignores_safe_area_edges, EdgeSet
     field :fill_style, FillStyle
   end
+
+  def params({type, _} = style, [in: shape, fill_style: fill_style]) when is_atom(type), do: [style: style, shape: shape, fill_style: fill_style]
+  def params({type, _} = style, [in: shape]) when is_atom(type), do: [style: style, shape: shape]
+  def params({type, _} = style, [ignores_safe_area_edges: edges]) when is_atom(type), do: [style: style, ignores_safe_area_edges: edges]
+  def params({type, _} = style) when is_atom(type), do: [style: style]
+  def params(params), do: params
 end


### PR DESCRIPTION
This adds modifier constructors such as the following:

```elixir
padding(:horizontal)
padding(16)
padding(:top, 16)
padding([top: 8, trailing: 10])

background({:color, :red})
background({:color, :red}, in: :capsule)
background(in: :capsule)

overlay({:color, :red})
overlay({:color, :red}, in: :capsule)

transition({:move, [edge: :bottom]})

button_style(:bordered_prominent)
progress_view_style(:linear)
```

This attempts to match SwiftUI modifier syntax as closely as possible. However, I'm not sure if its better to reflect this exactly in some cases, or to make something that is more natural in Elixir.

For example, in Swift it is encouraged to [use prepositions as argument labels](https://www.swift.org/documentation/api-design-guidelines/#argument-labels). However, I am not sure if this is common in Elixir (which doesn't really have separate "argument labels"). This is how the `background` modifier that fills a shape is written in SwiftUI, for example:

```swift
.background(.red, in: Capsule())
```

In this PR, I added a constructor that reads the same, using `in` as the option name:

```elixir
background({:color, :red}, in: :capsule)
```

But it may be better to use more verbose labels for the Elixir modifiers such as `shape`:

```elixir
background({:color, :red}, shape: :capsule)
```