### PR TITLE
Use `AsyncThrowingStream` to handle join replies

### DIFF
--- a/Sources/LiveViewNative/Coordinators/LiveViewCoordinator.swift
+++ b/Sources/LiveViewNative/Coordinators/LiveViewCoordinator.swift
@@ -280,7 +280,6 @@ public class LiveViewCoordinator<R: RootRegistry>: ObservableObject {
         
         let joinTask = Task {
             for try await joinResult in join(channel: channel) {
-                print("Received join result \(joinResult)")
                 switch joinResult {
                 case .rendered(let payload):
                     self.handleJoinPayload(renderedPayload: payload)


### PR DESCRIPTION
When implementing this initially, I assumed that a join event would only be sent once. However, it seems this is better represented by an `AsyncStream`.

This fixes some issues with reconnection. When the server crashes or the app is backgrounded, the channel receives another join message. Previously, this would crash the client. With these changes, the `LiveViewCoordinator` should be able to handle subsequent joins more gracefully.