### PR TITLE
Add transition configuration for page loads

### DIFF
--- a/Sources/LiveViewNative/Coordinators/LiveSessionConfiguration.swift
+++ b/Sources/LiveViewNative/Coordinators/LiveSessionConfiguration.swift
@@ -23,6 +23,9 @@ public struct LiveSessionConfiguration {
     /// The URL session the coordinator will use for performing HTTP and socket requests. By default, this is the shared session.
     public var urlSession: URLSession = .shared
     
+    /// The transition used when the live view changes connects.
+    public var transition: AnyTransition?
+    
     /// Constructs a default, empty configuration.
     public init() {
     }
@@ -30,11 +33,13 @@ public struct LiveSessionConfiguration {
     public init(
         navigationMode: NavigationMode = .enabled,
         connectParams: ((URL) -> [String: Any])? = nil,
-        urlSession: URLSession = .shared
+        urlSession: URLSession = .shared,
+        transition: AnyTransition? = nil
     ) {
         self.navigationMode = navigationMode
         self.connectParams = connectParams
         self.urlSession = urlSession
+        self.transition = transition
     }
     
     /// Possible modes for live view navigation.

--- a/Sources/LiveViewNative/NavStackEntryView.swift
+++ b/Sources/LiveViewNative/NavStackEntryView.swift
@@ -31,43 +31,53 @@ struct NavStackEntryView<R: RootRegistry>: View {
     
     @ViewBuilder
     private var elementTree: some View {
-        if coordinator.url == entry.url {
-            switch coordinator.state {
-            case .connected:
-                coordinator.builder.fromNodes(coordinator.document![coordinator.document!.root()].children(), coordinator: coordinator, url: coordinator.url)
-                    .environment(\.coordinatorEnvironment, CoordinatorEnvironment(coordinator, document: coordinator.document!))
-                    .onPreferenceChange(NavigationTitleModifierKey.self) { navigationTitle in
-                        self.liveViewModel.cachedNavigationTitle = navigationTitle
-                    }
-            default:
-                let content = SwiftUI.Group {
-                    if R.LoadingView.self == Never.self {
-                        switch coordinator.state {
-                        case .connected:
-                            fatalError()
-                        case .notConnected:
-                            SwiftUI.Text("Not Connected")
-                        case .connecting:
-                            SwiftUI.Text("Connecting")
-                        case .connectionFailed(let error):
-                            SwiftUI.VStack {
-                                SwiftUI.Text("Connection Failed")
-                                    .font(.subheadline)
-                                SwiftUI.Text(error.localizedDescription)
-                            }
+        SwiftUI.Group {
+            if coordinator.url == entry.url {
+                switch coordinator.state {
+                case .connected:
+                    coordinator.builder.fromNodes(coordinator.document![coordinator.document!.root()].children(), coordinator: coordinator, url: coordinator.url)
+                        .environment(\.coordinatorEnvironment, CoordinatorEnvironment(coordinator, document: coordinator.document!))
+                        .onPreferenceChange(NavigationTitleModifierKey.self) { navigationTitle in
+                            self.liveViewModel.cachedNavigationTitle = navigationTitle
                         }
+                default:
+                    let content = SwiftUI.Group {
+                        if R.LoadingView.self == Never.self {
+                            switch coordinator.state {
+                            case .connected:
+                                fatalError()
+                            case .notConnected:
+                                SwiftUI.Text("Not Connected")
+                            case .connecting:
+                                SwiftUI.ProgressView("Connecting")
+                            case .connectionFailed(let error):
+                                SwiftUI.VStack {
+                                    SwiftUI.Text("Connection Failed")
+                                        .font(.subheadline)
+                                    SwiftUI.Text(error.localizedDescription)
+                                }
+                            }
+                        } else {
+                            R.loadingView(for: coordinator.url, state: coordinator.state)
+                        }
+                    }
+                    if let cachedNavigationTitle = liveViewModel.cachedNavigationTitle {
+                        content.modifier(cachedNavigationTitle)
                     } else {
-                        R.loadingView(for: coordinator.url, state: coordinator.state)
+                        content
                     }
                 }
-                if let cachedNavigationTitle = liveViewModel.cachedNavigationTitle {
-                    content.modifier(cachedNavigationTitle)
-                } else {
-                    content
-                }
+            } else if let cachedNavigationTitle = liveViewModel.cachedNavigationTitle {
+                SwiftUI.Text("").modifier(cachedNavigationTitle)
             }
-        } else if let cachedNavigationTitle = liveViewModel.cachedNavigationTitle {
-            SwiftUI.Text("").modifier(cachedNavigationTitle)
         }
+        .transition(coordinator.session.configuration.transition ?? .identity)
+        .animation(coordinator.session.configuration.transition.map({ _ in .default }), value: { () -> Bool in
+            if case .connected = coordinator.state {
+                return true
+            } else {
+                return false
+            }
+        }())
     }
 }

--- a/Sources/LiveViewNative/NavStackEntryView.swift
+++ b/Sources/LiveViewNative/NavStackEntryView.swift
@@ -40,6 +40,7 @@ struct NavStackEntryView<R: RootRegistry>: View {
                         .onPreferenceChange(NavigationTitleModifierKey.self) { navigationTitle in
                             self.liveViewModel.cachedNavigationTitle = navigationTitle
                         }
+                        .transition(coordinator.session.configuration.transition ?? .identity)
                 default:
                     let content = SwiftUI.Group {
                         if R.LoadingView.self == Never.self {
@@ -61,6 +62,7 @@ struct NavStackEntryView<R: RootRegistry>: View {
                             R.loadingView(for: coordinator.url, state: coordinator.state)
                         }
                     }
+                    .transition(coordinator.session.configuration.transition ?? .identity)
                     if let cachedNavigationTitle = liveViewModel.cachedNavigationTitle {
                         content.modifier(cachedNavigationTitle)
                     } else {
@@ -71,7 +73,6 @@ struct NavStackEntryView<R: RootRegistry>: View {
                 SwiftUI.Text("").modifier(cachedNavigationTitle)
             }
         }
-        .transition(coordinator.session.configuration.transition ?? .identity)
         .animation(coordinator.session.configuration.transition.map({ _ in .default }), value: { () -> Bool in
             if case .connected = coordinator.state {
                 return true


### PR DESCRIPTION
This adds a configuration option that lets you add a transition between the progress indicator and the loaded page.

Simply add the `transition` argument to your `LiveSessionConfiguration`:

```swift
LiveView(.localhost, configuration: .init(transition: .opacity))
```

Here's a before/after sample using the `opacity` transition:

| Before | After |
| --- | --- |
| <video src="https://github.com/liveview-native/liveview-client-swiftui/assets/13581484/28947706-9dca-4632-bee4-d0c97bc22406" /> | <video src="https://github.com/liveview-native/liveview-client-swiftui/assets/13581484/75bfe372-ed07-4595-927c-803516344cff" /> |

Page loads are much less jarring with these changes. You can use any type of transition in your configuration, such as `.scale` or `.move(edge: .bottom)`:


https://github.com/liveview-native/liveview-client-swiftui/assets/13581484/e029a09d-41a7-40f8-a352-a43b68600b0b


https://github.com/liveview-native/liveview-client-swiftui/assets/13581484/c253b9a0-1b8c-4951-b30f-28c693c41fcf

