### PR TITLE
Update Swift version instructions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report---swift.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report---swift.yml
@@ -36,7 +36,7 @@ body:
     id: swift_version
     attributes:
       label: Swift Version
-      description: What version of Swift are you using? (Xcode -> About Xcode to get the version)
+      description: What version of Swift are you using? (`swift --version`)
   - type: dropdown
     id: device_target
     attributes:


### PR DESCRIPTION
The issue template had incorrect instructions on locating the Swift version.

The easiest way to find the Swift version is by running:

```
swift --version
```