### PR TITLE
Only allow atoms for View/Text/Toolbar references

### DIFF
--- a/Sources/LiveViewNative/Stylesheets/ViewReference.swift
+++ b/Sources/LiveViewNative/Stylesheets/ViewReference.swift
@@ -16,8 +16,10 @@ struct ViewReference: ParseableModifierValue {
             AtomLiteral().map({
                 Self.init(value: [$0])
             })
-            String.parser(in: context).map({ Self.init(value: [$0]) })
-            Array<String>.parser(in: context).map(Self.init(value:))
+            ListLiteral {
+                AtomLiteral()
+            }
+            .map(Self.init(value:))
         }
     }
 }
@@ -34,7 +36,7 @@ struct TextReference: ParseableModifierValue {
     }
 
     static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
-        String.parser(in: context).map({ Self.init(value: $0) })
+        AtomLiteral().map({ Self.init(value: $0) })
     }
 }
 
@@ -55,8 +57,10 @@ struct ToolbarContentReference: ParseableModifierValue {
             AtomLiteral().map({
                 Self.init(value: [$0])
             })
-            String.parser(in: context).map({ Self.init(value: [$0]) })
-            Array<String>.parser(in: context).map(Self.init(value:))
+            ListLiteral {
+                AtomLiteral()
+            }
+            .map(Self.init(value:))
         }
     }
 }
@@ -78,8 +82,10 @@ struct CustomizableToolbarContentReference: ParseableModifierValue {
             AtomLiteral().map({
                 Self.init(value: [$0])
             })
-            String.parser(in: context).map({ Self.init(value: [$0]) })
-            Array<String>.parser(in: context).map(Self.init(value:))
+            ListLiteral {
+                AtomLiteral()
+            }
+            .map(Self.init(value:))
         }
     }
 }

--- a/Sources/LiveViewNativeStylesheet/Parsing/Literals/ListLiteral.swift
+++ b/Sources/LiveViewNativeStylesheet/Parsing/Literals/ListLiteral.swift
@@ -3,7 +3,7 @@ import Parsing
 public struct ListLiteral<Content: Parser>: Parser where Content.Input == Substring.UTF8View {
     let content: Content
     
-    init(@ParserBuilder<Input> _ content: () -> Content) {
+    public init(@ParserBuilder<Input> _ content: () -> Content) {
         self.content = content()
     }
     


### PR DESCRIPTION
Closes #1173 

Previously, strings were accepted for references. Now, only atoms and lists of atoms are allowed.

```elixir
# before
background(content: "my_content")
# after
background(content: :my_content)
```