### PR TITLE
Continue rendering disconnected pages in navigation path

### DIFF
--- a/Sources/LiveViewNative/Coordinators/LiveSessionCoordinator.swift
+++ b/Sources/LiveViewNative/Coordinators/LiveSessionCoordinator.swift
@@ -389,7 +389,8 @@ public class LiveSessionCoordinator<R: RootRegistry>: ObservableObject {
             }
         case .patch:
             // patch is like `replaceTop`, but it does not disconnect.
-            let coordinator = LiveViewCoordinator(session: self, url: redirect.to, from: navigationPath.last?.coordinator ?? rootCoordinator)
+            let coordinator = (navigationPath.last?.coordinator ?? rootCoordinator)!
+            coordinator.url = redirect.to
             let entry = LiveNavigationEntry(url: redirect.to, coordinator: coordinator)
             switch redirect.kind {
             case .push:

--- a/Sources/LiveViewNative/Coordinators/LiveSessionCoordinator.swift
+++ b/Sources/LiveViewNative/Coordinators/LiveSessionCoordinator.swift
@@ -31,17 +31,13 @@ private let logger = Logger(subsystem: "LiveViewNative", category: "LiveSessionC
 /// - ``LiveConnectionError``
 @MainActor
 public class LiveSessionCoordinator<R: RootRegistry>: ObservableObject {
-    @Published internal private(set) var internalState: LiveSessionState = .notConnected
     /// The current state of the live view connection.
-    public var state: LiveSessionState {
-        internalState
-    }
+    @Published public private(set) var state = LiveSessionState.notConnected
     
     /// The current URL this live view is connected to.
     public private(set) var url: URL
     
     @Published var navigationPath = [LiveNavigationEntry<R>]()
-    var rootCoordinator: LiveViewCoordinator<R>!
     
     internal let configuration: LiveSessionConfiguration
     
@@ -70,9 +66,9 @@ public class LiveSessionCoordinator<R: RootRegistry>: ObservableObject {
     public init(_ url: URL, config: LiveSessionConfiguration = .init(), customRegistryType _: R.Type = R.self) {
         self.url = url.appending(path: "").absoluteURL
         self.configuration = config
-        self.rootCoordinator = .init(session: self, url: self.url)
-        self.mergedEventSubjects = self.rootCoordinator.eventSubject.compactMap({
-            [weak self] value in self.map({ ($0.rootCoordinator, value) })
+        self.navigationPath = [.init(url: url, coordinator: .init(session: self, url: self.url))]
+        self.mergedEventSubjects = self.navigationPath.first!.coordinator.eventSubject.compactMap({ [weak self] value in
+            self.map({ ($0.navigationPath.first!.coordinator, value) })
         })
         .sink(receiveValue: { [weak self] value in
             self?.eventSubject.send(value)
@@ -80,10 +76,15 @@ public class LiveSessionCoordinator<R: RootRegistry>: ObservableObject {
         $navigationPath.scan(([LiveNavigationEntry<R>](), [LiveNavigationEntry<R>]()), { ($0.1, $1) }).sink { [weak self] prev, next in
             guard let self else { return }
             if prev.count > next.count {
-                let last = next.last?.coordinator ?? rootCoordinator
-                if case .notConnected = last?.state {
+                let isDisconnected: Bool
+                if case .notConnected = next.last!.coordinator.state {
+                    isDisconnected = true
+                } else {
+                    isDisconnected = false
+                }
+                if next.last!.coordinator.url != next.last!.url || isDisconnected {
                     Task {
-                        try await last?.connect(domValues: self.domValues, redirect: true)
+                        try await next.last!.coordinator.connect(domValues: self.domValues, redirect: true)
                     }
                 }
             }
@@ -91,7 +92,7 @@ public class LiveSessionCoordinator<R: RootRegistry>: ObservableObject {
         // Receive events from all live views.
         $navigationPath.sink { [weak self] entries in
             if let self {
-                let allCoordinators = ([self.rootCoordinator] + entries.map(\.coordinator))
+                let allCoordinators = entries.map(\.coordinator)
                     .reduce(into: [LiveViewCoordinator<R>]()) { result, next in
                         guard !result.contains(where: { $0 === next }) else { return }
                         result.append(next)
@@ -121,19 +122,19 @@ public class LiveSessionCoordinator<R: RootRegistry>: ObservableObject {
     ///
     /// This is an async function which completes when the connection has been established or failed.
     public func connect() async {
-        guard case .notConnected = internalState else {
+        guard case .notConnected = state else {
             return
         }
         
         logger.debug("Connecting to \(self.url.absoluteString)")
         
-        internalState = .connecting
+        state = .connecting
         
         let html: String
         do {
             html = try await fetchDOM(url: self.url)
         } catch {
-            internalState = .connectionFailed(error)
+            state = .connectionFailed(error)
             return
         }
         
@@ -142,7 +143,7 @@ public class LiveSessionCoordinator<R: RootRegistry>: ObservableObject {
             let doc = try SwiftSoup.parse(html)
             domValues = try self.extractDOMValues(doc)
         } catch {
-            internalState = .connectionFailed(error)
+            state = .connectionFailed(error)
             return
         }
         
@@ -152,27 +153,26 @@ public class LiveSessionCoordinator<R: RootRegistry>: ObservableObject {
             do {
                 try await self.connectSocket(domValues)
             } catch {
-                internalState = .connectionFailed(error)
+                state = .connectionFailed(error)
                 return
             }
         }
         
         do {
-            try await rootCoordinator.connect(domValues: domValues, redirect: false)
+            try await navigationPath.first!.coordinator.connect(domValues: domValues, redirect: false)
         } catch {
-            self.internalState = .connectionFailed(error)
+            self.state = .connectionFailed(error)
         }
     }
     
     private func disconnect() async {
-        await rootCoordinator.disconnect()
         for entry in self.navigationPath {
             await entry.coordinator.disconnect()
         }
         self.navigationPath.removeAll()
         self.socket?.disconnect()
         self.socket = nil
-        self.internalState = .notConnected
+        self.state = .notConnected
     }
     
     /// Forces the session to disconnect then connect.
@@ -312,7 +312,7 @@ public class LiveSessionCoordinator<R: RootRegistry>: ObservableObject {
         self.socket?.onClose { logger.debug("[Socket] Closed") }
         self.socket?.logger = { message in logger.debug("[Socket] \(message)") }
         
-        self.internalState = .connected
+        self.state = .connected
         
         if domValues.liveReloadEnabled {
             await self.connectLiveReloadSocket(urlSessionConfiguration: configuration)
@@ -352,7 +352,7 @@ public class LiveSessionCoordinator<R: RootRegistry>: ObservableObject {
     func redirect(_ redirect: LiveRedirect) async throws {
         switch redirect.mode {
         case .replaceTop:
-            await (navigationPath.last?.coordinator ?? rootCoordinator)?.disconnect()
+            await navigationPath.last?.coordinator.disconnect()
             let coordinator = LiveViewCoordinator(session: self, url: redirect.to)
             let entry = LiveNavigationEntry(url: redirect.to, coordinator: coordinator)
             switch redirect.kind {
@@ -374,22 +374,17 @@ public class LiveSessionCoordinator<R: RootRegistry>: ObservableObject {
                 ))
             case .replace:
                 // If there is nothing to replace, change the root URL.
-                if navigationPath.isEmpty {
-                    rootCoordinator.url = redirect.to
-                    try await rootCoordinator.connect(domValues: self.domValues, redirect: true)
-                } else {
-                    navigationPath.removeLast()
-                    // If we are replacing the current path with the previous one, just pop the URL so the previous one is on top.
-                    guard (navigationPath.last?.coordinator.url ?? self.url) != redirect.to else { return }
-                    navigationPath.append(.init(
-                        url: redirect.to,
-                        coordinator: LiveViewCoordinator(session: self, url: redirect.to)
-                    ))
-                }
+                navigationPath.removeLast()
+                // If we are replacing the current path with the previous one, just pop the URL so the previous one is on top.
+                guard (navigationPath.last?.coordinator.url ?? self.url) != redirect.to else { return }
+                navigationPath.append(.init(
+                    url: redirect.to,
+                    coordinator: LiveViewCoordinator(session: self, url: redirect.to)
+                ))
             }
         case .patch:
             // patch is like `replaceTop`, but it does not disconnect.
-            let coordinator = (navigationPath.last?.coordinator ?? rootCoordinator)!
+            let coordinator = navigationPath.last!.coordinator
             coordinator.url = redirect.to
             let entry = LiveNavigationEntry(url: redirect.to, coordinator: coordinator)
             switch redirect.kind {

--- a/Sources/LiveViewNative/Coordinators/LiveSessionCoordinator.swift
+++ b/Sources/LiveViewNative/Coordinators/LiveSessionCoordinator.swift
@@ -169,7 +169,7 @@ public class LiveSessionCoordinator<R: RootRegistry>: ObservableObject {
         for entry in self.navigationPath {
             await entry.coordinator.disconnect()
         }
-        self.navigationPath.removeAll()
+        self.navigationPath = [self.navigationPath.first!]
         self.socket?.disconnect()
         self.socket = nil
         self.state = .notConnected

--- a/Sources/LiveViewNative/Coordinators/LiveViewCoordinator.swift
+++ b/Sources/LiveViewNative/Coordinators/LiveViewCoordinator.swift
@@ -53,14 +53,17 @@ public class LiveViewCoordinator<R: RootRegistry>: ObservableObject {
         self.url = url
         if let other {
             self.channel = other.channel
-            if let document = other.document {
-                self.document = try! Document.parse(document.toString())
+            if let rendered = other.rendered {
+                // create a new document that won't be merged into.
+                // should core have a "clone document" ability?
+                self.document = try! Document.parse(rendered.buildString())
             }
             self.rendered = other.rendered
             self.currentConnectionToken = other.currentConnectionToken
             self.currentConnectionTask = other.currentConnectionTask
             self.eventSubject = other.eventSubject
             self.eventHandlers = other.eventHandlers
+            self.internalState = other.internalState
         }
         
         self.handleEvent("native_redirect") { [weak self] payload in

--- a/Sources/LiveViewNative/NavStackEntryView.swift
+++ b/Sources/LiveViewNative/NavStackEntryView.swift
@@ -37,13 +37,16 @@ struct NavStackEntryView<R: RootRegistry>: View {
                 case .connected:
                     coordinator.builder.fromNodes(coordinator.document![coordinator.document!.root()].children(), coordinator: coordinator, url: coordinator.url)
                         .environment(\.coordinatorEnvironment, CoordinatorEnvironment(coordinator, document: coordinator.document!))
-                        .onPreferenceChange(NavigationTitleModifierKey.self) { navigationTitle in
-                            self.liveViewModel.cachedNavigationTitle = navigationTitle
-                        }
                         .transition(coordinator.session.configuration.transition ?? .identity)
                 default:
-                    let content = SwiftUI.Group {
-                        if R.LoadingView.self == Never.self {
+                    SwiftUI.Group {
+                        if case .notConnected = coordinator.state,
+                           let document = coordinator.document
+                        {
+                           coordinator.builder.fromNodes(document[document.root()].children(), coordinator: coordinator, url: coordinator.url)
+                               .environment(\.coordinatorEnvironment, CoordinatorEnvironment(coordinator, document: document))
+                               .disabled(true)
+                       } else if R.LoadingView.self == Never.self {
                             switch coordinator.state {
                             case .connected:
                                 fatalError()
@@ -63,11 +66,6 @@ struct NavStackEntryView<R: RootRegistry>: View {
                         }
                     }
                     .transition(coordinator.session.configuration.transition ?? .identity)
-                    if let cachedNavigationTitle = liveViewModel.cachedNavigationTitle {
-                        content.modifier(cachedNavigationTitle)
-                    } else {
-                        content
-                    }
                 }
             } else if let cachedNavigationTitle = liveViewModel.cachedNavigationTitle {
                 SwiftUI.Text("").modifier(cachedNavigationTitle)

--- a/Tests/RenderingTests/assertMatch.swift
+++ b/Tests/RenderingTests/assertMatch.swift
@@ -96,12 +96,12 @@ extension XCTestCase {
         #else
         let session = LiveSessionCoordinator(URL(string: "http://localhost")!)
         let document = try LiveViewNativeCore.Document.parse(markup)
-        let viewTree = session.rootCoordinator.builder.fromNodes(
+        let viewTree = session.navigationPath.first!.builder.fromNodes(
             document[document.root()].children(),
-            coordinator: session.rootCoordinator,
+            coordinator: session.navigationPath.first!,
             url: session.url
         )
-            .environment(\.coordinatorEnvironment, CoordinatorEnvironment(session.rootCoordinator, document: document))
+            .environment(\.coordinatorEnvironment, CoordinatorEnvironment(session.navigationPath.first!, document: document))
             .environmentObject(LiveViewModel())
         
         let modifyViewForRender: (any View) -> any View = {

--- a/Tests/RenderingTests/assertMatch.swift
+++ b/Tests/RenderingTests/assertMatch.swift
@@ -96,12 +96,12 @@ extension XCTestCase {
         #else
         let session = LiveSessionCoordinator(URL(string: "http://localhost")!)
         let document = try LiveViewNativeCore.Document.parse(markup)
-        let viewTree = session.navigationPath.first!.builder.fromNodes(
+        let viewTree = session.navigationPath.first!.coordinator.builder.fromNodes(
             document[document.root()].children(),
-            coordinator: session.navigationPath.first!,
+            coordinator: session.navigationPath.first!.coordinator,
             url: session.url
         )
-            .environment(\.coordinatorEnvironment, CoordinatorEnvironment(session.navigationPath.first!, document: document))
+            .environment(\.coordinatorEnvironment, CoordinatorEnvironment(session.navigationPath.first!.coordinator, document: document))
             .environmentObject(LiveViewModel())
         
         let modifyViewForRender: (any View) -> any View = {


### PR DESCRIPTION
Closes #1130

- ~~Provide the same functionality for `push_patch`~~ - `push_patch` is functional, but will instead show the current page due to the shared channel.
- [x] Navigating backward by multiple pages is broken (long press on back button)
- [x] Test `redirect` support

This persists the `Document` for disconnected pages, and ensures there is one `LiveViewCoordinator` per navigation history entry.

Previously, navigating backward would temporarily show a blank page:

https://github.com/liveview-native/liveview-client-swiftui/assets/13581484/08d829cd-16d2-4719-a251-970b7fbcb043

With these changes, there is now a disabled version of the page still visible, which is then replaced with the newly rendered page after it reconnects:

https://github.com/liveview-native/liveview-client-swiftui/assets/13581484/e4a25717-3692-4b54-a82d-b09527ca0c65
