### PR TITLE
Rename swift_ui to swiftui

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,7 +34,7 @@ erl_crash.dump
 *.ez
 
 # Ignore package tarball (built via "mix hex.build").
-live_view_native_swift_ui-*.tar
+live_view_native_swiftui-*.tar
 
 # Temporary files, for example, from tests.
 /tmp/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,4 @@
 * removed modifiers and types
 * migrated to `LiveViewNative.Stylesheet``
 * renamed `LiveViewNativeSwiftUi` to `LiveViewNative.SwiftUI` module namespace
+* Elixir `app` renamed to from `live_view_native_swift_ui` to `live_view_native_swiftui`

--- a/README.md
+++ b/README.md
@@ -31,19 +31,19 @@ This library is **experimental** in the current implementation. As we continue t
 ### Installation
 
 If [available in Hex](https://hex.pm/docs/publish), the package can be installed
-by adding `live_view_native_swift_ui` to your list of dependencies in `mix.exs`:
+by adding `live_view_native_swiftui` to your list of dependencies in `mix.exs`:
 
 ```elixir
 def deps do
   [
-    {:live_view_native_swift_ui, "~> 0.1.0"}
+    {:live_view_native_swiftui, "~> 0.1.0"}
   ]
 end
 ```
 
 Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
 and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
-be found at <https://hexdocs.pm/live_view_native_swift_ui>.
+be found at <https://hexdocs.pm/live_view_native_swiftui>.
 
 ## Resources
 

--- a/Sources/LiveViewNative/LiveViewNative.docc/LiveViewNative.md
+++ b/Sources/LiveViewNative/LiveViewNative.docc/LiveViewNative.md
@@ -35,19 +35,19 @@ This library is **experimental** in the current implementation. As we continue t
 ### Installation
 
 If [available in Hex](https://hex.pm/docs/publish), the package can be installed
-by adding `live_view_native_swift_ui` to your list of dependencies in `mix.exs`:
+by adding `live_view_native_swiftui` to your list of dependencies in `mix.exs`:
 
 ```elixir
 def deps do
   [
-    {:live_view_native_swift_ui, "~> 0.1.0"}
+    {:live_view_native_swiftui, "~> 0.1.0"}
   ]
 end
 ```
 
 Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
 and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
-be found at <https://hexdocs.pm/live_view_native_swift_ui>.
+be found at <https://hexdocs.pm/live_view_native_swiftui>.
 
 ## Resources
 

--- a/Sources/LiveViewNative/LiveViewNative.docc/Resources/01-01-03-mix.exs
+++ b/Sources/LiveViewNative/LiveViewNative.docc/Resources/01-01-03-mix.exs
@@ -45,7 +45,7 @@ defmodule LvnTutorial.MixProject do
       {:jason, "~> 1.2"},
       {:plug_cowboy, "~> 2.5"},
       {:live_view_native, "~> 0.0.8"},
-      {:live_view_native_swift_ui, "~> 0.0.8"}
+      {:live_view_native_swiftui, "~> 0.0.8"}
     ]
   end
 

--- a/Sources/LiveViewNative/LiveViewNative.docc/Tutorials/01 Initial List.tutorial
+++ b/Sources/LiveViewNative/LiveViewNative.docc/Tutorials/01 Initial List.tutorial
@@ -41,7 +41,7 @@
            }
                
            @Step {
-               Next, add the `live_view_native` and `live_view_native_swift_ui` libraries as dependencies. 
+               Next, add the `live_view_native` and `live_view_native_swiftui` libraries as dependencies. 
                
                These packages provide supporting functions for applying SwiftUI modifiers to elements from within HEEx templates.
                

--- a/lib/live_view_native/swiftui/platform.ex
+++ b/lib/live_view_native/swiftui/platform.ex
@@ -26,7 +26,7 @@ defmodule LiveViewNative.SwiftUI.Platform do
         custom_modifiers: struct.custom_modifiers,
         default_layouts: @default_layouts,
         render_macro: :sigil_SWIFTUI,
-        otp_app: :live_view_native_swift_ui,
+        otp_app: :live_view_native_swiftui,
         valid_targets: ~w(mac pad phone tv vision watch)a
       )
     end

--- a/lib/mix/tasks/install.ex
+++ b/lib/mix/tasks/install.ex
@@ -82,7 +82,7 @@ defmodule Mix.Tasks.Lvn.SwiftUI.Install do
   end
 
   defp copy_xcodegen_files(%{native_path: native_path}) do
-    priv_dir = :code.priv_dir(:live_view_native_swift_ui)
+    priv_dir = :code.priv_dir(:live_view_native_swiftui)
     native_project_dir = Path.join(native_path, "swiftui")
     xcodegen_path = Path.join(priv_dir, "xcodegen")
 

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule LiveViewNative.SwiftUI.MixProject do
 
   def project do
     [
-      app: :live_view_native_swift_ui,
+      app: :live_view_native_swiftui,
       version: "0.1.0",
       elixir: "~> 1.15",
       description: "LiveView Native platform for SwiftUI",

--- a/util/encode_modifiers.exs
+++ b/util/encode_modifiers.exs
@@ -1,5 +1,5 @@
 Mix.install([
-  {:live_view_native_swift_ui, path: "."},
+  {:live_view_native_swiftui, path: "."},
   {:live_view_native, git: "https://github.com/liveview-native/live_view_native", branch: "main"},
   {:html_entities, "~> 0.5"}
 ])


### PR DESCRIPTION
Our naming convention is `swiftui`