### PR TITLE
Add Swift range support

### DIFF
--- a/lib/live_view_native/swiftui/rules_parser/modifiers.ex
+++ b/lib/live_view_native/swiftui/rules_parser/modifiers.ex
@@ -171,6 +171,10 @@ defmodule LiveViewNative.SwiftUI.RulesParser.Modifiers do
         inside_key_value_pair?
       },
       {
+        swift_range(),
+        ~s'a Swift range eg ‘1..<10’ or ‘foo(Foo.bar...Baz.qux)’'
+      },
+      {
         literal(error_parser: empty(), generate_error?: false),
         ~s'a number, string, nil, boolean or :atom'
       },

--- a/lib/live_view_native/swiftui/rules_parser/post_processors.ex
+++ b/lib/live_view_native/swiftui/rules_parser/post_processors.ex
@@ -179,4 +179,14 @@ defmodule LiveViewNative.SwiftUI.RulesParser.PostProcessors do
     annotations = context_to_annotation(context.context, line)
     {rest, [{:__event__, annotations, [name, opts]}], context}
   end
+
+  def to_scoped_atom(rest, [variable_name, scope], context, {line, _}, _byte_offset) do
+    annotations = context_to_annotation(context.context, line)
+    {rest, [{:., annotations, [String.to_atom(scope), String.to_atom(variable_name)]}], context}
+  end
+
+  def to_swift_range_ast(rest, [end_, range, start], context, {line, _}, _byte_offset) do
+    annotations = context_to_annotation(context.context, line)
+    {rest, [{String.to_atom(range), annotations, [start, end_]}], context}
+  end
 end

--- a/lib/live_view_native/swiftui/rules_parser/tokens.ex
+++ b/lib/live_view_native/swiftui/rules_parser/tokens.ex
@@ -34,7 +34,7 @@ defmodule LiveViewNative.SwiftUI.RulesParser.Tokens do
     |> reduce({Enum, :join, [""]})
   end
 
-  def int() do
+  def integer() do
     optional(minus())
     |> concat(underscored_integer())
     |> reduce({Enum, :join, [""]})
@@ -46,14 +46,14 @@ defmodule LiveViewNative.SwiftUI.RulesParser.Tokens do
   end
 
   def float() do
-    int()
+    integer()
     |> concat(frac())
     |> reduce({Enum, :join, [""]})
     |> map({String, :to_float, []})
   end
 
   def number() do
-    choice([float(), int()])
+    choice([float(), integer()])
     |> expect(
       ignore_whitespace()
       |> utf8_char(String.to_charlist(".,)]"))
@@ -198,19 +198,21 @@ defmodule LiveViewNative.SwiftUI.RulesParser.Tokens do
     ~s'‘#{matched}’ can only be used as an argument to a modifier'
   end
 
-  def type_name() do
+  def type_name(opts \\ []) do
     ascii_string([?A..?Z], 1)
     |> ascii_string([?a..?z, ?A..?Z, ?0..?9, ?_], min: 0)
     |> reduce({Enum, :join, [""]})
     |> expect(
-      error_message: "Expected a type name",
-      error_parser:
-        choice([
-          non_whitespace(also_ignore: String.to_charlist("[](),"), fail_if_empty: true),
-          non_whitespace(also_ignore: String.to_charlist("]),"), fail_if_empty: true),
-          non_whitespace()
-        ]),
-      show_incorrect_text?: true
+      Keyword.merge(opts,
+        error_message: "Expected a type name",
+        error_parser:
+          choice([
+            non_whitespace(also_ignore: String.to_charlist("[](),"), fail_if_empty: true),
+            non_whitespace(also_ignore: String.to_charlist("]),"), fail_if_empty: true),
+            non_whitespace()
+          ]),
+        show_incorrect_text?: true
+      )
     )
   end
 end

--- a/test/live_view_native/swiftui/rules_parser_test.exs
+++ b/test/live_view_native/swiftui/rules_parser_test.exs
@@ -451,6 +451,7 @@ defmodule LiveViewNative.SwiftUI.RulesParserTest do
           |
 
         Expected ‘()’ or ‘(<modifier_arguments>)’ where <modifier_arguments> are a comma separated list of:
+         - a Swift range eg ‘1..<10’ or ‘foo(Foo.bar...Baz.qux)’
          - a number, string, nil, boolean or :atom
          - an event eg ‘event(\"search-event\", throttle: 10_000)’
          - an attribute eg ‘attr(\"placeholder\")’
@@ -712,6 +713,7 @@ defmodule LiveViewNative.SwiftUI.RulesParserTest do
           |
 
         Expected one of the following:
+         - a Swift range eg ‘1..<10’ or ‘foo(Foo.bar...Baz.qux)’
          - a number, string, nil, boolean or :atom
          - an event eg ‘event("search-event", throttle: 10_000)’
          - an attribute eg ‘attr("placeholder")’


### PR DESCRIPTION
@bcardarella, this PR supports `foo(Foo.bar...Baz.qux)` but not deeply nested members eg `foo(Foo.bar.baz...Baz.qux)`.

Let me know if we also need support for the latter.