### PR TITLE
Add SwiftUI specific rules helpers

### DIFF
--- a/lib/live_view_native/swiftui/rules_helpers.ex
+++ b/lib/live_view_native/swiftui/rules_helpers.ex
@@ -1,0 +1,5 @@
+defmodule LiveViewNative.SwiftUI.RulesHelpers do
+  def to_ime(expr) when is_binary(expr) do
+    {:., [], [nil, String.to_atom(expr)]}
+  end
+end

--- a/lib/live_view_native/swiftui/rules_parser.ex
+++ b/lib/live_view_native/swiftui/rules_parser.ex
@@ -1,6 +1,13 @@
 defmodule LiveViewNative.SwiftUI.RulesParser do
   use LiveViewNative.Stylesheet.RulesParser, :mock
 
+  def __using__(_) do
+    quote do
+      import LiveViewNative.SwiftUI.RulesParser, only: [sigil_RULES: 2]
+      import LiveViewNative.SwiftUI.RulesHelpers
+    end
+  end
+
   def parse(rules) do
     rules
   end

--- a/test/live_view_native/swiftui/rules_helpers_test.exs
+++ b/test/live_view_native/swiftui/rules_helpers_test.exs
@@ -1,0 +1,10 @@
+defmodule LiveViewNative.SwiftUI.RulesHelpersTest do
+  use ExUnit.Case
+  alias LiveViewNative.SwiftUI.RulesHelpers
+
+  describe "to_ime" do
+    test "convert to the ime syntax for the AST" do
+      assert RulesHelpers.to_ime("foobar") == {:., [], [nil, :foobar]}
+    end
+  end
+end


### PR DESCRIPTION
to_ime

This also added __using__/1 to LiveViewNative.RulesParser so we can import the rules helpers into the Sheet

The `to_ime` is half-baked. There will need to be more complex edge cases accounted for here like chaining and function calls.