### PR TITLE
Add `#LiveView` macro for registering add-on libraries

### DIFF
--- a/Sources/LiveViewNative/LiveView.swift
+++ b/Sources/LiveViewNative/LiveView.swift
@@ -13,10 +13,10 @@ import Combine
 /// Create a ``LiveView`` with a list of addons.
 ///
 /// Use this macro to automatically register any addons.
-/// Specialize the addon registries with ``EmptyRegistry``.
+/// Use a placeholder type (`_`) as the root for each registry.
 ///
 /// ```swift
-/// #LiveView(.localhost, addons: [ChartsRegistry<EmptyRegistry>.self, AVKitRegistry<EmptyRegistry>.self])
+/// #LiveView(.localhost, addons: [ChartsRegistry<_>.self, AVKitRegistry<_>.self])
 /// ```
 ///
 /// - Note: This macro erases the underlying ``LiveView`` to `AnyView`.

--- a/Sources/LiveViewNative/LiveView.swift
+++ b/Sources/LiveViewNative/LiveView.swift
@@ -9,6 +9,26 @@ import Foundation
 import SwiftUI
 import Combine
 
+#if swift(>=5.9)
+/// Create a ``LiveView`` with a list of addons.
+///
+/// Use this macro to automatically register any addons.
+/// Specialize the addon registries with ``EmptyRegistry``.
+///
+/// ```swift
+/// #LiveView(.localhost, addons: [ChartsRegistry<EmptyRegistry>.self, AVKitRegistry<EmptyRegistry>.self])
+/// ```
+///
+/// - Note: This macro erases the underlying ``LiveView`` to `AnyView`.
+/// This may incur a minor performance hit when updating the `View` containing the ``LiveView``.
+@freestanding(expression)
+public macro LiveView<Host: LiveViewHost>(
+    _ host: Host,
+    configuration: LiveSessionConfiguration = .init(),
+    addons: [any CustomRegistry<EmptyRegistry>.Type]
+) -> AnyView = #externalMacro(module: "LiveViewNativeMacros", type: "LiveViewMacro")
+#endif
+
 /// The SwiftUI root view for a Phoenix LiveView.
 ///
 /// The `LiveView` attempts to connect immediately when it appears.

--- a/Sources/LiveViewNativeMacros/LiveViewMacro.swift
+++ b/Sources/LiveViewNativeMacros/LiveViewMacro.swift
@@ -1,0 +1,98 @@
+//
+//  LiveViewMacro.swift
+//
+//
+//  Created by Carson Katri on 7/6/23.
+//
+
+import SwiftCompilerPlugin
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+
+public enum LiveViewMacro {}
+
+extension LiveViewMacro: ExpressionMacro {
+    public static func expansion<Node, Context>(
+        of node: Node,
+        in context: Context
+    ) throws -> ExprSyntax where Node : FreestandingMacroExpansionSyntax, Context : MacroExpansionContext {
+        let registryName = context.makeUniqueName("Registry")
+        
+        guard let addons = try node.argumentList.last?
+            .expression.as(ArrayExprSyntax.self)?
+            .elements.map(transformAddon(_:))
+        else { throw LiveViewMacroError.invalidAddonsSyntax }
+        
+        let registries: DeclSyntax
+        switch addons.count {
+        case 0:
+            throw LiveViewMacroError.missingAddons
+        case 1:
+            registries = "typealias Registries = \(addons.first!)"
+        default:
+            func multiRegistry(_ addons: some RandomAccessCollection<SimpleTypeIdentifierSyntax>) -> SimpleTypeIdentifierSyntax {
+                switch addons.count {
+                case 2:
+                    return SimpleTypeIdentifierSyntax(
+                        name: "_MultiRegistry",
+                        genericArgumentClause: .init(arguments: .init([
+                            .init(argumentType: addons.first!, trailingComma: .commaToken()),
+                            .init(argumentType: addons.last!)
+                        ]))
+                    )
+                default:
+                    return SimpleTypeIdentifierSyntax(
+                        name: "_MultiRegistry",
+                        genericArgumentClause: .init(arguments: .init([
+                            .init(argumentType: addons.first!, trailingComma: .commaToken()),
+                            .init(argumentType: multiRegistry(addons.dropFirst()))
+                        ]))
+                    )
+                }
+            }
+            registries = "typealias Registries = \(multiRegistry(addons))"
+        }
+        
+        let liveViewArguments = node.argumentList
+            .removingLast()
+            .replacing(childAt: node.argumentList.count - 2, with: node.argumentList.removingLast().last!.with(\.trailingComma, nil))
+        
+        return """
+        { () -> AnyView in
+            enum \(registryName): AggregateRegistry {
+                \(registries)
+            }
+        
+            return AnyView(LiveView<\(registryName)>(\(liveViewArguments)))
+        }()
+        """
+    }
+    
+    private static func transformAddon(_ element: ArrayElementSyntax) throws -> SimpleTypeIdentifierSyntax {
+        guard let registry = element.expression.as(MemberAccessExprSyntax.self)?.base?.as(SpecializeExprSyntax.self),
+              let name = registry.expression.as(IdentifierExprSyntax.self)
+        else { throw LiveViewMacroError.invalidAddonElement }
+        return SimpleTypeIdentifierSyntax(
+            name: name.identifier,
+            genericArgumentClause: .init(.init(arguments: .init([.init(argumentType: SimpleTypeIdentifierSyntax(name: .identifier("Self")))])))
+        )
+    }
+}
+
+enum LiveViewMacroError: Error, CustomStringConvertible {
+    case invalidAddonsSyntax
+    case invalidAddonElement
+    case missingAddons
+    
+    var description: String {
+        switch self {
+        case .invalidAddonsSyntax:
+            return "Invalid value specified for 'addons'. Expected a static array literal."
+        case .invalidAddonElement:
+            return "Invalid addon provided. Expected a specialized registry type, such as 'AddonRegistry<Self>.self'"
+        case .missingAddons:
+            return "'addons' must not be empty."
+        }
+    }
+}

--- a/Sources/LiveViewNativeMacros/LiveViewNativeMacros.swift
+++ b/Sources/LiveViewNativeMacros/LiveViewNativeMacros.swift
@@ -11,6 +11,7 @@ import SwiftSyntaxMacros
 @main
 struct LiveViewNativeMacrosPlugin: CompilerPlugin {
     let providingMacros: [Macro.Type] = [
-        RegistriesMacro.self
+        RegistriesMacro.self,
+        LiveViewMacro.self
     ]
 }


### PR DESCRIPTION
This adds a `#LiveView` macro that simplifies `LiveView` creation with add-on registries in Swift 5.9+.

Addons can be provided in an array of metatypes. The aggregate registry will be automatically synthesized, and passed as a generic argument to the `LiveView`.

```swift
struct ContentView: View {
    var body: some View {
        #LiveView(
            .localhost,
            addons: [ChartsRegistry<_>.self, AVKitRegistry<_>.self]
        )
    }
}
```

Previously, an `AggregateRegistry` needed to be created manually:

```swift
struct ContentView: View {
    var body: some View {
        LiveView<MyRegistry>(.localhost)
    }
}

enum MyRegistry: AggregateRegistry {
    #Registries<
        ChartsRegistry<Self>,
        AVKitRegistry<Self>
    >
}
```

This macro automatically expands to the following:

```swift
{ () -> AnyView in
    enum $s7TestBed11ContentViewV4bodyQrvg04LiveD0fMf0_8RegistryfMu_: AggregateRegistry {
        typealias Registries = _MultiRegistry<ChartsRegistry<Self>, AVKitRegistry<Self>>
    }

    return AnyView(LiveView<$s7TestBed11ContentViewV4bodyQrvg04LiveD0fMf0_8RegistryfMu_>(
            .localhost))
}()
```
This allows it to be used within `View.body` like any other `View`.