### PR TITLE
Disable onClose handler after receiving once

### DIFF
--- a/Sources/LiveViewNative/Coordinators/LiveViewCoordinator.swift
+++ b/Sources/LiveViewNative/Coordinators/LiveViewCoordinator.swift
@@ -268,7 +268,9 @@ public class LiveViewCoordinator<R: RootRegistry>: ObservableObject {
            !channel.isClosed
         {
             await withCheckedContinuation { continuation in
-                channel.onClose { _ in
+                var ref: Int?
+                ref = channel.onClose { [weak channel] _ in
+                    channel?.off("phx_close", ref: ref)
                     continuation.resume()
                 }
                 channel.leave()

--- a/Sources/LiveViewNative/Coordinators/LiveViewCoordinator.swift
+++ b/Sources/LiveViewNative/Coordinators/LiveViewCoordinator.swift
@@ -268,12 +268,10 @@ public class LiveViewCoordinator<R: RootRegistry>: ObservableObject {
            !channel.isClosed
         {
             await withCheckedContinuation { continuation in
-                var ref: Int?
-                ref = channel.onClose { [weak channel] _ in
-                    channel?.off("phx_close", ref: ref)
-                    continuation.resume()
-                }
                 channel.leave()
+                    .receive("ok") { _ in
+                        continuation.resume()
+                    }
             }
         }
         channel = nil


### PR DESCRIPTION
This appears to fix the issue described in #1062 by ensuring the `onClose` handler is removed before resuming the continuation. I also fixed a continuation misuse that happened if the server was shutdown after the socket already connected by disabling the `onError` and `onOpen` handlers after one is called.