### PR TITLE
Use `NodeRef` as element id with `ForEach` instead of `TupleView`

### DIFF
--- a/Sources/LiveViewNative/Property Wrappers/LiveContext.swift
+++ b/Sources/LiveViewNative/Property Wrappers/LiveContext.swift
@@ -50,7 +50,7 @@ public struct LiveContext<R: RootRegistry>: DynamicProperty {
     public func buildElement(_ element: ElementNode) -> some View {
         // can't use coordinator.builder.fromElement here, as it causes an infinitely recursive type when used with custom attributes
         // so use ElementView to break the cycle
-        return ElementView(element: element, context: storage)
+        return NodeView(node: element.node, context: storage)
     }
     
     /// Builds a view representing the children of the current element in the current context.

--- a/Sources/LiveViewNative/Utils/AnyTransition.swift
+++ b/Sources/LiveViewNative/Utils/AnyTransition.swift
@@ -263,6 +263,8 @@ extension AnyTransition {
 }
 
 #if canImport(Symbols)
+import Symbols
+
 /// A transition applied to a system image.
 ///
 /// Possible values:

--- a/Sources/LiveViewNative/Utils/ContentTransition.swift
+++ b/Sources/LiveViewNative/Utils/ContentTransition.swift
@@ -104,6 +104,8 @@ extension ContentTransition: Decodable {
 }
 
 #if canImport(Symbols)
+import Symbols
+
 /// A content transition applied to a system image.
 ///
 /// Possible values:

--- a/Sources/LiveViewNative/ViewTree.swift
+++ b/Sources/LiveViewNative/ViewTree.swift
@@ -20,34 +20,7 @@ struct ViewTreeBuilder<R: RootRegistry> {
     func fromNodes<Nodes>(_ nodes: Nodes, context: LiveContextStorage<R>) -> some View
         where Nodes: RandomAccessCollection, Nodes.Index == Int, Nodes.Element == Node
     {
-        let e = nodes
-        let c = context
-        switch e.count {
-        case 0:
-            EmptyView()
-        case 1:
-            f(e[0], c)
-        case 2:
-            TupleView((f(e[0], c), f(e[1], c)))
-        case 3:
-            TupleView((f(e[0], c), f(e[1], c), f(e[2], c)))
-        case 4:
-            TupleView((f(e[0], c), f(e[1], c), f(e[2], c), f(e[3], c)))
-        case 5:
-            TupleView((f(e[0], c), f(e[1], c), f(e[2], c), f(e[3], c), f(e[4], c)))
-        case 6:
-            TupleView((f(e[0], c), f(e[1], c), f(e[2], c), f(e[3], c), f(e[4], c), f(e[5], c)))
-        case 7:
-            TupleView((f(e[0], c), f(e[1], c), f(e[2], c), f(e[3], c), f(e[4], c), f(e[5], c), f(e[6], c)))
-        case 8:
-            TupleView((f(e[0], c), f(e[1], c), f(e[2], c), f(e[3], c), f(e[4], c), f(e[5], c), f(e[6], c), f(e[7], c)))
-        case 9:
-            TupleView((f(e[0], c), f(e[1], c), f(e[2], c), f(e[3], c), f(e[4], c), f(e[5], c), f(e[6], c), f(e[7], c), f(e[8], c)))
-        case 10:
-            TupleView((f(e[0], c), f(e[1], c), f(e[2], c), f(e[3], c), f(e[4], c), f(e[5], c), f(e[6], c), f(e[7], c), f(e[8], c), f(e[9], c)))
-        default:
-            forEach(nodes: nodes, context: c)
-        }
+        forEach(nodes: nodes, context: context)
     }
     
     // alias for typing
@@ -289,52 +262,45 @@ extension View {
     }
 }
 
-// not fileprivate because it's used by LiveContext
-// this cannot be "NodeView" because it's used by forEach which requires element ids, which leaf nodes can't have
-internal struct ElementView<R: RootRegistry>: View {
-    let element: ElementNode
+// not fileprivate because it's used by LiveContext.
+internal struct NodeView<R: RootRegistry>: View {
+    let node: Node
     let context: LiveContextStorage<R>
     
     var body: some View {
-        context.coordinator.builder.fromElement(element, context: context)
+        context.coordinator.builder.fromNode(node, context: context)
     }
 }
 
 private enum ForEachElement: Identifiable {
-    case element(ElementNode, String)
-    case error(Error)
+    case keyed(Node, id: String)
+    case unkeyed(Node)
     
-    var id: String {
+    var id: AnyHashable {
         switch self {
-        case .element(_, let id):
-            return id
-        case .error(let error):
-            return error.localizedDescription
+        case let .keyed(_, id):
+            return AnyHashable(id)
+        case let .unkeyed(node):
+            return AnyHashable(node.id)
         }
     }
 }
 // not fileprivate because List needs to use it so it has access to ForEach modifiers
 func forEach<R: CustomRegistry>(nodes: some Collection<Node>, context: LiveContextStorage<R>) -> some DynamicViewContent {
-    let elements: [ForEachElement]
-    do {
-        elements = try nodes.map { (node) -> ForEachElement in
-            guard let element = node.asElement() else {
-                throw ForEachViewError.invalidNode
-            }
-            guard let id = element.attributeValue(for: "id") else {
-                throw ForEachViewError.missingID
-            }
-            return .element(element, id)
+    let elements = nodes.map { (node) -> ForEachElement in
+        if let element = node.asElement(),
+           let id = element.attributeValue(for: "id")
+        {
+            return .keyed(node, id: id)
+        } else {
+            return .unkeyed(node)
         }
-    } catch {
-        elements = [.error(error)]
     }
     return ForEach(elements) {
         switch $0 {
-        case .element(let element, _):
-            ElementView<R>(element: element, context: context)
-        case let .error(error):
-            ErrorView<R>(error)
+        case let .keyed(node, _),
+             let .unkeyed(node):
+            NodeView(node: node, context: context)
         }
     }
 }


### PR DESCRIPTION
This resolves an issue where elements would stick around when replaced with another element, which can lead to undefined behavior.

Using `ForEach` instead of `TupleView` gives each element an explicit identifier based on its `NodeRef`. My guess is that having the structural identity provided by `TupleView` caused elements to not be replaced properly when the parent container received an update.