### PR TITLE
Add `Encodable` to `pushEvent` and `receiveEvent` from `LiveSessionCoordinator`

### DIFF
--- a/Sources/LiveViewNative/Coordinators/LiveConnectionError.swift
+++ b/Sources/LiveViewNative/Coordinators/LiveConnectionError.swift
@@ -17,6 +17,8 @@ public enum LiveConnectionError: Error, LocalizedError {
     case socketError(Error)
     case joinError(Message)
     case eventError(Message)
+    case sessionCoordinatorReleased
+    case viewCoordinatorReleased
     
     public var errorDescription: String? {
         switch self {
@@ -34,6 +36,10 @@ public enum LiveConnectionError: Error, LocalizedError {
             return "joinError(\(message.payload))"
         case .eventError(let message):
             return "eventError(\(message.payload))"
+        case .sessionCoordinatorReleased:
+            return "sessionCoordinatorReleased"
+        case .viewCoordinatorReleased:
+            return "viewCoordinatorReleased"
         }
     }
     

--- a/Sources/LiveViewNative/Coordinators/LiveSessionCoordinator.swift
+++ b/Sources/LiveViewNative/Coordinators/LiveSessionCoordinator.swift
@@ -31,10 +31,10 @@ private let logger = Logger(subsystem: "LiveViewNative", category: "LiveSessionC
 /// - ``LiveConnectionError``
 @MainActor
 public class LiveSessionCoordinator<R: RootRegistry>: ObservableObject {
-    @Published internal private(set) var internalState: InternalState = .notConnected(reconnectAutomatically: false)
+    @Published internal private(set) var internalState: LiveSessionState = .notConnected
     /// The current state of the live view connection.
     public var state: LiveSessionState {
-        internalState.publicState
+        internalState
     }
     
     /// The current URL this live view is connected to.
@@ -43,19 +43,13 @@ public class LiveSessionCoordinator<R: RootRegistry>: ObservableObject {
     @Published var navigationPath = [LiveNavigationEntry<R>]()
     var rootCoordinator: LiveViewCoordinator<R>!
     
-    internal let config: LiveSessionConfiguration
-    
-    // Values extracted from the DOM
-    var phxSession: String = ""
-    var phxStatic: String = ""
-    var phxView: String = ""
-    var phxID: String = ""
-    var phxCSRFToken: String = ""
+    internal let configuration: LiveSessionConfiguration
     
     // Socket connection
     var socket: Socket?
     
-    var liveReloadEnabled: Bool = false
+    private var domValues: DOMValues!
+    
     private var liveReloadSocket: Socket?
     private var liveReloadChannel: Channel?
     
@@ -77,7 +71,7 @@ public class LiveSessionCoordinator<R: RootRegistry>: ObservableObject {
     /// - Parameter customRegistryType: The type of the registry of custom views this coordinator will use when building the SwiftUI view tree from the DOM. This can generally be inferred automatically.
     public init(_ url: URL, config: LiveSessionConfiguration = .init(), customRegistryType _: R.Type = R.self) {
         self.url = url.appending(path: "").absoluteURL
-        self.config = config
+        self.configuration = config
         self.rootCoordinator = .init(session: self, url: self.url)
         self.mergedEventSubjects = self.rootCoordinator.eventSubject.compactMap({
             [weak self] value in self.map({ ($0.rootCoordinator, value) })
@@ -85,26 +79,21 @@ public class LiveSessionCoordinator<R: RootRegistry>: ObservableObject {
         .sink(receiveValue: { [weak self] value in
             self?.eventSubject.send(value)
         })
-        self.$internalState.sink { state in
-            if case .connected = state {
-                Task { [weak self] in
-                    await self?.rootCoordinator.connect()
-                }
-            }
-        }.store(in: &cancellables)
-        $navigationPath.scan(([LiveNavigationEntry<R>](), [LiveNavigationEntry<R>]()), { ($0.1, $1) }).sink { prev, next in
+        $navigationPath.scan(([LiveNavigationEntry<R>](), [LiveNavigationEntry<R>]()), { ($0.1, $1) }).sink { [weak self] prev, next in
+            guard let self else { return }
             if prev.count > next.count {
                 let last = next.last ?? .init(url: self.url, coordinator: self.rootCoordinator)
                 if last.coordinator.url != last.url {
                     last.coordinator.url = last.url
-                    Task {
-                        await last.coordinator.reconnect()
+                    print("NAVIGATE BACK")
+                    Task { @MainActor in
+                        try await last.coordinator.connect(domValues: self.domValues, redirect: true)
                     }
                 }
             }
         }.store(in: &cancellables)
+        // Receive events from all live views.
         $navigationPath.sink { [weak self] entries in
-            // Receive events from all live views.
             if let self {
                 let allCoordinators = ([self.rootCoordinator] + entries.map(\.coordinator))
                     .reduce(into: [LiveViewCoordinator<R>]()) { result, next in
@@ -117,16 +106,6 @@ public class LiveSessionCoordinator<R: RootRegistry>: ObservableObject {
                 .sink(receiveValue: { [weak self] value in
                     self?.eventSubject.send(value)
                 })
-            }
-            guard let entry = entries.last else { return }
-            Task {
-                // If the coordinator is not connected to the right URL, update it.
-                if entry.coordinator.url != entry.url {
-                    entry.coordinator.url = entry.url
-                    await entry.coordinator.reconnect()
-                } else {
-                    await entry.coordinator.connect()
-                }
             }
         }.store(in: &cancellables)
     }
@@ -146,61 +125,58 @@ public class LiveSessionCoordinator<R: RootRegistry>: ObservableObject {
     ///
     /// This is an async function which completes when the connection has been established or failed.
     public func connect() async {
-        guard case .notConnected = state else {
-            return
-        }
-        
-        do {
-            try await self.doConnect()
-        } catch {
-            // doConnect only throws CancellationErrors, which we swallow
-        }
-    }
-    
-    private func doConnect() async throws {
-        guard case .notConnected = state else {
+        guard case .notConnected = internalState else {
             return
         }
         
         logger.debug("Connecting to \(self.url.absoluteString)")
         
-        internalState = .startingConnection
+        internalState = .connecting
         
         let html: String
         do {
             html = try await fetchDOM(url: self.url)
-        } catch let error as LiveConnectionError {
-            internalState = .connectionFailed(error)
-            return
-        }
-        
-        try Task.checkCancellation()
-        
-        do {
-            let doc = try SwiftSoup.parse(html)
-            try self.extractDOMValues(doc)
         } catch {
             internalState = .connectionFailed(error)
             return
         }
         
+        let domValues: DOMValues
+        do {
+            let doc = try SwiftSoup.parse(html)
+            domValues = try self.extractDOMValues(doc)
+        } catch {
+            internalState = .connectionFailed(error)
+            return
+        }
+        
+        self.domValues = domValues
+        
         if socket == nil {
             do {
-                try await self.connectSocket()
-            } catch let error as LiveConnectionError {
+                try await self.connectSocket(domValues)
+            } catch {
                 internalState = .connectionFailed(error)
                 return
             }
         }
+        
+        do {
+            try await rootCoordinator.connect(domValues: domValues, redirect: false)
+        } catch {
+            self.internalState = .connectionFailed(error)
+        }
     }
     
     private func disconnect() {
-        self.rootCoordinator.disconnect()
-        navigationPath.removeAll()
+        rootCoordinator.disconnect()
+        for entry in self.navigationPath {
+            entry.coordinator.disconnect()
+        }
+        self.navigationPath.removeAll()
         self.socket?.disconnect()
         self.socket = nil
-        // when deliberately disconnect, don't let pending connections continue
-        internalState = .notConnected(reconnectAutomatically: false)
+        self.internalState = .notConnected
     }
     
     /// Forces the session to disconnect then connect.
@@ -209,9 +185,8 @@ public class LiveSessionCoordinator<R: RootRegistry>: ObservableObject {
     ///
     /// This can be used to force the LiveView to reset, for example after an unrecoverable error occurs.
     public func reconnect() async {
-        disconnect()
-        await connect()
-        await self.rootCoordinator.reconnect()
+        self.disconnect()
+        await self.connect()
     }
     
     /// Creates a publisher that can be used to listen for server-sent LiveView events.
@@ -246,7 +221,7 @@ public class LiveSessionCoordinator<R: RootRegistry>: ObservableObject {
         let data: Data
         let resp: URLResponse
         do {
-            (data, resp) = try await config.urlSession.data(from: url)
+            (data, resp) = try await configuration.urlSession.data(from: url)
         } catch {
             throw LiveConnectionError.initialFetchError(error)
         }
@@ -264,86 +239,89 @@ public class LiveSessionCoordinator<R: RootRegistry>: ObservableObject {
         }
     }
     
-    private func extractDOMValues(_ doc: SwiftSoup.Document) throws -> Void {
+    struct DOMValues {
+        let phxCSRFToken: String
+        let phxSession: String
+        let phxStatic: String
+        let phxView: String
+        let phxID: String
+        let liveReloadEnabled: Bool
+    }
+    
+    private func extractDOMValues(_ doc: SwiftSoup.Document) throws -> DOMValues {
         let metaRes = try doc.select("meta[name=\"csrf-token\"]")
         guard !metaRes.isEmpty() else {
             throw LiveConnectionError.initialParseError(missingOrInvalid: .csrfToken)
         }
-        self.phxCSRFToken = try metaRes[0].attr("content")
-        self.liveReloadEnabled = !(try doc.select("iframe[src=\"/phoenix/live_reload/frame\"]").isEmpty())
         
         let mainDivRes = try doc.select("div[data-phx-main]")
         guard !mainDivRes.isEmpty() else {
             throw LiveConnectionError.initialParseError(missingOrInvalid: .phxMain)
         }
         let mainDiv = mainDivRes[0]
-        self.phxSession = try mainDiv.attr("data-phx-session")
-        self.phxStatic = try mainDiv.attr("data-phx-static")
-        self.phxView = try mainDiv.attr("data-phx-view")
-        self.phxID = try mainDiv.attr("id")
+        return .init(
+            phxCSRFToken: try metaRes[0].attr("content"),
+            phxSession: try mainDiv.attr("data-phx-session"),
+            phxStatic: try mainDiv.attr("data-phx-static"),
+            phxView: try mainDiv.attr("data-phx-view"),
+            phxID: try mainDiv.attr("id"),
+            liveReloadEnabled: !(try doc.select("iframe[src=\"/phoenix/live_reload/frame\"]").isEmpty())
+        )
     }
 
-    private func connectSocket() async throws {
+    private func connectSocket(_ domValues: DOMValues) async throws {
         let cookies = HTTPCookieStorage.shared.cookies(for: self.url)
         
-        let configuration = config.urlSession.configuration
+        let configuration = configuration.urlSession.configuration
         for cookie in cookies! {
             configuration.httpCookieStorage!.setCookie(cookie)
         }
     
-        let _: Void = try await withCheckedThrowingContinuation { continuation in
-            self.internalState = .awaitingSocketConnection(continuation)
-            doConnectSocket(urlSessionConfiguration: configuration)
+        self.socket = try await withCheckedThrowingContinuation { [weak self] continuation in
+            guard let self else {
+                return continuation.resume(throwing: LiveConnectionError.sessionCoordinatorReleased)
+            }
+            
+            var wsEndpoint = URLComponents(url: self.url, resolvingAgainstBaseURL: true)!
+            wsEndpoint.scheme = self.url.scheme == "https" ? "wss" : "ws"
+            wsEndpoint.path = "/live/websocket"
+            let socket = Socket(endPoint: wsEndpoint.string!, transport: { URLSessionTransport(url: $0, configuration: configuration) }, paramsClosure: {["_csrf_token": domValues.phxCSRFToken]})
+            socket.onOpen { [weak self, weak socket] in
+                guard let socket else { return }
+                guard self != nil else {
+                    socket.disconnect()
+                    return
+                }
+                logger.debug("[Socket] Opened")
+                continuation.resume(returning: socket)
+            }
+            socket.onClose { logger.debug("[Socket] Closed") }
+            socket.onError { [weak self, weak socket] (error) in
+                guard let socket else { return }
+                guard self != nil else {
+                    socket.disconnect()
+                    return
+                }
+                logger.error("[Socket] Error: \(String(describing: error))")
+                continuation.resume(throwing: LiveConnectionError.socketError(error))
+            }
+            socket.logger = { message in logger.debug("[Socket] \(message)") }
+            socket.connect()
         }
         
-        if liveReloadEnabled {
-            Task {
-                await self.connectLiveReloadSocket(urlSessionConfiguration: configuration)
-            }
+        self.internalState = .connected
+        
+        if domValues.liveReloadEnabled {
+            await self.connectLiveReloadSocket(urlSessionConfiguration: configuration)
         }
-    }
-    
-    private func doConnectSocket(urlSessionConfiguration config: URLSessionConfiguration) {
-        var wsEndpoint = URLComponents(url: self.url, resolvingAgainstBaseURL: true)!
-        wsEndpoint.scheme = self.url.scheme == "https" ? "wss" : "ws"
-        wsEndpoint.path = "/live/websocket"
-        let socket = Socket(endPoint: wsEndpoint.string!, transport: { URLSessionTransport(url: $0, configuration: config) }, paramsClosure: {["_csrf_token": self.phxCSRFToken]})
-        self.socket = socket
-        socket.onOpen { [weak self, weak socket] in
-            guard let socket else { return }
-            guard let self = self else {
-                socket.disconnect()
-                return
-            }
-            logger.debug("[Socket] Opened")
-            if case .awaitingSocketConnection(let continuation) = self.internalState {
-                continuation.resume()
-            }
-            DispatchQueue.main.async {
-                self.internalState = .connected
-            }
-        }
-        socket.onClose { logger.debug("[Socket] Closed") }
-        socket.onError { [weak self, weak socket] (error) in
-            guard let socket else { return }
-            guard let self = self else {
-                socket.disconnect()
-                return
-            }
-            logger.error("[Socket] Error: \(String(describing: error))")
-            if case .awaitingSocketConnection(let continuation) = self.internalState {
-                continuation.resume(throwing: LiveConnectionError.socketError(error))
-            } else {
-                Task { @MainActor in
-                    self.internalState = .connectionFailed(LiveConnectionError.socketError(error))
-                }
-            }
-        }
-        socket.logger = { message in logger.debug("[Socket] \(message)") }
-        socket.connect()
     }
     
     private func connectLiveReloadSocket(urlSessionConfiguration: URLSessionConfiguration) async {
+        if let liveReloadSocket = self.liveReloadSocket {
+            liveReloadSocket.disconnect()
+            self.liveReloadSocket = nil
+        }
+        
         logger.debug("[LiveReload] attempting to connect...")
 
         var liveReloadEndpoint = URLComponents(url: self.url, resolvingAgainstBaseURL: true)!
@@ -368,7 +346,7 @@ public class LiveSessionCoordinator<R: RootRegistry>: ObservableObject {
         }
     }
     
-    func redirect(_ redirect: LiveRedirect) async {
+    func redirect(_ redirect: LiveRedirect) async throws {
         switch redirect.mode {
         case .replaceTop:
             let coordinator = (navigationPath.last?.coordinator ?? rootCoordinator)!
@@ -380,14 +358,11 @@ public class LiveSessionCoordinator<R: RootRegistry>: ObservableObject {
                 navigationPath.append(entry)
             case .replace:
                 // If there is nothing to replace, change the root URL.
-                if navigationPath.isEmpty {
-                    rootCoordinator.url = redirect.to
-                    await rootCoordinator.reconnect()
-                } else {
-                    navigationPath.removeLast()
-                    navigationPath.append(entry)
+                if !navigationPath.isEmpty {
+                    navigationPath[navigationPath.count - 1] = entry
                 }
             }
+            try await coordinator.connect(domValues: self.domValues, redirect: true)
         case .multiplex:
             switch redirect.kind {
             case .push:
@@ -399,7 +374,7 @@ public class LiveSessionCoordinator<R: RootRegistry>: ObservableObject {
                 // If there is nothing to replace, change the root URL.
                 if navigationPath.isEmpty {
                     rootCoordinator.url = redirect.to
-                    await rootCoordinator.reconnect()
+                    try await rootCoordinator.connect(domValues: self.domValues, redirect: true)
                 } else {
                     navigationPath.removeLast()
                     // If we are replacing the current path with the previous one, just pop the URL so the previous one is on top.
@@ -409,48 +384,6 @@ public class LiveSessionCoordinator<R: RootRegistry>: ObservableObject {
                         coordinator: LiveViewCoordinator(session: self, url: redirect.to)
                     ))
                 }
-            }
-        }
-    }
-}
-
-extension LiveSessionCoordinator {
-    // The internal state enum stores more details associated with particular states but that we don't want publicly exposed.
-    enum InternalState {
-        case notConnected(reconnectAutomatically: Bool)
-        case startingConnection
-        case awaitingSocketConnection(CheckedContinuation<Void, Swift.Error>)
-        case awaitingJoinResponse(CheckedContinuation<Payload, Swift.Error>)
-        case connected
-        case connectionFailed(Error)
-        
-        var publicState: LiveSessionState {
-            switch self {
-            case .notConnected(reconnectAutomatically: _):
-                return .notConnected
-            case .startingConnection, .awaitingSocketConnection(_), .awaitingJoinResponse(_):
-                return .connecting
-            case .connected:
-                return .connected
-            case .connectionFailed(let error):
-                return .connectionFailed(error)
-            }
-        }
-        
-        var reconnectAutomatically: Bool {
-            switch self {
-            case .notConnected(reconnectAutomatically: let b):
-                return b
-            case .startingConnection, .awaitingSocketConnection(_), .awaitingJoinResponse(_):
-                // connection attempt tokens should make this unreachable, but just in case
-                return false
-            case .connected:
-                //
-                return false
-            case .connectionFailed(_):
-                // if we've previously encountered and error, and SwiftPhoenixClient automatically tries to rejoin the channel
-                // and it succeeds, we accept the join
-                return true
             }
         }
     }

--- a/Sources/LiveViewNative/Coordinators/LiveViewCoordinator.swift
+++ b/Sources/LiveViewNative/Coordinators/LiveViewCoordinator.swift
@@ -217,8 +217,8 @@ public class LiveViewCoordinator<R: RootRegistry>: ObservableObject {
         var connectParams = session.configuration.connectParams?(self.url) ?? [:]
         connectParams["_mounts"] = 0
         connectParams["_csrf_token"] = domValues.phxCSRFToken
-        connectParams["_platform"] = "swiftui"
-        connectParams["_platform_meta"] = try getPlatformMetadata()
+        connectParams["_platform"] = session.platform
+        connectParams["_platform_meta"] = session.platformMeta
         connectParams["_global_native_bindings"] = Dictionary(uniqueKeysWithValues: R.globalBindings.map({ ($0, R.bindingValue(forKey: $0, in: nil)) }))
 
         let params: Payload = [
@@ -273,62 +273,6 @@ public class LiveViewCoordinator<R: RootRegistry>: ObservableObject {
         channel = nil
         self.internalState = .notConnected
         self.document = nil
-    }
-    
-    private func getPlatformMetadata() throws -> Payload {
-        return [
-            "os_name": getOSName(),
-            "os_version": getOSVersion(),
-            "user_interface_idiom": getUserInterfaceIdiom()
-        ]
-    }
-
-    private func getOSName() -> String {
-        #if os(macOS)
-        return "macOS"
-        #elseif os(tvOS)
-        return "tvOS"
-        #elseif os(watchOS)
-        return "watchOS"
-        #else
-        return "iOS"
-        #endif
-    }
-
-    private func getOSVersion() -> String {
-        #if os(watchOS)
-        return WKInterfaceDevice.current().systemVersion
-        #elseif os(macOS)
-        let operatingSystemVersion = ProcessInfo.processInfo.operatingSystemVersion
-        let majorVersion = operatingSystemVersion.majorVersion
-        let minorVersion = operatingSystemVersion.minorVersion
-        let patchVersion = operatingSystemVersion.patchVersion
-        
-        return "\(majorVersion).\(minorVersion).\(patchVersion)"
-        #else
-        return UIDevice.current.systemVersion
-        #endif
-    }
-
-    private func getUserInterfaceIdiom() -> String {
-        #if os(watchOS)
-        return "watch"
-        #elseif os(macOS)
-        return "mac"
-        #else
-        switch UIDevice.current.userInterfaceIdiom {
-        case .phone:
-            return "phone"
-        case .pad:
-            return "pad"
-        case .mac:
-            return "mac"
-        case .tv:
-            return "tv"
-        default:
-            return "unspecified"
-        }
-        #endif
     }
     
     enum JoinResult {

--- a/Sources/LiveViewNative/Coordinators/LiveViewCoordinator.swift
+++ b/Sources/LiveViewNative/Coordinators/LiveViewCoordinator.swift
@@ -45,8 +45,8 @@ public class LiveViewCoordinator<R: RootRegistry>: ObservableObject {
     private var currentConnectionToken: ConnectionAttemptToken?
     private var currentConnectionTask: Task<Void, Error>?
     
-    private var eventSubject = PassthroughSubject<(String, Payload), Never>()
-    private var eventHandlers = Set<AnyCancellable>()
+    private(set) internal var eventSubject = PassthroughSubject<(String, Payload), Never>()
+    private(set) internal var eventHandlers = Set<AnyCancellable>()
     
     init(session: LiveSessionCoordinator<R>, url: URL) {
         self.session = session
@@ -81,6 +81,15 @@ public class LiveViewCoordinator<R: RootRegistry>: ObservableObject {
             "value": value,
             "cid": target as Any
         ])
+    }
+    
+    public func pushEvent(type: String, event: String, value: some Encodable, target: Int? = nil) async throws {
+        try await pushEvent(
+            type: type,
+            event: event,
+            value: try JSONSerialization.jsonObject(with: JSONEncoder().encode(value)),
+            target: target
+        )
     }
     
     internal func doPushEvent(_ event: String, payload: Payload) async throws {


### PR DESCRIPTION
Closes #1015 
Closes #1014 

Events can now be received from the `LiveSessionCoordinator`. All `LiveViewCoordinator` events with matching names will be sent to the session coordinator. The `LiveViewCoordinator` is returned in the payload so the events can be distinguished, and replies can be sent.

`pushEvent` now supports sending an `Encodable` struct as well.

```swift
.onReceive(session.receiveEvent("my_custom_event")) { (coordinator, payload) in
    Task {
        try await coordinator.pushEvent(type: "click", event: "test_reply", value: EventData(reply1: 5, id: "hello, world!"))
    }
}
```