### PR TITLE
Remove `swiftSettings` arguments for documentation

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,12 +3,6 @@
 
 import PackageDescription
 
-#if swift(>=5.8)
-let swiftSettings = [SwiftSetting.unsafeFlags(["-emit-extension-block-symbols"])]
-#else
-let swiftSettings = [SwiftSetting]()
-#endif
-
 let package = Package(
     name: "LiveViewNative",
     platforms: [
@@ -43,7 +37,6 @@ let package = Package(
                 .product(name: "AsyncAlgorithms", package: "swift-async-algorithms"),
                 .product(name: "LiveViewNativeCore", package: "liveview-native-core-swift")
             ],
-            swiftSettings: swiftSettings,
             plugins: [
                 .plugin(name: "BuiltinRegistryGeneratorPlugin")
             ]

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -41,9 +41,6 @@ let package = Package(
                 .product(name: "LiveViewNativeCore", package: "liveview-native-core-swift"),
                 "LiveViewNativeMacros"
             ],
-            swiftSettings: [
-                SwiftSetting.unsafeFlags(["-emit-extension-block-symbols"])
-            ],
             plugins: [
                 .plugin(name: "BuiltinRegistryGeneratorPlugin")
             ]


### PR DESCRIPTION
Closes #1136 

Some flags were being passed to the compiler to improve our generated documentation output.
However, these flags were causing issues in newer versions of Xcode when using a version number instead of a branch name or commit hash.

The flags have been removed. If we decide to continue using DocC for documentation instead of switching to hexdocs, we may need to find a workaround for this. A few options are:

1. Move the documentation on affected extensions into articles
2. Conditionally add these "unsafe" flags when building documentation
3. See if newer/upcoming versions of Swift emit this documentation by default and use those for building documentation

I think one of these options could be implemented in a separate PR.