### PR TITLE
Fix navigation root URL state

### DIFF
--- a/Sources/LiveViewNative/Coordinators/LiveSessionCoordinator.swift
+++ b/Sources/LiveViewNative/Coordinators/LiveSessionCoordinator.swift
@@ -83,7 +83,7 @@ public class LiveSessionCoordinator<R: RootRegistry>: ObservableObject {
                 let last = next.last ?? .init(url: self.url, coordinator: self.rootCoordinator)
                 if last.coordinator.url != last.url {
                     last.coordinator.url = last.url
-                    Task { @MainActor in
+                    Task {
                         try await last.coordinator.connect(domValues: self.domValues, redirect: true)
                     }
                 }

--- a/Sources/LiveViewNative/Coordinators/LiveViewCoordinator.swift
+++ b/Sources/LiveViewNative/Coordinators/LiveViewCoordinator.swift
@@ -308,9 +308,11 @@ public class LiveViewCoordinator<R: RootRegistry>: ObservableObject {
                     }
             }
         }
-        channel = nil
-        self.internalState = .notConnected
-        self.document = nil
+        await MainActor.run { [weak self] in
+            self?.channel = nil
+            self?.internalState = .notConnected
+            self?.document = nil
+        }
     }
     
     enum JoinResult {

--- a/Sources/LiveViewNative/LiveView.swift
+++ b/Sources/LiveViewNative/LiveView.swift
@@ -219,7 +219,7 @@ public struct LiveView<R: RootRegistry>: View {
     }
     
     private var navigationRoot: some View {
-        NavStackEntryView(.init(url: storage.session.rootCoordinator.url, coordinator: rootCoordinator))
+        NavStackEntryView(.init(url: storage.session.url, coordinator: rootCoordinator))
     }
 }
 


### PR DESCRIPTION
This resolves the following issues:

* Incorrect back button titles on the second page
* Second page is shown when navigating back, until the first page loads