### PR TITLE
Fix key/value pairs with helper calls

### DIFF
--- a/lib/live_view_native/swiftui/rules_parser.ex
+++ b/lib/live_view_native/swiftui/rules_parser.ex
@@ -45,7 +45,7 @@ defmodule LiveViewNative.SwiftUI.RulesParser do
       {:ok, output, _unconsumed = "", _context, _current_line_and_offset, _} ->
         output
 
-      {:error, message, _unconsumed, _context, {line, _}, _} ->
+      {:error, message, _unconsumed, _context, {line, column}, _} ->
         raise SyntaxError,
           description: message,
           file: file,

--- a/lib/live_view_native/swiftui/rules_parser.ex
+++ b/lib/live_view_native/swiftui/rules_parser.ex
@@ -45,7 +45,7 @@ defmodule LiveViewNative.SwiftUI.RulesParser do
       {:ok, output, _unconsumed = "", _context, _current_line_and_offset, _} ->
         output
 
-      {:error, message, _unconsumed, _context, {line, column}, _} ->
+      {:error, message, _unconsumed, _context, {line, _}, _} ->
         raise SyntaxError,
           description: message,
           file: file,

--- a/lib/live_view_native/swiftui/rules_parser/expressions.ex
+++ b/lib/live_view_native/swiftui/rules_parser/expressions.ex
@@ -65,7 +65,7 @@ defmodule LiveViewNative.SwiftUI.RulesParser.Expressions do
 
   def key_value_pair(opts \\ []) do
     colon =
-      if opts[:generate_error?] || false do
+      if opts[:generate_error?] do
         # require that the colon be provided
         expect(ignore(string(":")), error_message: "expected ‘:’")
       else

--- a/lib/live_view_native/swiftui/rules_parser/expressions.ex
+++ b/lib/live_view_native/swiftui/rules_parser/expressions.ex
@@ -32,9 +32,9 @@ defmodule LiveViewNative.SwiftUI.RulesParser.Expressions do
   # Collections
   #
 
-  def comma_separated_list(start \\ empty(), elem_combinator, opts \\ []) do
+  def comma_separated_list(elem_combinator, opts \\ []) do
     delimiter_separated_list(
-      start,
+      empty(),
       elem_combinator,
       ",",
       Keyword.merge([allow_empty?: true], opts)
@@ -66,10 +66,10 @@ defmodule LiveViewNative.SwiftUI.RulesParser.Expressions do
   def key_value_pair(opts \\ []) do
     key =
       if opts[:generate_error?] || false do
+        # require that the colon be provided
         concat(
           word(),
-          ignore(string(":"))
-          |> expect(error_message: "expected ‘:’")
+          expect(ignore(string(":")), error_message: "expected ‘:’")
         )
       else
         concat(word(), ignore(string(":")))
@@ -85,8 +85,6 @@ defmodule LiveViewNative.SwiftUI.RulesParser.Expressions do
   end
 
   def key_value_pairs(opts \\ []) do
-    empty()
-    |> comma_separated_list(key_value_pair(opts), opts)
-    |> wrap()
+    wrap(comma_separated_list(key_value_pair(opts), opts))
   end
 end

--- a/lib/live_view_native/swiftui/rules_parser/expressions.ex
+++ b/lib/live_view_native/swiftui/rules_parser/expressions.ex
@@ -64,17 +64,15 @@ defmodule LiveViewNative.SwiftUI.RulesParser.Expressions do
   end
 
   def key_value_pair(opts \\ []) do
-    key =
+    colon =
       if opts[:generate_error?] || false do
         # require that the colon be provided
-        concat(
-          word(),
-          expect(ignore(string(":")), error_message: "expected ‘:’")
-        )
+        expect(ignore(string(":")), error_message: "expected ‘:’")
       else
-        concat(word(), ignore(string(":")))
+        ignore(string(":"))
       end
 
+    key = concat(word(), colon)
     value = parsec(:key_value_pairs_arguments)
 
     ignore_whitespace()

--- a/lib/live_view_native/swiftui/rules_parser/modifiers.ex
+++ b/lib/live_view_native/swiftui/rules_parser/modifiers.ex
@@ -8,7 +8,7 @@ defmodule LiveViewNative.SwiftUI.RulesParser.Modifiers do
 
   defcombinator(
     :key_value_list,
-    enclosed("[", key_value_pairs(generate_error?: false, allow_empty?: false), "]",
+    enclosed("[", key_value_pairs(generate_error?: true, allow_empty?: false), "]",
       allow_empty?: false,
       error_parser: non_whitespace(also_ignore: String.to_charlist(")],"))
     )
@@ -30,11 +30,11 @@ defmodule LiveViewNative.SwiftUI.RulesParser.Modifiers do
     if is_nested do
       combinator
     else
-      expected(combinator,
+      expect(combinator,
         error_message:
           """
           Expected ‘()’ or ‘(<modifier_arguments>)’ where <modifier_arguments> are a comma separated list of:
-          #{label_from_named_choices(@modifier_arguments)}
+          #{label_from_named_choices(@modifier_arguments.([]))}
           """
           |> String.trim()
       )
@@ -116,7 +116,7 @@ defmodule LiveViewNative.SwiftUI.RulesParser.Modifiers do
     |> string("attr")
     |> enclosed(
       "(",
-      expected(
+      expect(
         double_quoted_string(),
         error_message: "‘attr’ expects a string argument",
         error_parser: optional(non_whitespace(also_ignore: String.to_charlist(")],")))
@@ -128,7 +128,7 @@ defmodule LiveViewNative.SwiftUI.RulesParser.Modifiers do
   )
 
   event_arg_1 =
-    expected(
+    expect(
       double_quoted_string(),
       error_message: "‘event’ expects a string as the first argument",
       error_parser: optional(non_whitespace(also_ignore: String.to_charlist(")],")))
@@ -139,7 +139,7 @@ defmodule LiveViewNative.SwiftUI.RulesParser.Modifiers do
     |> ignore(string(","))
     |> ignore_whitespace()
     |> concat(
-      expected(
+      expect(
         choice([
           ignore(enclosed("[", ignore_whitespace(), "]", [])),
           parsec(:key_value_list),
@@ -163,53 +163,78 @@ defmodule LiveViewNative.SwiftUI.RulesParser.Modifiers do
     |> post_traverse({PostProcessors, :event_to_ast, []})
   )
 
-  @modifier_arguments [
-    {
-      literal(error_parser: empty(), generate_error?: false),
-      ~s'a number, string, nil, boolean or :atom'
-    },
-    {
-      parsec(:event),
-      ~s'an event eg ‘event("search-event", throttle: 10_000)’'
-    },
-    {
-      parsec(:attr),
-      ~s'an attribute eg ‘attr("placeholder")’'
-    },
-    {
-      parsec(:ime),
-      ~s'an IME eg ‘Color.red’ or ‘.largeTitle’ or ‘Color.to_ime(variable)’'
-    },
-    {
-      key_value_pairs(generate_error?: false, allow_empty?: false),
-      ~s'a list of keyword pairs eg ‘style: :dashed’, ‘size: 12’ or  ‘style: [lineWidth: 1]’'
-    },
-    {
-      parsec(:helper_function),
-      ~s'a helper function eg ‘to_float(variable)’'
-    },
-    {
-      frozen(parsec(:nested_modifier)),
-      "a modifier eg ‘bold()’"
-    },
-    {
-      variable(generate_error?: false),
-      ~s'a variable defined in the class header eg ‘color_name’'
-    }
-  ]
+  @modifier_arguments fn opts ->
+    [
+      {
+        literal(error_parser: empty(), generate_error?: false),
+        ~s'a number, string, nil, boolean or :atom'
+      },
+      {
+        parsec(:event),
+        ~s'an event eg ‘event("search-event", throttle: 10_000)’'
+      },
+      {
+        parsec(:attr),
+        ~s'an attribute eg ‘attr("placeholder")’'
+      },
+      {
+        parsec(:ime),
+        ~s'an IME eg ‘Color.red’ or ‘.largeTitle’ or ‘Color.to_ime(variable)’'
+      },
+      {
+        key_value_pairs(generate_error?: false, allow_empty?: false),
+        ~s'a list of keyword pairs eg ‘style: :dashed’, ‘size: 12’ or  ‘style: [lineWidth: 1]’',
+        not Keyword.get(opts, :exclude_key_value_pairs, false)
+      },
+      {
+        parsec(:helper_function),
+        ~s'a helper function eg ‘to_float(variable)’'
+      },
+      {
+        frozen(parsec(:nested_modifier)),
+        "a modifier eg ‘bold()’"
+      },
+      {
+        variable(generate_error?: false),
+        ~s'a variable defined in the class header eg ‘color_name’'
+      }
+    ]
+    |> Enum.flat_map(fn
+      {combinator, description} -> [{combinator, description}]
+      {combinator, description, true} -> [{combinator, description}]
+      {_, _, false} -> []
+    end)
+  end
+
+  defcombinator(
+    :key_value_pairs_arguments,
+    one_of(
+      [
+        {parsec(:key_value_list),
+         ~s'a keyword list eg ‘[style: :dashed]’, ‘[size: 12]’ or ‘[lineWidth: lineWidth]’'}
+        | @modifier_arguments.(exclude_key_value_pairs: true)
+      ],
+      error_parser: non_whitespace(also_ignore: String.to_charlist(")"))
+    )
+  )
+
+  defcombinator(
+    :modifier_argument,
+    one_of(@modifier_arguments.([]),
+      error_parser: non_whitespace(also_ignore: String.to_charlist(")"))
+    )
+  )
 
   defcombinator(
     :modifier_arguments,
-    empty()
-    |> comma_separated_list(
-      one_of(@modifier_arguments,
-        error_parser: non_whitespace(also_ignore: String.to_charlist(")"))
-      ),
+    comma_separated_list(
+      empty(),
+      parsec(:modifier_argument),
       allow_empty?: false,
       error_message:
         """
         Expected ‘(<modifier_arguments>)’ where <modifier_arguments> are a comma separated list of:
-        #{label_from_named_choices(@modifier_arguments)}
+        #{label_from_named_choices(@modifier_arguments.([]))}
         """
         |> String.trim(),
       error_parser: non_whitespace(also_ignore: String.to_charlist(")]"))

--- a/lib/live_view_native/swiftui/rules_parser/parser.ex
+++ b/lib/live_view_native/swiftui/rules_parser/parser.ex
@@ -45,7 +45,7 @@ defmodule LiveViewNative.SwiftUI.RulesParser.Parser do
     )
   end
 
-  def expected(combinator \\ empty(), combinator_2, opts) do
+  def expect(combinator \\ empty(), combinator_2, opts) do
     error_parser = Keyword.get(opts, :error_parser, non_whitespace())
     error_message = Keyword.get(opts, :error_message)
     generate_error? = Keyword.get(opts, :generate_error?, true)

--- a/lib/live_view_native/swiftui/rules_parser/tokens.ex
+++ b/lib/live_view_native/swiftui/rules_parser/tokens.ex
@@ -51,6 +51,14 @@ defmodule LiveViewNative.SwiftUI.RulesParser.Tokens do
 
   def number() do
     choice([float(), int()])
+    |> expect(
+      ignore_whitespace()
+      |> utf8_char(String.to_charlist(",)]"))
+      |> ignore()
+      |> lookahead(),
+      error_message: "Invalid suffix on number",
+      error_parser: non_whitespace(also_ignore: String.to_charlist(",)]"))
+    )
   end
 
   def atom() do
@@ -60,7 +68,7 @@ defmodule LiveViewNative.SwiftUI.RulesParser.Tokens do
         double_quoted_string(),
         variable_name()
       ])
-      |> expected(
+      |> expect(
         error_message: "Expected an atom",
         error_parser:
           choice([
@@ -147,7 +155,7 @@ defmodule LiveViewNative.SwiftUI.RulesParser.Tokens do
   def variable(opts \\ []) do
     variable_name()
     |> post_traverse({PostProcessors, :to_elixir_variable_ast, []})
-    |> expected(
+    |> expect(
       Keyword.merge(
         opts,
         error_message: "expected a variable"
@@ -159,7 +167,7 @@ defmodule LiveViewNative.SwiftUI.RulesParser.Tokens do
     ascii_string([?a..?z, ?A..?Z, ?_], 1)
     |> ascii_string([?a..?z, ?A..?Z, ?0..?9, ?_], min: 0)
     |> reduce({Enum, :join, [""]})
-    |> expected(
+    |> expect(
       error_message: "Expected a modifier name",
       error_parser:
         choice([
@@ -191,7 +199,7 @@ defmodule LiveViewNative.SwiftUI.RulesParser.Tokens do
     ascii_string([?A..?Z], 1)
     |> ascii_string([?a..?z, ?A..?Z, ?0..?9, ?_], min: 0)
     |> reduce({Enum, :join, [""]})
-    |> expected(
+    |> expect(
       error_message: "Expected a type name",
       error_parser:
         choice([

--- a/lib/live_view_native/swiftui/rules_parser/tokens.ex
+++ b/lib/live_view_native/swiftui/rules_parser/tokens.ex
@@ -53,11 +53,11 @@ defmodule LiveViewNative.SwiftUI.RulesParser.Tokens do
     choice([float(), int()])
     |> expect(
       ignore_whitespace()
-      |> utf8_char(String.to_charlist(",)]"))
+      |> utf8_char(String.to_charlist(".,)]"))
       |> ignore()
       |> lookahead(),
       error_message: "Invalid suffix on number",
-      error_parser: non_whitespace(also_ignore: String.to_charlist(",)]"))
+      error_parser: non_whitespace(also_ignore: String.to_charlist(".,)]"))
     )
   end
 

--- a/test/live_view_native/swiftui/rules_parser_test.exs
+++ b/test/live_view_native/swiftui/rules_parser_test.exs
@@ -649,6 +649,29 @@ defmodule LiveViewNative.SwiftUI.RulesParserTest do
       assert String.trim(error.description) == error_prefix
     end
 
+    test "invalid keyword list: missing closing brace" do
+      input = "abc(def: 11, b: [lineWidth: 1)"
+
+      error =
+        assert_raise SyntaxError, fn ->
+          parse(input)
+        end
+
+      error_prefix =
+        """
+        Unsupported input:
+          |
+        1 | abc(def: 11, b: [lineWidth: 1)
+          |                              ^
+          |
+
+        expected ‘]’
+        """
+        |> String.trim()
+
+      assert String.trim(error.description) == error_prefix
+    end
+
     test "unexpected trailing character" do
       input = "font(.largeTitle) {"
 

--- a/test/live_view_native/swiftui/rules_parser_test.exs
+++ b/test/live_view_native/swiftui/rules_parser_test.exs
@@ -108,7 +108,7 @@ defmodule LiveViewNative.SwiftUI.RulesParserTest do
 
       assert parse(input) == output
     end
-    
+
 
     test "parses multiple modifiers" do
       input = "font(.largeTitle) bold(true) italic(true)"
@@ -446,8 +446,8 @@ defmodule LiveViewNative.SwiftUI.RulesParserTest do
         """
         Unsupported input:
           |
-        1 | blue_
-          |
+        1 | blue‎
+          |     ^
           |
 
         Expected ‘()’ or ‘(<modifier_arguments>)’ where <modifier_arguments> are a comma separated list of:
@@ -527,7 +527,7 @@ defmodule LiveViewNative.SwiftUI.RulesParserTest do
           |          ^
           |
 
-        expected ‘)’
+        Invalid suffix on number
         """
         |> String.trim()
 
@@ -535,7 +535,7 @@ defmodule LiveViewNative.SwiftUI.RulesParserTest do
     end
 
     test "invalid keyword pair: missing colon" do
-      input = "abc(def: 11, b: [lineWidth a, l: 2a]"
+      input = "abc(def: 11, b: [lineWidth a, l: 2a])"
 
       error =
         assert_raise SyntaxError, fn ->
@@ -546,19 +546,34 @@ defmodule LiveViewNative.SwiftUI.RulesParserTest do
         """
         Unsupported input:
           |
-        1 | abc(def: 11, b: [lineWidth a, l: 2a]
-          |                 ^^^^^^^^^^
+        1 | abc(def: 11, b: [lineWidth‎ a, l: 2a])
+          |                           ^
           |
 
-        Expected one of the following:
-         - a number, string, nil, boolean or :atom
-         - an event eg ‘event("search-event", throttle: 10_000)’
-         - an attribute eg ‘attr("placeholder")’
-         - an IME eg ‘Color.red’ or ‘.largeTitle’ or ‘Color.to_ime(variable)’
-         - a list of keyword pairs eg ‘style: :dashed’, ‘size: 12’ or  ‘style: [lineWidth: 1]’
-         - a helper function eg ‘to_float(variable)’
-         - a modifier eg ‘bold()’
-         - a variable defined in the class header eg ‘color_name’
+        expected ‘:’
+        """
+        |> String.trim()
+
+      assert String.trim(error.description) == error_prefix
+    end
+
+    test "invalid keyword pair: double nesting" do
+      input = "abc(def: 11, b: lineWidth: a, l: 2a]"
+
+      error =
+        assert_raise SyntaxError, fn ->
+          parse(input)
+        end
+
+      error_prefix =
+        """
+        Unsupported input:
+          |
+        1 | abc(def: 11, b: lineWidth: a, l: 2a]
+          |                          ^
+          |
+
+        expected ‘)’
         """
         |> String.trim()
 
@@ -581,7 +596,7 @@ defmodule LiveViewNative.SwiftUI.RulesParserTest do
           |                              ^^^^^^^^^
           |
 
-        expected ‘]’
+        Invalid suffix on number
         """
         |> String.trim()
 
@@ -602,6 +617,29 @@ defmodule LiveViewNative.SwiftUI.RulesParserTest do
           |
         1 | abc(def: 11, b: [lineWidth: :1])
           |                              ^
+          |
+
+        Expected an atom, but got ‘1’
+        """
+        |> String.trim()
+
+      assert String.trim(error.description) == error_prefix
+    end
+
+    test "invalid keyword pair: invalid value (3)" do
+      input = "abc(def: 11, b: :1)"
+
+      error =
+        assert_raise SyntaxError, fn ->
+          parse(input)
+        end
+
+      error_prefix =
+        """
+        Unsupported input:
+          |
+        1 | abc(def: 11, b: :1)
+          |                  ^
           |
 
         Expected an atom, but got ‘1’


### PR DESCRIPTION
- Fix parsing of `foo(x: to_integer(value), y: 0)`.
- Improve related error handling