### PR TITLE
Update to use hex.pm for live_view_native and live_view_native_swiftui

### DIFF
--- a/Sources/LiveViewNative/LiveViewNative.docc/Resources/01-01-03-mix.exs
+++ b/Sources/LiveViewNative/LiveViewNative.docc/Resources/01-01-03-mix.exs
@@ -44,10 +44,8 @@ defmodule LvnTutorial.MixProject do
       {:telemetry_poller, "~> 1.0"},
       {:jason, "~> 1.2"},
       {:plug_cowboy, "~> 2.5"},
-      {:live_view_native,
-       git: "https://github.com/liveview-native/live_view_native.git", branch: "main"},
-      {:live_view_native_swift_ui,
-       git: "https://github.com/liveview-native/liveview-client-swiftui", branch: "main"}
+      {:live_view_native, "~> 0.0.8"},
+      {:live_view_native_swift_ui, "~> 0.0.8"}
     ]
   end
 


### PR DESCRIPTION
The tutorial repo pulls from the main branch, and should pull from the hex.pm versions to avoid issues with breaking code changes during LVN development. This changes the tutorial site code to fix that. I am not sure if this fixes the code that builds to https://github.com/liveview-native/ios-tutorial so if there is someplace else to fix that before it is pushed, please let me know and I will update this PR. AFAIK, elixir was already updated to 1.15 last week. 