### PR TITLE
Make `ProvidedBindingsKey` public

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -37,6 +37,15 @@
       }
     },
     {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-syntax.git",
+      "state" : {
+        "revision" : "83c2be9f6268e9f67622f130440cf43928c6bfb0",
+        "version" : "509.0.0-swift-DEVELOPMENT-SNAPSHOT-2023-05-20-a"
+      }
+    },
+    {
       "identity" : "swiftphoenixclient",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/davidstump/SwiftPhoenixClient.git",

--- a/Sources/LiveViewNative/BuiltinRegistry+applyBinding.swift
+++ b/Sources/LiveViewNative/BuiltinRegistry+applyBinding.swift
@@ -40,9 +40,9 @@ extension BuiltinRegistry {
 }
 
 /// A preference key that specifies what bindings the View handles internally.
-enum ProvidedBindingsKey: PreferenceKey {
-    static var defaultValue: Set<String> { [] }
-    static func reduce(value: inout Set<String>, nextValue: () -> Set<String>) {
+public enum _ProvidedBindingsKey: PreferenceKey {
+    public static var defaultValue: Set<String> { [] }
+    public static func reduce(value: inout Set<String>, nextValue: () -> Set<String>) {
         value = nextValue()
     }
 }
@@ -61,7 +61,7 @@ fileprivate struct ProvidedBindingsReader<Content: View, ApplyBinding: View>: Vi
                 applyBinding()
             }
         }
-        .onPreferenceChange(ProvidedBindingsKey.self) { self.providesBinding = $0.contains(binding) }
+        .onPreferenceChange(_ProvidedBindingsKey.self) { self.providesBinding = $0.contains(binding) }
     }
 }
 

--- a/Sources/LiveViewNative/ViewTree.swift
+++ b/Sources/LiveViewNative/ViewTree.swift
@@ -78,7 +78,7 @@ struct ViewTreeBuilder<R: RootRegistry> {
 
         return withIDAndTag
             .environment(\.element, element)
-            .preference(key: ProvidedBindingsKey.self, value: []) // reset for the next View.
+            .preference(key: _ProvidedBindingsKey.self, value: []) // reset for the next View.
     }
 
     @ViewBuilder

--- a/Sources/LiveViewNative/Views/Controls and Indicators/Buttons/Button.swift
+++ b/Sources/LiveViewNative/Views/Controls and Indicators/Buttons/Button.swift
@@ -57,7 +57,7 @@ public struct Button<R: RootRegistry>: View {
             context.buildChildren(of: element)
         }
         .disabled(disabled)
-        .preference(key: ProvidedBindingsKey.self, value: ["phx-click"])
+        .preference(key: _ProvidedBindingsKey.self, value: ["phx-click"])
     }
     
     private func handleClick() {

--- a/Sources/LiveViewNative/Views/Controls and Indicators/Buttons/PasteButton.swift
+++ b/Sources/LiveViewNative/Views/Controls and Indicators/Buttons/PasteButton.swift
@@ -55,7 +55,7 @@ struct PasteButton<R: RootRegistry>: View {
         SwiftUI.PasteButton(payloadType: String.self) { strings in
             click(value: ["value": strings]) {}
         }
-            .preference(key: ProvidedBindingsKey.self, value: ["phx-click"])
+            .preference(key: _ProvidedBindingsKey.self, value: ["phx-click"])
         #endif
     }
 }

--- a/Sources/LiveViewNative/Views/Text Input and Output/SecureField.swift
+++ b/Sources/LiveViewNative/Views/Text Input and Output/SecureField.swift
@@ -55,7 +55,7 @@ struct SecureField<R: RootRegistry>: TextFieldProtocol {
         }
             .focused($isFocused)
             .onChange(of: isFocused, perform: handleFocus)
-            .preference(key: ProvidedBindingsKey.self, value: ["phx-focus", "phx-blur"])
+            .preference(key: _ProvidedBindingsKey.self, value: ["phx-focus", "phx-blur"])
     }
     
     var label: some View {

--- a/Sources/LiveViewNative/Views/Text Input and Output/TextEditor.swift
+++ b/Sources/LiveViewNative/Views/Text Input and Output/TextEditor.swift
@@ -41,7 +41,7 @@ struct TextEditor: TextFieldProtocol {
         SwiftUI.TextEditor(text: textBinding)
             .focused($isFocused)
             .onChange(of: isFocused, perform: handleFocus)
-            .preference(key: ProvidedBindingsKey.self, value: ["phx-focus", "phx-blur"])
+            .preference(key: _ProvidedBindingsKey.self, value: ["phx-focus", "phx-blur"])
 #endif
     }
 }

--- a/Sources/LiveViewNative/Views/Text Input and Output/TextField.swift
+++ b/Sources/LiveViewNative/Views/Text Input and Output/TextField.swift
@@ -154,7 +154,7 @@ struct TextField<R: RootRegistry>: TextFieldProtocol {
         field
             .focused($isFocused)
             .onChange(of: isFocused, perform: handleFocus)
-            .preference(key: ProvidedBindingsKey.self, value: ["phx-focus", "phx-blur"])
+            .preference(key: _ProvidedBindingsKey.self, value: ["phx-focus", "phx-blur"])
     }
     
     @ViewBuilder


### PR DESCRIPTION
Needed for some MapKit functionality, and potentially other add-on libraries. The type has been underscored to discourage use in user code and hide from auto-complete.