### PR TITLE
Fix cached page rendering when nested in `<NavigationStack>`

### DIFF
--- a/Sources/LiveViewNative/Coordinators/LiveSessionState.swift
+++ b/Sources/LiveViewNative/Coordinators/LiveSessionState.swift
@@ -18,4 +18,15 @@ public enum LiveSessionState {
     // todo: disconnected state?
     /// The coordinator failed to connect and produced the given error.
     case connectionFailed(Error)
+    
+    /// Either `notConnected` or `connecting`
+    var isPending: Bool {
+        switch self {
+        case .notConnected,
+             .connecting:
+            return true
+        default:
+            return false
+        }
+    }
 }

--- a/Sources/LiveViewNative/NavStackEntryView.swift
+++ b/Sources/LiveViewNative/NavStackEntryView.swift
@@ -40,10 +40,10 @@ struct NavStackEntryView<R: RootRegistry>: View {
                         .transition(coordinator.session.configuration.transition ?? .identity)
                 default:
                     SwiftUI.Group {
-                        if case .notConnected = coordinator.state,
+                        if coordinator.state.isPending,
                            let document = coordinator.document
                         {
-                           coordinator.builder.fromNodes(document[document.root()].children(), coordinator: coordinator, url: coordinator.url)
+                            coordinator.builder.fromNodes(document[document.root()].children(), coordinator: coordinator, url: coordinator.url)
                                .environment(\.coordinatorEnvironment, CoordinatorEnvironment(coordinator, document: document))
                                .disabled(true)
                        } else if R.LoadingView.self == Never.self {

--- a/Sources/LiveViewNative/Views/Navigation/NavigationStack.swift
+++ b/Sources/LiveViewNative/Views/Navigation/NavigationStack.swift
@@ -20,9 +20,7 @@ struct NavigationStack<R: RootRegistry>: View {
             session.navigationPath[1...] = value
         }) {
             SwiftUI.VStack {
-                if session.navigationPath.count == 1 {
-                    context.buildChildren(of: element)
-                }
+                context.buildChildren(of: element)
             }
             .navigationDestination(for: LiveNavigationEntry<R>.self) { destination in
                 NavStackEntryView(destination)


### PR DESCRIPTION
This improves the cached page rendering when using `<NavigationStack>` in a layout.

Previously, the page would go blank during transitions. With these changes, the previous page will display with the `disabled` modifier applied until is focused. Here's a demo with animations slowed:

https://github.com/liveview-native/liveview-client-swiftui/assets/13581484/782db1d3-6db4-424a-9ebc-be2c1e489f84