### PR TITLE
Make `ShapeReference` public

### DIFF
--- a/Sources/LiveViewNative/ContentBuilder.swift
+++ b/Sources/LiveViewNative/ContentBuilder.swift
@@ -512,6 +512,18 @@ public protocol ContentModifier<Builder>: Decodable {
     ) -> Builder.Content
 }
 
+public struct EmptyContentModifier<Builder: ContentBuilder>: ContentModifier {
+    public init() {}
+    
+    public func apply<R>(
+        to content: Builder.Content,
+        on element: ElementNode,
+        in context: Builder.Context<R>
+    ) -> Builder.Content where R : RootRegistry {
+        return content
+    }
+}
+
 /// A type-erased ``ContentModifier`` in a stack.
 private struct AnyContentBuilderModifier<R: RootRegistry, Builder: ContentBuilder>: Decodable {
     let modifier: any ContentModifier<Builder>

--- a/Sources/LiveViewNative/Modifiers/Drawing and Graphics Modifiers/ClipShapeModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Drawing and Graphics Modifiers/ClipShapeModifier.swift
@@ -64,7 +64,7 @@ struct ClipShapeModifier<R: RootRegistry>: ViewModifier, Decodable {
 
     func body(content: Content) -> some View {
         content.clipShape(
-            shape.resolve(on: element, in: context),
+            shape.resolve(on: element),
             style: style
         )
     }

--- a/Sources/LiveViewNative/Modifiers/Layout Fundamentals Modifiers/BackgroundModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Layout Fundamentals Modifiers/BackgroundModifier.swift
@@ -124,7 +124,7 @@ struct BackgroundModifier<R: RootRegistry>: ViewModifier, Decodable {
                     context.buildChildren(of: element, forTemplate: reference)
                 }
         } else if let shape {
-            content.background(style ?? AnyShapeStyle(.background), in: shape.resolve(on: element, in: context), fillStyle: fillStyle)
+            content.background(style ?? AnyShapeStyle(.background), in: shape.resolve(on: element), fillStyle: fillStyle)
         } else if let style {
             content.background(style, ignoresSafeAreaEdges: ignoresSafeAreaEdges)
         } else {

--- a/Sources/LiveViewNative/Modifiers/Layout Fundamentals Modifiers/OverlayModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Layout Fundamentals Modifiers/OverlayModifier.swift
@@ -122,7 +122,7 @@ struct OverlayModifier<R: RootRegistry>: ViewModifier, Decodable {
         } else if let shape,
                   let style
         {
-            content.overlay(style, in: shape.resolve(on: element, in: context), fillStyle: fillStyle)
+            content.overlay(style, in: shape.resolve(on: element), fillStyle: fillStyle)
         } else if let style {
             content.overlay(style, ignoresSafeAreaEdges: ignoresSafeAreaEdges)
         } else {

--- a/Sources/LiveViewNative/Modifiers/Shapes Modifiers/ContainerShapeModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/Shapes Modifiers/ContainerShapeModifier.swift
@@ -49,7 +49,7 @@ struct ContainerShapeModifier<R: RootRegistry>: ViewModifier, Decodable {
     }
     
     func body(content: Content) -> some View {
-        content.containerShape(shape.resolveInsettableShape(on: element, in: context))
+        content.containerShape(shape.resolveInsettableShape(on: element))
     }
     
     enum CodingKeys: CodingKey {

--- a/Sources/LiveViewNative/Modifiers/View Styles Modifiers/ContentShapeModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/View Styles Modifiers/ContentShapeModifier.swift
@@ -58,7 +58,7 @@ struct ContentShapeModifier<R: RootRegistry>: ViewModifier, Decodable {
     func body(content: Content) -> some View {
         content.contentShape(
             kind,
-            shape.resolve(on: element, in: context),
+            shape.resolve(on: element),
             eoFill: eoFill
         )
     }


### PR DESCRIPTION
This type is used by some modifiers in add-on libraries, such as Swift Charts.