### PR TITLE
Use correct key for keyboard_type modifier in TextField docs

### DIFF
--- a/Sources/LiveViewNative/Views/Text Input and Output/TextField.swift
+++ b/Sources/LiveViewNative/Views/Text Input and Output/TextField.swift
@@ -35,7 +35,7 @@ import SwiftUI
 ///         @native
 ///         |> autocorrection_disabled(disable: true)
 ///         |> text_input_autocapitalization(autocapitalization: :words)
-///         |> keyboard_type(type: :web_search)
+///         |> keyboard_type(keyboard_type: :web_search)
 ///         |> submit_label(submit_label: :search)
 ///     }
 /// >
@@ -52,7 +52,7 @@ import SwiftUI
 ///         value-binding="amount"
 ///         format="currency"
 ///         currency-code="usd"
-///         modifier={@native |> keyboard_type(type: :decimal_pad)}
+///         modifier={@native |> keyboard_type(keyboard_type: :decimal_pad)}
 ///     >
 ///         Enter Amount
 ///     </TextField>


### PR DESCRIPTION
The docs are using the incorrect key for the `keyboard_type` modifier.