### PR TITLE
Persistent native bindings with UserDefaults

### DIFF
--- a/Sources/LiveViewNative/Coordinators/LiveViewCoordinator.swift
+++ b/Sources/LiveViewNative/Coordinators/LiveViewCoordinator.swift
@@ -253,6 +253,7 @@ public class LiveViewCoordinator<R: RootRegistry>: ObservableObject {
         connectParams["_csrf_token"] = session.phxCSRFToken
         connectParams["_platform"] = "swiftui"
         connectParams["_platform_meta"] = try getPlatformMetadata()
+        connectParams["_global_native_bindings"] = Dictionary(uniqueKeysWithValues: R.globalBindings.map({ ($0, R.bindingValue(forKey: $0, in: nil)) }))
 
         let params: Payload = [
             "session": session.phxSession,

--- a/Sources/LiveViewNative/NavStackEntryView.swift
+++ b/Sources/LiveViewNative/NavStackEntryView.swift
@@ -11,7 +11,7 @@ import LiveViewNativeCore
 struct NavStackEntryView<R: RootRegistry>: View {
     private let entry: LiveNavigationEntry<R>
     @ObservedObject private var coordinator: LiveViewCoordinator<R>
-    @StateObject private var liveViewModel = LiveViewModel()
+    @StateObject private var liveViewModel = LiveViewModel(bindingValue: R.bindingValue, setBindingValue: R.setBindingValue, globalBindings: { R.globalBindings }, registerGlobalBinding: R.registerGlobalBinding)
     
     init(_ entry: LiveNavigationEntry<R>) {
         self.entry = entry
@@ -28,6 +28,7 @@ struct NavStackEntryView<R: RootRegistry>: View {
                 }
             }
             .onReceive(coordinator.receiveEvent("_native_bindings"), perform: liveViewModel.updateBindings)
+            .onReceive(coordinator.receiveEvent("_native_bindings_init"), perform: liveViewModel.initBindings(payload:))
             .onReceive(
                 liveViewModel.bindingUpdatedByClient
                     .collect(.byTime(RunLoop.current, RunLoop.current.minimumTolerance))

--- a/Sources/LiveViewNative/Registries/CustomRegistry.swift
+++ b/Sources/LiveViewNative/Registries/CustomRegistry.swift
@@ -135,6 +135,11 @@ public protocol CustomRegistry<Root> {
     /// - Parameter error: The error of the view is reporting.
     @ViewBuilder
     static func errorView(for error: Error) -> ErrorView
+    
+    static func setBindingValue(_ value: Any, forKey key: String, in scope: String?) throws
+    static func bindingValue(forKey key: String, in scope: String?) -> Any?
+    static var globalBindings: Set<String> { get }
+    static func registerGlobalBinding(_ key: String)
 }
 
 extension CustomRegistry where LoadingView == Never {
@@ -148,6 +153,21 @@ extension CustomRegistry where ErrorView == Never {
     /// A default  implementation that falls back to the default framework error view.
     public static func errorView(for error: Error) -> Never {
         fatalError()
+    }
+}
+
+extension CustomRegistry {
+    public static func setBindingValue(_ value: Any, forKey key: String, in scope: String?) throws {
+        UserDefaults(suiteName: scope)?.setValue(value, forKey: key)
+    }
+    public static func bindingValue(forKey key: String, in scope: String?) -> Any? {
+        UserDefaults(suiteName: scope)?.value(forKey: key)
+    }
+    public static var globalBindings: Set<String> {
+        Set(UserDefaults.standard.stringArray(forKey: "_lvn_global_bindings") ?? [])
+    }
+    public static func registerGlobalBinding(_ key: String) {
+        UserDefaults.standard.setValue(Array<String>(globalBindings.union([key])), forKey: "_lvn_global_bindings")
     }
 }
 

--- a/Sources/LiveViewNative/ViewModel.swift
+++ b/Sources/LiveViewNative/ViewModel.swift
@@ -17,9 +17,39 @@ public class LiveViewModel: ObservableObject {
     private var forms = [String: FormModel]()
     var cachedNavigationTitle: NavigationTitleModifier?
     
+    private(set) var bindings = [String: NativeBinding]()
+    private(set) var bindingScope: String?
+    
     private(set) var bindingValues = [String: Any]()
     let bindingUpdatedByServer = PassthroughSubject<(String, Any), Never>()
     let bindingUpdatedByClient = PassthroughSubject<(String, Any), Never>()
+    
+    let bindingValue: (String, String?) -> Any?
+    let setBindingValue: (Any, String, String?) throws -> ()
+    let globalBindings: () -> Set<String>
+    let registerGlobalBinding: (String) -> ()
+    
+    init(
+        bindingValue: @escaping (String, String?) -> Any?,
+        setBindingValue: @escaping (Any, String, String?) throws -> (),
+        globalBindings: @escaping () -> Set<String>,
+        registerGlobalBinding: @escaping (String) -> ()
+    ) {
+        self.bindingValue = bindingValue
+        self.setBindingValue = setBindingValue
+        self.globalBindings = globalBindings
+        self.registerGlobalBinding = registerGlobalBinding
+    }
+    
+    struct NativeBinding {
+        let persist: PersistenceMode
+        
+        enum PersistenceMode: String {
+            case scoped
+            case global
+            case none
+        }
+    }
     
     /// Get or create a ``FormModel`` for the given `<live-form>`.
     ///
@@ -60,6 +90,7 @@ public class LiveViewModel: ObservableObject {
                 for (key, value) in data {
                     bindingValues[key] = value
                     bindingUpdatedByServer.send((key, value))
+                    storeBinding(key, value: value)
                 }
             }
         }
@@ -68,6 +99,52 @@ public class LiveViewModel: ObservableObject {
     func setBinding(_ name: String, to encodedValue: Any) {
         bindingValues[name] = encodedValue
         bindingUpdatedByClient.send((name, encodedValue))
+        storeBinding(name, value: encodedValue)
+    }
+    
+    func storeBinding(_ key: String, value: Any) {
+        if let options = bindings[key] {
+            switch options.persist {
+            case .scoped:
+                try? setBindingValue(value, key, self.bindingScope)
+            case .global:
+                try? setBindingValue(value, key, nil)
+            case .none:
+                break
+            }
+        }
+    }
+    
+    func initBindings(payload: Payload) {
+        self.bindingScope = payload["scope"] as? String
+        for (key, options) in (payload["bindings"] as? [String:[String:Any]] ?? [:]) {
+            let binding = NativeBinding(
+                persist: (options["persist"] as? String).flatMap(NativeBinding.PersistenceMode.init(rawValue:)) ?? .none
+            )
+            self.bindings[key] = binding
+            
+            let defaultValue = options["default"]
+            
+            switch binding.persist {
+            case .scoped:
+                if let value = bindingValue(key, self.bindingScope) {
+                    self.bindingValues[key] = value
+                    setBinding(key, to: value)
+                } else {
+                    self.bindingValues[key] = defaultValue
+                }
+            case .global:
+                registerGlobalBinding(key)
+                if let value = bindingValue(key, nil) {
+                    self.bindingValues[key] = value
+                    setBinding(key, to: value)
+                } else {
+                    self.bindingValues[key] = defaultValue
+                }
+            case .none:
+                self.bindingValues[key] = defaultValue
+            }
+        }
     }
 }
 

--- a/Tests/RenderingTests/assertMatch.swift
+++ b/Tests/RenderingTests/assertMatch.swift
@@ -102,7 +102,7 @@ extension XCTestCase {
             url: session.url
         )
             .environment(\.coordinatorEnvironment, CoordinatorEnvironment(session.rootCoordinator, document: document))
-            .environmentObject(LiveViewModel())
+            .environmentObject(LiveViewModel(bindingValue: EmptyRegistry.bindingValue, setBindingValue: EmptyRegistry.setBindingValue, globalBindings: { EmptyRegistry.globalBindings }, registerGlobalBinding: EmptyRegistry.registerGlobalBinding))
         
         let modifyViewForRender: (any View) -> any View = {
             if useDrawingGroup {


### PR DESCRIPTION
This adds support for persisting native binding values with UserDefaults.

```elixir
defmodule PersistenceTestLive do
  use Phoenix.LiveView
  use LiveViewNative.LiveView

  native_binding :count, :integer, default: 0, persist: :scoped

  def mount(_params, _session, socket) do
    {:ok, socket}
  end

  def render(%{ platform_id: :swiftui } = assigns) do
    ~SWIFTUI"""
    <Text>Persistent Counter</Text>
    <Button phx-click="increment"><%= @count %></Button>
    """
  end

  def render(assigns) do
    ~H"""
    """
  end
end
```

https://github.com/liveview-native/liveview-client-swiftui/assets/13581484/6933c59e-ffb3-4524-80e9-a3527e304f8d
