### PR TITLE
Fix invalid condition for disconnect

### DIFF
--- a/Sources/LiveViewNative/Coordinators/LiveViewCoordinator.swift
+++ b/Sources/LiveViewNative/Coordinators/LiveViewCoordinator.swift
@@ -265,7 +265,7 @@ public class LiveViewCoordinator<R: RootRegistry>: ObservableObject {
     
     func disconnect() async {
         if let channel,
-           !channel.isClosed
+           channel.isClosed
         {
             await withCheckedContinuation { continuation in
                 channel.onClose { _ in


### PR DESCRIPTION
I'm getting a `SWIFT TASK CONTINUATION MISUSE` error any time I try to `push_navigate` from a LiveView. This was originally reported in #1060 and fixed by https://github.com/liveview-native/liveview-client-swiftui/pull/1061 but it looks like the following change turned it from an intermittent error to one that is reproducible 100% of the time:

https://github.com/liveview-native/liveview-client-swiftui/pull/1061/files#diff-bae42148b049400c84c0d3c80e4c54378f44137193561bcbed5e8471c0a3ef9eR268

Reverting that line fixes the error which seems completely resolved by the other changes https://github.com/liveview-native/liveview-client-swiftui/pull/1061