### PR TITLE
Minor fixes for modifier constructors

### DIFF
--- a/lib/live_view_native_swift_ui/modifiers/images/image_scale.ex
+++ b/lib/live_view_native_swift_ui/modifiers/images/image_scale.ex
@@ -5,6 +5,6 @@ defmodule LiveViewNativeSwiftUi.Modifiers.ImageScale do
     field :scale, Ecto.Enum, values: ~w(small medium large)a
   end
 
-  def params(scale) when is_atom(scale) and not is_boolean(scale) and not is_nil(scale) , do: [scale: scale]
+  def params(scale) when is_atom(scale) and not is_boolean(scale) and not is_nil(scale), do: [scale: scale]
   def params(params), do: params
 end

--- a/lib/live_view_native_swift_ui/modifiers/layout_fundamentals/z_index.ex
+++ b/lib/live_view_native_swift_ui/modifiers/layout_fundamentals/z_index.ex
@@ -5,6 +5,6 @@ defmodule LiveViewNativeSwiftUi.Modifiers.ZIndex do
     field :value, :float
   end
 
-  def params(z_index) when is_float(z_index), do: [z_index: z_index]
+  def params(value) when is_number(value), do: [value: value]
   def params(params), do: params
 end

--- a/lib/live_view_native_swift_ui/modifiers/view_configuration/opacity.ex
+++ b/lib/live_view_native_swift_ui/modifiers/view_configuration/opacity.ex
@@ -5,6 +5,6 @@ defmodule LiveViewNativeSwiftUi.Modifiers.Opacity do
     field :opacity, :float
   end
 
-  def params(opacity) when is_float(opacity), do: [opacity: opacity]
+  def params(opacity) when is_number(opacity), do: [opacity: opacity]
   def params(params), do: params
 end


### PR DESCRIPTION
This fixes some argument names and formatting for currently implemented modifier constructors.

I also swapped `is_float` for `is_number` so that integer literals can be passed in.