### PR TITLE
Handle `live_redirect` outside of events

### DIFF
--- a/Sources/LiveViewNative/Coordinators/LiveSessionCoordinator.swift
+++ b/Sources/LiveViewNative/Coordinators/LiveSessionCoordinator.swift
@@ -389,6 +389,20 @@ public class LiveSessionCoordinator<R: RootRegistry>: ObservableObject {
                     ))
                 }
             }
+        case .patch:
+            // patch is like `replaceTop`, but it does not disconnect.
+            let coordinator = (navigationPath.last?.coordinator ?? rootCoordinator)!
+            coordinator.url = redirect.to
+            let entry = LiveNavigationEntry(url: redirect.to, coordinator: coordinator)
+            switch redirect.kind {
+            case .push:
+                navigationPath.append(entry)
+            case .replace:
+                // If there is nothing to replace, change the root URL.
+                if !navigationPath.isEmpty {
+                    navigationPath[navigationPath.count - 1] = entry
+                }
+            }
         }
     }
 }

--- a/Sources/LiveViewNative/Coordinators/LiveViewCoordinator.swift
+++ b/Sources/LiveViewNative/Coordinators/LiveViewCoordinator.swift
@@ -242,6 +242,14 @@ public class LiveViewCoordinator<R: RootRegistry>: ObservableObject {
                 try! self.handleDiff(payload: message.payload, baseURL: self.url)
             }
         }
+        channel.on("live_redirect") { [weak self] message in
+            Task {
+                guard let self,
+                      let redirect = LiveRedirect(from: message.payload, relativeTo: self.url)
+                else { return }
+                try await self.session.redirect(redirect)
+            }
+        }
         channel.on("phx_close") { [weak self, weak channel] message in
             Task { @MainActor in
                 guard channel === self?.channel else { return }

--- a/Sources/LiveViewNative/Navigation/LiveRedirect.swift
+++ b/Sources/LiveViewNative/Navigation/LiveRedirect.swift
@@ -56,14 +56,25 @@ struct LiveRedirect {
         /// 2. If the kind is ``LiveRedirect/Kind/redirect`` and the destination is the same as the previous path, the current entry is popped and no new ``LiveViewCoordinator`` is connected.
         /// Otherwise a new ``LiveViewCoordinator`` is created in place of the top-most entry.
         case multiplex
+        
+        /// A `live_patch` style redirect.
+        ///
+        /// This replaces the URL of the page without reloading anything. It can be a push or replace kind.
+        case patch
     }
     
-    init?(from payload: Payload, relativeTo rootURL: URL) {
+    init(kind: Kind, to: URL, mode: Mode) {
+        self.kind = kind
+        self.to = to
+        self.mode = mode
+    }
+    
+    init?(from payload: Payload, relativeTo rootURL: URL, mode: Mode = .replaceTop) {
         guard let kind = (payload["kind"] as? String).flatMap(Kind.init),
               let to = (payload["to"] as? String).flatMap({ URL.init(string: $0, relativeTo: rootURL) })
         else { return nil }
         self.kind = kind
         self.to = to.appending(path: "").absoluteURL
-        self.mode = (payload["mode"] as? String).flatMap(Mode.init) ?? .replaceTop
+        self.mode = (payload["mode"] as? String).flatMap(Mode.init) ?? mode
     }
 }


### PR DESCRIPTION
Closes #1109 

Previously, `live_redirect` was only handled in response to events. However, when `handle_info` results in a `push_navigate` a `live_redirect` message is sent independent of an event. This adds a handler for this message on all channels.