### PR TITLE
Optimize updates with ObservableObject

### DIFF
--- a/Sources/LiveViewNative/Property Wrappers/Attribute.swift
+++ b/Sources/LiveViewNative/Property Wrappers/Attribute.swift
@@ -91,6 +91,8 @@ public struct Attribute<T>: DynamicProperty {
     private final class Storage: ObservableObject {
         var value: T?
         var previousValue: LiveViewNativeCore.Attribute?
+        
+        let objectWillChange = ObjectWillChangePublisher()
     }
     
     /// Before the View's body is produced, check if the attribute needs to be recomputed.

--- a/Sources/LiveViewNative/Property Wrappers/LiveContext.swift
+++ b/Sources/LiveViewNative/Property Wrappers/LiveContext.swift
@@ -50,7 +50,7 @@ public struct LiveContext<R: RootRegistry>: DynamicProperty {
     public func buildElement(_ element: ElementNode) -> some View {
         // can't use coordinator.builder.fromElement here, as it causes an infinitely recursive type when used with custom attributes
         // so use ElementView to break the cycle
-        return NodeView(node: element.node, context: storage)
+        return coordinator.builder.fromElement(element, context: storage)
     }
     
     /// Builds a view representing the children of the current element in the current context.


### PR DESCRIPTION
This includes two optimizations:

1. Removed extra wrapping Views, such as `NodeView`. This manual inlining reduced some View.body evaluations.
2. Add explicit `objectWillChange` properties to `ObservableObject` subclasses. Oddly, the slowest part of a View update was the default `objectWillChange` getter provided by the `ObservableObject` protocol. I'm not sure how they implemented this getter, but adding a simple implementation drastically improved update performance.

I tested these changes on a LiveView with around 200 elements and some moderately complex modifier stacks:

Previously, Instruments reported a microhang of ~400ms anytime an updated happened. The initial app load also took over 4 seconds.

After these optimizations, updates typically take <=100ms and the initial app loads in 2.3 seconds.