### PR TITLE
Add backing storage and caching for `@Attribute`

### DIFF
--- a/Sources/LiveViewNative/ViewTree.swift
+++ b/Sources/LiveViewNative/ViewTree.swift
@@ -201,19 +201,19 @@ private struct ModifierObserver<Parent: View, R: RootRegistry>: View {
     let parent: Parent
     @ObservedElement private var element
     @LiveContext<R> private var context
+    @Attribute("modifiers", transform: { attribute in
+        guard let encoded = attribute?.value else { return [] }
+        print("Decoding modifiers \(encoded)")
+        
+        let decoder = makeJSONDecoder()
+        
+        guard let decoded = try? decoder.decode([ModifierContainer<R>].self, from: Data(encoded.utf8))
+        else { return [] }
+        
+        return decoded
+    }) private var modifiers: [ModifierContainer<R>]
     
     var body: some View {
-        let modifiers: [ModifierContainer<R>]
-        if let encoded = element.attributeValue(for: "modifiers") {
-            let decoder = makeJSONDecoder()
-            if let decoded = try? decoder.decode([ModifierContainer<R>].self, from: Data(encoded.utf8)) {
-                modifiers = decoded
-            } else {
-                modifiers = []
-            }
-        } else {
-            modifiers = []
-        }
         return parent
             .applyModifiers(modifiers[...], element: element, context: context.storage)
     }

--- a/Sources/LiveViewNative/ViewTree.swift
+++ b/Sources/LiveViewNative/ViewTree.swift
@@ -203,7 +203,6 @@ private struct ModifierObserver<Parent: View, R: RootRegistry>: View {
     @LiveContext<R> private var context
     @Attribute("modifiers", transform: { attribute in
         guard let encoded = attribute?.value else { return [] }
-        print("Decoding modifiers \(encoded)")
         
         let decoder = makeJSONDecoder()
         


### PR DESCRIPTION
This adds caching to the `@Attribute` property wrapper. The value will only be decoded if it has changed.

I've also updated the `modifiers` attribute to be handled with `@Attribute`, so it can get the benefits of the caching. It is especially useful here, as JSON decoding is expensive.