### PR TITLE
Fix modifier default values and missing initializers

### DIFF
--- a/Sources/LiveViewNative/Stylesheets/Modifiers/Overrides/MatchedGeometryEffectModifier.swift
+++ b/Sources/LiveViewNative/Stylesheets/Modifiers/Overrides/MatchedGeometryEffectModifier.swift
@@ -11,18 +11,21 @@ import LiveViewNativeStylesheet
 // manual implementation
 // `Namespace.ID` is a special case, and needs to be accessed from the environment.
 @ParseableExpression
-struct _MatchedGeometryEffectModifier: ViewModifier {
-    static let name = "matchedGeometryEffect"
+struct _MatchedGeometryEffectModifier<R: RootRegistry>: ViewModifier {
+    static var name: String { "matchedGeometryEffect" }
     
     @Environment(\.namespaces) private var namespaces
     
-    let id: String
-    let namespace: String
+    @ObservedElement private var element
+    @LiveContext<R> private var context
+    
+    let id: AttributeReference<String>
+    let namespace: AttributeReference<String>
     let properties: MatchedGeometryProperties
     let anchor: UnitPoint
-    let isSource: Bool
+    let isSource: AttributeReference<Bool>
     
-    init(id: String, in namespace: String, properties: MatchedGeometryProperties = .frame, anchor: UnitPoint = .center, isSource: Bool = true) {
+    init(id: AttributeReference<String>, in namespace: AttributeReference<String>, properties: MatchedGeometryProperties = .frame, anchor: UnitPoint = .center, isSource: AttributeReference<Bool> = .init(storage: .constant(true))) {
         self.id = id
         self.namespace = namespace
         self.properties = properties
@@ -32,11 +35,11 @@ struct _MatchedGeometryEffectModifier: ViewModifier {
     
     func body(content: Content) -> some View {
         content.matchedGeometryEffect(
-            id: id,
-            in: namespaces[namespace]!,
+            id: id.resolve(on: element, in: context),
+            in: namespaces[namespace.resolve(on: element, in: context)]!,
             properties: properties,
             anchor: anchor,
-            isSource: isSource
+            isSource: isSource.resolve(on: element, in: context)
         )
     }
 }

--- a/Sources/LiveViewNative/Stylesheets/ParseableTypes/Animation+ParseableModifierValue.swift
+++ b/Sources/LiveViewNative/Stylesheets/ParseableTypes/Animation+ParseableModifierValue.swift
@@ -12,14 +12,14 @@ extension Animation: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ChainedMemberExpression {
             OneOf {
-                "default".utf8.map({ Base.default })
+                ConstantAtomLiteral("default").map({ Base.default })
                 Base.EaseIn.parser(in: context).map(Base.easeIn)
                 Base.EaseOut.parser(in: context).map(Base.easeOut)
                 Base.EaseInOut.parser(in: context).map(Base.easeInOut)
                 Base.Linear.parser(in: context).map(Base.linear)
-                "spring".utf8.map({ Base.spring })
-                "interactiveSpring".utf8.map({ Base.interactiveSpring })
-                "interpolatingSpring".utf8.map({ Base.interpolatingSpring })
+                ConstantAtomLiteral("spring").map({ Base.spring })
+                ConstantAtomLiteral("interactiveSpring").map({ Base.interactiveSpring })
+                ConstantAtomLiteral("interpolatingSpring").map({ Base.interpolatingSpring })
                 Base.TimingCurve.parser(in: context).map(Base.timingCurve)
             }
         } member: {

--- a/Sources/LiveViewNative/Stylesheets/ParseableTypes/AnySymbolEffect.swift
+++ b/Sources/LiveViewNative/Stylesheets/ParseableTypes/AnySymbolEffect.swift
@@ -35,7 +35,7 @@ struct AnySymbolEffect: SymbolEffect, ContentTransitionSymbolEffect, ParseableMo
 extension AppearSymbolEffect: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ChainedMemberExpression {
-            "appear".utf8.map({ Self.appear })
+            ConstantAtomLiteral("appear").map({ Self.appear })
         } member: {
             Member.parser(in: context)
         }
@@ -62,7 +62,7 @@ extension AppearSymbolEffect: ParseableModifierValue {
         static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
             OneOf {
                 for `case` in Self.allCases {
-                    `case`.rawValue.utf8.map({ `case` })
+                    ConstantAtomLiteral(`case`.rawValue).map({ `case` })
                 }
             }
         }
@@ -72,7 +72,7 @@ extension AppearSymbolEffect: ParseableModifierValue {
 @available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *)
 extension AutomaticSymbolEffect: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
-        "automatic".utf8.map({ Self.automatic })
+        ImplicitStaticMember(["automatic": Self.automatic])
     }
 }
 
@@ -80,7 +80,7 @@ extension AutomaticSymbolEffect: ParseableModifierValue {
 extension BounceSymbolEffect: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ChainedMemberExpression {
-            "bounce".utf8.map({ Self.bounce })
+            ConstantAtomLiteral("bounce").map({ Self.bounce })
         } member: {
             Member.parser(in: context)
         }
@@ -107,7 +107,7 @@ extension BounceSymbolEffect: ParseableModifierValue {
         static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
             OneOf {
                 for `case` in Self.allCases {
-                    `case`.rawValue.utf8.map({ `case` })
+                    ConstantAtomLiteral(`case`.rawValue).map({ `case` })
                 }
             }
         }
@@ -118,7 +118,7 @@ extension BounceSymbolEffect: ParseableModifierValue {
 extension DisappearSymbolEffect: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ChainedMemberExpression {
-            "disappear".utf8.map({ Self.disappear })
+            ConstantAtomLiteral("disappear").map({ Self.disappear })
         } member: {
             Member.parser(in: context)
         }
@@ -145,7 +145,7 @@ extension DisappearSymbolEffect: ParseableModifierValue {
         static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
             OneOf {
                 for `case` in Self.allCases {
-                    `case`.rawValue.utf8.map({ `case` })
+                    ConstantAtomLiteral(`case`.rawValue).map({ `case` })
                 }
             }
         }
@@ -156,7 +156,7 @@ extension DisappearSymbolEffect: ParseableModifierValue {
 extension PulseSymbolEffect: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ChainedMemberExpression {
-            "pulse".utf8.map({ Self.pulse })
+            ConstantAtomLiteral("pulse").map({ Self.pulse })
         } member: {
             Member.parser(in: context)
         }
@@ -179,7 +179,7 @@ extension PulseSymbolEffect: ParseableModifierValue {
         static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
             OneOf {
                 for `case` in Self.allCases {
-                    `case`.rawValue.utf8.map({ `case` })
+                    ConstantAtomLiteral(`case`.rawValue).map({ `case` })
                 }
             }
         }
@@ -190,7 +190,7 @@ extension PulseSymbolEffect: ParseableModifierValue {
 extension ReplaceSymbolEffect: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ChainedMemberExpression {
-            "replace".utf8.map({ Self.replace })
+            ConstantAtomLiteral("replace").map({ Self.replace })
         } member: {
             Member.parser(in: context)
         }
@@ -219,7 +219,7 @@ extension ReplaceSymbolEffect: ParseableModifierValue {
         static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
             OneOf {
                 for `case` in Self.allCases {
-                    `case`.rawValue.utf8.map({ `case` })
+                    ConstantAtomLiteral(`case`.rawValue).map({ `case` })
                 }
             }
         }
@@ -230,7 +230,7 @@ extension ReplaceSymbolEffect: ParseableModifierValue {
 extension ScaleSymbolEffect: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ChainedMemberExpression {
-            "scale".utf8.map({ Self.scale })
+            ConstantAtomLiteral("scale").map({ Self.scale })
         } member: {
             Member.parser(in: context)
         }
@@ -257,7 +257,7 @@ extension ScaleSymbolEffect: ParseableModifierValue {
         static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
             OneOf {
                 for `case` in Self.allCases {
-                    `case`.rawValue.utf8.map({ `case` })
+                    ConstantAtomLiteral(`case`.rawValue).map({ `case` })
                 }
             }
         }
@@ -268,7 +268,7 @@ extension ScaleSymbolEffect: ParseableModifierValue {
 extension VariableColorSymbolEffect: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ChainedMemberExpression {
-            "variableColor".utf8.map({ Self.variableColor })
+            ConstantAtomLiteral("variableColor").map({ Self.variableColor })
         } member: {
             Member.parser(in: context)
         }
@@ -294,7 +294,7 @@ extension VariableColorSymbolEffect: ParseableModifierValue {
         static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
             OneOf {
                 for `case` in Self.allCases {
-                    `case`.rawValue.utf8.map({ `case` })
+                    ConstantAtomLiteral(`case`.rawValue).map({ `case` })
                 }
             }
         }
@@ -306,16 +306,16 @@ extension SymbolEffectOptions: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ChainedMemberExpression {
             OneOf {
-                "default".utf8.map({ Self.default })
-                "repeating".utf8.map({ Self.repeating })
-                "nonRepeating".utf8.map({ Self.nonRepeating })
+                ConstantAtomLiteral("default").map({ Self.default })
+                ConstantAtomLiteral("repeating").map({ Self.repeating })
+                ConstantAtomLiteral("nonRepeating").map({ Self.nonRepeating })
                 Speed.parser(in: context).map({ Self.speed($0.speed) })
                 Repeat.parser(in: context).map({ Self.repeat($0.count) })
             }
         } member: {
             OneOf {
-                "repeating".utf8.map({ Member.repeating })
-                "nonRepeating".utf8.map({ Member.nonRepeating })
+                ConstantAtomLiteral("repeating").map({ Member.repeating })
+                ConstantAtomLiteral("nonRepeating").map({ Member.nonRepeating })
                 Speed.parser(in: context).map(Member.speed)
                 Repeat.parser(in: context).map(Member.repeat)
             }

--- a/Sources/LiveViewNative/Stylesheets/ParseableTypes/SymbolVariants+ParseableModifierValue.swift
+++ b/Sources/LiveViewNative/Stylesheets/ParseableTypes/SymbolVariants+ParseableModifierValue.swift
@@ -12,20 +12,20 @@ extension SymbolVariants: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ChainedMemberExpression {
             OneOf {
-                "none".utf8.map({ Self.none })
-                "circle".utf8.map({ Self.circle })
-                "square".utf8.map({ Self.square })
-                "rectangle".utf8.map({ Self.rectangle })
-                "fill".utf8.map({ Self.fill })
-                "slash".utf8.map({ Self.slash })
+                ConstantAtomLiteral("none").map({ Self.none })
+                ConstantAtomLiteral("circle").map({ Self.circle })
+                ConstantAtomLiteral("square").map({ Self.square })
+                ConstantAtomLiteral("rectangle").map({ Self.rectangle })
+                ConstantAtomLiteral("fill").map({ Self.fill })
+                ConstantAtomLiteral("slash").map({ Self.slash })
             }
         } member: {
             OneOf {
-                "circle".utf8.map({ Member.circle })
-                "square".utf8.map({ Member.square })
-                "rectangle".utf8.map({ Member.rectangle })
-                "fill".utf8.map({ Member.fill })
-                "slash".utf8.map({ Member.slash })
+                ConstantAtomLiteral("circle").map({ Member.circle })
+                ConstantAtomLiteral("square").map({ Member.square })
+                ConstantAtomLiteral("rectangle").map({ Member.rectangle })
+                ConstantAtomLiteral("fill").map({ Member.fill })
+                ConstantAtomLiteral("slash").map({ Member.slash })
             }
         }.map { base, members in
             return members.reduce(into: base) { result, member in

--- a/Sources/LiveViewNative/Stylesheets/ParseableTypes/UnitCurve+ParseableModifierValue.swift
+++ b/Sources/LiveViewNative/Stylesheets/ParseableTypes/UnitCurve+ParseableModifierValue.swift
@@ -13,18 +13,18 @@ extension UnitCurve: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ChainedMemberExpression {
             OneOf {
-                "easeInOut".utf8.map({ Self.easeInOut })
-                "easeIn".utf8.map({ Self.easeIn })
-                "easeOut".utf8.map({ Self.easeOut })
-                "circularEaseIn".utf8.map({ Self.circularEaseIn })
-                "circularEaseOut".utf8.map({ Self.circularEaseOut })
-                "circularEaseInOut".utf8.map({ Self.circularEaseInOut })
-                "linear".utf8.map({ Self.linear })
+                ConstantAtomLiteral("easeInOut").map({ Self.easeInOut })
+                ConstantAtomLiteral("easeIn").map({ Self.easeIn })
+                ConstantAtomLiteral("easeOut").map({ Self.easeOut })
+                ConstantAtomLiteral("circularEaseIn").map({ Self.circularEaseIn })
+                ConstantAtomLiteral("circularEaseOut").map({ Self.circularEaseOut })
+                ConstantAtomLiteral("circularEaseInOut").map({ Self.circularEaseInOut })
+                ConstantAtomLiteral("linear").map({ Self.linear })
                 Bezier.parser(in: context).map(\.value)
             }
         } member: {
             OneOf {
-                "inverse".utf8.map({ Modifier.inverse })
+                ConstantAtomLiteral("inverse").map({ Modifier.inverse })
             }
         }
         .map { (base, members) in

--- a/Sources/LiveViewNative/Stylesheets/StylesheetParser.swift
+++ b/Sources/LiveViewNative/Stylesheets/StylesheetParser.swift
@@ -1,27 +1,137 @@
 import SwiftUI
 import LiveViewNativeStylesheet
 import Parsing
+import OSLog
+
+private let logger = Logger(subsystem: "LiveViewNative", category: "Stylesheet")
 
 struct StylesheetParser<M: ViewModifier & ParseableModifierValue>: Parser {
     let context: ParseableModifierContext
+
+    func parse(_ input: inout Substring.UTF8View) throws -> Dictionary<String, Array<M>> {
+        let fullStylesheet = input
+        try "%{".utf8.parse(&input)
+        // early exit
+        if (try? "}".utf8.parse(&input)) != nil {
+            return [:]
+        }
+        var classes = [String:[M]]()
+        while true {
+            try Whitespace().parse(&input)
+            let name = try String.parser(in: context).parse(&input)
+            try Whitespace().parse(&input)
+            try "=>".utf8.parse(&input)
+            try Whitespace().parse(&input)
+            do {
+                classes[name] = try ListLiteral {
+                    RecoverableModifier(className: name, fullStylesheet: String(fullStylesheet), context: context)
+                }
+                .parse(&input)
+                .compactMap({ $0 })
+            } catch {
+                // Log errors instead of propagating, returning the classes that successfully parsed.
+                logger.error(
+                    """
+                    Stylesheet parsing failed for class `\(name)`:
+                    
+                    \(error)
+                    
+                    in stylesheet:
+                    
+                    \(String(fullStylesheet) ?? "")
+                    """
+                )
+                // consume the rest
+                input = Substring().utf8
+                return classes
+            }
+            try Whitespace().parse(&input)
+            // check for a separator
+            do {
+                try ",".utf8.parse(&input)
+            } catch {
+                break
+            }
+        }
+        try "}".utf8.parse(&input)
+        return classes
+    }
     
-    var body: some Parser<Substring.UTF8View, [String:[M]]> {
-        "%{".utf8
-        Many(into: [String:[M]]()) { sheet, pair in
-            let (name, value) = pair
-            sheet[name] = value
-        } element: {
-            Whitespace()
-            String.parser(in: context)
-            Whitespace()
-            "=>".utf8
-            Whitespace()
-            Array<M>.parser(in: context)
-            Whitespace()
-        } separator: {
-            ",".utf8
-        } terminator: {
-            "}".utf8
+    struct RecoverableModifier: Parser {
+        let className: String
+        let fullStylesheet: String?
+        let context: ParseableModifierContext
+        
+        func parse(_ input: inout Substring.UTF8View) throws -> M? {
+            let copy = input
+            do {
+                return try M.parser(in: context).parse(&input)
+            } catch let modifierError {
+                input = copy
+                do {
+                    let (modifierName, _) = try AnyNode(context: context).parse(&input)
+                    logger.error(
+                        """
+                        Stylesheet parsing failed for modifier `\(modifierName)` in class `\(className)`:
+                        
+                        \(modifierError)
+                        
+                        in stylesheet:
+                        
+                        \(fullStylesheet ?? "")
+                        """
+                    )
+                    return nil
+                } catch {
+                    throw modifierError
+                }
+            }
+        }
+        
+        struct AnyNode: Parser {
+            let context: ParseableModifierContext
+            
+            var body: some Parser<Substring.UTF8View, (String, Metadata)> {
+                "{".utf8
+                Whitespace()
+                OneOf {
+                    ConstantAtomLiteral(".").map({ _ in "." })
+                    AtomLiteral()
+                }
+                Whitespace()
+                ",".utf8
+                Whitespace()
+                Metadata.parser()
+                Whitespace()
+                ",".utf8
+                Whitespace()
+                ListLiteral {
+                    AnyArgument(context: context)
+                }
+                .map({ _ in () })
+                Whitespace()
+                "}".utf8
+            }
+            
+            struct AnyArgument: Parser {
+                let context: ParseableModifierContext
+                
+                var body: some Parser<Substring.UTF8View, ()> {
+                    OneOf {
+                        AnyNode(context: context).map({ _ in () })
+                        NilLiteral()
+                        AtomLiteral().map({ _ in () })
+                        String.parser(in: context).map({ _ in () })
+                        Double.parser().map({ _ in () })
+                        Int.parser().map({ _ in () })
+                        Bool.parser().map({ _ in () })
+                        ListLiteral {
+                            AnyArgument(context: context)
+                        }
+                        .map({ _ in () })
+                    }
+                }
+            }
         }
     }
 }

--- a/Sources/LiveViewNative/_GeneratedModifiers.swift
+++ b/Sources/LiveViewNative/_GeneratedModifiers.swift
@@ -136,7 +136,7 @@ struct _accessibilityIgnoresInvertColorsModifier<R: RootRegistry>: ViewModifier 
     enum Value {
         case _never
         
-        case _0(active: AttributeReference<Swift.Bool> )
+        case _0(active: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) )
         
     }
 
@@ -150,7 +150,7 @@ struct _accessibilityIgnoresInvertColorsModifier<R: RootRegistry>: ViewModifier 
 
     
     
-    init(_ active: AttributeReference<Swift.Bool> ) {
+    init(_ active: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(active: active)
         
     }
@@ -570,7 +570,7 @@ struct _aspectRatioModifier<R: RootRegistry>: ViewModifier {
     enum Value {
         case _never
         
-        case _0(aspectRatio: AttributeReference<CoreFoundation.CGFloat?>?, contentMode: SwiftUI.ContentMode)
+        case _0(aspectRatio: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), contentMode: SwiftUI.ContentMode)
         
         
         case _1(aspectRatio: CoreFoundation.CGSize,contentMode: SwiftUI.ContentMode)
@@ -589,7 +589,7 @@ struct _aspectRatioModifier<R: RootRegistry>: ViewModifier {
 
     
     
-    init(_ aspectRatio: AttributeReference<CoreFoundation.CGFloat?>?, contentMode: SwiftUI.ContentMode) {
+    init(_ aspectRatio: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), contentMode: SwiftUI.ContentMode) {
         self.value = ._0(aspectRatio: aspectRatio, contentMode: contentMode)
         
     }
@@ -632,7 +632,7 @@ struct _autocorrectionDisabledModifier<R: RootRegistry>: ViewModifier {
     enum Value {
         case _never
         
-        case _0(disable: AttributeReference<Swift.Bool> )
+        case _0(disable: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) )
         
     }
 
@@ -646,7 +646,7 @@ struct _autocorrectionDisabledModifier<R: RootRegistry>: ViewModifier {
 
     
     
-    init(_ disable: AttributeReference<Swift.Bool> ) {
+    init(_ disable: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(disable: disable)
         
     }
@@ -877,13 +877,13 @@ struct _badgeModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS)
         case _0(count: Any)
         #endif
-        #if os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS)
         case _1(label: Any?)
         #endif
-        #if os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS)
         case _2(key: Any?)
         #endif
         #if os(iOS) || os(macOS)
@@ -905,22 +905,22 @@ struct _badgeModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(macOS) || os(iOS)
-    @available(macOS 12.0,iOS 15.0, *)
+    #if os(iOS) || os(macOS)
+    @available(iOS 15.0,macOS 12.0, *)
     init(_ count: AttributeReference<Swift.Int>) {
         self.value = ._0(count: count)
         
     }
     #endif
-    #if os(macOS) || os(iOS)
-    @available(macOS 12.0,iOS 15.0, *)
+    #if os(iOS) || os(macOS)
+    @available(iOS 15.0,macOS 12.0, *)
     init(_ label: TextReference?) {
         self.value = ._1(label: label)
         
     }
     #endif
-    #if os(macOS) || os(iOS)
-    @available(macOS 12.0,iOS 15.0, *)
+    #if os(iOS) || os(macOS)
+    @available(iOS 15.0,macOS 12.0, *)
     init(_ key: SwiftUI.LocalizedStringKey?) {
         self.value = ._2(key: key)
         
@@ -938,25 +938,25 @@ struct _badgeModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS)
         case let ._0(count):
-            if #available(macOS 12.0,iOS 15.0, *) {
+            if #available(iOS 15.0,macOS 12.0, *) {
             let count = count as! AttributeReference<Swift.Int>
             __content
                 .badge(count.resolve(on: element, in: context))
             } else { __content }
         #endif
-        #if os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS)
         case let ._1(label):
-            if #available(macOS 12.0,iOS 15.0, *) {
+            if #available(iOS 15.0,macOS 12.0, *) {
             let label = label as? TextReference
             __content
                 .badge(label?.resolve(on: element, in: context))
             } else { __content }
         #endif
-        #if os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS)
         case let ._2(key):
-            if #available(macOS 12.0,iOS 15.0, *) {
+            if #available(iOS 15.0,macOS 12.0, *) {
             let key = key as? SwiftUI.LocalizedStringKey
             __content
                 .badge(key)
@@ -1064,7 +1064,7 @@ struct _blurModifier<R: RootRegistry>: ViewModifier {
     enum Value {
         case _never
         
-        case _0(radius: AttributeReference<CoreFoundation.CGFloat>,opaque: AttributeReference<Swift.Bool> )
+        case _0(radius: AttributeReference<CoreFoundation.CGFloat>,opaque: AttributeReference<Swift.Bool> = .init(storage: .constant(false)) )
         
     }
 
@@ -1078,7 +1078,7 @@ struct _blurModifier<R: RootRegistry>: ViewModifier {
 
     
     
-    init(radius: AttributeReference<CoreFoundation.CGFloat>,opaque: AttributeReference<Swift.Bool> ) {
+    init(radius: AttributeReference<CoreFoundation.CGFloat>,opaque: AttributeReference<Swift.Bool> = .init(storage: .constant(false)) ) {
         self.value = ._0(radius: radius, opaque: opaque)
         
     }
@@ -1106,7 +1106,7 @@ struct _boldModifier<R: RootRegistry>: ViewModifier {
     enum Value {
         case _never
         
-        case _0(isActive: AttributeReference<Swift.Bool> )
+        case _0(isActive: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) )
         
     }
 
@@ -1120,7 +1120,7 @@ struct _boldModifier<R: RootRegistry>: ViewModifier {
 
     
     
-    init(_ isActive: AttributeReference<Swift.Bool> ) {
+    init(_ isActive: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(isActive: isActive)
         
     }
@@ -1148,7 +1148,7 @@ struct _borderModifier<R: RootRegistry>: ViewModifier {
     enum Value {
         case _never
         
-        case _0(content: AnyShapeStyle,width: AttributeReference<CoreFoundation.CGFloat> )
+        case _0(content: AnyShapeStyle,width: AttributeReference<CoreFoundation.CGFloat> = .init(storage: .constant(1)) )
         
     }
 
@@ -1162,7 +1162,7 @@ struct _borderModifier<R: RootRegistry>: ViewModifier {
 
     
     
-    init(_ content: AnyShapeStyle,width: AttributeReference<CoreFoundation.CGFloat> ) {
+    init(_ content: AnyShapeStyle,width: AttributeReference<CoreFoundation.CGFloat> = .init(storage: .constant(1)) ) {
         self.value = ._0(content: content, width: width)
         
     }
@@ -1378,7 +1378,7 @@ struct _clippedModifier<R: RootRegistry>: ViewModifier {
     enum Value {
         case _never
         
-        case _0(antialiased: AttributeReference<Swift.Bool> )
+        case _0(antialiased: AttributeReference<Swift.Bool> = .init(storage: .constant(false)) )
         
     }
 
@@ -1392,7 +1392,7 @@ struct _clippedModifier<R: RootRegistry>: ViewModifier {
 
     
     
-    init(antialiased: AttributeReference<Swift.Bool> ) {
+    init(antialiased: AttributeReference<Swift.Bool> = .init(storage: .constant(false)) ) {
         self.value = ._0(antialiased: antialiased)
         
     }
@@ -1687,10 +1687,10 @@ struct _containerRelativeFrameModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(tvOS) || os(watchOS) || os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
         case _0(axes: Any,alignment: Any)
         #endif
-        #if os(watchOS) || os(iOS) || os(tvOS) || os(macOS)
+        #if os(tvOS) || os(macOS) || os(watchOS) || os(iOS)
         case _1(axes: Any,count: Any,span: Any, spacing: Any,alignment: Any)
         #endif
     }
@@ -1705,16 +1705,16 @@ struct _containerRelativeFrameModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(tvOS) || os(watchOS) || os(macOS) || os(iOS)
-    @available(tvOS 17.0,watchOS 10.0,macOS 14.0,iOS 17.0, *)
+    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+    @available(iOS 17.0,macOS 14.0,tvOS 17.0,watchOS 10.0, *)
     init(_ axes: SwiftUI.Axis.Set,alignment: SwiftUI.Alignment = .center ) {
         self.value = ._0(axes: axes, alignment: alignment)
         
     }
     #endif
-    #if os(watchOS) || os(iOS) || os(tvOS) || os(macOS)
-    @available(watchOS 10.0,iOS 17.0,tvOS 17.0,macOS 14.0, *)
-    init(_ axes: SwiftUI.Axis.Set,count: AttributeReference<Swift.Int>,span: AttributeReference<Swift.Int>, spacing: AttributeReference<CoreFoundation.CGFloat>,alignment: SwiftUI.Alignment = .center ) {
+    #if os(tvOS) || os(macOS) || os(watchOS) || os(iOS)
+    @available(tvOS 17.0,macOS 14.0,watchOS 10.0,iOS 17.0, *)
+    init(_ axes: SwiftUI.Axis.Set,count: AttributeReference<Swift.Int>,span: AttributeReference<Swift.Int> = .init(storage: .constant(1)), spacing: AttributeReference<CoreFoundation.CGFloat>,alignment: SwiftUI.Alignment = .center ) {
         self.value = ._1(axes: axes, count: count, span: span, spacing: spacing, alignment: alignment)
         
     }
@@ -1724,18 +1724,18 @@ struct _containerRelativeFrameModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(tvOS) || os(watchOS) || os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
         case let ._0(axes, alignment):
-            if #available(tvOS 17.0,watchOS 10.0,macOS 14.0,iOS 17.0, *) {
+            if #available(iOS 17.0,macOS 14.0,tvOS 17.0,watchOS 10.0, *) {
             let axes = axes as! SwiftUI.Axis.Set
 let alignment = alignment as! SwiftUI.Alignment 
             __content
                 .containerRelativeFrame(axes, alignment: alignment)
             } else { __content }
         #endif
-        #if os(watchOS) || os(iOS) || os(tvOS) || os(macOS)
+        #if os(tvOS) || os(macOS) || os(watchOS) || os(iOS)
         case let ._1(axes, count, span, spacing, alignment):
-            if #available(watchOS 10.0,iOS 17.0,tvOS 17.0,macOS 14.0, *) {
+            if #available(tvOS 17.0,macOS 14.0,watchOS 10.0,iOS 17.0, *) {
             let axes = axes as! SwiftUI.Axis.Set
 let count = count as! AttributeReference<Swift.Int>
 let span = span as! AttributeReference<Swift.Int>
@@ -1797,10 +1797,10 @@ struct _contentShapeModifier<R: RootRegistry>: ViewModifier {
     enum Value {
         case _never
         
-        case _0(shape: AnyShape,eoFill: AttributeReference<Swift.Bool> )
+        case _0(shape: AnyShape,eoFill: AttributeReference<Swift.Bool> = .init(storage: .constant(false)) )
         
         
-        case _1(kind: SwiftUI.ContentShapeKinds,shape: AnyShape,eoFill: AttributeReference<Swift.Bool> )
+        case _1(kind: SwiftUI.ContentShapeKinds,shape: AnyShape,eoFill: AttributeReference<Swift.Bool> = .init(storage: .constant(false)) )
         
     }
 
@@ -1816,14 +1816,14 @@ struct _contentShapeModifier<R: RootRegistry>: ViewModifier {
 
     
     
-    init(_ shape: AnyShape,eoFill: AttributeReference<Swift.Bool> ) {
+    init(_ shape: AnyShape,eoFill: AttributeReference<Swift.Bool> = .init(storage: .constant(false)) ) {
         self.value = ._0(shape: shape, eoFill: eoFill)
         
     }
     
     
     
-    init(_ kind: SwiftUI.ContentShapeKinds,_ shape: AnyShape,eoFill: AttributeReference<Swift.Bool> ) {
+    init(_ kind: SwiftUI.ContentShapeKinds,_ shape: AnyShape,eoFill: AttributeReference<Swift.Bool> = .init(storage: .constant(false)) ) {
         self.value = ._1(kind: kind, shape: shape, eoFill: eoFill)
         
     }
@@ -1903,7 +1903,7 @@ struct _contextMenuModifier<R: RootRegistry>: ViewModifier {
         #if os(macOS) || os(tvOS) || os(iOS)
         case _0(menuItems: Any)
         #endif
-        #if os(iOS) || os(tvOS) || os(macOS)
+        #if os(macOS) || os(iOS) || os(tvOS)
         case _1(menuItems: Any,preview: Any)
         #endif
     }
@@ -1925,8 +1925,8 @@ struct _contextMenuModifier<R: RootRegistry>: ViewModifier {
         
     }
     #endif
-    #if os(iOS) || os(tvOS) || os(macOS)
-    @available(iOS 16.0,tvOS 16.0,macOS 13.0, *)
+    #if os(macOS) || os(iOS) || os(tvOS)
+    @available(macOS 13.0,iOS 16.0,tvOS 16.0, *)
     init(menuItems: ViewReference=ViewReference(value: []),preview: ViewReference=ViewReference(value: [])) {
         self.value = ._1(menuItems: menuItems, preview: preview)
         
@@ -1945,9 +1945,9 @@ struct _contextMenuModifier<R: RootRegistry>: ViewModifier {
                 .contextMenu(menuItems: { menuItems.resolve(on: element, in: context) })
             } else { __content }
         #endif
-        #if os(iOS) || os(tvOS) || os(macOS)
+        #if os(macOS) || os(iOS) || os(tvOS)
         case let ._1(menuItems, preview):
-            if #available(iOS 16.0,tvOS 16.0,macOS 13.0, *) {
+            if #available(macOS 13.0,iOS 16.0,tvOS 16.0, *) {
             let menuItems = menuItems as! ViewReference
 let preview = preview as! ViewReference
             __content
@@ -2005,7 +2005,7 @@ struct _controlGroupStyleModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(macOS) || os(tvOS) || os(iOS)
+        #if os(iOS) || os(macOS) || os(tvOS)
         case _0(style: Any)
         #endif
     }
@@ -2018,8 +2018,8 @@ struct _controlGroupStyleModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(macOS) || os(tvOS) || os(iOS)
-    @available(macOS 12.0,tvOS 17.0,iOS 15.0, *)
+    #if os(iOS) || os(macOS) || os(tvOS)
+    @available(iOS 15.0,macOS 12.0,tvOS 17.0, *)
     init(_ style: AnyControlGroupStyle) {
         self.value = ._0(style: style)
         
@@ -2030,9 +2030,9 @@ struct _controlGroupStyleModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(macOS) || os(tvOS) || os(iOS)
+        #if os(iOS) || os(macOS) || os(tvOS)
         case let ._0(style):
-            if #available(macOS 12.0,tvOS 17.0,iOS 15.0, *) {
+            if #available(iOS 15.0,macOS 12.0,tvOS 17.0, *) {
             let style = style as! AnyControlGroupStyle
             __content
                 .controlGroupStyle(style)
@@ -2047,7 +2047,7 @@ struct _controlSizeModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(macOS) || os(watchOS)
+        #if os(watchOS) || os(iOS) || os(macOS)
         case _0(controlSize: Any)
         #endif
     }
@@ -2060,8 +2060,8 @@ struct _controlSizeModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(macOS) || os(watchOS)
-    @available(iOS 15.0,macOS 10.15,watchOS 9.0, *)
+    #if os(watchOS) || os(iOS) || os(macOS)
+    @available(watchOS 9.0,iOS 15.0,macOS 10.15, *)
     init(_ controlSize: SwiftUI.ControlSize) {
         self.value = ._0(controlSize: controlSize)
         
@@ -2072,9 +2072,9 @@ struct _controlSizeModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(macOS) || os(watchOS)
+        #if os(watchOS) || os(iOS) || os(macOS)
         case let ._0(controlSize):
-            if #available(iOS 15.0,macOS 10.15,watchOS 9.0, *) {
+            if #available(watchOS 9.0,iOS 15.0,macOS 10.15, *) {
             let controlSize = controlSize as! SwiftUI.ControlSize
             __content
                 .controlSize(controlSize)
@@ -2089,7 +2089,7 @@ struct _coordinateSpaceModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(watchOS) || os(tvOS) || os(macOS)
+        #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
         case _0(name: Any)
         #endif
     }
@@ -2102,8 +2102,8 @@ struct _coordinateSpaceModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(watchOS) || os(tvOS) || os(macOS)
-    @available(iOS 17.0,watchOS 10.0,tvOS 17.0,macOS 14.0, *)
+    #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
+    @available(iOS 17.0,macOS 14.0,watchOS 10.0,tvOS 17.0, *)
     init(_ name: SwiftUI.NamedCoordinateSpace) {
         self.value = ._0(name: name)
         
@@ -2114,9 +2114,9 @@ struct _coordinateSpaceModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(watchOS) || os(tvOS) || os(macOS)
+        #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
         case let ._0(name):
-            if #available(iOS 17.0,watchOS 10.0,tvOS 17.0,macOS 14.0, *) {
+            if #available(iOS 17.0,macOS 14.0,watchOS 10.0,tvOS 17.0, *) {
             let name = name as! SwiftUI.NamedCoordinateSpace
             __content
                 .coordinateSpace(name)
@@ -2131,7 +2131,7 @@ struct _datePickerStyleModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(watchOS) || os(macOS)
+        #if os(macOS) || os(iOS) || os(watchOS)
         case _0(style: Any)
         #endif
     }
@@ -2144,8 +2144,8 @@ struct _datePickerStyleModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(watchOS) || os(macOS)
-    @available(iOS 13.0,watchOS 10.0,macOS 10.15, *)
+    #if os(macOS) || os(iOS) || os(watchOS)
+    @available(macOS 10.15,iOS 13.0,watchOS 10.0, *)
     init(_ style: AnyDatePickerStyle) {
         self.value = ._0(style: style)
         
@@ -2156,9 +2156,9 @@ struct _datePickerStyleModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(watchOS) || os(macOS)
+        #if os(macOS) || os(iOS) || os(watchOS)
         case let ._0(style):
-            if #available(iOS 13.0,watchOS 10.0,macOS 10.15, *) {
+            if #available(macOS 10.15,iOS 13.0,watchOS 10.0, *) {
             let style = style as! AnyDatePickerStyle
             __content
                 .datePickerStyle(style)
@@ -2173,7 +2173,7 @@ struct _defaultScrollAnchorModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(watchOS) || os(tvOS) || os(iOS) || os(macOS)
+        #if os(tvOS) || os(iOS) || os(macOS) || os(watchOS)
         case _0(anchor: Any?)
         #endif
     }
@@ -2186,8 +2186,8 @@ struct _defaultScrollAnchorModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(watchOS) || os(tvOS) || os(iOS) || os(macOS)
-    @available(watchOS 10.0,tvOS 17.0,iOS 17.0,macOS 14.0, *)
+    #if os(tvOS) || os(iOS) || os(macOS) || os(watchOS)
+    @available(tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0, *)
     init(_ anchor: SwiftUI.UnitPoint?) {
         self.value = ._0(anchor: anchor)
         
@@ -2198,9 +2198,9 @@ struct _defaultScrollAnchorModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(watchOS) || os(tvOS) || os(iOS) || os(macOS)
+        #if os(tvOS) || os(iOS) || os(macOS) || os(watchOS)
         case let ._0(anchor):
-            if #available(watchOS 10.0,tvOS 17.0,iOS 17.0,macOS 14.0, *) {
+            if #available(tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0, *) {
             let anchor = anchor as? SwiftUI.UnitPoint
             __content
                 .defaultScrollAnchor(anchor)
@@ -2341,16 +2341,16 @@ struct _dialogSuppressionToggleModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(tvOS) || os(macOS) || os(watchOS) || os(iOS)
+        #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
         case _0(titleKey: Any)
         #endif
-        #if os(macOS) || os(tvOS) || os(iOS) || os(watchOS)
+        #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
         case _1(title: Any)
         #endif
-        #if os(iOS) || os(tvOS) || os(macOS) || os(watchOS)
+        #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
         case _2(label: Any)
         #endif
-        #if os(iOS) || os(tvOS) || os(macOS) || os(watchOS)
+        #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
         case _3
         #endif
     }
@@ -2369,29 +2369,29 @@ struct _dialogSuppressionToggleModifier<R: RootRegistry>: ViewModifier {
 @ChangeTracked private var _3_isSuppressed: Swift.Bool
 
 
-    #if os(tvOS) || os(macOS) || os(watchOS) || os(iOS)
-    @available(tvOS 17.0,macOS 14.0,watchOS 10.0,iOS 17.0, *)
+    #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+    @available(macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0, *)
     init(_ titleKey: SwiftUI.LocalizedStringKey,isSuppressed: ChangeTracked<Swift.Bool>) {
         self.value = ._0(titleKey: titleKey)
         self.__0_isSuppressed = isSuppressed
     }
     #endif
-    #if os(macOS) || os(tvOS) || os(iOS) || os(watchOS)
-    @available(macOS 14.0,tvOS 17.0,iOS 17.0,watchOS 10.0, *)
+    #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+    @available(macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0, *)
     init(_ title: AttributeReference<String>,isSuppressed: ChangeTracked<Swift.Bool>) {
         self.value = ._1(title: title)
         self.__1_isSuppressed = isSuppressed
     }
     #endif
-    #if os(iOS) || os(tvOS) || os(macOS) || os(watchOS)
-    @available(iOS 17.0,tvOS 17.0,macOS 14.0,watchOS 10.0, *)
+    #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+    @available(macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0, *)
     init(_ label: TextReference,isSuppressed: ChangeTracked<Swift.Bool>) {
         self.value = ._2(label: label)
         self.__2_isSuppressed = isSuppressed
     }
     #endif
-    #if os(iOS) || os(tvOS) || os(macOS) || os(watchOS)
-    @available(iOS 17.0,tvOS 17.0,macOS 14.0,watchOS 10.0, *)
+    #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+    @available(macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0, *)
     init(isSuppressed: ChangeTracked<Swift.Bool>) {
         self.value = ._3
         self.__3_isSuppressed = isSuppressed
@@ -2402,33 +2402,33 @@ struct _dialogSuppressionToggleModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(tvOS) || os(macOS) || os(watchOS) || os(iOS)
+        #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
         case let ._0(titleKey):
-            if #available(tvOS 17.0,macOS 14.0,watchOS 10.0,iOS 17.0, *) {
+            if #available(macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0, *) {
             let titleKey = titleKey as! SwiftUI.LocalizedStringKey
             __content
                 .dialogSuppressionToggle(titleKey, isSuppressed: __0_isSuppressed.projectedValue)
             } else { __content }
         #endif
-        #if os(macOS) || os(tvOS) || os(iOS) || os(watchOS)
+        #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
         case let ._1(title):
-            if #available(macOS 14.0,tvOS 17.0,iOS 17.0,watchOS 10.0, *) {
+            if #available(macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0, *) {
             let title = title as! AttributeReference<String>
             __content
                 .dialogSuppressionToggle(title.resolve(on: element, in: context), isSuppressed: __1_isSuppressed.projectedValue)
             } else { __content }
         #endif
-        #if os(iOS) || os(tvOS) || os(macOS) || os(watchOS)
+        #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
         case let ._2(label):
-            if #available(iOS 17.0,tvOS 17.0,macOS 14.0,watchOS 10.0, *) {
+            if #available(macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0, *) {
             let label = label as! TextReference
             __content
                 .dialogSuppressionToggle(label.resolve(on: element, in: context), isSuppressed: __2_isSuppressed.projectedValue)
             } else { __content }
         #endif
-        #if os(iOS) || os(tvOS) || os(macOS) || os(watchOS)
+        #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
         case ._3:
-            if #available(iOS 17.0,tvOS 17.0,macOS 14.0,watchOS 10.0, *) {
+            if #available(macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0, *) {
             
             __content
                 .dialogSuppressionToggle(isSuppressed: __3_isSuppressed.projectedValue)
@@ -2548,7 +2548,7 @@ struct _drawingGroupModifier<R: RootRegistry>: ViewModifier {
     enum Value {
         case _never
         
-        case _0(opaque: AttributeReference<Swift.Bool>, colorMode: SwiftUI.ColorRenderingMode = .nonLinear )
+        case _0(opaque: AttributeReference<Swift.Bool> = .init(storage: .constant(false)), colorMode: SwiftUI.ColorRenderingMode = .nonLinear )
         
     }
 
@@ -2562,7 +2562,7 @@ struct _drawingGroupModifier<R: RootRegistry>: ViewModifier {
 
     
     
-    init(opaque: AttributeReference<Swift.Bool>, colorMode: SwiftUI.ColorRenderingMode = .nonLinear ) {
+    init(opaque: AttributeReference<Swift.Bool> = .init(storage: .constant(false)), colorMode: SwiftUI.ColorRenderingMode = .nonLinear ) {
         self.value = ._0(opaque: opaque, colorMode: colorMode)
         
     }
@@ -2651,7 +2651,7 @@ struct _fileDialogCustomizationIDModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(macOS)
+        #if os(macOS) || os(iOS)
         case _0(id: Any)
         #endif
     }
@@ -2664,8 +2664,8 @@ struct _fileDialogCustomizationIDModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(macOS)
-    @available(iOS 17.0,macOS 14.0, *)
+    #if os(macOS) || os(iOS)
+    @available(macOS 14.0,iOS 17.0, *)
     init(_ id: AttributeReference<Swift.String>) {
         self.value = ._0(id: id)
         
@@ -2676,9 +2676,9 @@ struct _fileDialogCustomizationIDModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(macOS)
+        #if os(macOS) || os(iOS)
         case let ._0(id):
-            if #available(iOS 17.0,macOS 14.0, *) {
+            if #available(macOS 14.0,iOS 17.0, *) {
             let id = id as! AttributeReference<Swift.String>
             __content
                 .fileDialogCustomizationID(id.resolve(on: element, in: context))
@@ -2750,7 +2750,7 @@ struct _findDisabledModifier<R: RootRegistry>: ViewModifier {
 
     #if os(iOS)
     @available(iOS 16.0, *)
-    init(_ isDisabled: AttributeReference<Swift.Bool> ) {
+    init(_ isDisabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(isDisabled: isDisabled)
         
     }
@@ -2763,7 +2763,7 @@ struct _findDisabledModifier<R: RootRegistry>: ViewModifier {
         #if os(iOS)
         case let ._0(isDisabled):
             if #available(iOS 16.0, *) {
-            let isDisabled = isDisabled as! AttributeReference<Swift.Bool> 
+            let isDisabled = isDisabled as! AttributeReference<Swift.Bool>
             __content
                 .findDisabled(isDisabled.resolve(on: element, in: context))
             } else { __content }
@@ -2923,7 +2923,7 @@ struct _focusEffectDisabledModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(tvOS) || os(watchOS) || os(iOS) || os(macOS)
+        #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
         case _0(disabled: Any)
         #endif
     }
@@ -2936,9 +2936,9 @@ struct _focusEffectDisabledModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(tvOS) || os(watchOS) || os(iOS) || os(macOS)
-    @available(tvOS 17.0,watchOS 10.0,iOS 17.0,macOS 14.0, *)
-    init(_ disabled: AttributeReference<Swift.Bool> ) {
+    #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+    @available(macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0, *)
+    init(_ disabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(disabled: disabled)
         
     }
@@ -2948,10 +2948,10 @@ struct _focusEffectDisabledModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(tvOS) || os(watchOS) || os(iOS) || os(macOS)
+        #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
         case let ._0(disabled):
-            if #available(tvOS 17.0,watchOS 10.0,iOS 17.0,macOS 14.0, *) {
-            let disabled = disabled as! AttributeReference<Swift.Bool> 
+            if #available(macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0, *) {
+            let disabled = disabled as! AttributeReference<Swift.Bool>
             __content
                 .focusEffectDisabled(disabled.resolve(on: element, in: context))
             } else { __content }
@@ -3007,10 +3007,10 @@ struct _focusableModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(tvOS) || os(watchOS) || os(macOS) || os(iOS)
+        #if os(watchOS) || os(tvOS) || os(iOS) || os(macOS)
         case _0(isFocusable: Any)
         #endif
-        #if os(macOS) || os(watchOS) || os(iOS) || os(tvOS)
+        #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
         case _1(isFocusable: Any, interactions: Any)
         #endif
     }
@@ -3025,16 +3025,16 @@ struct _focusableModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(tvOS) || os(watchOS) || os(macOS) || os(iOS)
-    @available(tvOS 15.0,watchOS 8.0,macOS 12.0,iOS 17.0, *)
-    init(_ isFocusable: AttributeReference<Swift.Bool> ) {
+    #if os(watchOS) || os(tvOS) || os(iOS) || os(macOS)
+    @available(watchOS 8.0,tvOS 15.0,iOS 17.0,macOS 12.0, *)
+    init(_ isFocusable: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(isFocusable: isFocusable)
         
     }
     #endif
-    #if os(macOS) || os(watchOS) || os(iOS) || os(tvOS)
-    @available(macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0, *)
-    init(_ isFocusable: AttributeReference<Swift.Bool>, interactions: SwiftUI.FocusInteractions) {
+    #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+    @available(macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0, *)
+    init(_ isFocusable: AttributeReference<Swift.Bool> = .init(storage: .constant(true)), interactions: SwiftUI.FocusInteractions) {
         self.value = ._1(isFocusable: isFocusable, interactions: interactions)
         
     }
@@ -3044,17 +3044,17 @@ struct _focusableModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(tvOS) || os(watchOS) || os(macOS) || os(iOS)
+        #if os(watchOS) || os(tvOS) || os(iOS) || os(macOS)
         case let ._0(isFocusable):
-            if #available(tvOS 15.0,watchOS 8.0,macOS 12.0,iOS 17.0, *) {
-            let isFocusable = isFocusable as! AttributeReference<Swift.Bool> 
+            if #available(watchOS 8.0,tvOS 15.0,iOS 17.0,macOS 12.0, *) {
+            let isFocusable = isFocusable as! AttributeReference<Swift.Bool>
             __content
                 .focusable(isFocusable.resolve(on: element, in: context))
             } else { __content }
         #endif
-        #if os(macOS) || os(watchOS) || os(iOS) || os(tvOS)
+        #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
         case let ._1(isFocusable, interactions):
-            if #available(macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0, *) {
+            if #available(macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0, *) {
             let isFocusable = isFocusable as! AttributeReference<Swift.Bool>
 let interactions = interactions as! SwiftUI.FocusInteractions
             __content
@@ -3112,7 +3112,7 @@ struct _fontDesignModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(watchOS) || os(tvOS) || os(macOS)
+        #if os(macOS) || os(watchOS) || os(tvOS) || os(iOS)
         case _0(design: Any?)
         #endif
     }
@@ -3125,8 +3125,8 @@ struct _fontDesignModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(watchOS) || os(tvOS) || os(macOS)
-    @available(iOS 16.1,watchOS 9.1,tvOS 16.1,macOS 13.0, *)
+    #if os(macOS) || os(watchOS) || os(tvOS) || os(iOS)
+    @available(macOS 13.0,watchOS 9.1,tvOS 16.1,iOS 16.1, *)
     init(_ design: SwiftUI.Font.Design?) {
         self.value = ._0(design: design)
         
@@ -3137,9 +3137,9 @@ struct _fontDesignModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(watchOS) || os(tvOS) || os(macOS)
+        #if os(macOS) || os(watchOS) || os(tvOS) || os(iOS)
         case let ._0(design):
-            if #available(iOS 16.1,watchOS 9.1,tvOS 16.1,macOS 13.0, *) {
+            if #available(macOS 13.0,watchOS 9.1,tvOS 16.1,iOS 16.1, *) {
             let design = design as? SwiftUI.Font.Design
             __content
                 .fontDesign(design)
@@ -3363,13 +3363,13 @@ struct _frameModifier<R: RootRegistry>: ViewModifier {
     enum Value {
         case _never
         
-        case _0(width: AttributeReference<CoreFoundation.CGFloat?>?, height: AttributeReference<CoreFoundation.CGFloat?>?, alignment: SwiftUI.Alignment = .center )
+        case _0(width: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), height: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), alignment: SwiftUI.Alignment = .center )
         
         
         case _1
         
         
-        case _2(minWidth: AttributeReference<CoreFoundation.CGFloat?>?, idealWidth: AttributeReference<CoreFoundation.CGFloat?>?, maxWidth: AttributeReference<CoreFoundation.CGFloat?>?, minHeight: AttributeReference<CoreFoundation.CGFloat?>?, idealHeight: AttributeReference<CoreFoundation.CGFloat?>?, maxHeight: AttributeReference<CoreFoundation.CGFloat?>?, alignment: SwiftUI.Alignment = .center )
+        case _2(minWidth: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), idealWidth: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), maxWidth: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), minHeight: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), idealHeight: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), maxHeight: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), alignment: SwiftUI.Alignment = .center )
         
     }
 
@@ -3387,7 +3387,7 @@ struct _frameModifier<R: RootRegistry>: ViewModifier {
 
     
     
-    init(width: AttributeReference<CoreFoundation.CGFloat?>?, height: AttributeReference<CoreFoundation.CGFloat?>?, alignment: SwiftUI.Alignment = .center ) {
+    init(width: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), height: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), alignment: SwiftUI.Alignment = .center ) {
         self.value = ._0(width: width, height: height, alignment: alignment)
         
     }
@@ -3401,7 +3401,7 @@ struct _frameModifier<R: RootRegistry>: ViewModifier {
     
     
     
-    init(minWidth: AttributeReference<CoreFoundation.CGFloat?>?, idealWidth: AttributeReference<CoreFoundation.CGFloat?>?, maxWidth: AttributeReference<CoreFoundation.CGFloat?>?, minHeight: AttributeReference<CoreFoundation.CGFloat?>?, idealHeight: AttributeReference<CoreFoundation.CGFloat?>?, maxHeight: AttributeReference<CoreFoundation.CGFloat?>?, alignment: SwiftUI.Alignment = .center ) {
+    init(minWidth: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), idealWidth: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), maxWidth: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), minHeight: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), idealHeight: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), maxHeight: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), alignment: SwiftUI.Alignment = .center ) {
         self.value = ._2(minWidth: minWidth, idealWidth: idealWidth, maxWidth: maxWidth, minHeight: minHeight, idealHeight: idealHeight, maxHeight: maxHeight, alignment: alignment)
         
     }
@@ -3444,7 +3444,7 @@ struct _fullScreenCoverModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(watchOS) || os(tvOS) || os(iOS)
+        #if os(watchOS) || os(iOS) || os(tvOS)
         case _0(content: Any)
         #endif
     }
@@ -3457,8 +3457,8 @@ struct _fullScreenCoverModifier<R: RootRegistry>: ViewModifier {
 @ChangeTracked private var _0_isPresented: Swift.Bool
 @Event private var _0_onDismiss__0: Event.EventHandler
 
-    #if os(watchOS) || os(tvOS) || os(iOS)
-    @available(watchOS 7.0,tvOS 14.0,iOS 14.0, *)
+    #if os(watchOS) || os(iOS) || os(tvOS)
+    @available(watchOS 7.0,iOS 14.0,tvOS 14.0, *)
     init(isPresented: ChangeTracked<Swift.Bool>,onDismiss onDismiss__0: Event=Event(), content: ViewReference=ViewReference(value: [])) {
         self.value = ._0(content: content)
         self.__0_isPresented = isPresented
@@ -3470,9 +3470,9 @@ self.__0_onDismiss__0 = onDismiss__0
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(watchOS) || os(tvOS) || os(iOS)
+        #if os(watchOS) || os(iOS) || os(tvOS)
         case let ._0(content):
-            if #available(watchOS 7.0,tvOS 14.0,iOS 14.0, *) {
+            if #available(watchOS 7.0,iOS 14.0,tvOS 14.0, *) {
             let content = content as! ViewReference
             __content
                 .fullScreenCover(isPresented: __0_isPresented.projectedValue, onDismiss: { __0_onDismiss__0.wrappedValue() }, content: { content.resolve(on: element, in: context) })
@@ -3487,7 +3487,7 @@ struct _gaugeStyleModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(macOS) || os(watchOS)
+        #if os(iOS) || os(watchOS) || os(macOS)
         case _0(style: Any)
         #endif
     }
@@ -3500,8 +3500,8 @@ struct _gaugeStyleModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(macOS) || os(watchOS)
-    @available(iOS 16.0,macOS 13.0,watchOS 7.0, *)
+    #if os(iOS) || os(watchOS) || os(macOS)
+    @available(iOS 16.0,watchOS 7.0,macOS 13.0, *)
     init(_ style: AnyGaugeStyle) {
         self.value = ._0(style: style)
         
@@ -3512,9 +3512,9 @@ struct _gaugeStyleModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(macOS) || os(watchOS)
+        #if os(iOS) || os(watchOS) || os(macOS)
         case let ._0(style):
-            if #available(iOS 16.0,macOS 13.0,watchOS 7.0, *) {
+            if #available(iOS 16.0,watchOS 7.0,macOS 13.0, *) {
             let style = style as! AnyGaugeStyle
             __content
                 .gaugeStyle(style)
@@ -3529,7 +3529,7 @@ struct _geometryGroupModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(macOS) || os(tvOS) || os(watchOS) || os(iOS)
+        #if os(watchOS) || os(iOS) || os(macOS) || os(tvOS)
         case _0
         #endif
     }
@@ -3542,8 +3542,8 @@ struct _geometryGroupModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(macOS) || os(tvOS) || os(watchOS) || os(iOS)
-    @available(macOS 14.0,tvOS 17.0,watchOS 10.0,iOS 17.0, *)
+    #if os(watchOS) || os(iOS) || os(macOS) || os(tvOS)
+    @available(watchOS 10.0,iOS 17.0,macOS 14.0,tvOS 17.0, *)
     init() {
         self.value = ._0
         
@@ -3554,9 +3554,9 @@ struct _geometryGroupModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(macOS) || os(tvOS) || os(watchOS) || os(iOS)
+        #if os(watchOS) || os(iOS) || os(macOS) || os(tvOS)
         case ._0:
-            if #available(macOS 14.0,tvOS 17.0,watchOS 10.0,iOS 17.0, *) {
+            if #available(watchOS 10.0,iOS 17.0,macOS 14.0,tvOS 17.0, *) {
             
             __content
                 .geometryGroup()
@@ -3823,7 +3823,7 @@ struct _groupBoxStyleModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(macOS)
+        #if os(macOS) || os(iOS)
         case _0(style: Any)
         #endif
     }
@@ -3836,8 +3836,8 @@ struct _groupBoxStyleModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(macOS)
-    @available(iOS 14.0,macOS 11.0, *)
+    #if os(macOS) || os(iOS)
+    @available(macOS 11.0,iOS 14.0, *)
     init(_ style: AnyGroupBoxStyle) {
         self.value = ._0(style: style)
         
@@ -3848,9 +3848,9 @@ struct _groupBoxStyleModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(macOS)
+        #if os(macOS) || os(iOS)
         case let ._0(style):
-            if #available(iOS 14.0,macOS 11.0, *) {
+            if #available(macOS 11.0,iOS 14.0, *) {
             let style = style as! AnyGroupBoxStyle
             __content
                 .groupBoxStyle(style)
@@ -4115,10 +4115,10 @@ struct _hoverEffectModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(xrOS) || os(tvOS)
+        #if os(xrOS) || os(tvOS) || os(iOS)
         case _0(effect: Any)
         #endif
-        #if os(iOS) || os(xrOS) || os(tvOS)
+        #if os(tvOS) || os(xrOS) || os(iOS)
         case _1(effect: Any, isEnabled: Any)
         #endif
     }
@@ -4133,16 +4133,16 @@ struct _hoverEffectModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(xrOS) || os(tvOS)
-    @available(iOS 13.4,xrOS 1.0,tvOS 16.0, *)
+    #if os(xrOS) || os(tvOS) || os(iOS)
+    @available(xrOS 1.0,tvOS 16.0,iOS 13.4, *)
     init(_ effect: SwiftUI.HoverEffect = .automatic ) {
         self.value = ._0(effect: effect)
         
     }
     #endif
-    #if os(iOS) || os(xrOS) || os(tvOS)
-    @available(iOS 17.0,xrOS 1.0,tvOS 17.0, *)
-    init(_ effect: SwiftUI.HoverEffect = .automatic, isEnabled: AttributeReference<Swift.Bool> ) {
+    #if os(tvOS) || os(xrOS) || os(iOS)
+    @available(tvOS 17.0,xrOS 1.0,iOS 17.0, *)
+    init(_ effect: SwiftUI.HoverEffect = .automatic, isEnabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._1(effect: effect, isEnabled: isEnabled)
         
     }
@@ -4152,19 +4152,19 @@ struct _hoverEffectModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(xrOS) || os(tvOS)
+        #if os(xrOS) || os(tvOS) || os(iOS)
         case let ._0(effect):
-            if #available(iOS 13.4,xrOS 1.0,tvOS 16.0, *) {
+            if #available(xrOS 1.0,tvOS 16.0,iOS 13.4, *) {
             let effect = effect as! SwiftUI.HoverEffect 
             __content
                 .hoverEffect(effect)
             } else { __content }
         #endif
-        #if os(iOS) || os(xrOS) || os(tvOS)
+        #if os(tvOS) || os(xrOS) || os(iOS)
         case let ._1(effect, isEnabled):
-            if #available(iOS 17.0,xrOS 1.0,tvOS 17.0, *) {
+            if #available(tvOS 17.0,xrOS 1.0,iOS 17.0, *) {
             let effect = effect as! SwiftUI.HoverEffect 
-let isEnabled = isEnabled as! AttributeReference<Swift.Bool> 
+let isEnabled = isEnabled as! AttributeReference<Swift.Bool>
             __content
                 .hoverEffect(effect, isEnabled: isEnabled.resolve(on: element, in: context))
             } else { __content }
@@ -4178,7 +4178,7 @@ struct _hoverEffectDisabledModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(xrOS) || os(iOS) || os(tvOS)
+        #if os(tvOS) || os(xrOS) || os(iOS)
         case _0(disabled: Any)
         #endif
     }
@@ -4191,9 +4191,9 @@ struct _hoverEffectDisabledModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(xrOS) || os(iOS) || os(tvOS)
-    @available(xrOS 1.0,iOS 17.0,tvOS 17.0, *)
-    init(_ disabled: AttributeReference<Swift.Bool> ) {
+    #if os(tvOS) || os(xrOS) || os(iOS)
+    @available(tvOS 17.0,xrOS 1.0,iOS 17.0, *)
+    init(_ disabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(disabled: disabled)
         
     }
@@ -4203,10 +4203,10 @@ struct _hoverEffectDisabledModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(xrOS) || os(iOS) || os(tvOS)
+        #if os(tvOS) || os(xrOS) || os(iOS)
         case let ._0(disabled):
-            if #available(xrOS 1.0,iOS 17.0,tvOS 17.0, *) {
-            let disabled = disabled as! AttributeReference<Swift.Bool> 
+            if #available(tvOS 17.0,xrOS 1.0,iOS 17.0, *) {
+            let disabled = disabled as! AttributeReference<Swift.Bool>
             __content
                 .hoverEffectDisabled(disabled.resolve(on: element, in: context))
             } else { __content }
@@ -4388,7 +4388,7 @@ struct _inspectorModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS)
         case _0(content: Any)
         #endif
     }
@@ -4401,8 +4401,8 @@ struct _inspectorModifier<R: RootRegistry>: ViewModifier {
 @ChangeTracked private var _0_isPresented: Swift.Bool
 
 
-    #if os(macOS) || os(iOS)
-    @available(macOS 14.0,iOS 17.0, *)
+    #if os(iOS) || os(macOS)
+    @available(iOS 17.0,macOS 14.0, *)
     init(isPresented: ChangeTracked<Swift.Bool>,content: ViewReference=ViewReference(value: [])) {
         self.value = ._0(content: content)
         self.__0_isPresented = isPresented
@@ -4413,9 +4413,9 @@ struct _inspectorModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS)
         case let ._0(content):
-            if #available(macOS 14.0,iOS 17.0, *) {
+            if #available(iOS 17.0,macOS 14.0, *) {
             let content = content as! ViewReference
             __content
                 .inspector(isPresented: __0_isPresented.projectedValue, content: { content.resolve(on: element, in: context) })
@@ -4450,7 +4450,7 @@ struct _inspectorColumnWidthModifier<R: RootRegistry>: ViewModifier {
 
     #if os(iOS) || os(macOS)
     @available(iOS 17.0,macOS 14.0, *)
-    init(min: AttributeReference<CoreFoundation.CGFloat?>?, ideal: AttributeReference<CoreFoundation.CGFloat>,max: AttributeReference<CoreFoundation.CGFloat?>? ) {
+    init(min: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), ideal: AttributeReference<CoreFoundation.CGFloat>,max: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)) ) {
         self.value = ._0(min: min, ideal: ideal, max: max)
         
     }
@@ -4537,7 +4537,7 @@ struct _interactiveDismissDisabledModifier<R: RootRegistry>: ViewModifier {
     enum Value {
         case _never
         
-        case _0(isDisabled: AttributeReference<Swift.Bool> )
+        case _0(isDisabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) )
         
     }
 
@@ -4551,7 +4551,7 @@ struct _interactiveDismissDisabledModifier<R: RootRegistry>: ViewModifier {
 
     
     
-    init(_ isDisabled: AttributeReference<Swift.Bool> ) {
+    init(_ isDisabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(isDisabled: isDisabled)
         
     }
@@ -4578,7 +4578,7 @@ struct _invalidatableContentModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
+        #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
         case _0(invalidatable: Any)
         #endif
     }
@@ -4591,9 +4591,9 @@ struct _invalidatableContentModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
-    @available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0, *)
-    init(_ invalidatable: AttributeReference<Swift.Bool> ) {
+    #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+    @available(macOS 14.0,iOS 17.0,watchOS 10.0,tvOS 17.0, *)
+    init(_ invalidatable: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(invalidatable: invalidatable)
         
     }
@@ -4603,10 +4603,10 @@ struct _invalidatableContentModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
+        #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
         case let ._0(invalidatable):
-            if #available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0, *) {
-            let invalidatable = invalidatable as! AttributeReference<Swift.Bool> 
+            if #available(macOS 14.0,iOS 17.0,watchOS 10.0,tvOS 17.0, *) {
+            let invalidatable = invalidatable as! AttributeReference<Swift.Bool>
             __content
                 .invalidatableContent(invalidatable.resolve(on: element, in: context))
             } else { __content }
@@ -4621,7 +4621,7 @@ struct _italicModifier<R: RootRegistry>: ViewModifier {
     enum Value {
         case _never
         
-        case _0(isActive: AttributeReference<Swift.Bool> )
+        case _0(isActive: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) )
         
     }
 
@@ -4635,7 +4635,7 @@ struct _italicModifier<R: RootRegistry>: ViewModifier {
 
     
     
-    init(_ isActive: AttributeReference<Swift.Bool> ) {
+    init(_ isActive: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(isActive: isActive)
         
     }
@@ -4704,10 +4704,10 @@ struct _keyboardShortcutModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(macOS)
+        #if os(macOS) || os(iOS)
         case _0(key: Any,modifiers: Any)
         #endif
-        #if os(iOS) || os(macOS)
+        #if os(macOS) || os(iOS)
         case _1(shortcut: Any)
         #endif
         #if os(iOS) || os(macOS)
@@ -4732,15 +4732,15 @@ struct _keyboardShortcutModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(macOS)
-    @available(iOS 14.0,macOS 11.0, *)
+    #if os(macOS) || os(iOS)
+    @available(macOS 11.0,iOS 14.0, *)
     init(_ key: SwiftUI.KeyEquivalent,modifiers: SwiftUI.EventModifiers = .command ) {
         self.value = ._0(key: key, modifiers: modifiers)
         
     }
     #endif
-    #if os(iOS) || os(macOS)
-    @available(iOS 14.0,macOS 11.0, *)
+    #if os(macOS) || os(iOS)
+    @available(macOS 11.0,iOS 14.0, *)
     init(_ shortcut: SwiftUI.KeyboardShortcut) {
         self.value = ._1(shortcut: shortcut)
         
@@ -4765,18 +4765,18 @@ struct _keyboardShortcutModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(macOS)
+        #if os(macOS) || os(iOS)
         case let ._0(key, modifiers):
-            if #available(iOS 14.0,macOS 11.0, *) {
+            if #available(macOS 11.0,iOS 14.0, *) {
             let key = key as! SwiftUI.KeyEquivalent
 let modifiers = modifiers as! SwiftUI.EventModifiers 
             __content
                 .keyboardShortcut(key, modifiers: modifiers)
             } else { __content }
         #endif
-        #if os(iOS) || os(macOS)
+        #if os(macOS) || os(iOS)
         case let ._1(shortcut):
-            if #available(iOS 14.0,macOS 11.0, *) {
+            if #available(macOS 11.0,iOS 14.0, *) {
             let shortcut = shortcut as! SwiftUI.KeyboardShortcut
             __content
                 .keyboardShortcut(shortcut)
@@ -4809,7 +4809,7 @@ struct _keyboardTypeModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(tvOS) || os(iOS)
+        #if os(iOS) || os(tvOS)
         case _0(type: Any)
         #endif
     }
@@ -4822,8 +4822,8 @@ struct _keyboardTypeModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(tvOS) || os(iOS)
-    @available(tvOS 13.0,iOS 13.0, *)
+    #if os(iOS) || os(tvOS)
+    @available(iOS 13.0,tvOS 13.0, *)
     init(_ type: UIKit.UIKeyboardType) {
         self.value = ._0(type: type)
         
@@ -4834,9 +4834,9 @@ struct _keyboardTypeModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(tvOS) || os(iOS)
+        #if os(iOS) || os(tvOS)
         case let ._0(type):
-            if #available(tvOS 13.0,iOS 13.0, *) {
+            if #available(iOS 13.0,tvOS 13.0, *) {
             let type = type as! UIKit.UIKeyboardType
             __content
                 .keyboardType(type)
@@ -5344,7 +5344,7 @@ struct _listRowHoverEffectDisabledModifier<R: RootRegistry>: ViewModifier {
 
     #if os(xrOS)
     @available(xrOS 1.0, *)
-    init(_ disabled: AttributeReference<Swift.Bool> ) {
+    init(_ disabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(disabled: disabled)
         
     }
@@ -5357,7 +5357,7 @@ struct _listRowHoverEffectDisabledModifier<R: RootRegistry>: ViewModifier {
         #if os(xrOS)
         case let ._0(disabled):
             if #available(xrOS 1.0, *) {
-            let disabled = disabled as! AttributeReference<Swift.Bool> 
+            let disabled = disabled as! AttributeReference<Swift.Bool>
             __content
                 .listRowHoverEffectDisabled(disabled.resolve(on: element, in: context))
             } else { __content }
@@ -5584,7 +5584,7 @@ struct _listSectionSeparatorTintModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS)
         case _0(color: Any?,edges: Any)
         #endif
     }
@@ -5597,8 +5597,8 @@ struct _listSectionSeparatorTintModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(macOS) || os(iOS)
-    @available(macOS 13.0,iOS 15.0, *)
+    #if os(iOS) || os(macOS)
+    @available(iOS 15.0,macOS 13.0, *)
     init(_ color: AttributeReference<SwiftUI.Color?>?,edges: SwiftUI.VerticalEdge.Set = .all ) {
         self.value = ._0(color: color, edges: edges)
         
@@ -5609,9 +5609,9 @@ struct _listSectionSeparatorTintModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS)
         case let ._0(color, edges):
-            if #available(macOS 13.0,iOS 15.0, *) {
+            if #available(iOS 15.0,macOS 13.0, *) {
             let color = color as? AttributeReference<SwiftUI.Color?>
 let edges = edges as! SwiftUI.VerticalEdge.Set 
             __content
@@ -5630,7 +5630,7 @@ struct _listSectionSpacingModifier<R: RootRegistry>: ViewModifier {
         #if os(iOS) || os(watchOS)
         case _0(spacing: Any)
         #endif
-        #if os(iOS) || os(watchOS)
+        #if os(watchOS) || os(iOS)
         case _1(spacing: Any)
         #endif
     }
@@ -5652,8 +5652,8 @@ struct _listSectionSpacingModifier<R: RootRegistry>: ViewModifier {
         
     }
     #endif
-    #if os(iOS) || os(watchOS)
-    @available(iOS 17.0,watchOS 10.0, *)
+    #if os(watchOS) || os(iOS)
+    @available(watchOS 10.0,iOS 17.0, *)
     init(_ spacing: AttributeReference<CoreFoundation.CGFloat>) {
         self.value = ._1(spacing: spacing)
         
@@ -5672,9 +5672,9 @@ struct _listSectionSpacingModifier<R: RootRegistry>: ViewModifier {
                 .listSectionSpacing(spacing)
             } else { __content }
         #endif
-        #if os(iOS) || os(watchOS)
+        #if os(watchOS) || os(iOS)
         case let ._1(spacing):
-            if #available(iOS 17.0,watchOS 10.0, *) {
+            if #available(watchOS 10.0,iOS 17.0, *) {
             let spacing = spacing as! AttributeReference<CoreFoundation.CGFloat>
             __content
                 .listSectionSpacing(spacing.resolve(on: element, in: context))
@@ -5773,7 +5773,7 @@ struct _menuIndicatorModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(macOS) || os(iOS) || os(tvOS)
+        #if os(tvOS) || os(iOS) || os(macOS)
         case _0(visibility: Any)
         #endif
     }
@@ -5786,8 +5786,8 @@ struct _menuIndicatorModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(macOS) || os(iOS) || os(tvOS)
-    @available(macOS 12.0,iOS 15.0,tvOS 17.0, *)
+    #if os(tvOS) || os(iOS) || os(macOS)
+    @available(tvOS 17.0,iOS 15.0,macOS 12.0, *)
     init(_ visibility: SwiftUI.Visibility) {
         self.value = ._0(visibility: visibility)
         
@@ -5798,9 +5798,9 @@ struct _menuIndicatorModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(macOS) || os(iOS) || os(tvOS)
+        #if os(tvOS) || os(iOS) || os(macOS)
         case let ._0(visibility):
-            if #available(macOS 12.0,iOS 15.0,tvOS 17.0, *) {
+            if #available(tvOS 17.0,iOS 15.0,macOS 12.0, *) {
             let visibility = visibility as! SwiftUI.Visibility
             __content
                 .menuIndicator(visibility)
@@ -5857,7 +5857,7 @@ struct _menuStyleModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(macOS) || os(iOS) || os(tvOS)
+        #if os(iOS) || os(tvOS) || os(macOS)
         case _0(style: Any)
         #endif
     }
@@ -5870,8 +5870,8 @@ struct _menuStyleModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(macOS) || os(iOS) || os(tvOS)
-    @available(macOS 11.0,iOS 14.0,tvOS 17.0, *)
+    #if os(iOS) || os(tvOS) || os(macOS)
+    @available(iOS 14.0,tvOS 17.0,macOS 11.0, *)
     init(_ style: AnyMenuStyle) {
         self.value = ._0(style: style)
         
@@ -5882,9 +5882,9 @@ struct _menuStyleModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(macOS) || os(iOS) || os(tvOS)
+        #if os(iOS) || os(tvOS) || os(macOS)
         case let ._0(style):
-            if #available(macOS 11.0,iOS 14.0,tvOS 17.0, *) {
+            if #available(iOS 14.0,tvOS 17.0,macOS 11.0, *) {
             let style = style as! AnyMenuStyle
             __content
                 .menuStyle(style)
@@ -5942,7 +5942,7 @@ struct _monospacedModifier<R: RootRegistry>: ViewModifier {
     enum Value {
         case _never
         
-        case _0(isActive: AttributeReference<Swift.Bool> )
+        case _0(isActive: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) )
         
     }
 
@@ -5956,7 +5956,7 @@ struct _monospacedModifier<R: RootRegistry>: ViewModifier {
 
     
     
-    init(_ isActive: AttributeReference<Swift.Bool> ) {
+    init(_ isActive: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(isActive: isActive)
         
     }
@@ -6110,7 +6110,7 @@ struct _navigationBarBackButtonHiddenModifier<R: RootRegistry>: ViewModifier {
     enum Value {
         case _never
         
-        case _0(hidesBackButton: AttributeReference<Swift.Bool> )
+        case _0(hidesBackButton: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) )
         
     }
 
@@ -6124,7 +6124,7 @@ struct _navigationBarBackButtonHiddenModifier<R: RootRegistry>: ViewModifier {
 
     
     
-    init(_ hidesBackButton: AttributeReference<Swift.Bool> ) {
+    init(_ hidesBackButton: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(hidesBackButton: hidesBackButton)
         
     }
@@ -6151,7 +6151,7 @@ struct _navigationBarTitleDisplayModeModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(watchOS) || os(iOS)
+        #if os(iOS) || os(watchOS)
         case _0(displayMode: Any)
         #endif
     }
@@ -6164,8 +6164,8 @@ struct _navigationBarTitleDisplayModeModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(watchOS) || os(iOS)
-    @available(watchOS 8.0,iOS 14.0, *)
+    #if os(iOS) || os(watchOS)
+    @available(iOS 14.0,watchOS 8.0, *)
     init(_ displayMode: SwiftUI.NavigationBarItem.TitleDisplayMode) {
         self.value = ._0(displayMode: displayMode)
         
@@ -6176,9 +6176,9 @@ struct _navigationBarTitleDisplayModeModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(watchOS) || os(iOS)
+        #if os(iOS) || os(watchOS)
         case let ._0(displayMode):
-            if #available(watchOS 8.0,iOS 14.0, *) {
+            if #available(iOS 14.0,watchOS 8.0, *) {
             let displayMode = displayMode as! SwiftUI.NavigationBarItem.TitleDisplayMode
             __content
                 .navigationBarTitleDisplayMode(displayMode)
@@ -6239,7 +6239,7 @@ struct _navigationSplitViewColumnWidthModifier<R: RootRegistry>: ViewModifier {
         case _0(width: AttributeReference<CoreFoundation.CGFloat>)
         
         
-        case _1(min: AttributeReference<CoreFoundation.CGFloat?>?, ideal: AttributeReference<CoreFoundation.CGFloat>,max: AttributeReference<CoreFoundation.CGFloat?>? )
+        case _1(min: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), ideal: AttributeReference<CoreFoundation.CGFloat>,max: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)) )
         
     }
 
@@ -6262,7 +6262,7 @@ struct _navigationSplitViewColumnWidthModifier<R: RootRegistry>: ViewModifier {
     
     
     
-    init(min: AttributeReference<CoreFoundation.CGFloat?>?, ideal: AttributeReference<CoreFoundation.CGFloat>,max: AttributeReference<CoreFoundation.CGFloat?>? ) {
+    init(min: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), ideal: AttributeReference<CoreFoundation.CGFloat>,max: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)) ) {
         self.value = ._1(min: min, ideal: ideal, max: max)
         
     }
@@ -6339,10 +6339,10 @@ struct _navigationSubtitleModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if targetEnvironment(macCatalyst) || os(macOS)
+        #if os(macOS) || targetEnvironment(macCatalyst)
         case _0(subtitle: Any)
         #endif
-        #if targetEnvironment(macCatalyst) || os(macOS)
+        #if os(macOS) || targetEnvironment(macCatalyst)
         case _1(subtitleKey: Any)
         #endif
         #if targetEnvironment(macCatalyst) || os(macOS)
@@ -6362,15 +6362,15 @@ struct _navigationSubtitleModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if targetEnvironment(macCatalyst) || os(macOS)
-    @available(macCatalyst 14.0,macOS 11.0, *)
+    #if os(macOS) || targetEnvironment(macCatalyst)
+    @available(macOS 11.0,macCatalyst 14.0, *)
     init(_ subtitle: TextReference) {
         self.value = ._0(subtitle: subtitle)
         
     }
     #endif
-    #if targetEnvironment(macCatalyst) || os(macOS)
-    @available(macCatalyst 14.0,macOS 11.0, *)
+    #if os(macOS) || targetEnvironment(macCatalyst)
+    @available(macOS 11.0,macCatalyst 14.0, *)
     init(_ subtitleKey: SwiftUI.LocalizedStringKey) {
         self.value = ._1(subtitleKey: subtitleKey)
         
@@ -6388,17 +6388,17 @@ struct _navigationSubtitleModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if targetEnvironment(macCatalyst) || os(macOS)
+        #if os(macOS) || targetEnvironment(macCatalyst)
         case let ._0(subtitle):
-            if #available(macCatalyst 14.0,macOS 11.0, *) {
+            if #available(macOS 11.0,macCatalyst 14.0, *) {
             let subtitle = subtitle as! TextReference
             __content
                 .navigationSubtitle(subtitle.resolve(on: element, in: context))
             } else { __content }
         #endif
-        #if targetEnvironment(macCatalyst) || os(macOS)
+        #if os(macOS) || targetEnvironment(macCatalyst)
         case let ._1(subtitleKey):
-            if #available(macCatalyst 14.0,macOS 11.0, *) {
+            if #available(macOS 11.0,macCatalyst 14.0, *) {
             let subtitleKey = subtitleKey as! SwiftUI.LocalizedStringKey
             __content
                 .navigationSubtitle(subtitleKey)
@@ -6476,7 +6476,7 @@ struct _navigationTitleModifier<R: RootRegistry>: ViewModifier {
     }
     
     #if os(watchOS)
-    @available(iOS 14.0,macOS 11.0,watchOS 7.0,tvOS 14.0, *)
+    @available(tvOS 14.0,iOS 14.0,macOS 11.0,watchOS 7.0, *)
     init(_ title: ViewReference=ViewReference(value: [])) {
         self.value = ._3(title: title)
         
@@ -6520,7 +6520,7 @@ struct _navigationTitleModifier<R: RootRegistry>: ViewModifier {
         
         #if os(watchOS)
         case let ._3(title):
-            if #available(iOS 14.0,macOS 11.0,watchOS 7.0,tvOS 14.0, *) {
+            if #available(tvOS 14.0,iOS 14.0,macOS 11.0,watchOS 7.0, *) {
             let title = title as! ViewReference
             __content
                 .navigationTitle({ title.resolve(on: element, in: context) })
@@ -6547,7 +6547,7 @@ struct _offsetModifier<R: RootRegistry>: ViewModifier {
         case _0(offset: CoreFoundation.CGSize)
         
         
-        case _1(x: AttributeReference<CoreFoundation.CGFloat>, y: AttributeReference<CoreFoundation.CGFloat> )
+        case _1(x: AttributeReference<CoreFoundation.CGFloat> = .init(storage: .constant(0)), y: AttributeReference<CoreFoundation.CGFloat> = .init(storage: .constant(0)) )
         
     }
 
@@ -6570,7 +6570,7 @@ struct _offsetModifier<R: RootRegistry>: ViewModifier {
     
     
     
-    init(x: AttributeReference<CoreFoundation.CGFloat>, y: AttributeReference<CoreFoundation.CGFloat> ) {
+    init(x: AttributeReference<CoreFoundation.CGFloat> = .init(storage: .constant(0)), y: AttributeReference<CoreFoundation.CGFloat> = .init(storage: .constant(0)) ) {
         self.value = ._1(x: x, y: y)
         
     }
@@ -6661,7 +6661,7 @@ struct _onDeleteCommandModifier<R: RootRegistry>: ViewModifier {
 @Event private var _0_action__0: Event.EventHandler
 
     #if os(macOS)
-    @available(tvOS 13.0,macOS 10.15, *)
+    @available(macOS 10.15,tvOS 13.0, *)
     init(perform action__0: Event=Event()) {
         self.value = ._0
         self.__0_action__0 = action__0
@@ -6674,7 +6674,7 @@ struct _onDeleteCommandModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(macOS)
         case ._0:
-            if #available(tvOS 13.0,macOS 10.15, *) {
+            if #available(macOS 10.15,tvOS 13.0, *) {
             
             __content
                 .onDeleteCommand(perform: { __0_action__0.wrappedValue() })
@@ -6773,7 +6773,7 @@ struct _onHoverModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(macOS)
+        #if os(macOS) || os(iOS)
         case _0
         #endif
     }
@@ -6786,8 +6786,8 @@ struct _onHoverModifier<R: RootRegistry>: ViewModifier {
 
 @Event private var _0_action__1: Event.EventHandler
 
-    #if os(iOS) || os(macOS)
-    @available(iOS 13.4,macOS 10.15, *)
+    #if os(macOS) || os(iOS)
+    @available(macOS 10.15,iOS 13.4, *)
     init(perform action__1: Event) {
         self.value = ._0
         self.__0_action__1 = action__1
@@ -6798,9 +6798,9 @@ struct _onHoverModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(macOS)
+        #if os(macOS) || os(iOS)
         case ._0:
-            if #available(iOS 13.4,macOS 10.15, *) {
+            if #available(macOS 10.15,iOS 13.4, *) {
             
             __content
                 .onHover(perform: { __0_action__1.wrappedValue(value: $0) })
@@ -6815,7 +6815,7 @@ struct _onLongPressGestureModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(macOS) || os(watchOS) || os(iOS)
+        #if os(watchOS) || os(iOS) || os(macOS)
         case _0(minimumDuration: Any, maximumDistance: Any)
         #endif
         #if os(tvOS)
@@ -6835,17 +6835,17 @@ struct _onLongPressGestureModifier<R: RootRegistry>: ViewModifier {
 @Event private var _1_action__0: Event.EventHandler
 @Event private var _1_onPressingChanged__1: Event.EventHandler
 
-    #if os(macOS) || os(watchOS) || os(iOS)
-    @available(macOS 10.15,watchOS 6.0,tvOS 14.0,iOS 13.0, *)
-    init(minimumDuration: AttributeReference<Swift.Double>, maximumDistance: AttributeReference<CoreFoundation.CGFloat>, perform action__0: Event,onPressingChanged onPressingChanged__1: Event=Event() ) {
+    #if os(watchOS) || os(iOS) || os(macOS)
+    @available(watchOS 6.0,tvOS 14.0,iOS 13.0,macOS 10.15, *)
+    init(minimumDuration: AttributeReference<Swift.Double> = .init(storage: .constant(0.5)), maximumDistance: AttributeReference<CoreFoundation.CGFloat> = .init(storage: .constant(10)), perform action__0: Event,onPressingChanged onPressingChanged__1: Event=Event() ) {
         self.value = ._0(minimumDuration: minimumDuration, maximumDistance: maximumDistance)
         self.__0_action__0 = action__0
 self.__0_onPressingChanged__1 = onPressingChanged__1
     }
     #endif
     #if os(tvOS)
-    @available(iOS 13.0,watchOS 6.0,macOS 10.15,tvOS 14.0, *)
-    init(minimumDuration: AttributeReference<Swift.Double>, perform action__0: Event,onPressingChanged onPressingChanged__1: Event=Event() ) {
+    @available(watchOS 6.0,iOS 13.0,macOS 10.15,tvOS 14.0, *)
+    init(minimumDuration: AttributeReference<Swift.Double> = .init(storage: .constant(0.5)), perform action__0: Event,onPressingChanged onPressingChanged__1: Event=Event() ) {
         self.value = ._1(minimumDuration: minimumDuration)
         self.__1_action__0 = action__0
 self.__1_onPressingChanged__1 = onPressingChanged__1
@@ -6856,9 +6856,9 @@ self.__1_onPressingChanged__1 = onPressingChanged__1
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(macOS) || os(watchOS) || os(iOS)
+        #if os(watchOS) || os(iOS) || os(macOS)
         case let ._0(minimumDuration, maximumDistance):
-            if #available(macOS 10.15,watchOS 6.0,tvOS 14.0,iOS 13.0, *) {
+            if #available(watchOS 6.0,tvOS 14.0,iOS 13.0,macOS 10.15, *) {
             let minimumDuration = minimumDuration as! AttributeReference<Swift.Double>
 let maximumDistance = maximumDistance as! AttributeReference<CoreFoundation.CGFloat>
             __content
@@ -6867,7 +6867,7 @@ let maximumDistance = maximumDistance as! AttributeReference<CoreFoundation.CGFl
         #endif
         #if os(tvOS)
         case let ._1(minimumDuration):
-            if #available(iOS 13.0,watchOS 6.0,macOS 10.15,tvOS 14.0, *) {
+            if #available(watchOS 6.0,iOS 13.0,macOS 10.15,tvOS 14.0, *) {
             let minimumDuration = minimumDuration as! AttributeReference<Swift.Double>
             __content
                 .onLongPressGesture(minimumDuration: minimumDuration.resolve(on: element, in: context), perform: { __1_action__0.wrappedValue() }, onPressingChanged: { __1_onPressingChanged__1.wrappedValue(value: $0) })
@@ -6898,7 +6898,7 @@ struct _onLongTouchGestureModifier<R: RootRegistry>: ViewModifier {
 
     #if os(tvOS)
     @available(tvOS 16.0, *)
-    init(minimumDuration: AttributeReference<Swift.Double>, perform action__0: Event,onTouchingChanged onTouchingChanged__1: Event=Event() ) {
+    init(minimumDuration: AttributeReference<Swift.Double> = .init(storage: .constant(0.5)), perform action__0: Event,onTouchingChanged onTouchingChanged__1: Event=Event() ) {
         self.value = ._0(minimumDuration: minimumDuration)
         self.__0_action__0 = action__0
 self.__0_onTouchingChanged__1 = onTouchingChanged__1
@@ -6926,7 +6926,7 @@ struct _onMoveCommandModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(macOS) || os(tvOS)
+        #if os(tvOS) || os(macOS)
         case _0
         #endif
     }
@@ -6939,8 +6939,8 @@ struct _onMoveCommandModifier<R: RootRegistry>: ViewModifier {
 
 @Event private var _0_action__1: Event.EventHandler
 
-    #if os(macOS) || os(tvOS)
-    @available(macOS 10.15,tvOS 13.0, *)
+    #if os(tvOS) || os(macOS)
+    @available(tvOS 13.0,macOS 10.15, *)
     init(perform action__1: Event=Event()) {
         self.value = ._0
         self.__0_action__1 = action__1
@@ -6951,9 +6951,9 @@ struct _onMoveCommandModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(macOS) || os(tvOS)
+        #if os(tvOS) || os(macOS)
         case ._0:
-            if #available(macOS 10.15,tvOS 13.0, *) {
+            if #available(tvOS 13.0,macOS 10.15, *) {
             
             __content
                 .onMoveCommand(perform: { __0_action__1.wrappedValue(value: $0) })
@@ -6982,7 +6982,7 @@ struct _onPlayPauseCommandModifier<R: RootRegistry>: ViewModifier {
 @Event private var _0_action__0: Event.EventHandler
 
     #if os(tvOS)
-    @available(macOS 10.15,tvOS 13.0, *)
+    @available(tvOS 13.0,macOS 10.15, *)
     init(perform action__0: Event=Event()) {
         self.value = ._0
         self.__0_action__0 = action__0
@@ -6995,7 +6995,7 @@ struct _onPlayPauseCommandModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(tvOS)
         case ._0:
-            if #available(macOS 10.15,tvOS 13.0, *) {
+            if #available(tvOS 13.0,macOS 10.15, *) {
             
             __content
                 .onPlayPauseCommand(perform: { __0_action__0.wrappedValue() })
@@ -7011,9 +7011,9 @@ struct _onTapGestureModifier<R: RootRegistry>: ViewModifier {
     enum Value {
         case _never
         
-        case _0(count: AttributeReference<Swift.Int>)
+        case _0(count: AttributeReference<Swift.Int> = .init(storage: .constant(1)))
         
-        #if os(iOS) || os(macOS) || os(watchOS)
+        #if os(macOS) || os(watchOS) || os(iOS)
         case _1(count: Any, coordinateSpace: Any)
         #endif
     }
@@ -7030,14 +7030,14 @@ struct _onTapGestureModifier<R: RootRegistry>: ViewModifier {
 
     
     
-    init(count: AttributeReference<Swift.Int>, perform action__0: Event) {
+    init(count: AttributeReference<Swift.Int> = .init(storage: .constant(1)), perform action__0: Event) {
         self.value = ._0(count: count)
         self.__0_action__0 = action__0
     }
     
-    #if os(iOS) || os(macOS) || os(watchOS)
-    @available(iOS 17.0,macOS 14.0,watchOS 10.0, *)
-    init(count: AttributeReference<Swift.Int>, coordinateSpace: AnyCoordinateSpaceProtocol = .local, perform action__1: Event) {
+    #if os(macOS) || os(watchOS) || os(iOS)
+    @available(macOS 14.0,watchOS 10.0,iOS 17.0, *)
+    init(count: AttributeReference<Swift.Int> = .init(storage: .constant(1)), coordinateSpace: AnyCoordinateSpaceProtocol = .local, perform action__1: Event) {
         self.value = ._1(count: count, coordinateSpace: coordinateSpace)
         self.__1_action__1 = action__1
     }
@@ -7055,9 +7055,9 @@ struct _onTapGestureModifier<R: RootRegistry>: ViewModifier {
                 .onTapGesture(count: count.resolve(on: element, in: context), perform: { __0_action__0.wrappedValue() })
             
         
-        #if os(iOS) || os(macOS) || os(watchOS)
+        #if os(macOS) || os(watchOS) || os(iOS)
         case let ._1(count, coordinateSpace):
-            if #available(iOS 17.0,macOS 14.0,watchOS 10.0, *) {
+            if #available(macOS 14.0,watchOS 10.0,iOS 17.0, *) {
             let count = count as! AttributeReference<Swift.Int>
 let coordinateSpace = coordinateSpace as! AnyCoordinateSpaceProtocol 
             __content
@@ -7201,7 +7201,7 @@ struct _paddingModifier<R: RootRegistry>: ViewModifier {
         case _0(insets: SwiftUI.EdgeInsets)
         
         
-        case _1(edges: SwiftUI.Edge.Set = .all, length: AttributeReference<CoreFoundation.CGFloat?>? )
+        case _1(edges: SwiftUI.Edge.Set = .all, length: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)) )
         
         
         case _2(length: AttributeReference<CoreFoundation.CGFloat>)
@@ -7229,7 +7229,7 @@ struct _paddingModifier<R: RootRegistry>: ViewModifier {
     
     
     
-    init(_ edges: SwiftUI.Edge.Set = .all, _ length: AttributeReference<CoreFoundation.CGFloat?>? ) {
+    init(_ edges: SwiftUI.Edge.Set = .all, _ length: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)) ) {
         self.value = ._1(edges: edges, length: length)
         
     }
@@ -7363,7 +7363,7 @@ struct _popoverModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(macOS)
+        #if os(macOS) || os(iOS)
         case _0(attachmentAnchor: Any, arrowEdge: Any, content: Any)
         #endif
     }
@@ -7376,8 +7376,8 @@ struct _popoverModifier<R: RootRegistry>: ViewModifier {
 @ChangeTracked private var _0_isPresented: Swift.Bool
 
 
-    #if os(iOS) || os(macOS)
-    @available(iOS 13.0,macOS 10.15, *)
+    #if os(macOS) || os(iOS)
+    @available(macOS 10.15,iOS 13.0, *)
     init(isPresented: ChangeTracked<Swift.Bool>,attachmentAnchor: SwiftUI.PopoverAttachmentAnchor = .rect(.bounds), arrowEdge: SwiftUI.Edge = .top, content: ViewReference=ViewReference(value: [])) {
         self.value = ._0(attachmentAnchor: attachmentAnchor, arrowEdge: arrowEdge, content: content)
         self.__0_isPresented = isPresented
@@ -7388,9 +7388,9 @@ struct _popoverModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(macOS)
+        #if os(macOS) || os(iOS)
         case let ._0(attachmentAnchor, arrowEdge, content):
-            if #available(iOS 13.0,macOS 10.15, *) {
+            if #available(macOS 10.15,iOS 13.0, *) {
             let attachmentAnchor = attachmentAnchor as! SwiftUI.PopoverAttachmentAnchor 
 let arrowEdge = arrowEdge as! SwiftUI.Edge 
 let content = content as! ViewReference
@@ -7411,7 +7411,7 @@ struct _positionModifier<R: RootRegistry>: ViewModifier {
         case _0(position: CoreFoundation.CGPoint)
         
         
-        case _1(x: AttributeReference<CoreFoundation.CGFloat>, y: AttributeReference<CoreFoundation.CGFloat> )
+        case _1(x: AttributeReference<CoreFoundation.CGFloat> = .init(storage: .constant(0)), y: AttributeReference<CoreFoundation.CGFloat> = .init(storage: .constant(0)) )
         
     }
 
@@ -7434,7 +7434,7 @@ struct _positionModifier<R: RootRegistry>: ViewModifier {
     
     
     
-    init(x: AttributeReference<CoreFoundation.CGFloat>, y: AttributeReference<CoreFoundation.CGFloat> ) {
+    init(x: AttributeReference<CoreFoundation.CGFloat> = .init(storage: .constant(0)), y: AttributeReference<CoreFoundation.CGFloat> = .init(storage: .constant(0)) ) {
         self.value = ._1(x: x, y: y)
         
     }
@@ -7511,10 +7511,10 @@ struct _presentationBackgroundModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+        #if os(watchOS) || os(tvOS) || os(macOS) || os(iOS)
         case _0(style: Any)
         #endif
-        #if os(watchOS) || os(tvOS) || os(iOS) || os(macOS)
+        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
         case _1(alignment: Any, content: Any)
         #endif
     }
@@ -7529,15 +7529,15 @@ struct _presentationBackgroundModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-    @available(iOS 16.4,macOS 13.3,tvOS 16.4,watchOS 9.4, *)
+    #if os(watchOS) || os(tvOS) || os(macOS) || os(iOS)
+    @available(watchOS 9.4,tvOS 16.4,macOS 13.3,iOS 16.4, *)
     init(_ style: AnyShapeStyle) {
         self.value = ._0(style: style)
         
     }
     #endif
-    #if os(watchOS) || os(tvOS) || os(iOS) || os(macOS)
-    @available(watchOS 9.4,tvOS 16.4,iOS 16.4,macOS 13.3, *)
+    #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
+    @available(iOS 16.4,watchOS 9.4,macOS 13.3,tvOS 16.4, *)
     init(alignment: SwiftUI.Alignment = .center, content: ViewReference=ViewReference(value: [])) {
         self.value = ._1(alignment: alignment, content: content)
         
@@ -7548,17 +7548,17 @@ struct _presentationBackgroundModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+        #if os(watchOS) || os(tvOS) || os(macOS) || os(iOS)
         case let ._0(style):
-            if #available(iOS 16.4,macOS 13.3,tvOS 16.4,watchOS 9.4, *) {
+            if #available(watchOS 9.4,tvOS 16.4,macOS 13.3,iOS 16.4, *) {
             let style = style as! AnyShapeStyle
             __content
                 .presentationBackground(style)
             } else { __content }
         #endif
-        #if os(watchOS) || os(tvOS) || os(iOS) || os(macOS)
+        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
         case let ._1(alignment, content):
-            if #available(watchOS 9.4,tvOS 16.4,iOS 16.4,macOS 13.3, *) {
+            if #available(iOS 16.4,watchOS 9.4,macOS 13.3,tvOS 16.4, *) {
             let alignment = alignment as! SwiftUI.Alignment 
 let content = content as! ViewReference
             __content
@@ -7574,7 +7574,7 @@ struct _presentationBackgroundInteractionModifier<R: RootRegistry>: ViewModifier
 
     enum Value {
         case _never
-        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
+        #if os(watchOS) || os(macOS) || os(tvOS) || os(iOS)
         case _0(interaction: Any)
         #endif
     }
@@ -7587,8 +7587,8 @@ struct _presentationBackgroundInteractionModifier<R: RootRegistry>: ViewModifier
 
 
 
-    #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
-    @available(iOS 16.4,watchOS 9.4,macOS 13.3,tvOS 16.4, *)
+    #if os(watchOS) || os(macOS) || os(tvOS) || os(iOS)
+    @available(watchOS 9.4,macOS 13.3,tvOS 16.4,iOS 16.4, *)
     init(_ interaction: SwiftUI.PresentationBackgroundInteraction) {
         self.value = ._0(interaction: interaction)
         
@@ -7599,9 +7599,9 @@ struct _presentationBackgroundInteractionModifier<R: RootRegistry>: ViewModifier
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
+        #if os(watchOS) || os(macOS) || os(tvOS) || os(iOS)
         case let ._0(interaction):
-            if #available(iOS 16.4,watchOS 9.4,macOS 13.3,tvOS 16.4, *) {
+            if #available(watchOS 9.4,macOS 13.3,tvOS 16.4,iOS 16.4, *) {
             let interaction = interaction as! SwiftUI.PresentationBackgroundInteraction
             __content
                 .presentationBackgroundInteraction(interaction)
@@ -7616,10 +7616,10 @@ struct _presentationCompactAdaptationModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(macOS) || os(tvOS) || os(watchOS) || os(iOS)
+        #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
         case _0(adaptation: Any)
         #endif
-        #if os(watchOS) || os(iOS) || os(macOS) || os(tvOS)
+        #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
         case _1(horizontalAdaptation: Any,verticalAdaptation: Any)
         #endif
     }
@@ -7634,15 +7634,15 @@ struct _presentationCompactAdaptationModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(macOS) || os(tvOS) || os(watchOS) || os(iOS)
-    @available(macOS 13.3,tvOS 16.4,watchOS 9.4,iOS 16.4, *)
+    #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
+    @available(iOS 16.4,macOS 13.3,watchOS 9.4,tvOS 16.4, *)
     init(_ adaptation: SwiftUI.PresentationAdaptation) {
         self.value = ._0(adaptation: adaptation)
         
     }
     #endif
-    #if os(watchOS) || os(iOS) || os(macOS) || os(tvOS)
-    @available(watchOS 9.4,iOS 16.4,macOS 13.3,tvOS 16.4, *)
+    #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
+    @available(tvOS 16.4,iOS 16.4,watchOS 9.4,macOS 13.3, *)
     init(horizontal horizontalAdaptation: SwiftUI.PresentationAdaptation,vertical verticalAdaptation: SwiftUI.PresentationAdaptation) {
         self.value = ._1(horizontalAdaptation: horizontalAdaptation, verticalAdaptation: verticalAdaptation)
         
@@ -7653,17 +7653,17 @@ struct _presentationCompactAdaptationModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(macOS) || os(tvOS) || os(watchOS) || os(iOS)
+        #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
         case let ._0(adaptation):
-            if #available(macOS 13.3,tvOS 16.4,watchOS 9.4,iOS 16.4, *) {
+            if #available(iOS 16.4,macOS 13.3,watchOS 9.4,tvOS 16.4, *) {
             let adaptation = adaptation as! SwiftUI.PresentationAdaptation
             __content
                 .presentationCompactAdaptation(adaptation)
             } else { __content }
         #endif
-        #if os(watchOS) || os(iOS) || os(macOS) || os(tvOS)
+        #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
         case let ._1(horizontalAdaptation, verticalAdaptation):
-            if #available(watchOS 9.4,iOS 16.4,macOS 13.3,tvOS 16.4, *) {
+            if #available(tvOS 16.4,iOS 16.4,watchOS 9.4,macOS 13.3, *) {
             let horizontalAdaptation = horizontalAdaptation as! SwiftUI.PresentationAdaptation
 let verticalAdaptation = verticalAdaptation as! SwiftUI.PresentationAdaptation
             __content
@@ -7679,7 +7679,7 @@ struct _presentationContentInteractionModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(watchOS) || os(tvOS) || os(macOS)
+        #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
         case _0(behavior: Any)
         #endif
     }
@@ -7692,8 +7692,8 @@ struct _presentationContentInteractionModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(watchOS) || os(tvOS) || os(macOS)
-    @available(iOS 16.4,watchOS 9.4,tvOS 16.4,macOS 13.3, *)
+    #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
+    @available(tvOS 16.4,iOS 16.4,watchOS 9.4,macOS 13.3, *)
     init(_ behavior: SwiftUI.PresentationContentInteraction) {
         self.value = ._0(behavior: behavior)
         
@@ -7704,9 +7704,9 @@ struct _presentationContentInteractionModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(watchOS) || os(tvOS) || os(macOS)
+        #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
         case let ._0(behavior):
-            if #available(iOS 16.4,watchOS 9.4,tvOS 16.4,macOS 13.3, *) {
+            if #available(tvOS 16.4,iOS 16.4,watchOS 9.4,macOS 13.3, *) {
             let behavior = behavior as! SwiftUI.PresentationContentInteraction
             __content
                 .presentationContentInteraction(behavior)
@@ -7721,7 +7721,7 @@ struct _presentationCornerRadiusModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(watchOS) || os(iOS) || os(macOS) || os(tvOS)
+        #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
         case _0(cornerRadius: Any?)
         #endif
     }
@@ -7734,8 +7734,8 @@ struct _presentationCornerRadiusModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(watchOS) || os(iOS) || os(macOS) || os(tvOS)
-    @available(watchOS 9.4,iOS 16.4,macOS 13.3,tvOS 16.4, *)
+    #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
+    @available(tvOS 16.4,iOS 16.4,watchOS 9.4,macOS 13.3, *)
     init(_ cornerRadius: AttributeReference<CoreFoundation.CGFloat?>?) {
         self.value = ._0(cornerRadius: cornerRadius)
         
@@ -7746,9 +7746,9 @@ struct _presentationCornerRadiusModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(watchOS) || os(iOS) || os(macOS) || os(tvOS)
+        #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
         case let ._0(cornerRadius):
-            if #available(watchOS 9.4,iOS 16.4,macOS 13.3,tvOS 16.4, *) {
+            if #available(tvOS 16.4,iOS 16.4,watchOS 9.4,macOS 13.3, *) {
             let cornerRadius = cornerRadius as? AttributeReference<CoreFoundation.CGFloat?>
             __content
                 .presentationCornerRadius(cornerRadius?.resolve(on: element, in: context))
@@ -7848,7 +7848,7 @@ struct _privacySensitiveModifier<R: RootRegistry>: ViewModifier {
     enum Value {
         case _never
         
-        case _0(sensitive: AttributeReference<Swift.Bool> )
+        case _0(sensitive: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) )
         
     }
 
@@ -7862,7 +7862,7 @@ struct _privacySensitiveModifier<R: RootRegistry>: ViewModifier {
 
     
     
-    init(_ sensitive: AttributeReference<Swift.Bool> ) {
+    init(_ sensitive: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(sensitive: sensitive)
         
     }
@@ -8072,7 +8072,7 @@ struct _replaceDisabledModifier<R: RootRegistry>: ViewModifier {
 
     #if os(iOS)
     @available(iOS 16.0, *)
-    init(_ isDisabled: AttributeReference<Swift.Bool> ) {
+    init(_ isDisabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(isDisabled: isDisabled)
         
     }
@@ -8085,7 +8085,7 @@ struct _replaceDisabledModifier<R: RootRegistry>: ViewModifier {
         #if os(iOS)
         case let ._0(isDisabled):
             if #available(iOS 16.0, *) {
-            let isDisabled = isDisabled as! AttributeReference<Swift.Bool> 
+            let isDisabled = isDisabled as! AttributeReference<Swift.Bool>
             __content
                 .replaceDisabled(isDisabled.resolve(on: element, in: context))
             } else { __content }
@@ -8142,10 +8142,10 @@ struct _safeAreaInsetModifier<R: RootRegistry>: ViewModifier {
     enum Value {
         case _never
         
-        case _0(edge: SwiftUI.VerticalEdge,alignment: SwiftUI.HorizontalAlignment = .center, spacing: AttributeReference<CoreFoundation.CGFloat?>?, content: ViewReference=ViewReference(value: []))
+        case _0(edge: SwiftUI.VerticalEdge,alignment: SwiftUI.HorizontalAlignment = .center, spacing: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), content: ViewReference=ViewReference(value: []))
         
         
-        case _1(edge: SwiftUI.HorizontalEdge,alignment: SwiftUI.VerticalAlignment = .center, spacing: AttributeReference<CoreFoundation.CGFloat?>?, content: ViewReference=ViewReference(value: []))
+        case _1(edge: SwiftUI.HorizontalEdge,alignment: SwiftUI.VerticalAlignment = .center, spacing: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), content: ViewReference=ViewReference(value: []))
         
     }
 
@@ -8161,14 +8161,14 @@ struct _safeAreaInsetModifier<R: RootRegistry>: ViewModifier {
 
     
     
-    init(edge: SwiftUI.VerticalEdge,alignment: SwiftUI.HorizontalAlignment = .center, spacing: AttributeReference<CoreFoundation.CGFloat?>?, content: ViewReference=ViewReference(value: [])) {
+    init(edge: SwiftUI.VerticalEdge,alignment: SwiftUI.HorizontalAlignment = .center, spacing: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), content: ViewReference=ViewReference(value: [])) {
         self.value = ._0(edge: edge, alignment: alignment, spacing: spacing, content: content)
         
     }
     
     
     
-    init(edge: SwiftUI.HorizontalEdge,alignment: SwiftUI.VerticalAlignment = .center, spacing: AttributeReference<CoreFoundation.CGFloat?>?, content: ViewReference=ViewReference(value: [])) {
+    init(edge: SwiftUI.HorizontalEdge,alignment: SwiftUI.VerticalAlignment = .center, spacing: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), content: ViewReference=ViewReference(value: [])) {
         self.value = ._1(edge: edge, alignment: alignment, spacing: spacing, content: content)
         
     }
@@ -8252,7 +8252,7 @@ struct _scaleEffectModifier<R: RootRegistry>: ViewModifier {
         case _1(s: AttributeReference<CoreFoundation.CGFloat>,anchor: SwiftUI.UnitPoint = .center )
         
         
-        case _2(x: AttributeReference<CoreFoundation.CGFloat>, y: AttributeReference<CoreFoundation.CGFloat>, anchor: SwiftUI.UnitPoint = .center )
+        case _2(x: AttributeReference<CoreFoundation.CGFloat> = .init(storage: .constant(1.0)), y: AttributeReference<CoreFoundation.CGFloat> = .init(storage: .constant(1.0)), anchor: SwiftUI.UnitPoint = .center )
         
     }
 
@@ -8284,7 +8284,7 @@ struct _scaleEffectModifier<R: RootRegistry>: ViewModifier {
     
     
     
-    init(x: AttributeReference<CoreFoundation.CGFloat>, y: AttributeReference<CoreFoundation.CGFloat>, anchor: SwiftUI.UnitPoint = .center ) {
+    init(x: AttributeReference<CoreFoundation.CGFloat> = .init(storage: .constant(1.0)), y: AttributeReference<CoreFoundation.CGFloat> = .init(storage: .constant(1.0)), anchor: SwiftUI.UnitPoint = .center ) {
         self.value = ._2(x: x, y: y, anchor: anchor)
         
     }
@@ -8473,7 +8473,7 @@ struct _scrollBounceBehaviorModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(watchOS) || os(tvOS) || os(iOS) || os(macOS)
+        #if os(tvOS) || os(macOS) || os(iOS) || os(watchOS)
         case _0(behavior: Any,axes: Any)
         #endif
     }
@@ -8486,8 +8486,8 @@ struct _scrollBounceBehaviorModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(watchOS) || os(tvOS) || os(iOS) || os(macOS)
-    @available(watchOS 9.4,tvOS 16.4,iOS 16.4,macOS 13.3, *)
+    #if os(tvOS) || os(macOS) || os(iOS) || os(watchOS)
+    @available(tvOS 16.4,macOS 13.3,iOS 16.4,watchOS 9.4, *)
     init(_ behavior: SwiftUI.ScrollBounceBehavior,axes: SwiftUI.Axis.Set = [.vertical] ) {
         self.value = ._0(behavior: behavior, axes: axes)
         
@@ -8498,9 +8498,9 @@ struct _scrollBounceBehaviorModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(watchOS) || os(tvOS) || os(iOS) || os(macOS)
+        #if os(tvOS) || os(macOS) || os(iOS) || os(watchOS)
         case let ._0(behavior, axes):
-            if #available(watchOS 9.4,tvOS 16.4,iOS 16.4,macOS 13.3, *) {
+            if #available(tvOS 16.4,macOS 13.3,iOS 16.4,watchOS 9.4, *) {
             let behavior = behavior as! SwiftUI.ScrollBounceBehavior
 let axes = axes as! SwiftUI.Axis.Set 
             __content
@@ -8516,7 +8516,7 @@ struct _scrollClipDisabledModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(macOS) || os(tvOS) || os(watchOS) || os(iOS)
+        #if os(tvOS) || os(iOS) || os(macOS) || os(watchOS)
         case _0(disabled: Any)
         #endif
     }
@@ -8529,9 +8529,9 @@ struct _scrollClipDisabledModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(macOS) || os(tvOS) || os(watchOS) || os(iOS)
-    @available(macOS 14.0,tvOS 17.0,watchOS 10.0,iOS 17.0, *)
-    init(_ disabled: AttributeReference<Swift.Bool> ) {
+    #if os(tvOS) || os(iOS) || os(macOS) || os(watchOS)
+    @available(tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0, *)
+    init(_ disabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(disabled: disabled)
         
     }
@@ -8541,10 +8541,10 @@ struct _scrollClipDisabledModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(macOS) || os(tvOS) || os(watchOS) || os(iOS)
+        #if os(tvOS) || os(iOS) || os(macOS) || os(watchOS)
         case let ._0(disabled):
-            if #available(macOS 14.0,tvOS 17.0,watchOS 10.0,iOS 17.0, *) {
-            let disabled = disabled as! AttributeReference<Swift.Bool> 
+            if #available(tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0, *) {
+            let disabled = disabled as! AttributeReference<Swift.Bool>
             __content
                 .scrollClipDisabled(disabled.resolve(on: element, in: context))
             } else { __content }
@@ -8558,7 +8558,7 @@ struct _scrollContentBackgroundModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(watchOS) || os(iOS) || os(macOS)
+        #if os(watchOS) || os(macOS) || os(iOS)
         case _0(visibility: Any)
         #endif
     }
@@ -8571,8 +8571,8 @@ struct _scrollContentBackgroundModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(watchOS) || os(iOS) || os(macOS)
-    @available(watchOS 9.0,iOS 16.0,macOS 13.0, *)
+    #if os(watchOS) || os(macOS) || os(iOS)
+    @available(watchOS 9.0,macOS 13.0,iOS 16.0, *)
     init(_ visibility: SwiftUI.Visibility) {
         self.value = ._0(visibility: visibility)
         
@@ -8583,9 +8583,9 @@ struct _scrollContentBackgroundModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(watchOS) || os(iOS) || os(macOS)
+        #if os(watchOS) || os(macOS) || os(iOS)
         case let ._0(visibility):
-            if #available(watchOS 9.0,iOS 16.0,macOS 13.0, *) {
+            if #available(watchOS 9.0,macOS 13.0,iOS 16.0, *) {
             let visibility = visibility as! SwiftUI.Visibility
             __content
                 .scrollContentBackground(visibility)
@@ -8642,7 +8642,7 @@ struct _scrollDismissesKeyboardModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(macOS) || os(tvOS) || os(iOS) || os(watchOS)
+        #if os(watchOS) || os(tvOS) || os(iOS) || os(macOS)
         case _0(mode: Any)
         #endif
     }
@@ -8655,8 +8655,8 @@ struct _scrollDismissesKeyboardModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(macOS) || os(tvOS) || os(iOS) || os(watchOS)
-    @available(macOS 13.0,tvOS 16.0,iOS 16.0,watchOS 9.0, *)
+    #if os(watchOS) || os(tvOS) || os(iOS) || os(macOS)
+    @available(watchOS 9.0,tvOS 16.0,iOS 16.0,macOS 13.0, *)
     init(_ mode: SwiftUI.ScrollDismissesKeyboardMode) {
         self.value = ._0(mode: mode)
         
@@ -8667,9 +8667,9 @@ struct _scrollDismissesKeyboardModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(macOS) || os(tvOS) || os(iOS) || os(watchOS)
+        #if os(watchOS) || os(tvOS) || os(iOS) || os(macOS)
         case let ._0(mode):
-            if #available(macOS 13.0,tvOS 16.0,iOS 16.0,watchOS 9.0, *) {
+            if #available(watchOS 9.0,tvOS 16.0,iOS 16.0,macOS 13.0, *) {
             let mode = mode as! SwiftUI.ScrollDismissesKeyboardMode
             __content
                 .scrollDismissesKeyboard(mode)
@@ -8726,10 +8726,10 @@ struct _scrollIndicatorsFlashModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(tvOS) || os(iOS) || os(macOS) || os(watchOS)
+        #if os(iOS) || os(tvOS) || os(watchOS) || os(macOS)
         case _0(value: Any)
         #endif
-        #if os(watchOS) || os(iOS) || os(tvOS) || os(macOS)
+        #if os(watchOS) || os(tvOS) || os(iOS) || os(macOS)
         case _1(onAppear: Any)
         #endif
     }
@@ -8744,15 +8744,15 @@ struct _scrollIndicatorsFlashModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(tvOS) || os(iOS) || os(macOS) || os(watchOS)
-    @available(tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0, *)
+    #if os(iOS) || os(tvOS) || os(watchOS) || os(macOS)
+    @available(iOS 17.0,tvOS 17.0,watchOS 10.0,macOS 14.0, *)
     init(trigger value: AttributeReference<String>) {
         self.value = ._0(value: value)
         
     }
     #endif
-    #if os(watchOS) || os(iOS) || os(tvOS) || os(macOS)
-    @available(watchOS 10.0,iOS 17.0,tvOS 17.0,macOS 14.0, *)
+    #if os(watchOS) || os(tvOS) || os(iOS) || os(macOS)
+    @available(watchOS 10.0,tvOS 17.0,iOS 17.0,macOS 14.0, *)
     init(onAppear: AttributeReference<Swift.Bool>) {
         self.value = ._1(onAppear: onAppear)
         
@@ -8763,17 +8763,17 @@ struct _scrollIndicatorsFlashModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(tvOS) || os(iOS) || os(macOS) || os(watchOS)
+        #if os(iOS) || os(tvOS) || os(watchOS) || os(macOS)
         case let ._0(value):
-            if #available(tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0, *) {
+            if #available(iOS 17.0,tvOS 17.0,watchOS 10.0,macOS 14.0, *) {
             let value = value as! AttributeReference<String>
             __content
                 .scrollIndicatorsFlash(trigger: value.resolve(on: element, in: context))
             } else { __content }
         #endif
-        #if os(watchOS) || os(iOS) || os(tvOS) || os(macOS)
+        #if os(watchOS) || os(tvOS) || os(iOS) || os(macOS)
         case let ._1(onAppear):
-            if #available(watchOS 10.0,iOS 17.0,tvOS 17.0,macOS 14.0, *) {
+            if #available(watchOS 10.0,tvOS 17.0,iOS 17.0,macOS 14.0, *) {
             let onAppear = onAppear as! AttributeReference<Swift.Bool>
             __content
                 .scrollIndicatorsFlash(onAppear: onAppear.resolve(on: element, in: context))
@@ -8788,7 +8788,7 @@ struct _scrollPositionModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(watchOS) || os(tvOS) || os(macOS) || os(iOS)
+        #if os(tvOS) || os(iOS) || os(macOS) || os(watchOS)
         case _0(anchor: Any?)
         #endif
     }
@@ -8801,8 +8801,8 @@ struct _scrollPositionModifier<R: RootRegistry>: ViewModifier {
 @ChangeTracked private var _0_id: String?
 
 
-    #if os(watchOS) || os(tvOS) || os(macOS) || os(iOS)
-    @available(watchOS 10.0,tvOS 17.0,macOS 14.0,iOS 17.0, *)
+    #if os(tvOS) || os(iOS) || os(macOS) || os(watchOS)
+    @available(tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0, *)
     init(id: ChangeTracked<String?>,anchor: SwiftUI.UnitPoint? = nil ) {
         self.value = ._0(anchor: anchor)
         self.__0_id = id
@@ -8813,9 +8813,9 @@ struct _scrollPositionModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(watchOS) || os(tvOS) || os(macOS) || os(iOS)
+        #if os(tvOS) || os(iOS) || os(macOS) || os(watchOS)
         case let ._0(anchor):
-            if #available(watchOS 10.0,tvOS 17.0,macOS 14.0,iOS 17.0, *) {
+            if #available(tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0, *) {
             let anchor = anchor as? SwiftUI.UnitPoint
             __content
                 .scrollPosition(id: __0_id.projectedValue, anchor: anchor)
@@ -8830,7 +8830,7 @@ struct _scrollTargetBehaviorModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
+        #if os(watchOS) || os(tvOS) || os(macOS) || os(iOS)
         case _0(behavior: Any)
         #endif
     }
@@ -8843,8 +8843,8 @@ struct _scrollTargetBehaviorModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
-    @available(iOS 17.0,macOS 14.0,watchOS 10.0,tvOS 17.0, *)
+    #if os(watchOS) || os(tvOS) || os(macOS) || os(iOS)
+    @available(watchOS 10.0,tvOS 17.0,macOS 14.0,iOS 17.0, *)
     init(_ behavior: AnyScrollTargetBehavior) {
         self.value = ._0(behavior: behavior)
         
@@ -8855,9 +8855,9 @@ struct _scrollTargetBehaviorModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
+        #if os(watchOS) || os(tvOS) || os(macOS) || os(iOS)
         case let ._0(behavior):
-            if #available(iOS 17.0,macOS 14.0,watchOS 10.0,tvOS 17.0, *) {
+            if #available(watchOS 10.0,tvOS 17.0,macOS 14.0,iOS 17.0, *) {
             let behavior = behavior as! AnyScrollTargetBehavior
             __content
                 .scrollTargetBehavior(behavior)
@@ -8872,7 +8872,7 @@ struct _scrollTargetLayoutModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(watchOS) || os(iOS) || os(tvOS) || os(macOS)
+        #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
         case _0(isEnabled: Any)
         #endif
     }
@@ -8885,9 +8885,9 @@ struct _scrollTargetLayoutModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(watchOS) || os(iOS) || os(tvOS) || os(macOS)
-    @available(watchOS 10.0,iOS 17.0,tvOS 17.0,macOS 14.0, *)
-    init(isEnabled: AttributeReference<Swift.Bool> ) {
+    #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
+    @available(iOS 17.0,macOS 14.0,watchOS 10.0,tvOS 17.0, *)
+    init(isEnabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(isEnabled: isEnabled)
         
     }
@@ -8897,10 +8897,10 @@ struct _scrollTargetLayoutModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(watchOS) || os(iOS) || os(tvOS) || os(macOS)
+        #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
         case let ._0(isEnabled):
-            if #available(watchOS 10.0,iOS 17.0,tvOS 17.0,macOS 14.0, *) {
-            let isEnabled = isEnabled as! AttributeReference<Swift.Bool> 
+            if #available(iOS 17.0,macOS 14.0,watchOS 10.0,tvOS 17.0, *) {
+            let isEnabled = isEnabled as! AttributeReference<Swift.Bool>
             __content
                 .scrollTargetLayout(isEnabled: isEnabled.resolve(on: element, in: context))
             } else { __content }
@@ -9169,7 +9169,7 @@ struct _selectionDisabledModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
+        #if os(macOS) || os(watchOS) || os(iOS) || os(tvOS)
         case _0(isDisabled: Any)
         #endif
     }
@@ -9182,9 +9182,9 @@ struct _selectionDisabledModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
-    @available(iOS 17.0,macOS 14.0,watchOS 10.0,tvOS 17.0, *)
-    init(_ isDisabled: AttributeReference<Swift.Bool> ) {
+    #if os(macOS) || os(watchOS) || os(iOS) || os(tvOS)
+    @available(macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0, *)
+    init(_ isDisabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(isDisabled: isDisabled)
         
     }
@@ -9194,10 +9194,10 @@ struct _selectionDisabledModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
+        #if os(macOS) || os(watchOS) || os(iOS) || os(tvOS)
         case let ._0(isDisabled):
-            if #available(iOS 17.0,macOS 14.0,watchOS 10.0,tvOS 17.0, *) {
-            let isDisabled = isDisabled as! AttributeReference<Swift.Bool> 
+            if #available(macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0, *) {
+            let isDisabled = isDisabled as! AttributeReference<Swift.Bool>
             __content
                 .selectionDisabled(isDisabled.resolve(on: element, in: context))
             } else { __content }
@@ -9212,7 +9212,7 @@ struct _shadowModifier<R: RootRegistry>: ViewModifier {
     enum Value {
         case _never
         
-        case _0(color: AttributeReference<SwiftUI.Color>, radius: AttributeReference<CoreFoundation.CGFloat>,x: AttributeReference<CoreFoundation.CGFloat>, y: AttributeReference<CoreFoundation.CGFloat> )
+        case _0(color: AttributeReference<SwiftUI.Color> = .init(storage: .constant(Color(.sRGBLinear, white: 0, opacity: 0.33))), radius: AttributeReference<CoreFoundation.CGFloat>,x: AttributeReference<CoreFoundation.CGFloat> = .init(storage: .constant(0)), y: AttributeReference<CoreFoundation.CGFloat> = .init(storage: .constant(0)) )
         
     }
 
@@ -9226,7 +9226,7 @@ struct _shadowModifier<R: RootRegistry>: ViewModifier {
 
     
     
-    init(color: AttributeReference<SwiftUI.Color>, radius: AttributeReference<CoreFoundation.CGFloat>,x: AttributeReference<CoreFoundation.CGFloat>, y: AttributeReference<CoreFoundation.CGFloat> ) {
+    init(color: AttributeReference<SwiftUI.Color> = .init(storage: .constant(Color(.sRGBLinear, white: 0, opacity: 0.33))), radius: AttributeReference<CoreFoundation.CGFloat>,x: AttributeReference<CoreFoundation.CGFloat> = .init(storage: .constant(0)), y: AttributeReference<CoreFoundation.CGFloat> = .init(storage: .constant(0)) ) {
         self.value = ._0(color: color, radius: radius, x: x, y: y)
         
     }
@@ -9381,7 +9381,7 @@ struct _speechAlwaysIncludesPunctuationModifier<R: RootRegistry>: ViewModifier {
     enum Value {
         case _never
         
-        case _0(value: AttributeReference<Swift.Bool> )
+        case _0(value: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) )
         
     }
 
@@ -9395,7 +9395,7 @@ struct _speechAlwaysIncludesPunctuationModifier<R: RootRegistry>: ViewModifier {
 
     
     
-    init(_ value: AttributeReference<Swift.Bool> ) {
+    init(_ value: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(value: value)
         
     }
@@ -9423,7 +9423,7 @@ struct _speechAnnouncementsQueuedModifier<R: RootRegistry>: ViewModifier {
     enum Value {
         case _never
         
-        case _0(value: AttributeReference<Swift.Bool> )
+        case _0(value: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) )
         
     }
 
@@ -9437,7 +9437,7 @@ struct _speechAnnouncementsQueuedModifier<R: RootRegistry>: ViewModifier {
 
     
     
-    init(_ value: AttributeReference<Swift.Bool> ) {
+    init(_ value: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(value: value)
         
     }
@@ -9465,7 +9465,7 @@ struct _speechSpellsOutCharactersModifier<R: RootRegistry>: ViewModifier {
     enum Value {
         case _never
         
-        case _0(value: AttributeReference<Swift.Bool> )
+        case _0(value: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) )
         
     }
 
@@ -9479,7 +9479,7 @@ struct _speechSpellsOutCharactersModifier<R: RootRegistry>: ViewModifier {
 
     
     
-    init(_ value: AttributeReference<Swift.Bool> ) {
+    init(_ value: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(value: value)
         
     }
@@ -9521,7 +9521,7 @@ struct _statusBarHiddenModifier<R: RootRegistry>: ViewModifier {
 
     #if os(iOS)
     @available(iOS 13.0, *)
-    init(_ hidden: AttributeReference<Swift.Bool> ) {
+    init(_ hidden: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(hidden: hidden)
         
     }
@@ -9534,7 +9534,7 @@ struct _statusBarHiddenModifier<R: RootRegistry>: ViewModifier {
         #if os(iOS)
         case let ._0(hidden):
             if #available(iOS 13.0, *) {
-            let hidden = hidden as! AttributeReference<Swift.Bool> 
+            let hidden = hidden as! AttributeReference<Swift.Bool>
             __content
                 .statusBarHidden(hidden.resolve(on: element, in: context))
             } else { __content }
@@ -9549,7 +9549,7 @@ struct _strikethroughModifier<R: RootRegistry>: ViewModifier {
     enum Value {
         case _never
         
-        case _0(isActive: AttributeReference<Swift.Bool>, pattern: SwiftUI.Text.LineStyle.Pattern = .solid, color: AttributeReference<SwiftUI.Color?>? )
+        case _0(isActive: AttributeReference<Swift.Bool> = .init(storage: .constant(true)), pattern: SwiftUI.Text.LineStyle.Pattern = .solid, color: AttributeReference<SwiftUI.Color?>? = .init(storage: .constant(nil)) )
         
     }
 
@@ -9563,7 +9563,7 @@ struct _strikethroughModifier<R: RootRegistry>: ViewModifier {
 
     
     
-    init(_ isActive: AttributeReference<Swift.Bool>, pattern: SwiftUI.Text.LineStyle.Pattern = .solid, color: AttributeReference<SwiftUI.Color?>? ) {
+    init(_ isActive: AttributeReference<Swift.Bool> = .init(storage: .constant(true)), pattern: SwiftUI.Text.LineStyle.Pattern = .solid, color: AttributeReference<SwiftUI.Color?>? = .init(storage: .constant(nil)) ) {
         self.value = ._0(isActive: isActive, pattern: pattern, color: color)
         
     }
@@ -9633,7 +9633,7 @@ struct _submitScopeModifier<R: RootRegistry>: ViewModifier {
     enum Value {
         case _never
         
-        case _0(isBlocking: AttributeReference<Swift.Bool> )
+        case _0(isBlocking: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) )
         
     }
 
@@ -9647,7 +9647,7 @@ struct _submitScopeModifier<R: RootRegistry>: ViewModifier {
 
     
     
-    init(_ isBlocking: AttributeReference<Swift.Bool> ) {
+    init(_ isBlocking: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(isBlocking: isBlocking)
         
     }
@@ -9674,7 +9674,7 @@ struct _swipeActionsModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(watchOS) || os(iOS) || os(macOS)
+        #if os(macOS) || os(watchOS) || os(iOS)
         case _0(edge: Any, allowsFullSwipe: Any, content: Any)
         #endif
     }
@@ -9687,9 +9687,9 @@ struct _swipeActionsModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(watchOS) || os(iOS) || os(macOS)
-    @available(watchOS 8.0,iOS 15.0,macOS 12.0, *)
-    init(edge: SwiftUI.HorizontalEdge = .trailing, allowsFullSwipe: AttributeReference<Swift.Bool>, content: ViewReference=ViewReference(value: [])) {
+    #if os(macOS) || os(watchOS) || os(iOS)
+    @available(macOS 12.0,watchOS 8.0,iOS 15.0, *)
+    init(edge: SwiftUI.HorizontalEdge = .trailing, allowsFullSwipe: AttributeReference<Swift.Bool> = .init(storage: .constant(true)), content: ViewReference=ViewReference(value: [])) {
         self.value = ._0(edge: edge, allowsFullSwipe: allowsFullSwipe, content: content)
         
     }
@@ -9699,9 +9699,9 @@ struct _swipeActionsModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(watchOS) || os(iOS) || os(macOS)
+        #if os(macOS) || os(watchOS) || os(iOS)
         case let ._0(edge, allowsFullSwipe, content):
-            if #available(watchOS 8.0,iOS 15.0,macOS 12.0, *) {
+            if #available(macOS 12.0,watchOS 8.0,iOS 15.0, *) {
             let edge = edge as! SwiftUI.HorizontalEdge 
 let allowsFullSwipe = allowsFullSwipe as! AttributeReference<Swift.Bool>
 let content = content as! ViewReference
@@ -9718,7 +9718,7 @@ struct _symbolEffectsRemovedModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(macOS) || os(tvOS) || os(iOS) || os(watchOS)
+        #if os(watchOS) || os(tvOS) || os(macOS) || os(iOS)
         case _0(isEnabled: Any)
         #endif
     }
@@ -9731,9 +9731,9 @@ struct _symbolEffectsRemovedModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(macOS) || os(tvOS) || os(iOS) || os(watchOS)
-    @available(macOS 14.0,tvOS 17.0,iOS 17.0,watchOS 10.0, *)
-    init(_ isEnabled: AttributeReference<Swift.Bool> ) {
+    #if os(watchOS) || os(tvOS) || os(macOS) || os(iOS)
+    @available(watchOS 10.0,tvOS 17.0,macOS 14.0,iOS 17.0, *)
+    init(_ isEnabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(isEnabled: isEnabled)
         
     }
@@ -9743,10 +9743,10 @@ struct _symbolEffectsRemovedModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(macOS) || os(tvOS) || os(iOS) || os(watchOS)
+        #if os(watchOS) || os(tvOS) || os(macOS) || os(iOS)
         case let ._0(isEnabled):
-            if #available(macOS 14.0,tvOS 17.0,iOS 17.0,watchOS 10.0, *) {
-            let isEnabled = isEnabled as! AttributeReference<Swift.Bool> 
+            if #available(watchOS 10.0,tvOS 17.0,macOS 14.0,iOS 17.0, *) {
+            let isEnabled = isEnabled as! AttributeReference<Swift.Bool>
             __content
                 .symbolEffectsRemoved(isEnabled.resolve(on: element, in: context))
             } else { __content }
@@ -10012,7 +10012,7 @@ struct _textContentTypeModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(tvOS) || os(iOS)
+        #if os(iOS) || os(tvOS)
         case _0(textContentType: Any?)
         #endif
     }
@@ -10025,8 +10025,8 @@ struct _textContentTypeModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(tvOS) || os(iOS)
-    @available(tvOS 13.0,iOS 13.0, *)
+    #if os(iOS) || os(tvOS)
+    @available(iOS 13.0,tvOS 13.0, *)
     init(_ textContentType: UIKit.UITextContentType?) {
         self.value = ._0(textContentType: textContentType)
         
@@ -10037,9 +10037,9 @@ struct _textContentTypeModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(tvOS) || os(iOS)
+        #if os(iOS) || os(tvOS)
         case let ._0(textContentType):
-            if #available(tvOS 13.0,iOS 13.0, *) {
+            if #available(iOS 13.0,tvOS 13.0, *) {
             let textContentType = textContentType as? UIKit.UITextContentType
             __content
                 .textContentType(textContentType)
@@ -10138,7 +10138,7 @@ struct _textInputAutocapitalizationModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(watchOS) || os(iOS) || os(tvOS)
+        #if os(iOS) || os(tvOS) || os(watchOS)
         case _0(autocapitalization: Any?)
         #endif
     }
@@ -10151,8 +10151,8 @@ struct _textInputAutocapitalizationModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(watchOS) || os(iOS) || os(tvOS)
-    @available(watchOS 8.0,iOS 15.0,tvOS 15.0, *)
+    #if os(iOS) || os(tvOS) || os(watchOS)
+    @available(iOS 15.0,tvOS 15.0,watchOS 8.0, *)
     init(_ autocapitalization: SwiftUI.TextInputAutocapitalization?) {
         self.value = ._0(autocapitalization: autocapitalization)
         
@@ -10163,9 +10163,9 @@ struct _textInputAutocapitalizationModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(watchOS) || os(iOS) || os(tvOS)
+        #if os(iOS) || os(tvOS) || os(watchOS)
         case let ._0(autocapitalization):
-            if #available(watchOS 8.0,iOS 15.0,tvOS 15.0, *) {
+            if #available(iOS 15.0,tvOS 15.0,watchOS 8.0, *) {
             let autocapitalization = autocapitalization as? SwiftUI.TextInputAutocapitalization
             __content
                 .textInputAutocapitalization(autocapitalization)
@@ -10180,7 +10180,7 @@ struct _textScaleModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(tvOS) || os(iOS) || os(macOS) || os(watchOS)
+        #if os(macOS) || os(watchOS) || os(iOS) || os(tvOS)
         case _0(scale: Any,isEnabled: Any)
         #endif
     }
@@ -10193,9 +10193,9 @@ struct _textScaleModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(tvOS) || os(iOS) || os(macOS) || os(watchOS)
-    @available(tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0, *)
-    init(_ scale: SwiftUI.Text.Scale,isEnabled: AttributeReference<Swift.Bool> ) {
+    #if os(macOS) || os(watchOS) || os(iOS) || os(tvOS)
+    @available(macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0, *)
+    init(_ scale: SwiftUI.Text.Scale,isEnabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(scale: scale, isEnabled: isEnabled)
         
     }
@@ -10205,11 +10205,11 @@ struct _textScaleModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(tvOS) || os(iOS) || os(macOS) || os(watchOS)
+        #if os(macOS) || os(watchOS) || os(iOS) || os(tvOS)
         case let ._0(scale, isEnabled):
-            if #available(tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0, *) {
+            if #available(macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0, *) {
             let scale = scale as! SwiftUI.Text.Scale
-let isEnabled = isEnabled as! AttributeReference<Swift.Bool> 
+let isEnabled = isEnabled as! AttributeReference<Swift.Bool>
             __content
                 .textScale(scale, isEnabled: isEnabled.resolve(on: element, in: context))
             } else { __content }
@@ -10223,7 +10223,7 @@ struct _textSelectionModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS)
         case _0(selectability: Any)
         #endif
     }
@@ -10236,8 +10236,8 @@ struct _textSelectionModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(macOS) || os(iOS)
-    @available(macOS 12.0,iOS 15.0, *)
+    #if os(iOS) || os(macOS)
+    @available(iOS 15.0,macOS 12.0, *)
     init(_ selectability: AnyTextSelectability) {
         self.value = ._0(selectability: selectability)
         
@@ -10248,9 +10248,9 @@ struct _textSelectionModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS)
         case let ._0(selectability):
-            if #available(macOS 12.0,iOS 15.0, *) {
+            if #available(iOS 15.0,macOS 12.0, *) {
             let selectability = selectability as! AnyTextSelectability
             __content
                 .textSelection(selectability)
@@ -10372,7 +10372,7 @@ struct _toolbarModifier<R: RootRegistry>: ViewModifier {
         
         case _0(visibility: SwiftUI.Visibility,bars: SwiftUI.ToolbarPlacement)
         
-        #if os(watchOS) || os(macOS) || os(tvOS) || os(iOS)
+        #if os(tvOS) || os(watchOS) || os(macOS) || os(iOS)
         case _1(defaultItemKind: Any?)
         #endif
         
@@ -10404,8 +10404,8 @@ struct _toolbarModifier<R: RootRegistry>: ViewModifier {
         
     }
     
-    #if os(watchOS) || os(macOS) || os(tvOS) || os(iOS)
-    @available(watchOS 10.0,macOS 14.0,tvOS 17.0,iOS 17.0, *)
+    #if os(tvOS) || os(watchOS) || os(macOS) || os(iOS)
+    @available(tvOS 17.0,watchOS 10.0,macOS 14.0,iOS 17.0, *)
     init(removing defaultItemKind: SwiftUI.ToolbarDefaultItemKind?) {
         self.value = ._1(defaultItemKind: defaultItemKind)
         
@@ -10438,9 +10438,9 @@ struct _toolbarModifier<R: RootRegistry>: ViewModifier {
                 .toolbar(visibility, for: bars)
             
         
-        #if os(watchOS) || os(macOS) || os(tvOS) || os(iOS)
+        #if os(tvOS) || os(watchOS) || os(macOS) || os(iOS)
         case let ._1(defaultItemKind):
-            if #available(watchOS 10.0,macOS 14.0,tvOS 17.0,iOS 17.0, *) {
+            if #available(tvOS 17.0,watchOS 10.0,macOS 14.0,iOS 17.0, *) {
             let defaultItemKind = defaultItemKind as? SwiftUI.ToolbarDefaultItemKind
             __content
                 .toolbar(removing: defaultItemKind)
@@ -10617,7 +10617,7 @@ struct _toolbarTitleDisplayModeModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(tvOS) || os(watchOS) || os(macOS)
+        #if os(watchOS) || os(iOS) || os(tvOS) || os(macOS)
         case _0(mode: Any)
         #endif
     }
@@ -10630,8 +10630,8 @@ struct _toolbarTitleDisplayModeModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(tvOS) || os(watchOS) || os(macOS)
-    @available(iOS 17.0,tvOS 17.0,watchOS 10.0,macOS 14.0, *)
+    #if os(watchOS) || os(iOS) || os(tvOS) || os(macOS)
+    @available(watchOS 10.0,iOS 17.0,tvOS 17.0,macOS 14.0, *)
     init(_ mode: SwiftUI.ToolbarTitleDisplayMode) {
         self.value = ._0(mode: mode)
         
@@ -10642,9 +10642,9 @@ struct _toolbarTitleDisplayModeModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(tvOS) || os(watchOS) || os(macOS)
+        #if os(watchOS) || os(iOS) || os(tvOS) || os(macOS)
         case let ._0(mode):
-            if #available(iOS 17.0,tvOS 17.0,watchOS 10.0,macOS 14.0, *) {
+            if #available(watchOS 10.0,iOS 17.0,tvOS 17.0,macOS 14.0, *) {
             let mode = mode as! SwiftUI.ToolbarTitleDisplayMode
             __content
                 .toolbarTitleDisplayMode(mode)
@@ -10758,7 +10758,7 @@ struct _touchBarItemPrincipalModifier<R: RootRegistry>: ViewModifier {
 
     #if os(macOS)
     @available(macOS 10.15, *)
-    init(_ principal: AttributeReference<Swift.Bool> ) {
+    init(_ principal: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(principal: principal)
         
     }
@@ -10771,7 +10771,7 @@ struct _touchBarItemPrincipalModifier<R: RootRegistry>: ViewModifier {
         #if os(macOS)
         case let ._0(principal):
             if #available(macOS 10.15, *) {
-            let principal = principal as! AttributeReference<Swift.Bool> 
+            let principal = principal as! AttributeReference<Swift.Bool>
             __content
                 .touchBarItemPrincipal(principal.resolve(on: element, in: context))
             } else { __content }
@@ -10954,7 +10954,7 @@ struct _underlineModifier<R: RootRegistry>: ViewModifier {
     enum Value {
         case _never
         
-        case _0(isActive: AttributeReference<Swift.Bool>, pattern: SwiftUI.Text.LineStyle.Pattern = .solid, color: AttributeReference<SwiftUI.Color?>? )
+        case _0(isActive: AttributeReference<Swift.Bool> = .init(storage: .constant(true)), pattern: SwiftUI.Text.LineStyle.Pattern = .solid, color: AttributeReference<SwiftUI.Color?>? = .init(storage: .constant(nil)) )
         
     }
 
@@ -10968,7 +10968,7 @@ struct _underlineModifier<R: RootRegistry>: ViewModifier {
 
     
     
-    init(_ isActive: AttributeReference<Swift.Bool>, pattern: SwiftUI.Text.LineStyle.Pattern = .solid, color: AttributeReference<SwiftUI.Color?>? ) {
+    init(_ isActive: AttributeReference<Swift.Bool> = .init(storage: .constant(true)), pattern: SwiftUI.Text.LineStyle.Pattern = .solid, color: AttributeReference<SwiftUI.Color?>? = .init(storage: .constant(nil)) ) {
         self.value = ._0(isActive: isActive, pattern: pattern, color: color)
         
     }
@@ -11299,28 +11299,28 @@ case truncationMode(_truncationModeModifier<R>)
 case underline(_underlineModifier<R>)
 case unredacted(_unredactedModifier<R>)
 case zIndex(_zIndexModifier<R>)
-        case _FillModifier(LiveViewNative._FillModifier)
-case _StrokeModifier(LiveViewNative._StrokeModifier)
-case _RenderingModeModifier(LiveViewNative._RenderingModeModifier)
-case _UnionModifier(LiveViewNative._UnionModifier)
-case _PresentationDetentsModifier(LiveViewNative._PresentationDetentsModifier)
-case _SymmetricDifferenceModifier(LiveViewNative._SymmetricDifferenceModifier)
-case _ResizableModifier(LiveViewNative._ResizableModifier)
-case _TransformModifier(LiveViewNative._TransformModifier)
-case _IntersectionModifier(LiveViewNative._IntersectionModifier)
-case _FocusScopeModifier(LiveViewNative._FocusScopeModifier)
+        case _OnSubmitModifier(LiveViewNative._OnSubmitModifier)
 case _ScaleModifier(LiveViewNative._ScaleModifier<R>)
-case _SearchCompletionModifier(LiveViewNative._SearchCompletionModifier)
-case _Rotation3DEffectModifier(LiveViewNative._Rotation3DEffectModifier)
-case _SubtractingModifier(LiveViewNative._SubtractingModifier)
+case _IntersectionModifier(LiveViewNative._IntersectionModifier)
+case _TransformModifier(LiveViewNative._TransformModifier)
+case _StrokeModifier(LiveViewNative._StrokeModifier)
 case _SearchScopesModifier(LiveViewNative._SearchScopesModifier<R>)
-case _LineSubtractionModifier(LiveViewNative._LineSubtractionModifier)
-case _MaskModifier(LiveViewNative._MaskModifier<R>)
-case _RotationModifier(LiveViewNative._RotationModifier)
+case _RenderingModeModifier(LiveViewNative._RenderingModeModifier)
 case _LineIntersectionModifier(LiveViewNative._LineIntersectionModifier)
 case _PrefersDefaultFocusModifier(LiveViewNative._PrefersDefaultFocusModifier<R>)
-case _OnSubmitModifier(LiveViewNative._OnSubmitModifier)
-case _MatchedGeometryEffectModifier(LiveViewNative._MatchedGeometryEffectModifier)
+case _RotationModifier(LiveViewNative._RotationModifier)
+case _SubtractingModifier(LiveViewNative._SubtractingModifier)
+case _MaskModifier(LiveViewNative._MaskModifier<R>)
+case _FocusScopeModifier(LiveViewNative._FocusScopeModifier)
+case _PresentationDetentsModifier(LiveViewNative._PresentationDetentsModifier)
+case _MatchedGeometryEffectModifier(LiveViewNative._MatchedGeometryEffectModifier<R>)
+case _SymmetricDifferenceModifier(LiveViewNative._SymmetricDifferenceModifier)
+case _FillModifier(LiveViewNative._FillModifier)
+case _UnionModifier(LiveViewNative._UnionModifier)
+case _LineSubtractionModifier(LiveViewNative._LineSubtractionModifier)
+case _Rotation3DEffectModifier(LiveViewNative._Rotation3DEffectModifier)
+case _SearchCompletionModifier(LiveViewNative._SearchCompletionModifier)
+case _ResizableModifier(LiveViewNative._ResizableModifier)
         
         func body(content: Content) -> some View {
             switch self {
@@ -11770,49 +11770,49 @@ case let .unredacted(modifier):
     content.modifier(modifier)
 case let .zIndex(modifier):
     content.modifier(modifier)
-            case let ._FillModifier(modifier):
-    content.modifier(modifier)
-case let ._StrokeModifier(modifier):
-    content.modifier(modifier)
-case let ._RenderingModeModifier(modifier):
-    content.modifier(modifier)
-case let ._UnionModifier(modifier):
-    content.modifier(modifier)
-case let ._PresentationDetentsModifier(modifier):
-    content.modifier(modifier)
-case let ._SymmetricDifferenceModifier(modifier):
-    content.modifier(modifier)
-case let ._ResizableModifier(modifier):
-    content.modifier(modifier)
-case let ._TransformModifier(modifier):
-    content.modifier(modifier)
-case let ._IntersectionModifier(modifier):
-    content.modifier(modifier)
-case let ._FocusScopeModifier(modifier):
+            case let ._OnSubmitModifier(modifier):
     content.modifier(modifier)
 case let ._ScaleModifier(modifier):
     content.modifier(modifier)
-case let ._SearchCompletionModifier(modifier):
+case let ._IntersectionModifier(modifier):
     content.modifier(modifier)
-case let ._Rotation3DEffectModifier(modifier):
+case let ._TransformModifier(modifier):
     content.modifier(modifier)
-case let ._SubtractingModifier(modifier):
+case let ._StrokeModifier(modifier):
     content.modifier(modifier)
 case let ._SearchScopesModifier(modifier):
     content.modifier(modifier)
-case let ._LineSubtractionModifier(modifier):
-    content.modifier(modifier)
-case let ._MaskModifier(modifier):
-    content.modifier(modifier)
-case let ._RotationModifier(modifier):
+case let ._RenderingModeModifier(modifier):
     content.modifier(modifier)
 case let ._LineIntersectionModifier(modifier):
     content.modifier(modifier)
 case let ._PrefersDefaultFocusModifier(modifier):
     content.modifier(modifier)
-case let ._OnSubmitModifier(modifier):
+case let ._RotationModifier(modifier):
+    content.modifier(modifier)
+case let ._SubtractingModifier(modifier):
+    content.modifier(modifier)
+case let ._MaskModifier(modifier):
+    content.modifier(modifier)
+case let ._FocusScopeModifier(modifier):
+    content.modifier(modifier)
+case let ._PresentationDetentsModifier(modifier):
     content.modifier(modifier)
 case let ._MatchedGeometryEffectModifier(modifier):
+    content.modifier(modifier)
+case let ._SymmetricDifferenceModifier(modifier):
+    content.modifier(modifier)
+case let ._FillModifier(modifier):
+    content.modifier(modifier)
+case let ._UnionModifier(modifier):
+    content.modifier(modifier)
+case let ._LineSubtractionModifier(modifier):
+    content.modifier(modifier)
+case let ._Rotation3DEffectModifier(modifier):
+    content.modifier(modifier)
+case let ._SearchCompletionModifier(modifier):
+    content.modifier(modifier)
+case let ._ResizableModifier(modifier):
     content.modifier(modifier)
             }
         }
@@ -12052,28 +12052,28 @@ _truncationModeModifier<R>.name: _truncationModeModifier<R>.parser(in: context).
 _underlineModifier<R>.name: _underlineModifier<R>.parser(in: context).map(Output.underline).eraseToAnyParser(),
 _unredactedModifier<R>.name: _unredactedModifier<R>.parser(in: context).map(Output.unredacted).eraseToAnyParser(),
 _zIndexModifier<R>.name: _zIndexModifier<R>.parser(in: context).map(Output.zIndex).eraseToAnyParser(),
-                    LiveViewNative._FillModifier.name: LiveViewNative._FillModifier.parser(in: context).map(Output._FillModifier).eraseToAnyParser(),
-LiveViewNative._StrokeModifier.name: LiveViewNative._StrokeModifier.parser(in: context).map(Output._StrokeModifier).eraseToAnyParser(),
-LiveViewNative._RenderingModeModifier.name: LiveViewNative._RenderingModeModifier.parser(in: context).map(Output._RenderingModeModifier).eraseToAnyParser(),
-LiveViewNative._UnionModifier.name: LiveViewNative._UnionModifier.parser(in: context).map(Output._UnionModifier).eraseToAnyParser(),
-LiveViewNative._PresentationDetentsModifier.name: LiveViewNative._PresentationDetentsModifier.parser(in: context).map(Output._PresentationDetentsModifier).eraseToAnyParser(),
-LiveViewNative._SymmetricDifferenceModifier.name: LiveViewNative._SymmetricDifferenceModifier.parser(in: context).map(Output._SymmetricDifferenceModifier).eraseToAnyParser(),
-LiveViewNative._ResizableModifier.name: LiveViewNative._ResizableModifier.parser(in: context).map(Output._ResizableModifier).eraseToAnyParser(),
-LiveViewNative._TransformModifier.name: LiveViewNative._TransformModifier.parser(in: context).map(Output._TransformModifier).eraseToAnyParser(),
-LiveViewNative._IntersectionModifier.name: LiveViewNative._IntersectionModifier.parser(in: context).map(Output._IntersectionModifier).eraseToAnyParser(),
-LiveViewNative._FocusScopeModifier.name: LiveViewNative._FocusScopeModifier.parser(in: context).map(Output._FocusScopeModifier).eraseToAnyParser(),
+                    LiveViewNative._OnSubmitModifier.name: LiveViewNative._OnSubmitModifier.parser(in: context).map(Output._OnSubmitModifier).eraseToAnyParser(),
 LiveViewNative._ScaleModifier<R>.name: LiveViewNative._ScaleModifier<R>.parser(in: context).map(Output._ScaleModifier).eraseToAnyParser(),
-LiveViewNative._SearchCompletionModifier.name: LiveViewNative._SearchCompletionModifier.parser(in: context).map(Output._SearchCompletionModifier).eraseToAnyParser(),
-LiveViewNative._Rotation3DEffectModifier.name: LiveViewNative._Rotation3DEffectModifier.parser(in: context).map(Output._Rotation3DEffectModifier).eraseToAnyParser(),
-LiveViewNative._SubtractingModifier.name: LiveViewNative._SubtractingModifier.parser(in: context).map(Output._SubtractingModifier).eraseToAnyParser(),
+LiveViewNative._IntersectionModifier.name: LiveViewNative._IntersectionModifier.parser(in: context).map(Output._IntersectionModifier).eraseToAnyParser(),
+LiveViewNative._TransformModifier.name: LiveViewNative._TransformModifier.parser(in: context).map(Output._TransformModifier).eraseToAnyParser(),
+LiveViewNative._StrokeModifier.name: LiveViewNative._StrokeModifier.parser(in: context).map(Output._StrokeModifier).eraseToAnyParser(),
 LiveViewNative._SearchScopesModifier<R>.name: LiveViewNative._SearchScopesModifier<R>.parser(in: context).map(Output._SearchScopesModifier).eraseToAnyParser(),
-LiveViewNative._LineSubtractionModifier.name: LiveViewNative._LineSubtractionModifier.parser(in: context).map(Output._LineSubtractionModifier).eraseToAnyParser(),
-LiveViewNative._MaskModifier<R>.name: LiveViewNative._MaskModifier<R>.parser(in: context).map(Output._MaskModifier).eraseToAnyParser(),
-LiveViewNative._RotationModifier.name: LiveViewNative._RotationModifier.parser(in: context).map(Output._RotationModifier).eraseToAnyParser(),
+LiveViewNative._RenderingModeModifier.name: LiveViewNative._RenderingModeModifier.parser(in: context).map(Output._RenderingModeModifier).eraseToAnyParser(),
 LiveViewNative._LineIntersectionModifier.name: LiveViewNative._LineIntersectionModifier.parser(in: context).map(Output._LineIntersectionModifier).eraseToAnyParser(),
 LiveViewNative._PrefersDefaultFocusModifier<R>.name: LiveViewNative._PrefersDefaultFocusModifier<R>.parser(in: context).map(Output._PrefersDefaultFocusModifier).eraseToAnyParser(),
-LiveViewNative._OnSubmitModifier.name: LiveViewNative._OnSubmitModifier.parser(in: context).map(Output._OnSubmitModifier).eraseToAnyParser(),
-LiveViewNative._MatchedGeometryEffectModifier.name: LiveViewNative._MatchedGeometryEffectModifier.parser(in: context).map(Output._MatchedGeometryEffectModifier).eraseToAnyParser(),
+LiveViewNative._RotationModifier.name: LiveViewNative._RotationModifier.parser(in: context).map(Output._RotationModifier).eraseToAnyParser(),
+LiveViewNative._SubtractingModifier.name: LiveViewNative._SubtractingModifier.parser(in: context).map(Output._SubtractingModifier).eraseToAnyParser(),
+LiveViewNative._MaskModifier<R>.name: LiveViewNative._MaskModifier<R>.parser(in: context).map(Output._MaskModifier).eraseToAnyParser(),
+LiveViewNative._FocusScopeModifier.name: LiveViewNative._FocusScopeModifier.parser(in: context).map(Output._FocusScopeModifier).eraseToAnyParser(),
+LiveViewNative._PresentationDetentsModifier.name: LiveViewNative._PresentationDetentsModifier.parser(in: context).map(Output._PresentationDetentsModifier).eraseToAnyParser(),
+LiveViewNative._MatchedGeometryEffectModifier<R>.name: LiveViewNative._MatchedGeometryEffectModifier<R>.parser(in: context).map(Output._MatchedGeometryEffectModifier).eraseToAnyParser(),
+LiveViewNative._SymmetricDifferenceModifier.name: LiveViewNative._SymmetricDifferenceModifier.parser(in: context).map(Output._SymmetricDifferenceModifier).eraseToAnyParser(),
+LiveViewNative._FillModifier.name: LiveViewNative._FillModifier.parser(in: context).map(Output._FillModifier).eraseToAnyParser(),
+LiveViewNative._UnionModifier.name: LiveViewNative._UnionModifier.parser(in: context).map(Output._UnionModifier).eraseToAnyParser(),
+LiveViewNative._LineSubtractionModifier.name: LiveViewNative._LineSubtractionModifier.parser(in: context).map(Output._LineSubtractionModifier).eraseToAnyParser(),
+LiveViewNative._Rotation3DEffectModifier.name: LiveViewNative._Rotation3DEffectModifier.parser(in: context).map(Output._Rotation3DEffectModifier).eraseToAnyParser(),
+LiveViewNative._SearchCompletionModifier.name: LiveViewNative._SearchCompletionModifier.parser(in: context).map(Output._SearchCompletionModifier).eraseToAnyParser(),
+LiveViewNative._ResizableModifier.name: LiveViewNative._ResizableModifier.parser(in: context).map(Output._ResizableModifier).eraseToAnyParser(),
                 ]
                 
                 var copy = input
@@ -12229,14 +12229,14 @@ ConstantAtomLiteral("vertical").map({ () -> Self in
     }
 }
 
-#if os(iOS) || os(macOS)
-@available(iOS 17.0,macOS 14.0, *)
+#if os(macOS) || os(iOS)
+@available(macOS 14.0,iOS 17.0, *)
 extension BadgeProminence: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             ConstantAtomLiteral("decreased").map({ () -> Self in
-#if os(iOS) || os(macOS)
+#if os(macOS) || os(iOS)
 
     return Self.decreased
 
@@ -12245,7 +12245,7 @@ fatalError("'decreased' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("standard").map({ () -> Self in
-#if os(iOS) || os(macOS)
+#if os(macOS) || os(iOS)
 
     return Self.standard
 
@@ -12254,7 +12254,7 @@ fatalError("'standard' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("increased").map({ () -> Self in
-#if os(iOS) || os(macOS)
+#if os(macOS) || os(iOS)
 
     return Self.increased
 
@@ -12467,14 +12467,14 @@ ConstantAtomLiteral("plusLighter").map({ () -> Self in
     }
 }
 
-#if os(iOS) || os(tvOS) || os(macOS) || os(watchOS)
-@available(iOS 17.0,tvOS 17.0,macOS 14.0,watchOS 10.0, *)
+#if os(watchOS) || os(macOS) || os(tvOS) || os(iOS)
+@available(watchOS 10.0,macOS 14.0,tvOS 17.0,iOS 17.0, *)
 extension ButtonRepeatBehavior: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             ConstantAtomLiteral("automatic").map({ () -> Self in
-#if os(tvOS) || os(macOS) || os(iOS) || os(watchOS)
+#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
 
     return Self.automatic
 
@@ -12483,7 +12483,7 @@ fatalError("'automatic' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("enabled").map({ () -> Self in
-#if os(tvOS) || os(watchOS) || os(macOS) || os(iOS)
+#if os(macOS) || os(tvOS) || os(iOS) || os(watchOS)
 
     return Self.enabled
 
@@ -12492,7 +12492,7 @@ fatalError("'enabled' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("disabled").map({ () -> Self in
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+#if os(iOS) || os(tvOS) || os(watchOS) || os(macOS)
 
     return Self.disabled
 
@@ -12572,8 +12572,8 @@ ConstantAtomLiteral("dark").map({ () -> Self in
     }
 }
 
-#if os(watchOS) || os(tvOS) || os(iOS) || os(macOS)
-@available(watchOS 10.0,tvOS 17.0,iOS 17.0,macOS 14.0, *)
+#if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
+@available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0, *)
 extension ContainerBackgroundPlacement: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -12601,14 +12601,14 @@ fatalError("'navigation' is not available on this OS")
     }
 }
 #endif
-#if os(iOS) || os(tvOS) || os(macOS) || os(watchOS)
-@available(iOS 17.0,tvOS 17.0,macOS 14.0,watchOS 10.0, *)
+#if os(tvOS) || os(macOS) || os(watchOS) || os(iOS)
+@available(tvOS 17.0,macOS 14.0,watchOS 10.0,iOS 17.0, *)
 extension ContentMarginPlacement: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             ConstantAtomLiteral("automatic").map({ () -> Self in
-#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+#if os(macOS) || os(tvOS) || os(watchOS) || os(iOS)
 
     return Self.automatic
 
@@ -12617,7 +12617,7 @@ fatalError("'automatic' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("scrollContent").map({ () -> Self in
-#if os(iOS) || os(tvOS) || os(macOS) || os(watchOS)
+#if os(macOS) || os(tvOS) || os(watchOS) || os(iOS)
 
     return Self.scrollContent
 
@@ -12626,7 +12626,7 @@ fatalError("'scrollContent' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("scrollIndicators").map({ () -> Self in
-#if os(tvOS) || os(iOS) || os(macOS) || os(watchOS)
+#if os(macOS) || os(tvOS) || os(watchOS) || os(iOS)
 
     return Self.scrollIndicators
 
@@ -12655,8 +12655,8 @@ extension ContentShapeKinds: ParseableModifierValue {
 
 })
 ConstantAtomLiteral("dragPreview").map({ () -> Self in
-#if os(macOS) || os(iOS)
-if #available(watchOS 8.0,tvOS 15.0,macOS 12.0,iOS 15.0, *) {
+#if os(iOS) || os(macOS)
+if #available(iOS 15.0,watchOS 8.0,tvOS 15.0,macOS 12.0, *) {
     return Self.dragPreview
 } else { fatalError("'dragPreview' is not available in this OS version") }
 #else
@@ -12664,8 +12664,8 @@ fatalError("'dragPreview' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("contextMenuPreview").map({ () -> Self in
-#if os(tvOS) || os(iOS)
-if #available(watchOS 8.0,macOS 12.0,tvOS 17.0,iOS 15.0, *) {
+#if os(iOS) || os(tvOS)
+if #available(macOS 12.0,iOS 15.0,watchOS 8.0,tvOS 17.0, *) {
     return Self.contextMenuPreview
 } else { fatalError("'contextMenuPreview' is not available in this OS version") }
 #else
@@ -12674,7 +12674,7 @@ fatalError("'contextMenuPreview' is not available on this OS")
 })
 ConstantAtomLiteral("hoverEffect").map({ () -> Self in
 #if os(iOS)
-if #available(watchOS 8.0,macOS 12.0,tvOS 15.0,iOS 15.0, *) {
+if #available(macOS 12.0,iOS 15.0,watchOS 8.0,tvOS 15.0, *) {
     return Self.hoverEffect
 } else { fatalError("'hoverEffect' is not available in this OS version") }
 #else
@@ -12683,7 +12683,7 @@ fatalError("'hoverEffect' is not available on this OS")
 })
 ConstantAtomLiteral("focusEffect").map({ () -> Self in
 #if os(macOS) || os(watchOS)
-if #available(macOS 12.0,watchOS 8.0,tvOS 15.0,iOS 15.0, *) {
+if #available(macOS 12.0,iOS 15.0,watchOS 8.0,tvOS 15.0, *) {
     return Self.focusEffect
 } else { fatalError("'focusEffect' is not available in this OS version") }
 #else
@@ -12691,8 +12691,8 @@ fatalError("'focusEffect' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("accessibility").map({ () -> Self in
-#if os(macOS) || os(tvOS) || os(iOS) || os(watchOS)
-if #available(macOS 14.0,tvOS 17.0,iOS 17.0,watchOS 10.0, *) {
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+if #available(macOS 14.0,iOS 17.0,watchOS 10.0,tvOS 17.0, *) {
     return Self.accessibility
 } else { fatalError("'accessibility' is not available in this OS version") }
 #else
@@ -12704,14 +12704,14 @@ fatalError("'accessibility' is not available on this OS")
     }
 }
 
-#if os(watchOS) || os(iOS) || os(macOS)
-@available(watchOS 9.0,iOS 15.0,macOS 10.15, *)
+#if os(iOS) || os(macOS) || os(watchOS)
+@available(iOS 15.0,macOS 10.15,watchOS 9.0, *)
 extension ControlSize: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             ConstantAtomLiteral("mini").map({ () -> Self in
-#if os(watchOS) || os(macOS) || os(iOS)
+#if os(iOS) || os(macOS) || os(watchOS)
 
     return Self.mini
 
@@ -12720,7 +12720,7 @@ fatalError("'mini' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("small").map({ () -> Self in
-#if os(watchOS) || os(macOS) || os(iOS)
+#if os(iOS) || os(macOS) || os(watchOS)
 
     return Self.small
 
@@ -12729,7 +12729,7 @@ fatalError("'small' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("regular").map({ () -> Self in
-#if os(watchOS) || os(macOS) || os(iOS)
+#if os(iOS) || os(macOS) || os(watchOS)
 
     return Self.regular
 
@@ -12738,8 +12738,8 @@ fatalError("'regular' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("large").map({ () -> Self in
-#if os(watchOS) || os(iOS) || os(macOS)
-if #available(watchOS 9.0,iOS 15.0,macOS 11.0, *) {
+#if os(macOS) || os(watchOS) || os(iOS)
+if #available(macOS 11.0,watchOS 9.0,iOS 15.0, *) {
     return Self.large
 } else { fatalError("'large' is not available in this OS version") }
 #else
@@ -12747,8 +12747,8 @@ fatalError("'large' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("extraLarge").map({ () -> Self in
-#if os(xrOS) || os(macOS) || os(watchOS) || os(iOS)
-if #available(xrOS 1.0,macOS 14.0,watchOS 10.0,iOS 17.0, *) {
+#if os(watchOS) || os(iOS) || os(xrOS) || os(macOS)
+if #available(watchOS 10.0,iOS 17.0,xrOS 1.0,macOS 14.0, *) {
     return Self.extraLarge
 } else { fatalError("'extraLarge' is not available in this OS version") }
 #else
@@ -12789,14 +12789,14 @@ ConstantAtomLiteral("userInitiated").map({ () -> Self in
     }
 }
 
-#if os(watchOS) || os(macOS)
-@available(tvOS 17.0,watchOS 10.0,iOS 17.0,macOS 13.0, *)
+#if os(macOS) || os(watchOS)
+@available(macOS 13.0,iOS 17.0,watchOS 10.0,tvOS 17.0, *)
 extension DialogSeverity: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             ConstantAtomLiteral("automatic").map({ () -> Self in
-#if os(watchOS) || os(macOS) || os(iOS) || os(tvOS)
+#if os(tvOS) || os(macOS) || os(iOS) || os(watchOS)
 
     return Self.automatic
 
@@ -12805,7 +12805,7 @@ fatalError("'automatic' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("critical").map({ () -> Self in
-#if os(iOS) || os(tvOS) || os(macOS) || os(watchOS)
+#if os(tvOS) || os(iOS) || os(macOS) || os(watchOS)
 
     return Self.critical
 
@@ -12814,8 +12814,8 @@ fatalError("'critical' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("standard").map({ () -> Self in
-#if os(iOS) || os(tvOS) || os(macOS) || os(watchOS)
-if #available(iOS 17.0,tvOS 17.0,macOS 14.0,watchOS 10.0, *) {
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+if #available(macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0, *) {
     return Self.standard
 } else { fatalError("'standard' is not available in this OS version") }
 #else
@@ -12973,7 +12973,7 @@ fatalError("'includeHiddenFiles' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("displayFileExtensions").map({ () -> Self in
-#if os(macOS) || os(iOS)
+#if os(iOS) || os(macOS)
 
     return Self.displayFileExtensions
 
@@ -12986,14 +12986,14 @@ fatalError("'displayFileExtensions' is not available on this OS")
     }
 }
 #endif
-#if os(iOS) || os(tvOS) || os(watchOS) || os(macOS)
-@available(iOS 17.0,tvOS 17.0,watchOS 10.0,macOS 14.0, *)
+#if os(tvOS) || os(watchOS) || os(iOS) || os(macOS)
+@available(tvOS 17.0,watchOS 10.0,iOS 17.0,macOS 14.0, *)
 extension FocusInteractions: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             ConstantAtomLiteral("activate").map({ () -> Self in
-#if os(macOS) || os(tvOS) || os(watchOS) || os(iOS)
+#if os(tvOS) || os(watchOS) || os(iOS) || os(macOS)
 
     return Self.activate
 
@@ -13002,7 +13002,7 @@ fatalError("'activate' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("edit").map({ () -> Self in
-#if os(iOS) || os(tvOS) || os(watchOS) || os(macOS)
+#if os(tvOS) || os(watchOS) || os(iOS) || os(macOS)
 
     return Self.edit
 
@@ -13011,7 +13011,7 @@ fatalError("'edit' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("automatic").map({ () -> Self in
-#if os(tvOS) || os(iOS) || os(macOS) || os(watchOS)
+#if os(watchOS) || os(macOS) || os(tvOS) || os(iOS)
 
     return Self.automatic
 
@@ -13105,8 +13105,8 @@ ConstantAtomLiteral("trailing").map({ () -> Self in
 
 })
 ConstantAtomLiteral("listRowSeparatorLeading").map({ () -> Self in
-#if os(macOS) || os(iOS)
-if #available(macOS 13.0,iOS 16.0, *) {
+#if os(iOS) || os(macOS)
+if #available(iOS 16.0,macOS 13.0, *) {
     return Self.listRowSeparatorLeading
 } else { fatalError("'listRowSeparatorLeading' is not available in this OS version") }
 #else
@@ -13172,8 +13172,8 @@ fatalError("'automatic' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("highlight").map({ () -> Self in
-#if os(tvOS) || os(iOS)
-if #available(tvOS 17.0,iOS 13.4, *) {
+#if os(iOS) || os(tvOS)
+if #available(iOS 13.4,tvOS 17.0, *) {
     return Self.highlight
 } else { fatalError("'highlight' is not available in this OS version") }
 #else
@@ -13181,7 +13181,7 @@ fatalError("'highlight' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("lift").map({ () -> Self in
-#if os(tvOS) || os(iOS)
+#if os(iOS) || os(tvOS)
 
     return Self.lift
 
@@ -13194,8 +13194,8 @@ fatalError("'lift' is not available on this OS")
     }
 }
 #endif
-#if os(macOS) || os(iOS)
-@available(macOS 11.0,iOS 14.0, *)
+#if os(iOS) || os(macOS)
+@available(iOS 14.0,macOS 11.0, *)
 extension KeyboardShortcut: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -13278,7 +13278,7 @@ extension MenuOrder: ParseableModifierValue {
 })
 ConstantAtomLiteral("priority").map({ () -> Self in
 #if os(iOS)
-if #available(iOS 16.0,watchOS 9.0,macOS 13.0,tvOS 16.0, *) {
+if #available(watchOS 9.0,iOS 16.0,tvOS 16.0,macOS 13.0, *) {
     return Self.priority
 } else { fatalError("'priority' is not available in this OS version") }
 #else
@@ -13299,14 +13299,14 @@ ConstantAtomLiteral("fixed").map({ () -> Self in
     }
 }
 
-#if os(tvOS) || os(macOS) || os(iOS) || os(watchOS)
-@available(tvOS 16.4,macOS 13.3,iOS 16.4,watchOS 9.4, *)
+#if os(macOS) || os(tvOS) || os(watchOS) || os(iOS)
+@available(macOS 13.3,tvOS 16.4,watchOS 9.4,iOS 16.4, *)
 extension PresentationAdaptation: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             ConstantAtomLiteral("automatic").map({ () -> Self in
-#if os(tvOS) || os(macOS) || os(iOS) || os(watchOS)
+#if os(macOS) || os(tvOS) || os(watchOS) || os(iOS)
 
     return Self.automatic
 
@@ -13315,7 +13315,7 @@ fatalError("'automatic' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("none").map({ () -> Self in
-#if os(tvOS) || os(macOS) || os(iOS) || os(watchOS)
+#if os(macOS) || os(tvOS) || os(watchOS) || os(iOS)
 
     return Self.none
 
@@ -13324,7 +13324,7 @@ fatalError("'none' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("popover").map({ () -> Self in
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+#if os(watchOS) || os(tvOS) || os(macOS) || os(iOS)
 
     return Self.popover
 
@@ -13342,7 +13342,7 @@ fatalError("'sheet' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("fullScreenCover").map({ () -> Self in
-#if os(iOS) || os(tvOS) || os(macOS) || os(watchOS)
+#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
 
     return Self.fullScreenCover
 
@@ -13355,14 +13355,14 @@ fatalError("'fullScreenCover' is not available on this OS")
     }
 }
 #endif
-#if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
-@available(tvOS 16.4,iOS 16.4,watchOS 9.4,macOS 13.3, *)
+#if os(tvOS) || os(macOS) || os(watchOS) || os(iOS)
+@available(tvOS 16.4,macOS 13.3,watchOS 9.4,iOS 16.4, *)
 extension PresentationContentInteraction: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             ConstantAtomLiteral("automatic").map({ () -> Self in
-#if os(watchOS) || os(tvOS) || os(iOS) || os(macOS)
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 
     return Self.automatic
 
@@ -13371,7 +13371,7 @@ fatalError("'automatic' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("resizes").map({ () -> Self in
-#if os(watchOS) || os(tvOS) || os(macOS) || os(iOS)
+#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
 
     return Self.resizes
 
@@ -13380,7 +13380,7 @@ fatalError("'resizes' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("scrolls").map({ () -> Self in
-#if os(tvOS) || os(watchOS) || os(macOS) || os(iOS)
+#if os(iOS) || os(tvOS) || os(watchOS) || os(macOS)
 
     return Self.scrolls
 
@@ -13447,8 +13447,8 @@ ConstantAtomLiteral("privacy").map({ () -> Self in
 
 })
 ConstantAtomLiteral("invalidated").map({ () -> Self in
-#if os(macOS) || os(tvOS) || os(iOS) || os(watchOS)
-if #available(macOS 14.0,tvOS 17.0,iOS 17.0,watchOS 10.0, *) {
+#if os(tvOS) || os(macOS) || os(iOS) || os(watchOS)
+if #available(tvOS 17.0,macOS 14.0,iOS 17.0,watchOS 10.0, *) {
     return Self.invalidated
 } else { fatalError("'invalidated' is not available in this OS version") }
 #else
@@ -13556,14 +13556,14 @@ fatalError("'navigationBar' is not available on this OS")
     }
 }
 
-#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-@available(iOS 16.4,macOS 13.3,tvOS 16.4,watchOS 9.4, *)
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+@available(macOS 13.3,iOS 16.4,tvOS 16.4,watchOS 9.4, *)
 extension ScrollBounceBehavior: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             ConstantAtomLiteral("automatic").map({ () -> Self in
-#if os(watchOS) || os(tvOS) || os(iOS) || os(macOS)
+#if os(watchOS) || os(iOS) || os(tvOS) || os(macOS)
 
     return Self.automatic
 
@@ -13572,7 +13572,7 @@ fatalError("'automatic' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("always").map({ () -> Self in
-#if os(watchOS) || os(tvOS) || os(iOS) || os(macOS)
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 
     return Self.always
 
@@ -13581,7 +13581,7 @@ fatalError("'always' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("basedOnSize").map({ () -> Self in
-#if os(watchOS) || os(tvOS) || os(iOS) || os(macOS)
+#if os(macOS) || os(tvOS) || os(iOS) || os(watchOS)
 
     return Self.basedOnSize
 
@@ -13594,8 +13594,8 @@ fatalError("'basedOnSize' is not available on this OS")
     }
 }
 #endif
-#if os(macOS) || os(tvOS) || os(watchOS) || os(iOS)
-@available(macOS 13.0,tvOS 16.0,watchOS 9.0,iOS 16.0, *)
+#if os(macOS) || os(watchOS) || os(tvOS) || os(iOS)
+@available(macOS 13.0,watchOS 9.0,tvOS 16.0,iOS 16.0, *)
 extension ScrollDismissesKeyboardMode: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -13688,14 +13688,14 @@ ConstantAtomLiteral("never").map({ () -> Self in
     }
 }
 
-#if os(iOS) || os(tvOS) || os(macOS) || os(watchOS)
-@available(iOS 16.4,tvOS 16.4,macOS 13.3,watchOS 9.4, *)
+#if os(tvOS) || os(watchOS) || os(iOS) || os(macOS)
+@available(tvOS 16.4,watchOS 9.4,iOS 16.4,macOS 13.3, *)
 extension SearchScopeActivation: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             ConstantAtomLiteral("automatic").map({ () -> Self in
-#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+#if os(tvOS) || os(watchOS) || os(iOS) || os(macOS)
 
     return Self.automatic
 
@@ -13704,7 +13704,7 @@ fatalError("'automatic' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("onTextEntry").map({ () -> Self in
-#if os(iOS) || os(macOS) || os(watchOS)
+#if os(watchOS) || os(iOS) || os(macOS)
 
     return Self.onTextEntry
 
@@ -13713,7 +13713,7 @@ fatalError("'onTextEntry' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("onSearchPresentation").map({ () -> Self in
-#if os(iOS) || os(macOS) || os(watchOS)
+#if os(watchOS) || os(iOS) || os(macOS)
 
     return Self.onSearchPresentation
 
@@ -13764,14 +13764,14 @@ ConstantAtomLiteral("content").map({ () -> Self in
     }
 }
 
-#if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
-@available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0, *)
+#if os(iOS) || os(tvOS) || os(watchOS) || os(macOS)
+@available(iOS 17.0,tvOS 17.0,watchOS 10.0,macOS 14.0, *)
 extension SpringLoadingBehavior: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             ConstantAtomLiteral("automatic").map({ () -> Self in
-#if os(watchOS) || os(iOS) || os(tvOS) || os(macOS)
+#if os(watchOS) || os(tvOS) || os(iOS) || os(macOS)
 
     return Self.automatic
 
@@ -13780,7 +13780,7 @@ fatalError("'automatic' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("enabled").map({ () -> Self in
-#if os(watchOS) || os(macOS) || os(tvOS) || os(iOS)
+#if os(tvOS) || os(watchOS) || os(iOS) || os(macOS)
 
     return Self.enabled
 
@@ -13789,7 +13789,7 @@ fatalError("'enabled' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("disabled").map({ () -> Self in
-#if os(watchOS) || os(macOS) || os(iOS) || os(tvOS)
+#if os(iOS) || os(tvOS) || os(macOS) || os(watchOS)
 
     return Self.disabled
 
@@ -13923,14 +13923,14 @@ ConstantAtomLiteral("search").map({ () -> Self in
     }
 }
 
-#if os(iOS) || os(tvOS) || os(macOS) || os(watchOS)
-@available(iOS 17.0,tvOS 17.0,macOS 14.0,watchOS 10.0, *)
+#if os(macOS) || os(watchOS) || os(iOS) || os(tvOS)
+@available(macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0, *)
 extension ToolbarDefaultItemKind: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             ConstantAtomLiteral("sidebarToggle").map({ () -> Self in
-#if os(iOS) || os(tvOS) || os(macOS) || os(watchOS)
+#if os(tvOS) || os(macOS) || os(iOS) || os(watchOS)
 
     return Self.sidebarToggle
 
@@ -13960,7 +13960,7 @@ extension ToolbarRole: ParseableModifierValue {
 })
 ConstantAtomLiteral("navigationStack").map({ () -> Self in
 #if os(tvOS) || os(iOS) || os(watchOS)
-if #available(tvOS 16.0,macOS 13.0,iOS 16.0,watchOS 9.0, *) {
+if #available(tvOS 16.0,iOS 16.0,macOS 13.0,watchOS 9.0, *) {
     return Self.navigationStack
 } else { fatalError("'navigationStack' is not available in this OS version") }
 #else
@@ -13969,7 +13969,7 @@ fatalError("'navigationStack' is not available on this OS")
 })
 ConstantAtomLiteral("browser").map({ () -> Self in
 #if os(iOS)
-if #available(iOS 16.0,macOS 13.0,tvOS 16.0,watchOS 9.0, *) {
+if #available(tvOS 16.0,iOS 16.0,macOS 13.0,watchOS 9.0, *) {
     return Self.browser
 } else { fatalError("'browser' is not available in this OS version") }
 #else
@@ -13990,14 +13990,14 @@ fatalError("'editor' is not available on this OS")
     }
 }
 
-#if os(watchOS) || os(macOS) || os(iOS) || os(tvOS)
-@available(watchOS 10.0,macOS 14.0,iOS 17.0,tvOS 17.0, *)
+#if os(tvOS) || os(macOS) || os(iOS) || os(watchOS)
+@available(tvOS 17.0,macOS 14.0,iOS 17.0,watchOS 10.0, *)
 extension ToolbarTitleDisplayMode: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             ConstantAtomLiteral("automatic").map({ () -> Self in
-#if os(macOS) || os(tvOS) || os(iOS) || os(watchOS)
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 
     return Self.automatic
 

--- a/Sources/LiveViewNativeStylesheet/Parsing/Literals/ListLiteral.swift
+++ b/Sources/LiveViewNativeStylesheet/Parsing/Literals/ListLiteral.swift
@@ -3,7 +3,7 @@ import Parsing
 public struct ListLiteral<Content: Parser>: Parser where Content.Input == Substring.UTF8View {
     let content: Content
     
-    init(@ParserBuilder<Input> _ content: () -> Content) {
+    public init(@ParserBuilder<Input> _ content: () -> Content) {
         self.content = content()
     }
     

--- a/Sources/LiveViewNativeStylesheet/Parsing/Literals/NilLiteral.swift
+++ b/Sources/LiveViewNativeStylesheet/Parsing/Literals/NilLiteral.swift
@@ -1,7 +1,9 @@
 import Parsing
 
-struct NilLiteral: Parser {
-    var body: some Parser<Substring.UTF8View, ()> {
+public struct NilLiteral: Parser {
+    public init() {}
+    
+    public var body: some Parser<Substring.UTF8View, ()> {
         "nil".utf8
     }
 }

--- a/Sources/ModifierGenerator/ModifierGenerator.swift
+++ b/Sources/ModifierGenerator/ModifierGenerator.swift
@@ -12,9 +12,6 @@ struct ModifierGenerator: ParsableCommand {
     )
     private var interface: URL
 
-    // missing View-specific: resizable
-    // missing: fullScreenCover
-
     static let extraModifierTypes: Set<String> = [
         // Image modifiers
         "_ResizableModifier",
@@ -38,7 +35,7 @@ struct ModifierGenerator: ParsableCommand {
         "_SearchCompletionModifier",
         "_OnSubmitModifier",
         "_MaskModifier<R>",
-        "_MatchedGeometryEffectModifier",
+        "_MatchedGeometryEffectModifier<R>",
         "_Rotation3DEffectModifier",
         "_PresentationDetentsModifier",
         "_FocusScopeModifier",
@@ -233,7 +230,6 @@ struct ModifierGenerator: ParsableCommand {
         var modifierList = [String]()
 
         for (modifier, signatures) in visitor.modifiers.sorted(by: { $0.key < $1.key }) {
-            // guard modifier == "scrollPosition" else { continue }
             guard !modifier.starts(with: "_"),
                   !Self.denylist.contains(modifier),
                   !signatures.allSatisfy({ !isValid($0.0) })

--- a/Sources/ModifierGenerator/Signature.swift
+++ b/Sources/ModifierGenerator/Signature.swift
@@ -289,7 +289,7 @@ extension FunctionParameterSyntax {
         {
             self = self
                 .with(\.type, TypeSyntax("AttributeReference<\(self.type.trimmed)>\(raw: self.type.is(OptionalTypeSyntax.self) ? "?" : "")"))
-                .with(\.defaultValue, self.defaultValue != nil ? InitializerClauseSyntax(ExprSyntax(".init(storage: .constant(\(self.defaultValue!)))")) : nil)
+                .with(\.defaultValue, self.defaultValue?.as(InitializerClauseSyntax.self).flatMap({ InitializerClauseSyntax.init(equal: .equalToken(leadingTrivia: .space, trailingTrivia: .space), value: ExprSyntax(".init(storage: .constant(\($0.value)))")) }))
         }
 
         self = self


### PR DESCRIPTION
This fixes a bug where generated `AttributeReference` types would have their default values removed.

It also includes fixes for the parsers of a few modifiers and types.