### PR TITLE
Add `.#{ime}` and `#{number}` syntax

### DIFF
--- a/lib/live_view_native/swiftui/rules_parser/modifiers.ex
+++ b/lib/live_view_native/swiftui/rules_parser/modifiers.ex
@@ -58,21 +58,16 @@ defmodule LiveViewNative.SwiftUI.RulesParser.Modifiers do
   end
 
   ime_function = fn is_initial ->
-    if is_initial do
-      empty()
-    else
-      ignore(string("."))
-    end
-    |> ignore(string("to_ime"))
+    ignore(string("."))
     |> enclosed(
-      "(",
+      "{",
       variable(
         force_error?: true,
         error_message: "Expected a variable",
-        error_parser: non_whitespace(also_ignore: String.to_charlist(")"))
+        error_parser: non_whitespace(also_ignore: String.to_charlist("}"))
       )
       |> post_traverse({PostProcessors, :to_ime_function_call_ast, [is_initial]}),
-      ")",
+      "}",
       []
     )
   end
@@ -92,7 +87,7 @@ defmodule LiveViewNative.SwiftUI.RulesParser.Modifiers do
       # Scoped
       # Color.red
       scoped_ime,
-      # to_ime(color)
+      # .{color}
       ime_function.(true),
       # Implicit
       # .red
@@ -101,7 +96,7 @@ defmodule LiveViewNative.SwiftUI.RulesParser.Modifiers do
     # scoped_ime
     |> repeat(
       choice([
-        # <other_ime>.to_ime(color)
+        # <other_ime>.{color}
         ime_function.(false),
         # <other_ime>.red
         dotted_ime.(false)
@@ -188,7 +183,7 @@ defmodule LiveViewNative.SwiftUI.RulesParser.Modifiers do
       },
       {
         parsec(:ime),
-        ~s'an IME eg ‘Color.red’ or ‘.largeTitle’ or ‘Color.to_ime(variable)’'
+        ~s'an IME eg ‘Color.red’ or ‘.largeTitle’ or ‘.{variable}’ or ‘Color.{variable}’'
       },
       {
         key_value_pairs(generate_error?: false, allow_empty?: false),

--- a/lib/live_view_native/swiftui/rules_parser/post_processors.ex
+++ b/lib/live_view_native/swiftui/rules_parser/post_processors.ex
@@ -110,6 +110,10 @@ defmodule LiveViewNative.SwiftUI.RulesParser.PostProcessors do
     {:., [], [outer, inner]}
   end
 
+  def chain_ast(rest, [], context, {_line, _}, _byte_offset) do
+    {rest, [[]], context}
+  end
+
   def chain_ast(rest, sections, context, {_line, _}, _byte_offset) do
     sections = Enum.reduce(sections, &combine_chain_ast_parts/2)
 
@@ -150,6 +154,11 @@ defmodule LiveViewNative.SwiftUI.RulesParser.PostProcessors do
       ) do
     annotations = context_to_annotation(context.context, line)
     {rest, [{Elixir, annotations, {:to_atom, variable_annotations, [variable]}}], context}
+  end
+
+  # Ignore error case
+  def to_ime_function_call_ast(rest, _, context, {_line, _}, _byte_offset, _) do
+    {rest, [], context}
   end
 
   def to_keyword_tuple_ast(rest, [arg1, arg2], context, {_line, _}, _byte_offset) do

--- a/test/mocks/mock_sheet.ex
+++ b/test/mocks/mock_sheet.ex
@@ -10,13 +10,13 @@ defmodule MockSheet do
 
   "button-" <> style do
     # this is also a comment that isn't included in the output
-    buttonStyle(to_ime(style))
+    buttonStyle(.{style})
   end
   """
 
   def class("color-" <> color_name, _target) do
     ~RULES"""
-    color(to_ime(color_name))
+    color(.{color_name})
     """
   end
 


### PR DESCRIPTION
Depends on https://github.com/liveview-native/live_view_native_stylesheet/pull/34.

Adds support for:
```swift
  "button-" <> style do
    buttonStyle(.#{style})
  end

  "h-" <> height do
    height(#{height})
  end
```

Which lets us do:
```elixir
<Button class="h-16 button-bordered"> ... </Button>
```