### PR TITLE
Improve stylesheet parsing failure

### DIFF
--- a/Sources/LiveViewNative/Stylesheets/StylesheetParser.swift
+++ b/Sources/LiveViewNative/Stylesheets/StylesheetParser.swift
@@ -1,27 +1,55 @@
 import SwiftUI
 import LiveViewNativeStylesheet
 import Parsing
+import OSLog
+
+private let logger = Logger(subsystem: "LiveViewNative", category: "Stylesheet")
 
 struct StylesheetParser<M: ViewModifier & ParseableModifierValue>: Parser {
     let context: ParseableModifierContext
-    
-    var body: some Parser<Substring.UTF8View, [String:[M]]> {
-        "%{".utf8
-        Many(into: [String:[M]]()) { sheet, pair in
-            let (name, value) = pair
-            sheet[name] = value
-        } element: {
-            Whitespace()
-            String.parser(in: context)
-            Whitespace()
-            "=>".utf8
-            Whitespace()
-            Array<M>.parser(in: context)
-            Whitespace()
-        } separator: {
-            ",".utf8
-        } terminator: {
-            "}".utf8
+
+    func parse(_ input: inout Substring.UTF8View) throws -> Dictionary<String, Array<M>> {
+        let fullStylesheet = input
+        try "%{".utf8.parse(&input)
+        // early exit
+        if (try? "}".utf8.parse(&input)) != nil {
+            return [:]
         }
+        var classes = [String:[M]]()
+        while true {
+            try Whitespace().parse(&input)
+            let name = try String.parser(in: context).parse(&input)
+            try Whitespace().parse(&input)
+            try "=>".utf8.parse(&input)
+            try Whitespace().parse(&input)
+            do {
+                classes[name] = try Array<M>.parser(in: context).parse(&input)
+            } catch {
+                // Log errors instead of propagating, returning the classes that successfully parsed.
+                logger.error(
+                    """
+                    Stylesheet parsing failed for class `\(name)`:
+                    
+                    \(error)
+                    
+                    in stylesheet:
+                    
+                    \(String(fullStylesheet) ?? "")
+                    """
+                )
+                // consume the rest
+                input = Substring().utf8
+                return classes
+            }
+            try Whitespace().parse(&input)
+            // check for a separator
+            do {
+                try ",".utf8.parse(&input)
+            } catch {
+                break
+            }
+        }
+        try "}".utf8.parse(&input)
+        return classes
     }
 }


### PR DESCRIPTION
Previously, when a class failed to parse, the entire stylesheet would be ignored.

This PR stops early when it fails to parse a class, but still returns the classes that succeeded.

For example, this stylesheet has an invalid `font` modifier:
```elixir
"bold" do
  bold(true)
end

"font" do
  font(.nonExistentFont)
end
```

```html
<Text class="bold font">Hello, world!</Text>
```

This results in the following message:

```
Stylesheet parsing failed for class `font`:

error: multiple failures occurred

error: /Users/carson.katri/Documents/LiveViewNative/ElixirConf23Apps/elixirconf_chess/lib/elixirconf_chess_web/styles/app_styles.ex:ElixirconfChessWeb.Styles.AppStyles:10: No matching clause found for modifier 'font'. Expected one of `font(_:)`
 --> input:1:433
1 | …Styles.AppStyles], [{:., [file: "/Users/carson.katri/Documents/LiveViewNat…
  |                      ^

error: unexpected input
 --> input:1:233
1 | …true]}], "font" => [{:font, [file: "/Users/carson.katri/Documents/LiveView…
  |                      ^ expected "]"

in stylesheet:

%{"bold" => [{:bold, [file: "/Users/carson.katri/Documents/LiveViewNative/ElixirConf23Apps/elixirconf_chess/lib/elixirconf_chess_web/styles/app_styles.ex", line: 6, module: ElixirconfChessWeb.Styles.AppStyles], [true]}], "font" => [{:font, [file: "/Users/carson.katri/Documents/LiveViewNative/ElixirConf23Apps/elixirconf_chess/lib/elixirconf_chess_web/styles/app_styles.ex", line: 10, module: ElixirconfChessWeb.Styles.AppStyles], [{:., [file: "/Users/carson.katri/Documents/LiveViewNative/ElixirConf23Apps/elixirconf_chess/lib/elixirconf_chess_web/styles/app_styles.ex", line: 10, module: ElixirconfChessWeb.Styles.AppStyles], [nil, :nonExistentFont]}]}]}
```

But the text is still displayed in `bold`, as that class finished parsing before the `font` class failed:

<img src="https://github.com/liveview-native/liveview-client-swiftui/assets/13581484/82e2e9ba-11b2-40eb-a1dc-256615460243" width="300" />
