### PR TITLE
Support custom modifiers from registries and in `ContentBuilder`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,6 +17,9 @@ let package = Package(
         .library(
             name: "LiveViewNative",
             targets: ["LiveViewNative"]),
+        .library(
+            name: "LiveViewNativeStylesheet",
+            targets: ["LiveViewNativeStylesheet"]),
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.

--- a/Sources/LiveViewNative/ContentBuilder.swift
+++ b/Sources/LiveViewNative/ContentBuilder.swift
@@ -674,7 +674,8 @@ public struct EmptyContentModifier<Builder: ContentBuilder>: ContentModifier {
     }
     
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
-        Parse {}.map({ Self() })
+        ASTNode("__never__", in: context) {}
+            .map({ _ in fatalError() })
     }
 }
 

--- a/Sources/LiveViewNative/Registries/CustomRegistry.swift
+++ b/Sources/LiveViewNative/Registries/CustomRegistry.swift
@@ -108,6 +108,11 @@ public protocol CustomRegistry<Root> {
     /// - Parameter error: The error of the view is reporting.
     @ViewBuilder
     static func errorView(for error: Error) -> ErrorView
+    
+    static func parseModifier(
+        _ input: inout Substring.UTF8View,
+        in context: ParseableModifierContext
+    ) throws -> CustomModifier
 }
 
 extension CustomRegistry where LoadingView == Never {
@@ -124,6 +129,15 @@ extension CustomRegistry where ErrorView == Never {
     }
 }
 
+extension CustomRegistry {
+    public static func parseModifier(
+        _ input: inout Substring.UTF8View,
+        in context: ParseableModifierContext
+    ) throws -> CustomModifier {
+        try Self.CustomModifier.parser(in: context).parse(&input)
+    }
+}
+
 /// The empty registry is the default ``CustomRegistry`` implementation that does not provide any views or modifiers.
 public struct EmptyRegistry {
 }
@@ -137,9 +151,6 @@ extension EmptyRegistry: RootRegistry {
             return nil
         }
     }
-    
-    public typealias TagName = None
-    public typealias ModifierType = None
 }
 extension CustomRegistry where TagName == EmptyRegistry.None, CustomView == Never {
     /// A default implementation that does not provide any custom elements. If you omit the ``CustomRegistry/TagName`` type alias, this implementation will be used.

--- a/Sources/LiveViewNative/Registries/CustomRegistry.swift
+++ b/Sources/LiveViewNative/Registries/CustomRegistry.swift
@@ -28,9 +28,8 @@ import LiveViewNativeStylesheet
 /// - ``lookup(_:element:context:)-5bvqg``
 /// - ``CustomView``
 /// ### Custom View Modifiers
-/// - ``ModifierType``
-/// - ``decodeModifier(_:from:context:)-4cqvs``
 /// - ``CustomModifier``
+/// - ``parseModifier(_:in:)-tj5n``
 /// ### Customizing the Loading View
 /// - ``loadingView(for:state:)-6jd3b``
 /// - ``LoadingView``
@@ -69,9 +68,9 @@ public protocol CustomRegistry<Root> {
     ///
     /// Generally, implementors will use an opaque return type on their ``lookup(_:element:context:)-5bvqg`` implementations and this will be inferred automatically.
     associatedtype CustomView: View = Never
-    /// The type of view modifier this registry returns from the `decodeModifiers` method.
+    /// The type of view modifier this registry can parse.
     ///
-    /// Generally, implementors will use an opaque return type on their ``decodeModifier(_:from:context:)-4cqvs`` implementations and this will be inferred automatically.
+    /// Use the ``LiveViewNativeStylesheet/ParseableExpression`` macro to generate a parser for a modifier from its `init` clauses.
     associatedtype CustomModifier: ViewModifier & ParseableModifierValue = EmptyModifier
     /// The type of view this registry produces for loading views.
     ///
@@ -109,6 +108,11 @@ public protocol CustomRegistry<Root> {
     @ViewBuilder
     static func errorView(for error: Error) -> ErrorView
     
+    /// Parse the ``CustomModifier`` from ``input``.
+    ///
+    /// It is recommended to use the ``LiveViewNativeStylesheet/ParseableExpression`` macro to generate a parser.
+    /// This parser can then be called inside this function.
+    /// A default implementation is provided that automatically uses ``CustomModifier/parser(in:)``.
     static func parseModifier(
         _ input: inout Substring.UTF8View,
         in context: ParseableModifierContext

--- a/Sources/LiveViewNative/Stylesheets/AttributeReference.swift
+++ b/Sources/LiveViewNative/Stylesheets/AttributeReference.swift
@@ -8,7 +8,8 @@
 import LiveViewNativeStylesheet
 import LiveViewNativeCore
 
-struct AttributeReference<Value: ParseableModifierValue & AttributeDecodable>: ParseableModifierValue {
+/// An `attr("...")` reference in a stylesheet, or a concrete value.
+public struct AttributeReference<Value: ParseableModifierValue & AttributeDecodable>: ParseableModifierValue {
     enum Storage {
         case constant(Value)
         case reference(AttributeName)
@@ -16,7 +17,7 @@ struct AttributeReference<Value: ParseableModifierValue & AttributeDecodable>: P
     
     let storage: Storage
     
-    static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
+    public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         OneOf {
             Value.parser(in: context).map(Storage.constant)
             AttributeName.parser(in: context).map(Storage.reference)
@@ -24,7 +25,11 @@ struct AttributeReference<Value: ParseableModifierValue & AttributeDecodable>: P
         .map(Self.init)
     }
     
-    func resolve<R: RootRegistry>(on element: ElementNode, in context: LiveContext<R>) -> Value {
+    public func resolve<R: RootRegistry>(on element: ElementNode, in context: LiveContext<R>) -> Value {
+        resolve(on: element)
+    }
+    
+    public func resolve(on element: ElementNode) -> Value {
         switch storage {
         case .constant(let value):
             return value

--- a/Sources/LiveViewNative/Stylesheets/Stylesheet.swift
+++ b/Sources/LiveViewNative/Stylesheets/Stylesheet.swift
@@ -13,13 +13,16 @@ protocol StylesheetProtocol<R> {
 }
 
 struct Stylesheet<R: RootRegistry> {
+    let content: [String]
     let classes: [String:[BuiltinRegistry<R>.BuiltinModifier]]
     
-    init(_ classes: [String:[BuiltinRegistry<R>.BuiltinModifier]]) {
+    init(content: [String], classes: [String:[BuiltinRegistry<R>.BuiltinModifier]]) {
+        self.content = content
         self.classes = classes
     }
     
     init(from data: String, in context: ParseableModifierContext) throws {
+        self.content = [data]
         self.classes = try StylesheetParser<BuiltinRegistry<R>.BuiltinModifier>(context: context).parse(data.utf8)
     }
 }
@@ -30,7 +33,7 @@ extension Stylesheet: StylesheetProtocol {
     }
     
     func merge(with other: Stylesheet<R>) -> Stylesheet<R> {
-        .init(classes.merging(other.classes, uniquingKeysWith: { $1 }))
+        .init(content: self.content + other.content, classes: classes.merging(other.classes, uniquingKeysWith: { $1 }))
     }
 }
 
@@ -53,7 +56,7 @@ extension Stylesheet: AttributeDecodable {
                 \(value)
                 """
             )
-            self.init([:])
+            self.init(content: ["%{}"], classes: [:])
         }
     }
 }

--- a/Sources/LiveViewNative/Stylesheets/StylesheetParser.swift
+++ b/Sources/LiveViewNative/Stylesheets/StylesheetParser.swift
@@ -95,10 +95,7 @@ struct StylesheetParser<M: ViewModifier & ParseableModifierValue>: Parser {
                 Whitespace()
                 ",".utf8
                 Whitespace()
-                ListLiteral {
-                    AnyArgument(context: context)
-                }
-                .map({ _ in () })
+                AnyArgument(context: context)
                 Whitespace()
                 "}".utf8
             }

--- a/Sources/LiveViewNative/Stylesheets/ViewReference.swift
+++ b/Sources/LiveViewNative/Stylesheets/ViewReference.swift
@@ -2,16 +2,19 @@ import SwiftUI
 import LiveViewNativeStylesheet
 import LiveViewNativeCore
 
-struct ViewReference: ParseableModifierValue {
+/// A reference to nested content from a stylesheet.
+///
+/// Parses an atom or list of atoms.
+public struct ViewReference: ParseableModifierValue {
     let value: [String]
 
-    func resolve<R: RootRegistry>(on element: ElementNode, in context: LiveContext<R>) -> some View {
+    public func resolve<R: RootRegistry>(on element: ElementNode, in context: LiveContext<R>) -> some View {
         ForEach(value, id: \.self) {
             context.buildChildren(of: element, forTemplate: $0)
         }
     }
 
-    static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
+    public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         OneOf {
             AtomLiteral().map({
                 Self.init(value: [$0])
@@ -27,15 +30,16 @@ struct ViewReference: ParseableModifierValue {
 /// A type reference that is resolved inline (an argument that accepts `some View`, not `() -> some View`)
 typealias InlineViewReference = ViewReference
 
-struct TextReference: ParseableModifierValue {
+/// A `ViewReference` that only resolves to `SwiftUI.Text`.
+public struct TextReference: ParseableModifierValue {
     let value: String
 
-    func resolve<R: RootRegistry>(on element: ElementNode, in context: LiveContext<R>) -> SwiftUI.Text {
+    public func resolve<R: RootRegistry>(on element: ElementNode, in context: LiveContext<R>) -> SwiftUI.Text {
         context.children(of: element, forTemplate: value).first?.asElement().flatMap({ Text<R>(element: $0).body })
-            ?? SwiftUI.Text(value)
+            ?? SwiftUI.Text("")
     }
 
-    static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
+    public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         AtomLiteral().map({ Self.init(value: $0) })
     }
 }

--- a/Sources/LiveViewNative/ViewModifierBuilder.swift
+++ b/Sources/LiveViewNative/ViewModifierBuilder.swift
@@ -56,11 +56,10 @@ public struct _AnyViewModifier: ViewModifier {
 }
 
 /// A `ViewModifier` that switches between two possible modifier types.
-@frozen public struct _ConditionalModifier<TrueModifier, FalseModifier>: ViewModifier
+public struct _ConditionalModifier<TrueModifier, FalseModifier>: ViewModifier
     where TrueModifier: ViewModifier, FalseModifier: ViewModifier
 {
     @usableFromInline
-    @frozen
     internal enum Storage {
         case trueModifier(TrueModifier)
         case falseModifier(FalseModifier)

--- a/Sources/LiveViewNative/ViewTree.swift
+++ b/Sources/LiveViewNative/ViewTree.swift
@@ -114,34 +114,6 @@ extension CodingUserInfoKey {
     static var modifierAnimationScale: Self { .init(rawValue: "modifierAnimationScale")! }
 }
 
-enum ModifierContainer<R: RootRegistry>: ParseableModifierValue {
-    case builtin(BuiltinRegistry<R>.BuiltinModifier)
-    case custom(R.CustomModifier)
-    case error(ErrorModifier<R>)
-    case inert
-    
-    static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
-        OneOf {
-            R.CustomModifier.parser(in: context).map({ .custom($0) })
-            BuiltinRegistry.BuiltinModifier.parser(in: context).map({ .builtin($0) })
-        }
-    }
-    
-    @ViewModifierBuilder
-    var modifier: some ViewModifier {
-        switch self {
-        case let .builtin(modifier):
-            modifier
-        case let .custom(modifier):
-            modifier
-        case let .error(modifier):
-            modifier
-        case .inert:
-            EmptyModifier()
-        }
-    }
-}
-
 private struct ModifierObserver<Parent: View, R: RootRegistry>: View {
     let parent: Parent
     @ObservedElement private var element

--- a/Sources/LiveViewNative/_GeneratedModifiers.swift
+++ b/Sources/LiveViewNative/_GeneratedModifiers.swift
@@ -877,16 +877,16 @@ struct _badgeModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS)
         case _0(count: Any)
         #endif
-        #if os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS)
         case _1(label: Any?)
         #endif
-        #if os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS)
         case _2(key: Any?)
         #endif
-        #if os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS)
         case _3(label: Any)
         #endif
     }
@@ -905,29 +905,29 @@ struct _badgeModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(macOS) || os(iOS)
-    @available(macOS 12.0,iOS 15.0, *)
+    #if os(iOS) || os(macOS)
+    @available(iOS 15.0,macOS 12.0, *)
     init(_ count: AttributeReference<Swift.Int>) {
         self.value = ._0(count: count)
         
     }
     #endif
-    #if os(macOS) || os(iOS)
-    @available(macOS 12.0,iOS 15.0, *)
+    #if os(iOS) || os(macOS)
+    @available(iOS 15.0,macOS 12.0, *)
     init(_ label: TextReference?) {
         self.value = ._1(label: label)
         
     }
     #endif
-    #if os(macOS) || os(iOS)
-    @available(macOS 12.0,iOS 15.0, *)
+    #if os(iOS) || os(macOS)
+    @available(iOS 15.0,macOS 12.0, *)
     init(_ key: SwiftUI.LocalizedStringKey?) {
         self.value = ._2(key: key)
         
     }
     #endif
-    #if os(macOS) || os(iOS)
-    @available(macOS 12.0,iOS 15.0, *)
+    #if os(iOS) || os(macOS)
+    @available(iOS 15.0,macOS 12.0, *)
     init(_ label: AttributeReference<String>) {
         self.value = ._3(label: label)
         
@@ -938,33 +938,33 @@ struct _badgeModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS)
         case let ._0(count):
-            if #available(macOS 12.0,iOS 15.0, *) {
+            if #available(iOS 15.0,macOS 12.0, *) {
             let count = count as! AttributeReference<Swift.Int>
             __content
                 .badge(count.resolve(on: element, in: context))
             } else { __content }
         #endif
-        #if os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS)
         case let ._1(label):
-            if #available(macOS 12.0,iOS 15.0, *) {
+            if #available(iOS 15.0,macOS 12.0, *) {
             let label = label as? TextReference
             __content
                 .badge(label?.resolve(on: element, in: context))
             } else { __content }
         #endif
-        #if os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS)
         case let ._2(key):
-            if #available(macOS 12.0,iOS 15.0, *) {
+            if #available(iOS 15.0,macOS 12.0, *) {
             let key = key as? SwiftUI.LocalizedStringKey
             __content
                 .badge(key)
             } else { __content }
         #endif
-        #if os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS)
         case let ._3(label):
-            if #available(macOS 12.0,iOS 15.0, *) {
+            if #available(iOS 15.0,macOS 12.0, *) {
             let label = label as! AttributeReference<String>
             __content
                 .badge(label.resolve(on: element, in: context))
@@ -1687,10 +1687,10 @@ struct _containerRelativeFrameModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(macOS) || os(watchOS) || os(iOS) || os(tvOS)
+        #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
         case _0(axes: Any,alignment: Any)
         #endif
-        #if os(macOS) || os(watchOS) || os(iOS) || os(tvOS)
+        #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
         case _1(axes: Any,count: Any,span: Any, spacing: Any,alignment: Any)
         #endif
     }
@@ -1705,15 +1705,15 @@ struct _containerRelativeFrameModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(macOS) || os(watchOS) || os(iOS) || os(tvOS)
-    @available(macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0, *)
+    #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
+    @available(tvOS 17.0,iOS 17.0,watchOS 10.0,macOS 14.0, *)
     init(_ axes: SwiftUI.Axis.Set,alignment: AttributeReference<SwiftUI.Alignment> = .init(storage: .constant(.center)) ) {
         self.value = ._0(axes: axes, alignment: alignment)
         
     }
     #endif
-    #if os(macOS) || os(watchOS) || os(iOS) || os(tvOS)
-    @available(macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0, *)
+    #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
+    @available(tvOS 17.0,iOS 17.0,watchOS 10.0,macOS 14.0, *)
     init(_ axes: SwiftUI.Axis.Set,count: AttributeReference<Swift.Int>,span: AttributeReference<Swift.Int> = .init(storage: .constant(1)), spacing: AttributeReference<CoreFoundation.CGFloat>,alignment: AttributeReference<SwiftUI.Alignment> = .init(storage: .constant(.center)) ) {
         self.value = ._1(axes: axes, count: count, span: span, spacing: spacing, alignment: alignment)
         
@@ -1724,18 +1724,18 @@ struct _containerRelativeFrameModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(macOS) || os(watchOS) || os(iOS) || os(tvOS)
+        #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
         case let ._0(axes, alignment):
-            if #available(macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0, *) {
+            if #available(tvOS 17.0,iOS 17.0,watchOS 10.0,macOS 14.0, *) {
             let axes = axes as! SwiftUI.Axis.Set
 let alignment = alignment as! AttributeReference<SwiftUI.Alignment>
             __content
                 .containerRelativeFrame(axes, alignment: alignment.resolve(on: element, in: context))
             } else { __content }
         #endif
-        #if os(macOS) || os(watchOS) || os(iOS) || os(tvOS)
+        #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
         case let ._1(axes, count, span, spacing, alignment):
-            if #available(macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0, *) {
+            if #available(tvOS 17.0,iOS 17.0,watchOS 10.0,macOS 14.0, *) {
             let axes = axes as! SwiftUI.Axis.Set
 let count = count as! AttributeReference<Swift.Int>
 let span = span as! AttributeReference<Swift.Int>
@@ -1900,10 +1900,10 @@ struct _contextMenuModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(macOS) || os(tvOS) || os(iOS)
+        #if os(macOS) || os(iOS) || os(tvOS)
         case _0(menuItems: Any)
         #endif
-        #if os(macOS) || os(tvOS) || os(iOS)
+        #if os(iOS) || os(tvOS) || os(macOS)
         case _1(menuItems: Any,preview: Any)
         #endif
     }
@@ -1918,15 +1918,15 @@ struct _contextMenuModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(macOS) || os(tvOS) || os(iOS)
-    @available(macOS 10.15,tvOS 14.0,iOS 13.0, *)
+    #if os(macOS) || os(iOS) || os(tvOS)
+    @available(macOS 10.15,iOS 13.0,tvOS 14.0, *)
     init(menuItems: ViewReference=ViewReference(value: [])) {
         self.value = ._0(menuItems: menuItems)
         
     }
     #endif
-    #if os(macOS) || os(tvOS) || os(iOS)
-    @available(macOS 13.0,tvOS 16.0,iOS 16.0, *)
+    #if os(iOS) || os(tvOS) || os(macOS)
+    @available(iOS 16.0,tvOS 16.0,macOS 13.0, *)
     init(menuItems: ViewReference=ViewReference(value: []),preview: ViewReference=ViewReference(value: [])) {
         self.value = ._1(menuItems: menuItems, preview: preview)
         
@@ -1937,17 +1937,17 @@ struct _contextMenuModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(macOS) || os(tvOS) || os(iOS)
+        #if os(macOS) || os(iOS) || os(tvOS)
         case let ._0(menuItems):
-            if #available(macOS 10.15,tvOS 14.0,iOS 13.0, *) {
+            if #available(macOS 10.15,iOS 13.0,tvOS 14.0, *) {
             let menuItems = menuItems as! ViewReference
             __content
                 .contextMenu(menuItems: { menuItems.resolve(on: element, in: context) })
             } else { __content }
         #endif
-        #if os(macOS) || os(tvOS) || os(iOS)
+        #if os(iOS) || os(tvOS) || os(macOS)
         case let ._1(menuItems, preview):
-            if #available(macOS 13.0,tvOS 16.0,iOS 16.0, *) {
+            if #available(iOS 16.0,tvOS 16.0,macOS 13.0, *) {
             let menuItems = menuItems as! ViewReference
 let preview = preview as! ViewReference
             __content
@@ -2005,7 +2005,7 @@ struct _controlGroupStyleModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(macOS) || os(tvOS) || os(iOS)
+        #if os(iOS) || os(macOS) || os(tvOS)
         case _0(style: Any)
         #endif
     }
@@ -2018,8 +2018,8 @@ struct _controlGroupStyleModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(macOS) || os(tvOS) || os(iOS)
-    @available(macOS 12.0,tvOS 17.0,iOS 15.0, *)
+    #if os(iOS) || os(macOS) || os(tvOS)
+    @available(iOS 15.0,macOS 12.0,tvOS 17.0, *)
     init(_ style: AnyControlGroupStyle) {
         self.value = ._0(style: style)
         
@@ -2030,9 +2030,9 @@ struct _controlGroupStyleModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(macOS) || os(tvOS) || os(iOS)
+        #if os(iOS) || os(macOS) || os(tvOS)
         case let ._0(style):
-            if #available(macOS 12.0,tvOS 17.0,iOS 15.0, *) {
+            if #available(iOS 15.0,macOS 12.0,tvOS 17.0, *) {
             let style = style as! AnyControlGroupStyle
             __content
                 .controlGroupStyle(style)
@@ -2047,7 +2047,7 @@ struct _controlSizeModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(macOS) || os(watchOS) || os(iOS)
+        #if os(watchOS) || os(iOS) || os(macOS)
         case _0(controlSize: Any)
         #endif
     }
@@ -2060,8 +2060,8 @@ struct _controlSizeModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(macOS) || os(watchOS) || os(iOS)
-    @available(macOS 10.15,watchOS 9.0,iOS 15.0, *)
+    #if os(watchOS) || os(iOS) || os(macOS)
+    @available(watchOS 9.0,iOS 15.0,macOS 10.15, *)
     init(_ controlSize: SwiftUI.ControlSize) {
         self.value = ._0(controlSize: controlSize)
         
@@ -2072,9 +2072,9 @@ struct _controlSizeModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(macOS) || os(watchOS) || os(iOS)
+        #if os(watchOS) || os(iOS) || os(macOS)
         case let ._0(controlSize):
-            if #available(macOS 10.15,watchOS 9.0,iOS 15.0, *) {
+            if #available(watchOS 9.0,iOS 15.0,macOS 10.15, *) {
             let controlSize = controlSize as! SwiftUI.ControlSize
             __content
                 .controlSize(controlSize)
@@ -2089,7 +2089,7 @@ struct _coordinateSpaceModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(watchOS) || os(macOS) || os(iOS) || os(tvOS)
+        #if os(tvOS) || os(macOS) || os(watchOS) || os(iOS)
         case _0(name: Any)
         #endif
     }
@@ -2102,8 +2102,8 @@ struct _coordinateSpaceModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(watchOS) || os(macOS) || os(iOS) || os(tvOS)
-    @available(watchOS 10.0,macOS 14.0,iOS 17.0,tvOS 17.0, *)
+    #if os(tvOS) || os(macOS) || os(watchOS) || os(iOS)
+    @available(tvOS 17.0,macOS 14.0,watchOS 10.0,iOS 17.0, *)
     init(_ name: SwiftUI.NamedCoordinateSpace) {
         self.value = ._0(name: name)
         
@@ -2114,9 +2114,9 @@ struct _coordinateSpaceModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(watchOS) || os(macOS) || os(iOS) || os(tvOS)
+        #if os(tvOS) || os(macOS) || os(watchOS) || os(iOS)
         case let ._0(name):
-            if #available(watchOS 10.0,macOS 14.0,iOS 17.0,tvOS 17.0, *) {
+            if #available(tvOS 17.0,macOS 14.0,watchOS 10.0,iOS 17.0, *) {
             let name = name as! SwiftUI.NamedCoordinateSpace
             __content
                 .coordinateSpace(name)
@@ -2131,7 +2131,7 @@ struct _datePickerStyleModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(macOS) || os(watchOS) || os(iOS)
+        #if os(watchOS) || os(iOS) || os(macOS)
         case _0(style: Any)
         #endif
     }
@@ -2144,8 +2144,8 @@ struct _datePickerStyleModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(macOS) || os(watchOS) || os(iOS)
-    @available(macOS 10.15,watchOS 10.0,iOS 13.0, *)
+    #if os(watchOS) || os(iOS) || os(macOS)
+    @available(watchOS 10.0,iOS 13.0,macOS 10.15, *)
     init(_ style: AnyDatePickerStyle) {
         self.value = ._0(style: style)
         
@@ -2156,9 +2156,9 @@ struct _datePickerStyleModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(macOS) || os(watchOS) || os(iOS)
+        #if os(watchOS) || os(iOS) || os(macOS)
         case let ._0(style):
-            if #available(macOS 10.15,watchOS 10.0,iOS 13.0, *) {
+            if #available(watchOS 10.0,iOS 13.0,macOS 10.15, *) {
             let style = style as! AnyDatePickerStyle
             __content
                 .datePickerStyle(style)
@@ -2173,7 +2173,7 @@ struct _defaultScrollAnchorModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
+        #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
         case _0(anchor: Any?)
         #endif
     }
@@ -2186,8 +2186,8 @@ struct _defaultScrollAnchorModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
-    @available(tvOS 17.0,iOS 17.0,watchOS 10.0,macOS 14.0, *)
+    #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
+    @available(iOS 17.0,macOS 14.0,watchOS 10.0,tvOS 17.0, *)
     init(_ anchor: AttributeReference<SwiftUI.UnitPoint?>?) {
         self.value = ._0(anchor: anchor)
         
@@ -2198,9 +2198,9 @@ struct _defaultScrollAnchorModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
+        #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
         case let ._0(anchor):
-            if #available(tvOS 17.0,iOS 17.0,watchOS 10.0,macOS 14.0, *) {
+            if #available(iOS 17.0,macOS 14.0,watchOS 10.0,tvOS 17.0, *) {
             let anchor = anchor as? AttributeReference<SwiftUI.UnitPoint?>
             __content
                 .defaultScrollAnchor(anchor?.resolve(on: element, in: context))
@@ -2341,16 +2341,16 @@ struct _dialogSuppressionToggleModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
+        #if os(tvOS) || os(watchOS) || os(iOS) || os(macOS)
         case _0(titleKey: Any)
         #endif
-        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
+        #if os(tvOS) || os(watchOS) || os(iOS) || os(macOS)
         case _1(title: Any)
         #endif
-        #if os(tvOS) || os(macOS) || os(watchOS) || os(iOS)
+        #if os(tvOS) || os(watchOS) || os(iOS) || os(macOS)
         case _2(label: Any)
         #endif
-        #if os(tvOS) || os(macOS) || os(watchOS) || os(iOS)
+        #if os(tvOS) || os(watchOS) || os(iOS) || os(macOS)
         case _3
         #endif
     }
@@ -2369,29 +2369,29 @@ struct _dialogSuppressionToggleModifier<R: RootRegistry>: ViewModifier {
 @ChangeTracked private var _3_isSuppressed: Swift.Bool
 
 
-    #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
-    @available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0, *)
+    #if os(tvOS) || os(watchOS) || os(iOS) || os(macOS)
+    @available(tvOS 17.0,watchOS 10.0,iOS 17.0,macOS 14.0, *)
     init(_ titleKey: SwiftUI.LocalizedStringKey,isSuppressed: ChangeTracked<Swift.Bool>) {
         self.value = ._0(titleKey: titleKey)
         self.__0_isSuppressed = isSuppressed
     }
     #endif
-    #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
-    @available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0, *)
+    #if os(tvOS) || os(watchOS) || os(iOS) || os(macOS)
+    @available(tvOS 17.0,watchOS 10.0,iOS 17.0,macOS 14.0, *)
     init(_ title: AttributeReference<String>,isSuppressed: ChangeTracked<Swift.Bool>) {
         self.value = ._1(title: title)
         self.__1_isSuppressed = isSuppressed
     }
     #endif
-    #if os(tvOS) || os(macOS) || os(watchOS) || os(iOS)
-    @available(tvOS 17.0,macOS 14.0,watchOS 10.0,iOS 17.0, *)
+    #if os(tvOS) || os(watchOS) || os(iOS) || os(macOS)
+    @available(tvOS 17.0,watchOS 10.0,iOS 17.0,macOS 14.0, *)
     init(_ label: TextReference,isSuppressed: ChangeTracked<Swift.Bool>) {
         self.value = ._2(label: label)
         self.__2_isSuppressed = isSuppressed
     }
     #endif
-    #if os(tvOS) || os(macOS) || os(watchOS) || os(iOS)
-    @available(tvOS 17.0,macOS 14.0,watchOS 10.0,iOS 17.0, *)
+    #if os(tvOS) || os(watchOS) || os(iOS) || os(macOS)
+    @available(tvOS 17.0,watchOS 10.0,iOS 17.0,macOS 14.0, *)
     init(isSuppressed: ChangeTracked<Swift.Bool>) {
         self.value = ._3
         self.__3_isSuppressed = isSuppressed
@@ -2402,33 +2402,33 @@ struct _dialogSuppressionToggleModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
+        #if os(tvOS) || os(watchOS) || os(iOS) || os(macOS)
         case let ._0(titleKey):
-            if #available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0, *) {
+            if #available(tvOS 17.0,watchOS 10.0,iOS 17.0,macOS 14.0, *) {
             let titleKey = titleKey as! SwiftUI.LocalizedStringKey
             __content
                 .dialogSuppressionToggle(titleKey, isSuppressed: __0_isSuppressed.projectedValue)
             } else { __content }
         #endif
-        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
+        #if os(tvOS) || os(watchOS) || os(iOS) || os(macOS)
         case let ._1(title):
-            if #available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0, *) {
+            if #available(tvOS 17.0,watchOS 10.0,iOS 17.0,macOS 14.0, *) {
             let title = title as! AttributeReference<String>
             __content
                 .dialogSuppressionToggle(title.resolve(on: element, in: context), isSuppressed: __1_isSuppressed.projectedValue)
             } else { __content }
         #endif
-        #if os(tvOS) || os(macOS) || os(watchOS) || os(iOS)
+        #if os(tvOS) || os(watchOS) || os(iOS) || os(macOS)
         case let ._2(label):
-            if #available(tvOS 17.0,macOS 14.0,watchOS 10.0,iOS 17.0, *) {
+            if #available(tvOS 17.0,watchOS 10.0,iOS 17.0,macOS 14.0, *) {
             let label = label as! TextReference
             __content
                 .dialogSuppressionToggle(label.resolve(on: element, in: context), isSuppressed: __2_isSuppressed.projectedValue)
             } else { __content }
         #endif
-        #if os(tvOS) || os(macOS) || os(watchOS) || os(iOS)
+        #if os(tvOS) || os(watchOS) || os(iOS) || os(macOS)
         case ._3:
-            if #available(tvOS 17.0,macOS 14.0,watchOS 10.0,iOS 17.0, *) {
+            if #available(tvOS 17.0,watchOS 10.0,iOS 17.0,macOS 14.0, *) {
             
             __content
                 .dialogSuppressionToggle(isSuppressed: __3_isSuppressed.projectedValue)
@@ -2651,7 +2651,7 @@ struct _fileDialogCustomizationIDModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS)
         case _0(id: Any)
         #endif
     }
@@ -2664,8 +2664,8 @@ struct _fileDialogCustomizationIDModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(macOS) || os(iOS)
-    @available(macOS 14.0,iOS 17.0, *)
+    #if os(iOS) || os(macOS)
+    @available(iOS 17.0,macOS 14.0, *)
     init(_ id: AttributeReference<Swift.String>) {
         self.value = ._0(id: id)
         
@@ -2676,9 +2676,9 @@ struct _fileDialogCustomizationIDModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS)
         case let ._0(id):
-            if #available(macOS 14.0,iOS 17.0, *) {
+            if #available(iOS 17.0,macOS 14.0, *) {
             let id = id as! AttributeReference<Swift.String>
             __content
                 .fileDialogCustomizationID(id.resolve(on: element, in: context))
@@ -2693,7 +2693,7 @@ struct _fileDialogImportsUnresolvedAliasesModifier<R: RootRegistry>: ViewModifie
 
     enum Value {
         case _never
-        #if os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS)
         case _0(imports: Any)
         #endif
     }
@@ -2706,8 +2706,8 @@ struct _fileDialogImportsUnresolvedAliasesModifier<R: RootRegistry>: ViewModifie
 
 
 
-    #if os(macOS) || os(iOS)
-    @available(macOS 14.0,iOS 17.0, *)
+    #if os(iOS) || os(macOS)
+    @available(iOS 17.0,macOS 14.0, *)
     init(_ imports: AttributeReference<Swift.Bool>) {
         self.value = ._0(imports: imports)
         
@@ -2718,9 +2718,9 @@ struct _fileDialogImportsUnresolvedAliasesModifier<R: RootRegistry>: ViewModifie
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS)
         case let ._0(imports):
-            if #available(macOS 14.0,iOS 17.0, *) {
+            if #available(iOS 17.0,macOS 14.0, *) {
             let imports = imports as! AttributeReference<Swift.Bool>
             __content
                 .fileDialogImportsUnresolvedAliases(imports.resolve(on: element, in: context))
@@ -2923,7 +2923,7 @@ struct _focusEffectDisabledModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
+        #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
         case _0(disabled: Any)
         #endif
     }
@@ -2936,8 +2936,8 @@ struct _focusEffectDisabledModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
-    @available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0, *)
+    #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
+    @available(iOS 17.0,macOS 14.0,watchOS 10.0,tvOS 17.0, *)
     init(_ disabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(disabled: disabled)
         
@@ -2948,9 +2948,9 @@ struct _focusEffectDisabledModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
+        #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
         case let ._0(disabled):
-            if #available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0, *) {
+            if #available(iOS 17.0,macOS 14.0,watchOS 10.0,tvOS 17.0, *) {
             let disabled = disabled as! AttributeReference<Swift.Bool>
             __content
                 .focusEffectDisabled(disabled.resolve(on: element, in: context))
@@ -3007,10 +3007,10 @@ struct _focusableModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(watchOS) || os(iOS) || os(tvOS) || os(macOS)
+        #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
         case _0(isFocusable: Any)
         #endif
-        #if os(watchOS) || os(iOS) || os(tvOS) || os(macOS)
+        #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
         case _1(isFocusable: Any, interactions: Any)
         #endif
     }
@@ -3025,15 +3025,15 @@ struct _focusableModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(watchOS) || os(iOS) || os(tvOS) || os(macOS)
-    @available(watchOS 8.0,iOS 17.0,tvOS 15.0,macOS 12.0, *)
+    #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
+    @available(tvOS 15.0,iOS 17.0,watchOS 8.0,macOS 12.0, *)
     init(_ isFocusable: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(isFocusable: isFocusable)
         
     }
     #endif
-    #if os(watchOS) || os(iOS) || os(tvOS) || os(macOS)
-    @available(watchOS 10.0,iOS 17.0,tvOS 17.0,macOS 14.0, *)
+    #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
+    @available(tvOS 17.0,iOS 17.0,watchOS 10.0,macOS 14.0, *)
     init(_ isFocusable: AttributeReference<Swift.Bool> = .init(storage: .constant(true)), interactions: SwiftUI.FocusInteractions) {
         self.value = ._1(isFocusable: isFocusable, interactions: interactions)
         
@@ -3044,17 +3044,17 @@ struct _focusableModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(watchOS) || os(iOS) || os(tvOS) || os(macOS)
+        #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
         case let ._0(isFocusable):
-            if #available(watchOS 8.0,iOS 17.0,tvOS 15.0,macOS 12.0, *) {
+            if #available(tvOS 15.0,iOS 17.0,watchOS 8.0,macOS 12.0, *) {
             let isFocusable = isFocusable as! AttributeReference<Swift.Bool>
             __content
                 .focusable(isFocusable.resolve(on: element, in: context))
             } else { __content }
         #endif
-        #if os(watchOS) || os(iOS) || os(tvOS) || os(macOS)
+        #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
         case let ._1(isFocusable, interactions):
-            if #available(watchOS 10.0,iOS 17.0,tvOS 17.0,macOS 14.0, *) {
+            if #available(tvOS 17.0,iOS 17.0,watchOS 10.0,macOS 14.0, *) {
             let isFocusable = isFocusable as! AttributeReference<Swift.Bool>
 let interactions = interactions as! SwiftUI.FocusInteractions
             __content
@@ -3112,7 +3112,7 @@ struct _fontDesignModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(watchOS) || os(macOS) || os(iOS) || os(tvOS)
+        #if os(tvOS) || os(macOS) || os(watchOS) || os(iOS)
         case _0(design: Any?)
         #endif
     }
@@ -3125,8 +3125,8 @@ struct _fontDesignModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(watchOS) || os(macOS) || os(iOS) || os(tvOS)
-    @available(watchOS 9.1,macOS 13.0,iOS 16.1,tvOS 16.1, *)
+    #if os(tvOS) || os(macOS) || os(watchOS) || os(iOS)
+    @available(tvOS 16.1,macOS 13.0,watchOS 9.1,iOS 16.1, *)
     init(_ design: SwiftUI.Font.Design?) {
         self.value = ._0(design: design)
         
@@ -3137,9 +3137,9 @@ struct _fontDesignModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(watchOS) || os(macOS) || os(iOS) || os(tvOS)
+        #if os(tvOS) || os(macOS) || os(watchOS) || os(iOS)
         case let ._0(design):
-            if #available(watchOS 9.1,macOS 13.0,iOS 16.1,tvOS 16.1, *) {
+            if #available(tvOS 16.1,macOS 13.0,watchOS 9.1,iOS 16.1, *) {
             let design = design as? SwiftUI.Font.Design
             __content
                 .fontDesign(design)
@@ -3444,7 +3444,7 @@ struct _fullScreenCoverModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(watchOS) || os(tvOS) || os(iOS)
+        #if os(watchOS) || os(iOS) || os(tvOS)
         case _0(content: Any)
         #endif
     }
@@ -3457,8 +3457,8 @@ struct _fullScreenCoverModifier<R: RootRegistry>: ViewModifier {
 @ChangeTracked private var _0_isPresented: Swift.Bool
 @Event private var _0_onDismiss__0: Event.EventHandler
 
-    #if os(watchOS) || os(tvOS) || os(iOS)
-    @available(watchOS 7.0,tvOS 14.0,iOS 14.0, *)
+    #if os(watchOS) || os(iOS) || os(tvOS)
+    @available(watchOS 7.0,iOS 14.0,tvOS 14.0, *)
     init(isPresented: ChangeTracked<Swift.Bool>,onDismiss onDismiss__0: Event=Event(), content: ViewReference=ViewReference(value: [])) {
         self.value = ._0(content: content)
         self.__0_isPresented = isPresented
@@ -3470,9 +3470,9 @@ self.__0_onDismiss__0 = onDismiss__0
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(watchOS) || os(tvOS) || os(iOS)
+        #if os(watchOS) || os(iOS) || os(tvOS)
         case let ._0(content):
-            if #available(watchOS 7.0,tvOS 14.0,iOS 14.0, *) {
+            if #available(watchOS 7.0,iOS 14.0,tvOS 14.0, *) {
             let content = content as! ViewReference
             __content
                 .fullScreenCover(isPresented: __0_isPresented.projectedValue, onDismiss: { __0_onDismiss__0.wrappedValue() }, content: { content.resolve(on: element, in: context) })
@@ -3487,7 +3487,7 @@ struct _gaugeStyleModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(macOS) || os(watchOS) || os(iOS)
+        #if os(iOS) || os(macOS) || os(watchOS)
         case _0(style: Any)
         #endif
     }
@@ -3500,8 +3500,8 @@ struct _gaugeStyleModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(macOS) || os(watchOS) || os(iOS)
-    @available(macOS 13.0,watchOS 7.0,iOS 16.0, *)
+    #if os(iOS) || os(macOS) || os(watchOS)
+    @available(iOS 16.0,macOS 13.0,watchOS 7.0, *)
     init(_ style: AnyGaugeStyle) {
         self.value = ._0(style: style)
         
@@ -3512,9 +3512,9 @@ struct _gaugeStyleModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(macOS) || os(watchOS) || os(iOS)
+        #if os(iOS) || os(macOS) || os(watchOS)
         case let ._0(style):
-            if #available(macOS 13.0,watchOS 7.0,iOS 16.0, *) {
+            if #available(iOS 16.0,macOS 13.0,watchOS 7.0, *) {
             let style = style as! AnyGaugeStyle
             __content
                 .gaugeStyle(style)
@@ -3529,7 +3529,7 @@ struct _geometryGroupModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(watchOS) || os(tvOS) || os(iOS) || os(macOS)
+        #if os(tvOS) || os(watchOS) || os(iOS) || os(macOS)
         case _0
         #endif
     }
@@ -3542,8 +3542,8 @@ struct _geometryGroupModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(watchOS) || os(tvOS) || os(iOS) || os(macOS)
-    @available(watchOS 10.0,tvOS 17.0,iOS 17.0,macOS 14.0, *)
+    #if os(tvOS) || os(watchOS) || os(iOS) || os(macOS)
+    @available(tvOS 17.0,watchOS 10.0,iOS 17.0,macOS 14.0, *)
     init() {
         self.value = ._0
         
@@ -3554,9 +3554,9 @@ struct _geometryGroupModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(watchOS) || os(tvOS) || os(iOS) || os(macOS)
+        #if os(tvOS) || os(watchOS) || os(iOS) || os(macOS)
         case ._0:
-            if #available(watchOS 10.0,tvOS 17.0,iOS 17.0,macOS 14.0, *) {
+            if #available(tvOS 17.0,watchOS 10.0,iOS 17.0,macOS 14.0, *) {
             
             __content
                 .geometryGroup()
@@ -3823,7 +3823,7 @@ struct _groupBoxStyleModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS)
         case _0(style: Any)
         #endif
     }
@@ -3836,8 +3836,8 @@ struct _groupBoxStyleModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(macOS) || os(iOS)
-    @available(macOS 11.0,iOS 14.0, *)
+    #if os(iOS) || os(macOS)
+    @available(iOS 14.0,macOS 11.0, *)
     init(_ style: AnyGroupBoxStyle) {
         self.value = ._0(style: style)
         
@@ -3848,9 +3848,9 @@ struct _groupBoxStyleModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS)
         case let ._0(style):
-            if #available(macOS 11.0,iOS 14.0, *) {
+            if #available(iOS 14.0,macOS 11.0, *) {
             let style = style as! AnyGroupBoxStyle
             __content
                 .groupBoxStyle(style)
@@ -4115,7 +4115,7 @@ struct _hoverEffectModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(visionOS) || os(tvOS)
+        #if os(tvOS) || os(iOS) || os(visionOS)
         case _0(effect: Any)
         #endif
         #if os(tvOS) || os(iOS) || os(visionOS)
@@ -4133,8 +4133,8 @@ struct _hoverEffectModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(visionOS) || os(tvOS)
-    @available(iOS 13.4,visionOS 1.0,tvOS 16.0, *)
+    #if os(tvOS) || os(iOS) || os(visionOS)
+    @available(tvOS 16.0,iOS 13.4,visionOS 1.0, *)
     init(_ effect: SwiftUI.HoverEffect = .automatic ) {
         self.value = ._0(effect: effect)
         
@@ -4152,9 +4152,9 @@ struct _hoverEffectModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(visionOS) || os(tvOS)
+        #if os(tvOS) || os(iOS) || os(visionOS)
         case let ._0(effect):
-            if #available(iOS 13.4,visionOS 1.0,tvOS 16.0, *) {
+            if #available(tvOS 16.0,iOS 13.4,visionOS 1.0, *) {
             let effect = effect as! SwiftUI.HoverEffect 
             __content
                 .hoverEffect(effect)
@@ -4346,7 +4346,7 @@ struct _indexViewStyleModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(watchOS) || os(tvOS) || os(iOS)
+        #if os(iOS) || os(tvOS) || os(watchOS)
         case _0(style: Any)
         #endif
     }
@@ -4359,8 +4359,8 @@ struct _indexViewStyleModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(watchOS) || os(tvOS) || os(iOS)
-    @available(watchOS 8.0,tvOS 14.0,iOS 14.0, *)
+    #if os(iOS) || os(tvOS) || os(watchOS)
+    @available(iOS 14.0,tvOS 14.0,watchOS 8.0, *)
     init(_ style: AnyIndexViewStyle) {
         self.value = ._0(style: style)
         
@@ -4371,9 +4371,9 @@ struct _indexViewStyleModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(watchOS) || os(tvOS) || os(iOS)
+        #if os(iOS) || os(tvOS) || os(watchOS)
         case let ._0(style):
-            if #available(watchOS 8.0,tvOS 14.0,iOS 14.0, *) {
+            if #available(iOS 14.0,tvOS 14.0,watchOS 8.0, *) {
             let style = style as! AnyIndexViewStyle
             __content
                 .indexViewStyle(style)
@@ -4388,7 +4388,7 @@ struct _inspectorModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS)
         case _0(content: Any)
         #endif
     }
@@ -4401,8 +4401,8 @@ struct _inspectorModifier<R: RootRegistry>: ViewModifier {
 @ChangeTracked private var _0_isPresented: Swift.Bool
 
 
-    #if os(macOS) || os(iOS)
-    @available(macOS 14.0,iOS 17.0, *)
+    #if os(iOS) || os(macOS)
+    @available(iOS 17.0,macOS 14.0, *)
     init(isPresented: ChangeTracked<Swift.Bool>,content: ViewReference=ViewReference(value: [])) {
         self.value = ._0(content: content)
         self.__0_isPresented = isPresented
@@ -4413,9 +4413,9 @@ struct _inspectorModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS)
         case let ._0(content):
-            if #available(macOS 14.0,iOS 17.0, *) {
+            if #available(iOS 17.0,macOS 14.0, *) {
             let content = content as! ViewReference
             __content
                 .inspector(isPresented: __0_isPresented.projectedValue, content: { content.resolve(on: element, in: context) })
@@ -4430,10 +4430,10 @@ struct _inspectorColumnWidthModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS)
         case _0(min: Any?, ideal: Any,max: Any?)
         #endif
-        #if os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS)
         case _1(width: Any)
         #endif
     }
@@ -4448,15 +4448,15 @@ struct _inspectorColumnWidthModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(macOS) || os(iOS)
-    @available(macOS 14.0,iOS 17.0, *)
+    #if os(iOS) || os(macOS)
+    @available(iOS 17.0,macOS 14.0, *)
     init(min: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), ideal: AttributeReference<CoreFoundation.CGFloat>,max: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)) ) {
         self.value = ._0(min: min, ideal: ideal, max: max)
         
     }
     #endif
-    #if os(macOS) || os(iOS)
-    @available(macOS 14.0,iOS 17.0, *)
+    #if os(iOS) || os(macOS)
+    @available(iOS 17.0,macOS 14.0, *)
     init(_ width: AttributeReference<CoreFoundation.CGFloat>) {
         self.value = ._1(width: width)
         
@@ -4467,9 +4467,9 @@ struct _inspectorColumnWidthModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS)
         case let ._0(min, ideal, max):
-            if #available(macOS 14.0,iOS 17.0, *) {
+            if #available(iOS 17.0,macOS 14.0, *) {
             let min = min as? AttributeReference<CoreFoundation.CGFloat?>
 let ideal = ideal as! AttributeReference<CoreFoundation.CGFloat>
 let max = max as? AttributeReference<CoreFoundation.CGFloat?>
@@ -4477,9 +4477,9 @@ let max = max as? AttributeReference<CoreFoundation.CGFloat?>
                 .inspectorColumnWidth(min: min?.resolve(on: element, in: context), ideal: ideal.resolve(on: element, in: context), max: max?.resolve(on: element, in: context))
             } else { __content }
         #endif
-        #if os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS)
         case let ._1(width):
-            if #available(macOS 14.0,iOS 17.0, *) {
+            if #available(iOS 17.0,macOS 14.0, *) {
             let width = width as! AttributeReference<CoreFoundation.CGFloat>
             __content
                 .inspectorColumnWidth(width.resolve(on: element, in: context))
@@ -4578,7 +4578,7 @@ struct _invalidatableContentModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(macOS) || os(watchOS) || os(iOS) || os(tvOS)
+        #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
         case _0(invalidatable: Any)
         #endif
     }
@@ -4591,8 +4591,8 @@ struct _invalidatableContentModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(macOS) || os(watchOS) || os(iOS) || os(tvOS)
-    @available(macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0, *)
+    #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
+    @available(tvOS 17.0,iOS 17.0,watchOS 10.0,macOS 14.0, *)
     init(_ invalidatable: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(invalidatable: invalidatable)
         
@@ -4603,9 +4603,9 @@ struct _invalidatableContentModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(macOS) || os(watchOS) || os(iOS) || os(tvOS)
+        #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
         case let ._0(invalidatable):
-            if #available(macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0, *) {
+            if #available(tvOS 17.0,iOS 17.0,watchOS 10.0,macOS 14.0, *) {
             let invalidatable = invalidatable as! AttributeReference<Swift.Bool>
             __content
                 .invalidatableContent(invalidatable.resolve(on: element, in: context))
@@ -4809,7 +4809,7 @@ struct _keyboardTypeModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(tvOS) || os(iOS)
+        #if os(iOS) || os(tvOS)
         case _0(type: Any)
         #endif
     }
@@ -4822,8 +4822,8 @@ struct _keyboardTypeModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(tvOS) || os(iOS)
-    @available(tvOS 13.0,iOS 13.0, *)
+    #if os(iOS) || os(tvOS)
+    @available(iOS 13.0,tvOS 13.0, *)
     init(_ type: UIKit.UIKeyboardType) {
         self.value = ._0(type: type)
         
@@ -4834,9 +4834,9 @@ struct _keyboardTypeModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(tvOS) || os(iOS)
+        #if os(iOS) || os(tvOS)
         case let ._0(type):
-            if #available(tvOS 13.0,iOS 13.0, *) {
+            if #available(iOS 13.0,tvOS 13.0, *) {
             let type = type as! UIKit.UIKeyboardType
             __content
                 .keyboardType(type)
@@ -5456,7 +5456,7 @@ struct _listRowSeparatorTintModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS)
         case _0(color: Any?,edges: Any)
         #endif
     }
@@ -5469,8 +5469,8 @@ struct _listRowSeparatorTintModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(macOS) || os(iOS)
-    @available(macOS 13.0,iOS 15.0, *)
+    #if os(iOS) || os(macOS)
+    @available(iOS 15.0,macOS 13.0, *)
     init(_ color: AttributeReference<SwiftUI.Color?>?,edges: SwiftUI.VerticalEdge.Set = .all ) {
         self.value = ._0(color: color, edges: edges)
         
@@ -5481,9 +5481,9 @@ struct _listRowSeparatorTintModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS)
         case let ._0(color, edges):
-            if #available(macOS 13.0,iOS 15.0, *) {
+            if #available(iOS 15.0,macOS 13.0, *) {
             let color = color as? AttributeReference<SwiftUI.Color?>
 let edges = edges as! SwiftUI.VerticalEdge.Set 
             __content
@@ -5541,7 +5541,7 @@ struct _listSectionSeparatorModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS)
         case _0(visibility: Any,edges: Any)
         #endif
     }
@@ -5554,8 +5554,8 @@ struct _listSectionSeparatorModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(macOS) || os(iOS)
-    @available(macOS 13.0,iOS 15.0, *)
+    #if os(iOS) || os(macOS)
+    @available(iOS 15.0,macOS 13.0, *)
     init(_ visibility: AttributeReference<SwiftUI.Visibility>,edges: SwiftUI.VerticalEdge.Set = .all ) {
         self.value = ._0(visibility: visibility, edges: edges)
         
@@ -5566,9 +5566,9 @@ struct _listSectionSeparatorModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS)
         case let ._0(visibility, edges):
-            if #available(macOS 13.0,iOS 15.0, *) {
+            if #available(iOS 15.0,macOS 13.0, *) {
             let visibility = visibility as! AttributeReference<SwiftUI.Visibility>
 let edges = edges as! SwiftUI.VerticalEdge.Set 
             __content
@@ -5584,7 +5584,7 @@ struct _listSectionSeparatorTintModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS)
         case _0(color: Any?,edges: Any)
         #endif
     }
@@ -5597,8 +5597,8 @@ struct _listSectionSeparatorTintModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(macOS) || os(iOS)
-    @available(macOS 13.0,iOS 15.0, *)
+    #if os(iOS) || os(macOS)
+    @available(iOS 15.0,macOS 13.0, *)
     init(_ color: AttributeReference<SwiftUI.Color?>?,edges: SwiftUI.VerticalEdge.Set = .all ) {
         self.value = ._0(color: color, edges: edges)
         
@@ -5609,9 +5609,9 @@ struct _listSectionSeparatorTintModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS)
         case let ._0(color, edges):
-            if #available(macOS 13.0,iOS 15.0, *) {
+            if #available(iOS 15.0,macOS 13.0, *) {
             let color = color as? AttributeReference<SwiftUI.Color?>
 let edges = edges as! SwiftUI.VerticalEdge.Set 
             __content
@@ -5773,7 +5773,7 @@ struct _menuIndicatorModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(tvOS) || os(iOS) || os(macOS)
+        #if os(iOS) || os(tvOS) || os(macOS)
         case _0(visibility: Any)
         #endif
     }
@@ -5786,8 +5786,8 @@ struct _menuIndicatorModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(tvOS) || os(iOS) || os(macOS)
-    @available(tvOS 17.0,iOS 15.0,macOS 12.0, *)
+    #if os(iOS) || os(tvOS) || os(macOS)
+    @available(iOS 15.0,tvOS 17.0,macOS 12.0, *)
     init(_ visibility: AttributeReference<SwiftUI.Visibility>) {
         self.value = ._0(visibility: visibility)
         
@@ -5798,9 +5798,9 @@ struct _menuIndicatorModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(tvOS) || os(iOS) || os(macOS)
+        #if os(iOS) || os(tvOS) || os(macOS)
         case let ._0(visibility):
-            if #available(tvOS 17.0,iOS 15.0,macOS 12.0, *) {
+            if #available(iOS 15.0,tvOS 17.0,macOS 12.0, *) {
             let visibility = visibility as! AttributeReference<SwiftUI.Visibility>
             __content
                 .menuIndicator(visibility.resolve(on: element, in: context))
@@ -5857,7 +5857,7 @@ struct _menuStyleModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(tvOS) || os(iOS) || os(macOS)
+        #if os(macOS) || os(iOS) || os(tvOS)
         case _0(style: Any)
         #endif
     }
@@ -5870,8 +5870,8 @@ struct _menuStyleModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(tvOS) || os(iOS) || os(macOS)
-    @available(tvOS 17.0,iOS 14.0,macOS 11.0, *)
+    #if os(macOS) || os(iOS) || os(tvOS)
+    @available(macOS 11.0,iOS 14.0,tvOS 17.0, *)
     init(_ style: AnyMenuStyle) {
         self.value = ._0(style: style)
         
@@ -5882,9 +5882,9 @@ struct _menuStyleModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(tvOS) || os(iOS) || os(macOS)
+        #if os(macOS) || os(iOS) || os(tvOS)
         case let ._0(style):
-            if #available(tvOS 17.0,iOS 14.0,macOS 11.0, *) {
+            if #available(macOS 11.0,iOS 14.0,tvOS 17.0, *) {
             let style = style as! AnyMenuStyle
             __content
                 .menuStyle(style)
@@ -6339,13 +6339,13 @@ struct _navigationSubtitleModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(macOS) || targetEnvironment(macCatalyst)
+        #if targetEnvironment(macCatalyst) || os(macOS)
         case _0(subtitle: Any)
         #endif
-        #if os(macOS) || targetEnvironment(macCatalyst)
+        #if targetEnvironment(macCatalyst) || os(macOS)
         case _1(subtitleKey: Any)
         #endif
-        #if os(macOS) || targetEnvironment(macCatalyst)
+        #if targetEnvironment(macCatalyst) || os(macOS)
         case _2(subtitle: Any)
         #endif
     }
@@ -6362,22 +6362,22 @@ struct _navigationSubtitleModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(macOS) || targetEnvironment(macCatalyst)
-    @available(macOS 11.0,macCatalyst 14.0, *)
+    #if targetEnvironment(macCatalyst) || os(macOS)
+    @available(macCatalyst 14.0,macOS 11.0, *)
     init(_ subtitle: TextReference) {
         self.value = ._0(subtitle: subtitle)
         
     }
     #endif
-    #if os(macOS) || targetEnvironment(macCatalyst)
-    @available(macOS 11.0,macCatalyst 14.0, *)
+    #if targetEnvironment(macCatalyst) || os(macOS)
+    @available(macCatalyst 14.0,macOS 11.0, *)
     init(_ subtitleKey: SwiftUI.LocalizedStringKey) {
         self.value = ._1(subtitleKey: subtitleKey)
         
     }
     #endif
-    #if os(macOS) || targetEnvironment(macCatalyst)
-    @available(macOS 11.0,macCatalyst 14.0, *)
+    #if targetEnvironment(macCatalyst) || os(macOS)
+    @available(macCatalyst 14.0,macOS 11.0, *)
     init(_ subtitle: AttributeReference<String>) {
         self.value = ._2(subtitle: subtitle)
         
@@ -6388,25 +6388,25 @@ struct _navigationSubtitleModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(macOS) || targetEnvironment(macCatalyst)
+        #if targetEnvironment(macCatalyst) || os(macOS)
         case let ._0(subtitle):
-            if #available(macOS 11.0,macCatalyst 14.0, *) {
+            if #available(macCatalyst 14.0,macOS 11.0, *) {
             let subtitle = subtitle as! TextReference
             __content
                 .navigationSubtitle(subtitle.resolve(on: element, in: context))
             } else { __content }
         #endif
-        #if os(macOS) || targetEnvironment(macCatalyst)
+        #if targetEnvironment(macCatalyst) || os(macOS)
         case let ._1(subtitleKey):
-            if #available(macOS 11.0,macCatalyst 14.0, *) {
+            if #available(macCatalyst 14.0,macOS 11.0, *) {
             let subtitleKey = subtitleKey as! SwiftUI.LocalizedStringKey
             __content
                 .navigationSubtitle(subtitleKey)
             } else { __content }
         #endif
-        #if os(macOS) || targetEnvironment(macCatalyst)
+        #if targetEnvironment(macCatalyst) || os(macOS)
         case let ._2(subtitle):
-            if #available(macOS 11.0,macCatalyst 14.0, *) {
+            if #available(macCatalyst 14.0,macOS 11.0, *) {
             let subtitle = subtitle as! AttributeReference<String>
             __content
                 .navigationSubtitle(subtitle.resolve(on: element, in: context))
@@ -6476,7 +6476,7 @@ struct _navigationTitleModifier<R: RootRegistry>: ViewModifier {
     }
     
     #if os(watchOS)
-    @available(watchOS 7.0,macOS 11.0,iOS 14.0,tvOS 14.0, *)
+    @available(macOS 11.0,watchOS 7.0,tvOS 14.0,iOS 14.0, *)
     init(_ title: ViewReference=ViewReference(value: [])) {
         self.value = ._3(title: title)
         
@@ -6520,7 +6520,7 @@ struct _navigationTitleModifier<R: RootRegistry>: ViewModifier {
         
         #if os(watchOS)
         case let ._3(title):
-            if #available(watchOS 7.0,macOS 11.0,iOS 14.0,tvOS 14.0, *) {
+            if #available(macOS 11.0,watchOS 7.0,tvOS 14.0,iOS 14.0, *) {
             let title = title as! ViewReference
             __content
                 .navigationTitle({ title.resolve(on: element, in: context) })
@@ -6661,7 +6661,7 @@ struct _onDeleteCommandModifier<R: RootRegistry>: ViewModifier {
 @Event private var _0_action__0: Event.EventHandler
 
     #if os(macOS)
-    @available(tvOS 13.0,macOS 10.15, *)
+    @available(macOS 10.15,tvOS 13.0, *)
     init(perform action__0: Event=Event()) {
         self.value = ._0
         self.__0_action__0 = action__0
@@ -6674,7 +6674,7 @@ struct _onDeleteCommandModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(macOS)
         case ._0:
-            if #available(tvOS 13.0,macOS 10.15, *) {
+            if #available(macOS 10.15,tvOS 13.0, *) {
             
             __content
                 .onDeleteCommand(perform: { __0_action__0.wrappedValue() })
@@ -6731,7 +6731,7 @@ struct _onExitCommandModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(tvOS) || os(macOS)
+        #if os(macOS) || os(tvOS)
         case _0
         #endif
     }
@@ -6744,8 +6744,8 @@ struct _onExitCommandModifier<R: RootRegistry>: ViewModifier {
 
 @Event private var _0_action__0: Event.EventHandler
 
-    #if os(tvOS) || os(macOS)
-    @available(tvOS 13.0,macOS 10.15, *)
+    #if os(macOS) || os(tvOS)
+    @available(macOS 10.15,tvOS 13.0, *)
     init(perform action__0: Event=Event()) {
         self.value = ._0
         self.__0_action__0 = action__0
@@ -6756,9 +6756,9 @@ struct _onExitCommandModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(tvOS) || os(macOS)
+        #if os(macOS) || os(tvOS)
         case ._0:
-            if #available(tvOS 13.0,macOS 10.15, *) {
+            if #available(macOS 10.15,tvOS 13.0, *) {
             
             __content
                 .onExitCommand(perform: { __0_action__0.wrappedValue() })
@@ -6773,7 +6773,7 @@ struct _onHoverModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS)
         case _0
         #endif
     }
@@ -6786,8 +6786,8 @@ struct _onHoverModifier<R: RootRegistry>: ViewModifier {
 
 @Event private var _0_action__1: Event.EventHandler
 
-    #if os(macOS) || os(iOS)
-    @available(macOS 10.15,iOS 13.4, *)
+    #if os(iOS) || os(macOS)
+    @available(iOS 13.4,macOS 10.15, *)
     init(perform action__1: Event) {
         self.value = ._0
         self.__0_action__1 = action__1
@@ -6798,9 +6798,9 @@ struct _onHoverModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS)
         case ._0:
-            if #available(macOS 10.15,iOS 13.4, *) {
+            if #available(iOS 13.4,macOS 10.15, *) {
             
             __content
                 .onHover(perform: { __0_action__1.wrappedValue(value: $0) })
@@ -6815,7 +6815,7 @@ struct _onLongPressGestureModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(macOS) || os(iOS) || os(watchOS)
+        #if os(watchOS) || os(iOS) || os(macOS)
         case _0(minimumDuration: Any, maximumDistance: Any)
         #endif
         #if os(tvOS)
@@ -6835,8 +6835,8 @@ struct _onLongPressGestureModifier<R: RootRegistry>: ViewModifier {
 @Event private var _1_action__0: Event.EventHandler
 @Event private var _1_onPressingChanged__1: Event.EventHandler
 
-    #if os(macOS) || os(iOS) || os(watchOS)
-    @available(macOS 10.15,tvOS 14.0,iOS 13.0,watchOS 6.0, *)
+    #if os(watchOS) || os(iOS) || os(macOS)
+    @available(tvOS 14.0,watchOS 6.0,iOS 13.0,macOS 10.15, *)
     init(minimumDuration: AttributeReference<Swift.Double> = .init(storage: .constant(0.5)), maximumDistance: AttributeReference<CoreFoundation.CGFloat> = .init(storage: .constant(10)), perform action__0: Event,onPressingChanged onPressingChanged__1: Event=Event() ) {
         self.value = ._0(minimumDuration: minimumDuration, maximumDistance: maximumDistance)
         self.__0_action__0 = action__0
@@ -6844,7 +6844,7 @@ self.__0_onPressingChanged__1 = onPressingChanged__1
     }
     #endif
     #if os(tvOS)
-    @available(iOS 13.0,tvOS 14.0,watchOS 6.0,macOS 10.15, *)
+    @available(tvOS 14.0,watchOS 6.0,iOS 13.0,macOS 10.15, *)
     init(minimumDuration: AttributeReference<Swift.Double> = .init(storage: .constant(0.5)), perform action__0: Event,onPressingChanged onPressingChanged__1: Event=Event() ) {
         self.value = ._1(minimumDuration: minimumDuration)
         self.__1_action__0 = action__0
@@ -6856,9 +6856,9 @@ self.__1_onPressingChanged__1 = onPressingChanged__1
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(macOS) || os(iOS) || os(watchOS)
+        #if os(watchOS) || os(iOS) || os(macOS)
         case let ._0(minimumDuration, maximumDistance):
-            if #available(macOS 10.15,tvOS 14.0,iOS 13.0,watchOS 6.0, *) {
+            if #available(tvOS 14.0,watchOS 6.0,iOS 13.0,macOS 10.15, *) {
             let minimumDuration = minimumDuration as! AttributeReference<Swift.Double>
 let maximumDistance = maximumDistance as! AttributeReference<CoreFoundation.CGFloat>
             __content
@@ -6867,7 +6867,7 @@ let maximumDistance = maximumDistance as! AttributeReference<CoreFoundation.CGFl
         #endif
         #if os(tvOS)
         case let ._1(minimumDuration):
-            if #available(iOS 13.0,tvOS 14.0,watchOS 6.0,macOS 10.15, *) {
+            if #available(tvOS 14.0,watchOS 6.0,iOS 13.0,macOS 10.15, *) {
             let minimumDuration = minimumDuration as! AttributeReference<Swift.Double>
             __content
                 .onLongPressGesture(minimumDuration: minimumDuration.resolve(on: element, in: context), perform: { __1_action__0.wrappedValue() }, onPressingChanged: { __1_onPressingChanged__1.wrappedValue(value: $0) })
@@ -6926,7 +6926,7 @@ struct _onMoveCommandModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(tvOS) || os(macOS)
+        #if os(macOS) || os(tvOS)
         case _0
         #endif
     }
@@ -6939,8 +6939,8 @@ struct _onMoveCommandModifier<R: RootRegistry>: ViewModifier {
 
 @Event private var _0_action__1: Event.EventHandler
 
-    #if os(tvOS) || os(macOS)
-    @available(tvOS 13.0,macOS 10.15, *)
+    #if os(macOS) || os(tvOS)
+    @available(macOS 10.15,tvOS 13.0, *)
     init(perform action__1: Event=Event()) {
         self.value = ._0
         self.__0_action__1 = action__1
@@ -6951,9 +6951,9 @@ struct _onMoveCommandModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(tvOS) || os(macOS)
+        #if os(macOS) || os(tvOS)
         case ._0:
-            if #available(tvOS 13.0,macOS 10.15, *) {
+            if #available(macOS 10.15,tvOS 13.0, *) {
             
             __content
                 .onMoveCommand(perform: { __0_action__1.wrappedValue(value: $0) })
@@ -6982,7 +6982,7 @@ struct _onPlayPauseCommandModifier<R: RootRegistry>: ViewModifier {
 @Event private var _0_action__0: Event.EventHandler
 
     #if os(tvOS)
-    @available(tvOS 13.0,macOS 10.15, *)
+    @available(macOS 10.15,tvOS 13.0, *)
     init(perform action__0: Event=Event()) {
         self.value = ._0
         self.__0_action__0 = action__0
@@ -6995,7 +6995,7 @@ struct _onPlayPauseCommandModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(tvOS)
         case ._0:
-            if #available(tvOS 13.0,macOS 10.15, *) {
+            if #available(macOS 10.15,tvOS 13.0, *) {
             
             __content
                 .onPlayPauseCommand(perform: { __0_action__0.wrappedValue() })
@@ -7013,7 +7013,7 @@ struct _onTapGestureModifier<R: RootRegistry>: ViewModifier {
         
         case _0(count: AttributeReference<Swift.Int> = .init(storage: .constant(1)))
         
-        #if os(macOS) || os(watchOS) || os(iOS)
+        #if os(iOS) || os(macOS) || os(watchOS)
         case _1(count: Any, coordinateSpace: Any)
         #endif
     }
@@ -7035,8 +7035,8 @@ struct _onTapGestureModifier<R: RootRegistry>: ViewModifier {
         self.__0_action__0 = action__0
     }
     
-    #if os(macOS) || os(watchOS) || os(iOS)
-    @available(macOS 14.0,watchOS 10.0,iOS 17.0, *)
+    #if os(iOS) || os(macOS) || os(watchOS)
+    @available(iOS 17.0,macOS 14.0,watchOS 10.0, *)
     init(count: AttributeReference<Swift.Int> = .init(storage: .constant(1)), coordinateSpace: AnyCoordinateSpaceProtocol = .local, perform action__1: Event) {
         self.value = ._1(count: count, coordinateSpace: coordinateSpace)
         self.__1_action__1 = action__1
@@ -7055,9 +7055,9 @@ struct _onTapGestureModifier<R: RootRegistry>: ViewModifier {
                 .onTapGesture(count: count.resolve(on: element, in: context), perform: { __0_action__0.wrappedValue() })
             
         
-        #if os(macOS) || os(watchOS) || os(iOS)
+        #if os(iOS) || os(macOS) || os(watchOS)
         case let ._1(count, coordinateSpace):
-            if #available(macOS 14.0,watchOS 10.0,iOS 17.0, *) {
+            if #available(iOS 17.0,macOS 14.0,watchOS 10.0, *) {
             let count = count as! AttributeReference<Swift.Int>
 let coordinateSpace = coordinateSpace as! AnyCoordinateSpaceProtocol 
             __content
@@ -7363,7 +7363,7 @@ struct _popoverModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS)
         case _0(attachmentAnchor: Any, arrowEdge: Any, content: Any)
         #endif
     }
@@ -7376,8 +7376,8 @@ struct _popoverModifier<R: RootRegistry>: ViewModifier {
 @ChangeTracked private var _0_isPresented: Swift.Bool
 
 
-    #if os(macOS) || os(iOS)
-    @available(macOS 10.15,iOS 13.0, *)
+    #if os(iOS) || os(macOS)
+    @available(iOS 13.0,macOS 10.15, *)
     init(isPresented: ChangeTracked<Swift.Bool>,attachmentAnchor: SwiftUI.PopoverAttachmentAnchor = .rect(.bounds), arrowEdge: SwiftUI.Edge = .top, content: ViewReference=ViewReference(value: [])) {
         self.value = ._0(attachmentAnchor: attachmentAnchor, arrowEdge: arrowEdge, content: content)
         self.__0_isPresented = isPresented
@@ -7388,9 +7388,9 @@ struct _popoverModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS)
         case let ._0(attachmentAnchor, arrowEdge, content):
-            if #available(macOS 10.15,iOS 13.0, *) {
+            if #available(iOS 13.0,macOS 10.15, *) {
             let attachmentAnchor = attachmentAnchor as! SwiftUI.PopoverAttachmentAnchor 
 let arrowEdge = arrowEdge as! SwiftUI.Edge 
 let content = content as! ViewReference
@@ -7511,10 +7511,10 @@ struct _presentationBackgroundModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(watchOS) || os(tvOS) || os(macOS)
+        #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
         case _0(style: Any)
         #endif
-        #if os(iOS) || os(watchOS) || os(tvOS) || os(macOS)
+        #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
         case _1(alignment: Any, content: Any)
         #endif
     }
@@ -7529,15 +7529,15 @@ struct _presentationBackgroundModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(watchOS) || os(tvOS) || os(macOS)
-    @available(iOS 16.4,watchOS 9.4,tvOS 16.4,macOS 13.3, *)
+    #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
+    @available(tvOS 16.4,iOS 16.4,watchOS 9.4,macOS 13.3, *)
     init(_ style: AnyShapeStyle) {
         self.value = ._0(style: style)
         
     }
     #endif
-    #if os(iOS) || os(watchOS) || os(tvOS) || os(macOS)
-    @available(iOS 16.4,watchOS 9.4,tvOS 16.4,macOS 13.3, *)
+    #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
+    @available(tvOS 16.4,iOS 16.4,watchOS 9.4,macOS 13.3, *)
     init(alignment: AttributeReference<SwiftUI.Alignment> = .init(storage: .constant(.center)), content: ViewReference=ViewReference(value: [])) {
         self.value = ._1(alignment: alignment, content: content)
         
@@ -7548,17 +7548,17 @@ struct _presentationBackgroundModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(watchOS) || os(tvOS) || os(macOS)
+        #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
         case let ._0(style):
-            if #available(iOS 16.4,watchOS 9.4,tvOS 16.4,macOS 13.3, *) {
+            if #available(tvOS 16.4,iOS 16.4,watchOS 9.4,macOS 13.3, *) {
             let style = style as! AnyShapeStyle
             __content
                 .presentationBackground(style)
             } else { __content }
         #endif
-        #if os(iOS) || os(watchOS) || os(tvOS) || os(macOS)
+        #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
         case let ._1(alignment, content):
-            if #available(iOS 16.4,watchOS 9.4,tvOS 16.4,macOS 13.3, *) {
+            if #available(tvOS 16.4,iOS 16.4,watchOS 9.4,macOS 13.3, *) {
             let alignment = alignment as! AttributeReference<SwiftUI.Alignment>
 let content = content as! ViewReference
             __content
@@ -7574,7 +7574,7 @@ struct _presentationBackgroundInteractionModifier<R: RootRegistry>: ViewModifier
 
     enum Value {
         case _never
-        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
+        #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
         case _0(interaction: Any)
         #endif
     }
@@ -7587,8 +7587,8 @@ struct _presentationBackgroundInteractionModifier<R: RootRegistry>: ViewModifier
 
 
 
-    #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
-    @available(iOS 16.4,watchOS 9.4,macOS 13.3,tvOS 16.4, *)
+    #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
+    @available(tvOS 16.4,iOS 16.4,watchOS 9.4,macOS 13.3, *)
     init(_ interaction: SwiftUI.PresentationBackgroundInteraction) {
         self.value = ._0(interaction: interaction)
         
@@ -7599,9 +7599,9 @@ struct _presentationBackgroundInteractionModifier<R: RootRegistry>: ViewModifier
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
+        #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
         case let ._0(interaction):
-            if #available(iOS 16.4,watchOS 9.4,macOS 13.3,tvOS 16.4, *) {
+            if #available(tvOS 16.4,iOS 16.4,watchOS 9.4,macOS 13.3, *) {
             let interaction = interaction as! SwiftUI.PresentationBackgroundInteraction
             __content
                 .presentationBackgroundInteraction(interaction)
@@ -7616,10 +7616,10 @@ struct _presentationCompactAdaptationModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
+        #if os(tvOS) || os(watchOS) || os(macOS) || os(iOS)
         case _0(adaptation: Any)
         #endif
-        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
+        #if os(tvOS) || os(watchOS) || os(macOS) || os(iOS)
         case _1(horizontalAdaptation: Any,verticalAdaptation: Any)
         #endif
     }
@@ -7634,15 +7634,15 @@ struct _presentationCompactAdaptationModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
-    @available(iOS 16.4,watchOS 9.4,macOS 13.3,tvOS 16.4, *)
+    #if os(tvOS) || os(watchOS) || os(macOS) || os(iOS)
+    @available(tvOS 16.4,watchOS 9.4,macOS 13.3,iOS 16.4, *)
     init(_ adaptation: SwiftUI.PresentationAdaptation) {
         self.value = ._0(adaptation: adaptation)
         
     }
     #endif
-    #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
-    @available(iOS 16.4,watchOS 9.4,macOS 13.3,tvOS 16.4, *)
+    #if os(tvOS) || os(watchOS) || os(macOS) || os(iOS)
+    @available(tvOS 16.4,watchOS 9.4,macOS 13.3,iOS 16.4, *)
     init(horizontal horizontalAdaptation: SwiftUI.PresentationAdaptation,vertical verticalAdaptation: SwiftUI.PresentationAdaptation) {
         self.value = ._1(horizontalAdaptation: horizontalAdaptation, verticalAdaptation: verticalAdaptation)
         
@@ -7653,17 +7653,17 @@ struct _presentationCompactAdaptationModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
+        #if os(tvOS) || os(watchOS) || os(macOS) || os(iOS)
         case let ._0(adaptation):
-            if #available(iOS 16.4,watchOS 9.4,macOS 13.3,tvOS 16.4, *) {
+            if #available(tvOS 16.4,watchOS 9.4,macOS 13.3,iOS 16.4, *) {
             let adaptation = adaptation as! SwiftUI.PresentationAdaptation
             __content
                 .presentationCompactAdaptation(adaptation)
             } else { __content }
         #endif
-        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
+        #if os(tvOS) || os(watchOS) || os(macOS) || os(iOS)
         case let ._1(horizontalAdaptation, verticalAdaptation):
-            if #available(iOS 16.4,watchOS 9.4,macOS 13.3,tvOS 16.4, *) {
+            if #available(tvOS 16.4,watchOS 9.4,macOS 13.3,iOS 16.4, *) {
             let horizontalAdaptation = horizontalAdaptation as! SwiftUI.PresentationAdaptation
 let verticalAdaptation = verticalAdaptation as! SwiftUI.PresentationAdaptation
             __content
@@ -7679,7 +7679,7 @@ struct _presentationContentInteractionModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(watchOS) || os(iOS) || os(tvOS) || os(macOS)
+        #if os(tvOS) || os(watchOS) || os(macOS) || os(iOS)
         case _0(behavior: Any)
         #endif
     }
@@ -7692,8 +7692,8 @@ struct _presentationContentInteractionModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(watchOS) || os(iOS) || os(tvOS) || os(macOS)
-    @available(watchOS 9.4,iOS 16.4,tvOS 16.4,macOS 13.3, *)
+    #if os(tvOS) || os(watchOS) || os(macOS) || os(iOS)
+    @available(tvOS 16.4,watchOS 9.4,macOS 13.3,iOS 16.4, *)
     init(_ behavior: SwiftUI.PresentationContentInteraction) {
         self.value = ._0(behavior: behavior)
         
@@ -7704,9 +7704,9 @@ struct _presentationContentInteractionModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(watchOS) || os(iOS) || os(tvOS) || os(macOS)
+        #if os(tvOS) || os(watchOS) || os(macOS) || os(iOS)
         case let ._0(behavior):
-            if #available(watchOS 9.4,iOS 16.4,tvOS 16.4,macOS 13.3, *) {
+            if #available(tvOS 16.4,watchOS 9.4,macOS 13.3,iOS 16.4, *) {
             let behavior = behavior as! SwiftUI.PresentationContentInteraction
             __content
                 .presentationContentInteraction(behavior)
@@ -7721,7 +7721,7 @@ struct _presentationCornerRadiusModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
+        #if os(tvOS) || os(watchOS) || os(macOS) || os(iOS)
         case _0(cornerRadius: Any?)
         #endif
     }
@@ -7734,8 +7734,8 @@ struct _presentationCornerRadiusModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
-    @available(iOS 16.4,watchOS 9.4,macOS 13.3,tvOS 16.4, *)
+    #if os(tvOS) || os(watchOS) || os(macOS) || os(iOS)
+    @available(tvOS 16.4,watchOS 9.4,macOS 13.3,iOS 16.4, *)
     init(_ cornerRadius: AttributeReference<CoreFoundation.CGFloat?>?) {
         self.value = ._0(cornerRadius: cornerRadius)
         
@@ -7746,9 +7746,9 @@ struct _presentationCornerRadiusModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
+        #if os(tvOS) || os(watchOS) || os(macOS) || os(iOS)
         case let ._0(cornerRadius):
-            if #available(iOS 16.4,watchOS 9.4,macOS 13.3,tvOS 16.4, *) {
+            if #available(tvOS 16.4,watchOS 9.4,macOS 13.3,iOS 16.4, *) {
             let cornerRadius = cornerRadius as? AttributeReference<CoreFoundation.CGFloat?>
             __content
                 .presentationCornerRadius(cornerRadius?.resolve(on: element, in: context))
@@ -8515,7 +8515,7 @@ struct _scrollBounceBehaviorModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
+        #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
         case _0(behavior: Any,axes: Any)
         #endif
     }
@@ -8528,8 +8528,8 @@ struct _scrollBounceBehaviorModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
-    @available(tvOS 16.4,iOS 16.4,watchOS 9.4,macOS 13.3, *)
+    #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
+    @available(iOS 16.4,macOS 13.3,watchOS 9.4,tvOS 16.4, *)
     init(_ behavior: SwiftUI.ScrollBounceBehavior,axes: SwiftUI.Axis.Set = [.vertical] ) {
         self.value = ._0(behavior: behavior, axes: axes)
         
@@ -8540,9 +8540,9 @@ struct _scrollBounceBehaviorModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
+        #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
         case let ._0(behavior, axes):
-            if #available(tvOS 16.4,iOS 16.4,watchOS 9.4,macOS 13.3, *) {
+            if #available(iOS 16.4,macOS 13.3,watchOS 9.4,tvOS 16.4, *) {
             let behavior = behavior as! SwiftUI.ScrollBounceBehavior
 let axes = axes as! SwiftUI.Axis.Set 
             __content
@@ -8558,7 +8558,7 @@ struct _scrollClipDisabledModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
+        #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
         case _0(disabled: Any)
         #endif
     }
@@ -8571,8 +8571,8 @@ struct _scrollClipDisabledModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
-    @available(tvOS 17.0,iOS 17.0,watchOS 10.0,macOS 14.0, *)
+    #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
+    @available(iOS 17.0,macOS 14.0,watchOS 10.0,tvOS 17.0, *)
     init(_ disabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(disabled: disabled)
         
@@ -8583,9 +8583,9 @@ struct _scrollClipDisabledModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
+        #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
         case let ._0(disabled):
-            if #available(tvOS 17.0,iOS 17.0,watchOS 10.0,macOS 14.0, *) {
+            if #available(iOS 17.0,macOS 14.0,watchOS 10.0,tvOS 17.0, *) {
             let disabled = disabled as! AttributeReference<Swift.Bool>
             __content
                 .scrollClipDisabled(disabled.resolve(on: element, in: context))
@@ -8600,7 +8600,7 @@ struct _scrollContentBackgroundModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(macOS) || os(watchOS) || os(iOS)
+        #if os(watchOS) || os(iOS) || os(macOS)
         case _0(visibility: Any)
         #endif
     }
@@ -8613,8 +8613,8 @@ struct _scrollContentBackgroundModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(macOS) || os(watchOS) || os(iOS)
-    @available(macOS 13.0,watchOS 9.0,iOS 16.0, *)
+    #if os(watchOS) || os(iOS) || os(macOS)
+    @available(watchOS 9.0,iOS 16.0,macOS 13.0, *)
     init(_ visibility: AttributeReference<SwiftUI.Visibility>) {
         self.value = ._0(visibility: visibility)
         
@@ -8625,9 +8625,9 @@ struct _scrollContentBackgroundModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(macOS) || os(watchOS) || os(iOS)
+        #if os(watchOS) || os(iOS) || os(macOS)
         case let ._0(visibility):
-            if #available(macOS 13.0,watchOS 9.0,iOS 16.0, *) {
+            if #available(watchOS 9.0,iOS 16.0,macOS 13.0, *) {
             let visibility = visibility as! AttributeReference<SwiftUI.Visibility>
             __content
                 .scrollContentBackground(visibility.resolve(on: element, in: context))
@@ -8684,7 +8684,7 @@ struct _scrollDismissesKeyboardModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
+        #if os(tvOS) || os(watchOS) || os(iOS) || os(macOS)
         case _0(mode: Any)
         #endif
     }
@@ -8697,8 +8697,8 @@ struct _scrollDismissesKeyboardModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
-    @available(tvOS 16.0,iOS 16.0,watchOS 9.0,macOS 13.0, *)
+    #if os(tvOS) || os(watchOS) || os(iOS) || os(macOS)
+    @available(tvOS 16.0,watchOS 9.0,iOS 16.0,macOS 13.0, *)
     init(_ mode: SwiftUI.ScrollDismissesKeyboardMode) {
         self.value = ._0(mode: mode)
         
@@ -8709,9 +8709,9 @@ struct _scrollDismissesKeyboardModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
+        #if os(tvOS) || os(watchOS) || os(iOS) || os(macOS)
         case let ._0(mode):
-            if #available(tvOS 16.0,iOS 16.0,watchOS 9.0,macOS 13.0, *) {
+            if #available(tvOS 16.0,watchOS 9.0,iOS 16.0,macOS 13.0, *) {
             let mode = mode as! SwiftUI.ScrollDismissesKeyboardMode
             __content
                 .scrollDismissesKeyboard(mode)
@@ -8768,10 +8768,10 @@ struct _scrollIndicatorsFlashModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(watchOS) || os(macOS) || os(iOS) || os(tvOS)
+        #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
         case _0(value: Any)
         #endif
-        #if os(watchOS) || os(tvOS) || os(iOS) || os(macOS)
+        #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
         case _1(onAppear: Any)
         #endif
     }
@@ -8786,15 +8786,15 @@ struct _scrollIndicatorsFlashModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(watchOS) || os(macOS) || os(iOS) || os(tvOS)
-    @available(watchOS 10.0,macOS 14.0,iOS 17.0,tvOS 17.0, *)
+    #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
+    @available(iOS 17.0,macOS 14.0,watchOS 10.0,tvOS 17.0, *)
     init(trigger value: AttributeReference<String>) {
         self.value = ._0(value: value)
         
     }
     #endif
-    #if os(watchOS) || os(tvOS) || os(iOS) || os(macOS)
-    @available(watchOS 10.0,tvOS 17.0,iOS 17.0,macOS 14.0, *)
+    #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
+    @available(iOS 17.0,macOS 14.0,watchOS 10.0,tvOS 17.0, *)
     init(onAppear: AttributeReference<Swift.Bool>) {
         self.value = ._1(onAppear: onAppear)
         
@@ -8805,17 +8805,17 @@ struct _scrollIndicatorsFlashModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(watchOS) || os(macOS) || os(iOS) || os(tvOS)
+        #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
         case let ._0(value):
-            if #available(watchOS 10.0,macOS 14.0,iOS 17.0,tvOS 17.0, *) {
+            if #available(iOS 17.0,macOS 14.0,watchOS 10.0,tvOS 17.0, *) {
             let value = value as! AttributeReference<String>
             __content
                 .scrollIndicatorsFlash(trigger: value.resolve(on: element, in: context))
             } else { __content }
         #endif
-        #if os(watchOS) || os(tvOS) || os(iOS) || os(macOS)
+        #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
         case let ._1(onAppear):
-            if #available(watchOS 10.0,tvOS 17.0,iOS 17.0,macOS 14.0, *) {
+            if #available(iOS 17.0,macOS 14.0,watchOS 10.0,tvOS 17.0, *) {
             let onAppear = onAppear as! AttributeReference<Swift.Bool>
             __content
                 .scrollIndicatorsFlash(onAppear: onAppear.resolve(on: element, in: context))
@@ -8830,7 +8830,7 @@ struct _scrollPositionModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(tvOS) || os(macOS) || os(iOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
         case _0(anchor: Any?)
         #endif
     }
@@ -8843,8 +8843,8 @@ struct _scrollPositionModifier<R: RootRegistry>: ViewModifier {
 @ChangeTracked private var _0_id: String?
 
 
-    #if os(tvOS) || os(macOS) || os(iOS) || os(watchOS)
-    @available(tvOS 17.0,macOS 14.0,iOS 17.0,watchOS 10.0, *)
+    #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
+    @available(iOS 17.0,macOS 14.0,watchOS 10.0,tvOS 17.0, *)
     init(id: ChangeTracked<String?>,anchor: AttributeReference<SwiftUI.UnitPoint?>? = .init(storage: .constant(nil)) ) {
         self.value = ._0(anchor: anchor)
         self.__0_id = id
@@ -8855,9 +8855,9 @@ struct _scrollPositionModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(tvOS) || os(macOS) || os(iOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
         case let ._0(anchor):
-            if #available(tvOS 17.0,macOS 14.0,iOS 17.0,watchOS 10.0, *) {
+            if #available(iOS 17.0,macOS 14.0,watchOS 10.0,tvOS 17.0, *) {
             let anchor = anchor as? AttributeReference<SwiftUI.UnitPoint?>
             __content
                 .scrollPosition(id: __0_id.projectedValue, anchor: anchor?.resolve(on: element, in: context))
@@ -8872,7 +8872,7 @@ struct _scrollTargetBehaviorModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
+        #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
         case _0(behavior: Any)
         #endif
     }
@@ -8885,8 +8885,8 @@ struct _scrollTargetBehaviorModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
-    @available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0, *)
+    #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
+    @available(iOS 17.0,macOS 14.0,watchOS 10.0,tvOS 17.0, *)
     init(_ behavior: AnyScrollTargetBehavior) {
         self.value = ._0(behavior: behavior)
         
@@ -8897,9 +8897,9 @@ struct _scrollTargetBehaviorModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
+        #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
         case let ._0(behavior):
-            if #available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0, *) {
+            if #available(iOS 17.0,macOS 14.0,watchOS 10.0,tvOS 17.0, *) {
             let behavior = behavior as! AnyScrollTargetBehavior
             __content
                 .scrollTargetBehavior(behavior)
@@ -8914,7 +8914,7 @@ struct _scrollTargetLayoutModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
+        #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
         case _0(isEnabled: Any)
         #endif
     }
@@ -8927,8 +8927,8 @@ struct _scrollTargetLayoutModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
-    @available(tvOS 17.0,iOS 17.0,watchOS 10.0,macOS 14.0, *)
+    #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
+    @available(iOS 17.0,macOS 14.0,watchOS 10.0,tvOS 17.0, *)
     init(isEnabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(isEnabled: isEnabled)
         
@@ -8939,9 +8939,9 @@ struct _scrollTargetLayoutModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
+        #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
         case let ._0(isEnabled):
-            if #available(tvOS 17.0,iOS 17.0,watchOS 10.0,macOS 14.0, *) {
+            if #available(iOS 17.0,macOS 14.0,watchOS 10.0,tvOS 17.0, *) {
             let isEnabled = isEnabled as! AttributeReference<Swift.Bool>
             __content
                 .scrollTargetLayout(isEnabled: isEnabled.resolve(on: element, in: context))
@@ -8998,7 +8998,7 @@ struct _searchPresentationToolbarBehaviorModifier<R: RootRegistry>: ViewModifier
 
     enum Value {
         case _never
-        #if os(tvOS) || os(iOS) || os(macOS) || os(watchOS)
+        #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
         case _0(behavior: Any)
         #endif
     }
@@ -9011,8 +9011,8 @@ struct _searchPresentationToolbarBehaviorModifier<R: RootRegistry>: ViewModifier
 
 
 
-    #if os(tvOS) || os(iOS) || os(macOS) || os(watchOS)
-    @available(tvOS 17.1,iOS 17.1,macOS 14.1,watchOS 10.1, *)
+    #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
+    @available(tvOS 17.1,iOS 17.1,watchOS 10.1,macOS 14.1, *)
     init(_ behavior: SwiftUI.SearchPresentationToolbarBehavior) {
         self.value = ._0(behavior: behavior)
         
@@ -9023,9 +9023,9 @@ struct _searchPresentationToolbarBehaviorModifier<R: RootRegistry>: ViewModifier
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(tvOS) || os(iOS) || os(macOS) || os(watchOS)
+        #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
         case let ._0(behavior):
-            if #available(tvOS 17.1,iOS 17.1,macOS 14.1,watchOS 10.1, *) {
+            if #available(tvOS 17.1,iOS 17.1,watchOS 10.1,macOS 14.1, *) {
             let behavior = behavior as! SwiftUI.SearchPresentationToolbarBehavior
             __content
                 .searchPresentationToolbarBehavior(behavior)
@@ -9253,7 +9253,7 @@ struct _selectionDisabledModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(watchOS) || os(tvOS) || os(macOS)
+        #if os(tvOS) || os(macOS) || os(watchOS) || os(iOS)
         case _0(isDisabled: Any)
         #endif
     }
@@ -9266,8 +9266,8 @@ struct _selectionDisabledModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(watchOS) || os(tvOS) || os(macOS)
-    @available(iOS 17.0,watchOS 10.0,tvOS 17.0,macOS 14.0, *)
+    #if os(tvOS) || os(macOS) || os(watchOS) || os(iOS)
+    @available(tvOS 17.0,macOS 14.0,watchOS 10.0,iOS 17.0, *)
     init(_ isDisabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(isDisabled: isDisabled)
         
@@ -9278,9 +9278,9 @@ struct _selectionDisabledModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(watchOS) || os(tvOS) || os(macOS)
+        #if os(tvOS) || os(macOS) || os(watchOS) || os(iOS)
         case let ._0(isDisabled):
-            if #available(iOS 17.0,watchOS 10.0,tvOS 17.0,macOS 14.0, *) {
+            if #available(tvOS 17.0,macOS 14.0,watchOS 10.0,iOS 17.0, *) {
             let isDisabled = isDisabled as! AttributeReference<Swift.Bool>
             __content
                 .selectionDisabled(isDisabled.resolve(on: element, in: context))
@@ -9758,7 +9758,7 @@ struct _swipeActionsModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(macOS) || os(watchOS) || os(iOS)
+        #if os(iOS) || os(macOS) || os(watchOS)
         case _0(edge: Any, allowsFullSwipe: Any, content: Any)
         #endif
     }
@@ -9771,8 +9771,8 @@ struct _swipeActionsModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(macOS) || os(watchOS) || os(iOS)
-    @available(macOS 12.0,watchOS 8.0,iOS 15.0, *)
+    #if os(iOS) || os(macOS) || os(watchOS)
+    @available(iOS 15.0,macOS 12.0,watchOS 8.0, *)
     init(edge: SwiftUI.HorizontalEdge = .trailing, allowsFullSwipe: AttributeReference<Swift.Bool> = .init(storage: .constant(true)), content: ViewReference=ViewReference(value: [])) {
         self.value = ._0(edge: edge, allowsFullSwipe: allowsFullSwipe, content: content)
         
@@ -9783,9 +9783,9 @@ struct _swipeActionsModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(macOS) || os(watchOS) || os(iOS)
+        #if os(iOS) || os(macOS) || os(watchOS)
         case let ._0(edge, allowsFullSwipe, content):
-            if #available(macOS 12.0,watchOS 8.0,iOS 15.0, *) {
+            if #available(iOS 15.0,macOS 12.0,watchOS 8.0, *) {
             let edge = edge as! SwiftUI.HorizontalEdge 
 let allowsFullSwipe = allowsFullSwipe as! AttributeReference<Swift.Bool>
 let content = content as! ViewReference
@@ -9802,7 +9802,7 @@ struct _symbolEffectsRemovedModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
+        #if os(tvOS) || os(macOS) || os(watchOS) || os(iOS)
         case _0(isEnabled: Any)
         #endif
     }
@@ -9815,8 +9815,8 @@ struct _symbolEffectsRemovedModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
-    @available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0, *)
+    #if os(tvOS) || os(macOS) || os(watchOS) || os(iOS)
+    @available(tvOS 17.0,macOS 14.0,watchOS 10.0,iOS 17.0, *)
     init(_ isEnabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(isEnabled: isEnabled)
         
@@ -9827,9 +9827,9 @@ struct _symbolEffectsRemovedModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
+        #if os(tvOS) || os(macOS) || os(watchOS) || os(iOS)
         case let ._0(isEnabled):
-            if #available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0, *) {
+            if #available(tvOS 17.0,macOS 14.0,watchOS 10.0,iOS 17.0, *) {
             let isEnabled = isEnabled as! AttributeReference<Swift.Bool>
             __content
                 .symbolEffectsRemoved(isEnabled.resolve(on: element, in: context))
@@ -10012,7 +10012,7 @@ struct _tableStyleModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS)
         case _0(style: Any)
         #endif
     }
@@ -10025,8 +10025,8 @@ struct _tableStyleModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(macOS) || os(iOS)
-    @available(macOS 12.0,iOS 16.0, *)
+    #if os(iOS) || os(macOS)
+    @available(iOS 16.0,macOS 12.0, *)
     init(_ style: AnyTableStyle) {
         self.value = ._0(style: style)
         
@@ -10037,9 +10037,9 @@ struct _tableStyleModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS)
         case let ._0(style):
-            if #available(macOS 12.0,iOS 16.0, *) {
+            if #available(iOS 16.0,macOS 12.0, *) {
             let style = style as! AnyTableStyle
             __content
                 .tableStyle(style)
@@ -10096,7 +10096,7 @@ struct _textContentTypeModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(tvOS) || os(iOS)
+        #if os(iOS) || os(tvOS)
         case _0(textContentType: Any?)
         #endif
     }
@@ -10109,8 +10109,8 @@ struct _textContentTypeModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(tvOS) || os(iOS)
-    @available(tvOS 13.0,iOS 13.0, *)
+    #if os(iOS) || os(tvOS)
+    @available(iOS 13.0,tvOS 13.0, *)
     init(_ textContentType: UIKit.UITextContentType?) {
         self.value = ._0(textContentType: textContentType)
         
@@ -10121,9 +10121,9 @@ struct _textContentTypeModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(tvOS) || os(iOS)
+        #if os(iOS) || os(tvOS)
         case let ._0(textContentType):
-            if #available(tvOS 13.0,iOS 13.0, *) {
+            if #available(iOS 13.0,tvOS 13.0, *) {
             let textContentType = textContentType as? UIKit.UITextContentType
             __content
                 .textContentType(textContentType)
@@ -10138,7 +10138,7 @@ struct _textEditorStyleModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(visionOS) || os(macOS) || os(iOS)
+        #if os(macOS) || os(iOS) || os(visionOS)
         case _0(style: Any)
         #endif
     }
@@ -10151,8 +10151,8 @@ struct _textEditorStyleModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(visionOS) || os(macOS) || os(iOS)
-    @available(visionOS 1.0,macOS 14.0,iOS 17.0, *)
+    #if os(macOS) || os(iOS) || os(visionOS)
+    @available(macOS 14.0,iOS 17.0,visionOS 1.0, *)
     init(_ style: AnyTextEditorStyle) {
         self.value = ._0(style: style)
         
@@ -10163,9 +10163,9 @@ struct _textEditorStyleModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(visionOS) || os(macOS) || os(iOS)
+        #if os(macOS) || os(iOS) || os(visionOS)
         case let ._0(style):
-            if #available(visionOS 1.0,macOS 14.0,iOS 17.0, *) {
+            if #available(macOS 14.0,iOS 17.0,visionOS 1.0, *) {
             let style = style as! AnyTextEditorStyle
             __content
                 .textEditorStyle(style)
@@ -10222,7 +10222,7 @@ struct _textInputAutocapitalizationModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(watchOS) || os(tvOS) || os(iOS)
+        #if os(watchOS) || os(iOS) || os(tvOS)
         case _0(autocapitalization: Any?)
         #endif
     }
@@ -10235,8 +10235,8 @@ struct _textInputAutocapitalizationModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(watchOS) || os(tvOS) || os(iOS)
-    @available(watchOS 8.0,tvOS 15.0,iOS 15.0, *)
+    #if os(watchOS) || os(iOS) || os(tvOS)
+    @available(watchOS 8.0,iOS 15.0,tvOS 15.0, *)
     init(_ autocapitalization: SwiftUI.TextInputAutocapitalization?) {
         self.value = ._0(autocapitalization: autocapitalization)
         
@@ -10247,9 +10247,9 @@ struct _textInputAutocapitalizationModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(watchOS) || os(tvOS) || os(iOS)
+        #if os(watchOS) || os(iOS) || os(tvOS)
         case let ._0(autocapitalization):
-            if #available(watchOS 8.0,tvOS 15.0,iOS 15.0, *) {
+            if #available(watchOS 8.0,iOS 15.0,tvOS 15.0, *) {
             let autocapitalization = autocapitalization as? SwiftUI.TextInputAutocapitalization
             __content
                 .textInputAutocapitalization(autocapitalization)
@@ -10264,7 +10264,7 @@ struct _textScaleModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
+        #if os(tvOS) || os(watchOS) || os(macOS) || os(iOS)
         case _0(scale: Any,isEnabled: Any)
         #endif
     }
@@ -10277,8 +10277,8 @@ struct _textScaleModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
-    @available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0, *)
+    #if os(tvOS) || os(watchOS) || os(macOS) || os(iOS)
+    @available(tvOS 17.0,watchOS 10.0,macOS 14.0,iOS 17.0, *)
     init(_ scale: SwiftUI.Text.Scale,isEnabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(scale: scale, isEnabled: isEnabled)
         
@@ -10289,9 +10289,9 @@ struct _textScaleModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
+        #if os(tvOS) || os(watchOS) || os(macOS) || os(iOS)
         case let ._0(scale, isEnabled):
-            if #available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0, *) {
+            if #available(tvOS 17.0,watchOS 10.0,macOS 14.0,iOS 17.0, *) {
             let scale = scale as! SwiftUI.Text.Scale
 let isEnabled = isEnabled as! AttributeReference<Swift.Bool>
             __content
@@ -10456,7 +10456,7 @@ struct _toolbarModifier<R: RootRegistry>: ViewModifier {
         
         case _0(visibility: AttributeReference<SwiftUI.Visibility>,bars: SwiftUI.ToolbarPlacement)
         
-        #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
+        #if os(tvOS) || os(watchOS) || os(iOS) || os(macOS)
         case _1(defaultItemKind: Any?)
         #endif
         
@@ -10488,8 +10488,8 @@ struct _toolbarModifier<R: RootRegistry>: ViewModifier {
         
     }
     
-    #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
-    @available(iOS 17.0,macOS 14.0,watchOS 10.0,tvOS 17.0, *)
+    #if os(tvOS) || os(watchOS) || os(iOS) || os(macOS)
+    @available(tvOS 17.0,watchOS 10.0,iOS 17.0,macOS 14.0, *)
     init(removing defaultItemKind: SwiftUI.ToolbarDefaultItemKind?) {
         self.value = ._1(defaultItemKind: defaultItemKind)
         
@@ -10522,9 +10522,9 @@ struct _toolbarModifier<R: RootRegistry>: ViewModifier {
                 .toolbar(visibility.resolve(on: element, in: context), for: bars)
             
         
-        #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
+        #if os(tvOS) || os(watchOS) || os(iOS) || os(macOS)
         case let ._1(defaultItemKind):
-            if #available(iOS 17.0,macOS 14.0,watchOS 10.0,tvOS 17.0, *) {
+            if #available(tvOS 17.0,watchOS 10.0,iOS 17.0,macOS 14.0, *) {
             let defaultItemKind = defaultItemKind as? SwiftUI.ToolbarDefaultItemKind
             __content
                 .toolbar(removing: defaultItemKind)
@@ -10701,7 +10701,7 @@ struct _toolbarTitleDisplayModeModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
+        #if os(tvOS) || os(watchOS) || os(macOS) || os(iOS)
         case _0(mode: Any)
         #endif
     }
@@ -10714,8 +10714,8 @@ struct _toolbarTitleDisplayModeModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
-    @available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0, *)
+    #if os(tvOS) || os(watchOS) || os(macOS) || os(iOS)
+    @available(tvOS 17.0,watchOS 10.0,macOS 14.0,iOS 17.0, *)
     init(_ mode: SwiftUI.ToolbarTitleDisplayMode) {
         self.value = ._0(mode: mode)
         
@@ -10726,9 +10726,9 @@ struct _toolbarTitleDisplayModeModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
+        #if os(tvOS) || os(watchOS) || os(macOS) || os(iOS)
         case let ._0(mode):
-            if #available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0, *) {
+            if #available(tvOS 17.0,watchOS 10.0,macOS 14.0,iOS 17.0, *) {
             let mode = mode as! SwiftUI.ToolbarTitleDisplayMode
             __content
                 .toolbarTitleDisplayMode(mode)
@@ -11385,28 +11385,29 @@ case truncationMode(_truncationModeModifier<R>)
 case underline(_underlineModifier<R>)
 case unredacted(_unredactedModifier<R>)
 case zIndex(_zIndexModifier<R>)
-        case _ResizableModifier(LiveViewNative._ResizableModifier)
+        case _PrefersDefaultFocusModifier(LiveViewNative._PrefersDefaultFocusModifier<R>)
+case _MaskModifier(LiveViewNative._MaskModifier<R>)
 case _RotationModifier(LiveViewNative._RotationModifier)
-case _LineSubtractionModifier(LiveViewNative._LineSubtractionModifier)
-case _LineIntersectionModifier(LiveViewNative._LineIntersectionModifier)
+case _TransformModifier(LiveViewNative._TransformModifier)
 case _SearchCompletionModifier(LiveViewNative._SearchCompletionModifier<R>)
 case _UnionModifier(LiveViewNative._UnionModifier)
-case _FocusScopeModifier(LiveViewNative._FocusScopeModifier<R>)
-case _SymmetricDifferenceModifier(LiveViewNative._SymmetricDifferenceModifier)
-case _MatchedGeometryEffectModifier(LiveViewNative._MatchedGeometryEffectModifier<R>)
-case _FillModifier(LiveViewNative._FillModifier)
-case _RenderingModeModifier(LiveViewNative._RenderingModeModifier)
-case _ScaleModifier(LiveViewNative._ScaleModifier<R>)
-case _TransformModifier(LiveViewNative._TransformModifier)
-case _OnSubmitModifier(LiveViewNative._OnSubmitModifier)
+case _LineIntersectionModifier(LiveViewNative._LineIntersectionModifier)
+case _StrokeModifier(LiveViewNative._StrokeModifier<R>)
+case _IntersectionModifier(LiveViewNative._IntersectionModifier)
+case _ResizableModifier(LiveViewNative._ResizableModifier)
 case _SearchScopesModifier(LiveViewNative._SearchScopesModifier<R>)
-case _MaskModifier(LiveViewNative._MaskModifier<R>)
+case _MatchedGeometryEffectModifier(LiveViewNative._MatchedGeometryEffectModifier<R>)
+case _OnSubmitModifier(LiveViewNative._OnSubmitModifier)
+case _ScaleModifier(LiveViewNative._ScaleModifier<R>)
+case _FillModifier(LiveViewNative._FillModifier)
+case _LineSubtractionModifier(LiveViewNative._LineSubtractionModifier)
+case _RenderingModeModifier(LiveViewNative._RenderingModeModifier)
 case _Rotation3DEffectModifier(LiveViewNative._Rotation3DEffectModifier<R>)
 case _PresentationDetentsModifier(LiveViewNative._PresentationDetentsModifier)
-case _PrefersDefaultFocusModifier(LiveViewNative._PrefersDefaultFocusModifier<R>)
-case _IntersectionModifier(LiveViewNative._IntersectionModifier)
 case _SubtractingModifier(LiveViewNative._SubtractingModifier)
-case _StrokeModifier(LiveViewNative._StrokeModifier<R>)
+case _SymmetricDifferenceModifier(LiveViewNative._SymmetricDifferenceModifier)
+case _FocusScopeModifier(LiveViewNative._FocusScopeModifier<R>)
+        case _customRegistryModifier(R.CustomModifier)
         
         func body(content: Content) -> some View {
             switch self {
@@ -11860,50 +11861,52 @@ case let .unredacted(modifier):
     content.modifier(modifier)
 case let .zIndex(modifier):
     content.modifier(modifier)
-            case let ._ResizableModifier(modifier):
+            case let ._PrefersDefaultFocusModifier(modifier):
+    content.modifier(modifier)
+case let ._MaskModifier(modifier):
     content.modifier(modifier)
 case let ._RotationModifier(modifier):
     content.modifier(modifier)
-case let ._LineSubtractionModifier(modifier):
-    content.modifier(modifier)
-case let ._LineIntersectionModifier(modifier):
+case let ._TransformModifier(modifier):
     content.modifier(modifier)
 case let ._SearchCompletionModifier(modifier):
     content.modifier(modifier)
 case let ._UnionModifier(modifier):
     content.modifier(modifier)
-case let ._FocusScopeModifier(modifier):
+case let ._LineIntersectionModifier(modifier):
     content.modifier(modifier)
-case let ._SymmetricDifferenceModifier(modifier):
+case let ._StrokeModifier(modifier):
     content.modifier(modifier)
-case let ._MatchedGeometryEffectModifier(modifier):
+case let ._IntersectionModifier(modifier):
     content.modifier(modifier)
-case let ._FillModifier(modifier):
-    content.modifier(modifier)
-case let ._RenderingModeModifier(modifier):
-    content.modifier(modifier)
-case let ._ScaleModifier(modifier):
-    content.modifier(modifier)
-case let ._TransformModifier(modifier):
-    content.modifier(modifier)
-case let ._OnSubmitModifier(modifier):
+case let ._ResizableModifier(modifier):
     content.modifier(modifier)
 case let ._SearchScopesModifier(modifier):
     content.modifier(modifier)
-case let ._MaskModifier(modifier):
+case let ._MatchedGeometryEffectModifier(modifier):
+    content.modifier(modifier)
+case let ._OnSubmitModifier(modifier):
+    content.modifier(modifier)
+case let ._ScaleModifier(modifier):
+    content.modifier(modifier)
+case let ._FillModifier(modifier):
+    content.modifier(modifier)
+case let ._LineSubtractionModifier(modifier):
+    content.modifier(modifier)
+case let ._RenderingModeModifier(modifier):
     content.modifier(modifier)
 case let ._Rotation3DEffectModifier(modifier):
     content.modifier(modifier)
 case let ._PresentationDetentsModifier(modifier):
     content.modifier(modifier)
-case let ._PrefersDefaultFocusModifier(modifier):
-    content.modifier(modifier)
-case let ._IntersectionModifier(modifier):
-    content.modifier(modifier)
 case let ._SubtractingModifier(modifier):
     content.modifier(modifier)
-case let ._StrokeModifier(modifier):
+case let ._SymmetricDifferenceModifier(modifier):
     content.modifier(modifier)
+case let ._FocusScopeModifier(modifier):
+    content.modifier(modifier)
+            case let ._customRegistryModifier(modifier):
+                content.modifier(modifier)
             }
         }
         
@@ -12144,28 +12147,28 @@ _truncationModeModifier<R>.name: _truncationModeModifier<R>.parser(in: context).
 _underlineModifier<R>.name: _underlineModifier<R>.parser(in: context).map(Output.underline).eraseToAnyParser(),
 _unredactedModifier<R>.name: _unredactedModifier<R>.parser(in: context).map(Output.unredacted).eraseToAnyParser(),
 _zIndexModifier<R>.name: _zIndexModifier<R>.parser(in: context).map(Output.zIndex).eraseToAnyParser(),
-                    LiveViewNative._ResizableModifier.name: LiveViewNative._ResizableModifier.parser(in: context).map(Output._ResizableModifier).eraseToAnyParser(),
+                    LiveViewNative._PrefersDefaultFocusModifier<R>.name: LiveViewNative._PrefersDefaultFocusModifier<R>.parser(in: context).map(Output._PrefersDefaultFocusModifier).eraseToAnyParser(),
+LiveViewNative._MaskModifier<R>.name: LiveViewNative._MaskModifier<R>.parser(in: context).map(Output._MaskModifier).eraseToAnyParser(),
 LiveViewNative._RotationModifier.name: LiveViewNative._RotationModifier.parser(in: context).map(Output._RotationModifier).eraseToAnyParser(),
-LiveViewNative._LineSubtractionModifier.name: LiveViewNative._LineSubtractionModifier.parser(in: context).map(Output._LineSubtractionModifier).eraseToAnyParser(),
-LiveViewNative._LineIntersectionModifier.name: LiveViewNative._LineIntersectionModifier.parser(in: context).map(Output._LineIntersectionModifier).eraseToAnyParser(),
+LiveViewNative._TransformModifier.name: LiveViewNative._TransformModifier.parser(in: context).map(Output._TransformModifier).eraseToAnyParser(),
 LiveViewNative._SearchCompletionModifier<R>.name: LiveViewNative._SearchCompletionModifier<R>.parser(in: context).map(Output._SearchCompletionModifier).eraseToAnyParser(),
 LiveViewNative._UnionModifier.name: LiveViewNative._UnionModifier.parser(in: context).map(Output._UnionModifier).eraseToAnyParser(),
-LiveViewNative._FocusScopeModifier<R>.name: LiveViewNative._FocusScopeModifier<R>.parser(in: context).map(Output._FocusScopeModifier).eraseToAnyParser(),
-LiveViewNative._SymmetricDifferenceModifier.name: LiveViewNative._SymmetricDifferenceModifier.parser(in: context).map(Output._SymmetricDifferenceModifier).eraseToAnyParser(),
-LiveViewNative._MatchedGeometryEffectModifier<R>.name: LiveViewNative._MatchedGeometryEffectModifier<R>.parser(in: context).map(Output._MatchedGeometryEffectModifier).eraseToAnyParser(),
-LiveViewNative._FillModifier.name: LiveViewNative._FillModifier.parser(in: context).map(Output._FillModifier).eraseToAnyParser(),
-LiveViewNative._RenderingModeModifier.name: LiveViewNative._RenderingModeModifier.parser(in: context).map(Output._RenderingModeModifier).eraseToAnyParser(),
-LiveViewNative._ScaleModifier<R>.name: LiveViewNative._ScaleModifier<R>.parser(in: context).map(Output._ScaleModifier).eraseToAnyParser(),
-LiveViewNative._TransformModifier.name: LiveViewNative._TransformModifier.parser(in: context).map(Output._TransformModifier).eraseToAnyParser(),
-LiveViewNative._OnSubmitModifier.name: LiveViewNative._OnSubmitModifier.parser(in: context).map(Output._OnSubmitModifier).eraseToAnyParser(),
+LiveViewNative._LineIntersectionModifier.name: LiveViewNative._LineIntersectionModifier.parser(in: context).map(Output._LineIntersectionModifier).eraseToAnyParser(),
+LiveViewNative._StrokeModifier<R>.name: LiveViewNative._StrokeModifier<R>.parser(in: context).map(Output._StrokeModifier).eraseToAnyParser(),
+LiveViewNative._IntersectionModifier.name: LiveViewNative._IntersectionModifier.parser(in: context).map(Output._IntersectionModifier).eraseToAnyParser(),
+LiveViewNative._ResizableModifier.name: LiveViewNative._ResizableModifier.parser(in: context).map(Output._ResizableModifier).eraseToAnyParser(),
 LiveViewNative._SearchScopesModifier<R>.name: LiveViewNative._SearchScopesModifier<R>.parser(in: context).map(Output._SearchScopesModifier).eraseToAnyParser(),
-LiveViewNative._MaskModifier<R>.name: LiveViewNative._MaskModifier<R>.parser(in: context).map(Output._MaskModifier).eraseToAnyParser(),
+LiveViewNative._MatchedGeometryEffectModifier<R>.name: LiveViewNative._MatchedGeometryEffectModifier<R>.parser(in: context).map(Output._MatchedGeometryEffectModifier).eraseToAnyParser(),
+LiveViewNative._OnSubmitModifier.name: LiveViewNative._OnSubmitModifier.parser(in: context).map(Output._OnSubmitModifier).eraseToAnyParser(),
+LiveViewNative._ScaleModifier<R>.name: LiveViewNative._ScaleModifier<R>.parser(in: context).map(Output._ScaleModifier).eraseToAnyParser(),
+LiveViewNative._FillModifier.name: LiveViewNative._FillModifier.parser(in: context).map(Output._FillModifier).eraseToAnyParser(),
+LiveViewNative._LineSubtractionModifier.name: LiveViewNative._LineSubtractionModifier.parser(in: context).map(Output._LineSubtractionModifier).eraseToAnyParser(),
+LiveViewNative._RenderingModeModifier.name: LiveViewNative._RenderingModeModifier.parser(in: context).map(Output._RenderingModeModifier).eraseToAnyParser(),
 LiveViewNative._Rotation3DEffectModifier<R>.name: LiveViewNative._Rotation3DEffectModifier<R>.parser(in: context).map(Output._Rotation3DEffectModifier).eraseToAnyParser(),
 LiveViewNative._PresentationDetentsModifier.name: LiveViewNative._PresentationDetentsModifier.parser(in: context).map(Output._PresentationDetentsModifier).eraseToAnyParser(),
-LiveViewNative._PrefersDefaultFocusModifier<R>.name: LiveViewNative._PrefersDefaultFocusModifier<R>.parser(in: context).map(Output._PrefersDefaultFocusModifier).eraseToAnyParser(),
-LiveViewNative._IntersectionModifier.name: LiveViewNative._IntersectionModifier.parser(in: context).map(Output._IntersectionModifier).eraseToAnyParser(),
 LiveViewNative._SubtractingModifier.name: LiveViewNative._SubtractingModifier.parser(in: context).map(Output._SubtractingModifier).eraseToAnyParser(),
-LiveViewNative._StrokeModifier<R>.name: LiveViewNative._StrokeModifier<R>.parser(in: context).map(Output._StrokeModifier).eraseToAnyParser(),
+LiveViewNative._SymmetricDifferenceModifier.name: LiveViewNative._SymmetricDifferenceModifier.parser(in: context).map(Output._SymmetricDifferenceModifier).eraseToAnyParser(),
+LiveViewNative._FocusScopeModifier<R>.name: LiveViewNative._FocusScopeModifier<R>.parser(in: context).map(Output._FocusScopeModifier).eraseToAnyParser(),
                 ]
                 
                 var copy = input
@@ -12179,10 +12182,22 @@ LiveViewNative._StrokeModifier<R>.name: LiveViewNative._StrokeModifier<R>.parser
                     Metadata.parser()
                 }.parse(&copy)
                 
-                guard let parser = parsers[modifierName]
-                else { throw ModifierParseError(error: .unknownModifier(modifierName), metadata: metadata) }
-                
-                return try parser.parse(&input)
+                // attempt to parse the built-in modifiers first.
+                if let parser = parsers[modifierName] {
+                    return try parser.parse(&input)
+                } else {
+                    // if the modifier name is not a known built-in, try to parse as a custom modifier
+                    do {
+                        return try ._customRegistryModifier(R.parseModifier(&input, in: context))
+                    } catch let error as ModifierParseError {
+                        throw error
+                    } catch {
+                        throw ModifierParseError(
+                            error: .unknownModifier(modifierName),
+                            metadata: metadata
+                        )
+                    }
+                }
             }
         }
     }
@@ -12321,14 +12336,14 @@ ConstantAtomLiteral("vertical").map({ () -> Self in
     }
 }
 
-#if os(macOS) || os(iOS)
-@available(macOS 14.0,iOS 17.0, *)
+#if os(iOS) || os(macOS)
+@available(iOS 17.0,macOS 14.0, *)
 extension BadgeProminence: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             ConstantAtomLiteral("decreased").map({ () -> Self in
-#if os(macOS) || os(iOS)
+#if os(iOS) || os(macOS)
 
     return Self.decreased
 
@@ -12337,7 +12352,7 @@ fatalError("'decreased' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("standard").map({ () -> Self in
-#if os(macOS) || os(iOS)
+#if os(iOS) || os(macOS)
 
     return Self.standard
 
@@ -12346,7 +12361,7 @@ fatalError("'standard' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("increased").map({ () -> Self in
-#if os(macOS) || os(iOS)
+#if os(iOS) || os(macOS)
 
     return Self.increased
 
@@ -12559,14 +12574,14 @@ ConstantAtomLiteral("plusLighter").map({ () -> Self in
     }
 }
 
-#if os(tvOS) || os(macOS) || os(iOS) || os(watchOS)
-@available(tvOS 17.0,macOS 14.0,iOS 17.0,watchOS 10.0, *)
+#if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
+@available(iOS 17.0,macOS 14.0,watchOS 10.0,tvOS 17.0, *)
 extension ButtonRepeatBehavior: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             ConstantAtomLiteral("automatic").map({ () -> Self in
-#if os(tvOS) || os(macOS) || os(iOS) || os(watchOS)
+#if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
 
     return Self.automatic
 
@@ -12575,7 +12590,7 @@ fatalError("'automatic' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("enabled").map({ () -> Self in
-#if os(tvOS) || os(macOS) || os(iOS) || os(watchOS)
+#if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
 
     return Self.enabled
 
@@ -12584,7 +12599,7 @@ fatalError("'enabled' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("disabled").map({ () -> Self in
-#if os(tvOS) || os(macOS) || os(iOS) || os(watchOS)
+#if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
 
     return Self.disabled
 
@@ -12664,8 +12679,8 @@ ConstantAtomLiteral("dark").map({ () -> Self in
     }
 }
 
-#if os(tvOS) || os(macOS) || os(iOS) || os(watchOS)
-@available(tvOS 17.0,macOS 14.0,iOS 17.0,watchOS 10.0, *)
+#if os(tvOS) || os(macOS) || os(watchOS) || os(iOS)
+@available(tvOS 17.0,macOS 14.0,watchOS 10.0,iOS 17.0, *)
 extension ContainerBackgroundPlacement: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -12693,14 +12708,14 @@ fatalError("'navigation' is not available on this OS")
     }
 }
 #endif
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
-@available(macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0, *)
+#if os(watchOS) || os(iOS) || os(tvOS) || os(macOS)
+@available(watchOS 10.0,iOS 17.0,tvOS 17.0,macOS 14.0, *)
 extension ContentMarginPlacement: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             ConstantAtomLiteral("automatic").map({ () -> Self in
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+#if os(watchOS) || os(iOS) || os(tvOS) || os(macOS)
 
     return Self.automatic
 
@@ -12709,7 +12724,7 @@ fatalError("'automatic' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("scrollContent").map({ () -> Self in
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+#if os(watchOS) || os(iOS) || os(tvOS) || os(macOS)
 
     return Self.scrollContent
 
@@ -12718,7 +12733,7 @@ fatalError("'scrollContent' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("scrollIndicators").map({ () -> Self in
-#if os(macOS) || os(watchOS) || os(iOS) || os(tvOS)
+#if os(watchOS) || os(iOS) || os(tvOS) || os(macOS)
 
     return Self.scrollIndicators
 
@@ -12748,7 +12763,7 @@ extension ContentShapeKinds: ParseableModifierValue {
 })
 ConstantAtomLiteral("dragPreview").map({ () -> Self in
 #if os(macOS) || os(iOS)
-if #available(tvOS 15.0,macOS 12.0,iOS 15.0,watchOS 8.0, *) {
+if #available(tvOS 15.0,macOS 12.0,watchOS 8.0,iOS 15.0, *) {
     return Self.dragPreview
 } else { fatalError("'dragPreview' is not available in this OS version") }
 #else
@@ -12756,8 +12771,8 @@ fatalError("'dragPreview' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("contextMenuPreview").map({ () -> Self in
-#if os(iOS) || os(tvOS)
-if #available(macOS 12.0,iOS 15.0,tvOS 17.0,watchOS 8.0, *) {
+#if os(tvOS) || os(iOS)
+if #available(tvOS 17.0,macOS 12.0,watchOS 8.0,iOS 15.0, *) {
     return Self.contextMenuPreview
 } else { fatalError("'contextMenuPreview' is not available in this OS version") }
 #else
@@ -12766,7 +12781,7 @@ fatalError("'contextMenuPreview' is not available on this OS")
 })
 ConstantAtomLiteral("hoverEffect").map({ () -> Self in
 #if os(iOS)
-if #available(macOS 12.0,iOS 15.0,tvOS 15.0,watchOS 8.0, *) {
+if #available(tvOS 15.0,macOS 12.0,watchOS 8.0,iOS 15.0, *) {
     return Self.hoverEffect
 } else { fatalError("'hoverEffect' is not available in this OS version") }
 #else
@@ -12775,7 +12790,7 @@ fatalError("'hoverEffect' is not available on this OS")
 })
 ConstantAtomLiteral("focusEffect").map({ () -> Self in
 #if os(macOS) || os(watchOS)
-if #available(macOS 12.0,iOS 15.0,tvOS 15.0,watchOS 8.0, *) {
+if #available(tvOS 15.0,macOS 12.0,watchOS 8.0,iOS 15.0, *) {
     return Self.focusEffect
 } else { fatalError("'focusEffect' is not available in this OS version") }
 #else
@@ -12783,8 +12798,8 @@ fatalError("'focusEffect' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("accessibility").map({ () -> Self in
-#if os(macOS) || os(watchOS) || os(iOS) || os(tvOS)
-if #available(macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0, *) {
+#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+if #available(iOS 17.0,macOS 14.0,tvOS 17.0,watchOS 10.0, *) {
     return Self.accessibility
 } else { fatalError("'accessibility' is not available in this OS version") }
 #else
@@ -12796,14 +12811,14 @@ fatalError("'accessibility' is not available on this OS")
     }
 }
 
-#if os(macOS) || os(watchOS) || os(iOS)
-@available(macOS 10.15,watchOS 9.0,iOS 15.0, *)
+#if os(macOS) || os(iOS) || os(watchOS)
+@available(macOS 10.15,iOS 15.0,watchOS 9.0, *)
 extension ControlSize: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             ConstantAtomLiteral("mini").map({ () -> Self in
-#if os(macOS) || os(watchOS) || os(iOS)
+#if os(macOS) || os(iOS) || os(watchOS)
 
     return Self.mini
 
@@ -12812,7 +12827,7 @@ fatalError("'mini' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("small").map({ () -> Self in
-#if os(macOS) || os(watchOS) || os(iOS)
+#if os(macOS) || os(iOS) || os(watchOS)
 
     return Self.small
 
@@ -12821,7 +12836,7 @@ fatalError("'small' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("regular").map({ () -> Self in
-#if os(macOS) || os(watchOS) || os(iOS)
+#if os(macOS) || os(iOS) || os(watchOS)
 
     return Self.regular
 
@@ -12830,8 +12845,8 @@ fatalError("'regular' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("large").map({ () -> Self in
-#if os(macOS) || os(watchOS) || os(iOS)
-if #available(macOS 11.0,watchOS 9.0,iOS 15.0, *) {
+#if os(macOS) || os(iOS) || os(watchOS)
+if #available(macOS 11.0,iOS 15.0,watchOS 9.0, *) {
     return Self.large
 } else { fatalError("'large' is not available in this OS version") }
 #else
@@ -12839,8 +12854,8 @@ fatalError("'large' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("extraLarge").map({ () -> Self in
-#if os(watchOS) || os(macOS) || os(visionOS) || os(iOS)
-if #available(watchOS 10.0,macOS 14.0,visionOS 1.0,iOS 17.0, *) {
+#if os(visionOS) || os(macOS) || os(watchOS) || os(iOS)
+if #available(visionOS 1.0,macOS 14.0,watchOS 10.0,iOS 17.0, *) {
     return Self.extraLarge
 } else { fatalError("'extraLarge' is not available in this OS version") }
 #else
@@ -12881,14 +12896,14 @@ ConstantAtomLiteral("userInitiated").map({ () -> Self in
     }
 }
 
-#if os(watchOS) || os(macOS) || os(tvOS) || os(iOS)
-@available(watchOS 10.0,macOS 13.0,tvOS 17.0,iOS 17.0, *)
+#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+@available(iOS 17.0,macOS 13.0,tvOS 17.0,watchOS 10.0, *)
 extension DialogSeverity: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             ConstantAtomLiteral("automatic").map({ () -> Self in
-#if os(tvOS) || os(macOS) || os(iOS) || os(watchOS)
+#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
 
     return Self.automatic
 
@@ -12897,7 +12912,7 @@ fatalError("'automatic' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("critical").map({ () -> Self in
-#if os(watchOS) || os(macOS) || os(tvOS) || os(iOS)
+#if os(watchOS) || os(iOS) || os(tvOS) || os(macOS)
 
     return Self.critical
 
@@ -12906,8 +12921,8 @@ fatalError("'critical' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("standard").map({ () -> Self in
-#if os(tvOS) || os(watchOS) || os(macOS) || os(iOS)
-if #available(tvOS 17.0,watchOS 10.0,macOS 14.0,iOS 17.0, *) {
+#if os(watchOS) || os(iOS) || os(tvOS) || os(macOS)
+if #available(watchOS 10.0,iOS 17.0,tvOS 17.0,macOS 14.0, *) {
     return Self.standard
 } else { fatalError("'standard' is not available in this OS version") }
 #else
@@ -13056,7 +13071,7 @@ fatalError("'enumeratePackages' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("includeHiddenFiles").map({ () -> Self in
-#if os(iOS) || os(macOS)
+#if os(macOS) || os(iOS)
 
     return Self.includeHiddenFiles
 
@@ -13078,14 +13093,14 @@ fatalError("'displayFileExtensions' is not available on this OS")
     }
 }
 #endif
-#if os(tvOS) || os(watchOS) || os(macOS) || os(iOS)
-@available(tvOS 17.0,watchOS 10.0,macOS 14.0,iOS 17.0, *)
+#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+@available(iOS 17.0,macOS 14.0,tvOS 17.0,watchOS 10.0, *)
 extension FocusInteractions: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             ConstantAtomLiteral("activate").map({ () -> Self in
-#if os(tvOS) || os(macOS) || os(iOS) || os(watchOS)
+#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
 
     return Self.activate
 
@@ -13094,7 +13109,7 @@ fatalError("'activate' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("edit").map({ () -> Self in
-#if os(tvOS) || os(macOS) || os(iOS) || os(watchOS)
+#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
 
     return Self.edit
 
@@ -13103,7 +13118,7 @@ fatalError("'edit' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("automatic").map({ () -> Self in
-#if os(tvOS) || os(macOS) || os(iOS) || os(watchOS)
+#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
 
     return Self.automatic
 
@@ -13264,8 +13279,8 @@ fatalError("'automatic' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("highlight").map({ () -> Self in
-#if os(iOS) || os(tvOS)
-if #available(iOS 13.4,tvOS 17.0, *) {
+#if os(tvOS) || os(iOS)
+if #available(tvOS 17.0,iOS 13.4, *) {
     return Self.highlight
 } else { fatalError("'highlight' is not available in this OS version") }
 #else
@@ -13273,7 +13288,7 @@ fatalError("'highlight' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("lift").map({ () -> Self in
-#if os(iOS) || os(tvOS)
+#if os(tvOS) || os(iOS)
 
     return Self.lift
 
@@ -13370,7 +13385,7 @@ extension MenuOrder: ParseableModifierValue {
 })
 ConstantAtomLiteral("priority").map({ () -> Self in
 #if os(iOS)
-if #available(watchOS 9.0,macOS 13.0,iOS 16.0,tvOS 16.0, *) {
+if #available(tvOS 16.0,iOS 16.0,watchOS 9.0,macOS 13.0, *) {
     return Self.priority
 } else { fatalError("'priority' is not available in this OS version") }
 #else
@@ -13391,14 +13406,14 @@ ConstantAtomLiteral("fixed").map({ () -> Self in
     }
 }
 
-#if os(tvOS) || os(macOS) || os(iOS) || os(watchOS)
-@available(tvOS 16.4,macOS 13.3,iOS 16.4,watchOS 9.4, *)
+#if os(tvOS) || os(watchOS) || os(iOS) || os(macOS)
+@available(tvOS 16.4,watchOS 9.4,iOS 16.4,macOS 13.3, *)
 extension PresentationAdaptation: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             ConstantAtomLiteral("automatic").map({ () -> Self in
-#if os(macOS) || os(watchOS) || os(iOS) || os(tvOS)
+#if os(tvOS) || os(watchOS) || os(iOS) || os(macOS)
 
     return Self.automatic
 
@@ -13407,7 +13422,7 @@ fatalError("'automatic' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("none").map({ () -> Self in
-#if os(macOS) || os(watchOS) || os(iOS) || os(tvOS)
+#if os(tvOS) || os(watchOS) || os(iOS) || os(macOS)
 
     return Self.none
 
@@ -13416,7 +13431,7 @@ fatalError("'none' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("popover").map({ () -> Self in
-#if os(macOS) || os(watchOS) || os(iOS) || os(tvOS)
+#if os(tvOS) || os(watchOS) || os(iOS) || os(macOS)
 
     return Self.popover
 
@@ -13425,7 +13440,7 @@ fatalError("'popover' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("sheet").map({ () -> Self in
-#if os(macOS) || os(watchOS) || os(iOS) || os(tvOS)
+#if os(tvOS) || os(watchOS) || os(iOS) || os(macOS)
 
     return Self.sheet
 
@@ -13434,7 +13449,7 @@ fatalError("'sheet' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("fullScreenCover").map({ () -> Self in
-#if os(watchOS) || os(macOS) || os(tvOS) || os(iOS)
+#if os(tvOS) || os(watchOS) || os(iOS) || os(macOS)
 
     return Self.fullScreenCover
 
@@ -13447,14 +13462,14 @@ fatalError("'fullScreenCover' is not available on this OS")
     }
 }
 #endif
-#if os(tvOS) || os(macOS) || os(iOS) || os(watchOS)
-@available(tvOS 16.4,macOS 13.3,iOS 16.4,watchOS 9.4, *)
+#if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
+@available(iOS 16.4,macOS 13.3,watchOS 9.4,tvOS 16.4, *)
 extension PresentationContentInteraction: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             ConstantAtomLiteral("automatic").map({ () -> Self in
-#if os(macOS) || os(watchOS) || os(iOS) || os(tvOS)
+#if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
 
     return Self.automatic
 
@@ -13463,7 +13478,7 @@ fatalError("'automatic' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("resizes").map({ () -> Self in
-#if os(tvOS) || os(macOS) || os(iOS) || os(watchOS)
+#if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
 
     return Self.resizes
 
@@ -13472,7 +13487,7 @@ fatalError("'resizes' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("scrolls").map({ () -> Self in
-#if os(tvOS) || os(watchOS) || os(macOS) || os(iOS)
+#if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
 
     return Self.scrolls
 
@@ -13539,8 +13554,8 @@ ConstantAtomLiteral("privacy").map({ () -> Self in
 
 })
 ConstantAtomLiteral("invalidated").map({ () -> Self in
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
-if #available(macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0, *) {
+#if os(tvOS) || os(watchOS) || os(iOS) || os(macOS)
+if #available(tvOS 17.0,watchOS 10.0,iOS 17.0,macOS 14.0, *) {
     return Self.invalidated
 } else { fatalError("'invalidated' is not available in this OS version") }
 #else
@@ -13636,7 +13651,7 @@ extension ScenePadding: ParseableModifierValue {
 })
 ConstantAtomLiteral("navigationBar").map({ () -> Self in
 #if os(watchOS)
-if #available(tvOS 16.0,watchOS 9.0,macOS 13.0,iOS 16.0, *) {
+if #available(watchOS 9.0,tvOS 16.0,macOS 13.0,iOS 16.0, *) {
     return Self.navigationBar
 } else { fatalError("'navigationBar' is not available in this OS version") }
 #else
@@ -13648,14 +13663,14 @@ fatalError("'navigationBar' is not available on this OS")
     }
 }
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
-@available(macOS 13.3,iOS 16.4,tvOS 16.4,watchOS 9.4, *)
+#if os(tvOS) || os(macOS) || os(watchOS) || os(iOS)
+@available(tvOS 16.4,macOS 13.3,watchOS 9.4,iOS 16.4, *)
 extension ScrollBounceBehavior: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             ConstantAtomLiteral("automatic").map({ () -> Self in
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+#if os(tvOS) || os(macOS) || os(watchOS) || os(iOS)
 
     return Self.automatic
 
@@ -13664,7 +13679,7 @@ fatalError("'automatic' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("always").map({ () -> Self in
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+#if os(tvOS) || os(macOS) || os(watchOS) || os(iOS)
 
     return Self.always
 
@@ -13673,7 +13688,7 @@ fatalError("'always' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("basedOnSize").map({ () -> Self in
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+#if os(tvOS) || os(macOS) || os(watchOS) || os(iOS)
 
     return Self.basedOnSize
 
@@ -13686,8 +13701,8 @@ fatalError("'basedOnSize' is not available on this OS")
     }
 }
 #endif
-#if os(macOS) || os(watchOS) || os(iOS) || os(tvOS)
-@available(macOS 13.0,watchOS 9.0,iOS 16.0,tvOS 16.0, *)
+#if os(tvOS) || os(macOS) || os(watchOS) || os(iOS)
+@available(tvOS 16.0,macOS 13.0,watchOS 9.0,iOS 16.0, *)
 extension ScrollDismissesKeyboardMode: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -13780,14 +13795,14 @@ ConstantAtomLiteral("never").map({ () -> Self in
     }
 }
 
-#if os(watchOS) || os(macOS) || os(tvOS) || os(iOS)
-@available(watchOS 9.4,macOS 13.3,tvOS 16.4,iOS 16.4, *)
+#if os(watchOS) || os(iOS) || os(tvOS) || os(macOS)
+@available(watchOS 9.4,iOS 16.4,tvOS 16.4,macOS 13.3, *)
 extension SearchScopeActivation: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             ConstantAtomLiteral("automatic").map({ () -> Self in
-#if os(watchOS) || os(macOS) || os(tvOS) || os(iOS)
+#if os(watchOS) || os(iOS) || os(tvOS) || os(macOS)
 
     return Self.automatic
 
@@ -13796,7 +13811,7 @@ fatalError("'automatic' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("onTextEntry").map({ () -> Self in
-#if os(watchOS) || os(macOS) || os(iOS)
+#if os(watchOS) || os(iOS) || os(macOS)
 
     return Self.onTextEntry
 
@@ -13805,7 +13820,7 @@ fatalError("'onTextEntry' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("onSearchPresentation").map({ () -> Self in
-#if os(watchOS) || os(macOS) || os(iOS)
+#if os(watchOS) || os(iOS) || os(macOS)
 
     return Self.onSearchPresentation
 
@@ -13856,14 +13871,14 @@ ConstantAtomLiteral("content").map({ () -> Self in
     }
 }
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
-@available(macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0, *)
+#if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
+@available(iOS 17.0,macOS 14.0,watchOS 10.0,tvOS 17.0, *)
 extension SpringLoadingBehavior: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             ConstantAtomLiteral("automatic").map({ () -> Self in
-#if os(watchOS) || os(iOS) || os(tvOS) || os(macOS)
+#if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
 
     return Self.automatic
 
@@ -13872,7 +13887,7 @@ fatalError("'automatic' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("enabled").map({ () -> Self in
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+#if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
 
     return Self.enabled
 
@@ -13881,7 +13896,7 @@ fatalError("'enabled' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("disabled").map({ () -> Self in
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+#if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
 
     return Self.disabled
 
@@ -14015,14 +14030,14 @@ ConstantAtomLiteral("search").map({ () -> Self in
     }
 }
 
-#if os(tvOS) || os(macOS) || os(iOS) || os(watchOS)
-@available(tvOS 17.0,macOS 14.0,iOS 17.0,watchOS 10.0, *)
+#if os(watchOS) || os(iOS) || os(tvOS) || os(macOS)
+@available(watchOS 10.0,iOS 17.0,tvOS 17.0,macOS 14.0, *)
 extension ToolbarDefaultItemKind: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             ConstantAtomLiteral("sidebarToggle").map({ () -> Self in
-#if os(tvOS) || os(macOS) || os(iOS) || os(watchOS)
+#if os(watchOS) || os(iOS) || os(tvOS) || os(macOS)
 
     return Self.sidebarToggle
 
@@ -14051,8 +14066,8 @@ extension ToolbarRole: ParseableModifierValue {
 
 })
 ConstantAtomLiteral("navigationStack").map({ () -> Self in
-#if os(tvOS) || os(iOS) || os(watchOS)
-if #available(tvOS 16.0,macOS 13.0,iOS 16.0,watchOS 9.0, *) {
+#if os(iOS) || os(tvOS) || os(watchOS)
+if #available(iOS 16.0,macOS 13.0,tvOS 16.0,watchOS 9.0, *) {
     return Self.navigationStack
 } else { fatalError("'navigationStack' is not available in this OS version") }
 #else
@@ -14061,7 +14076,7 @@ fatalError("'navigationStack' is not available on this OS")
 })
 ConstantAtomLiteral("browser").map({ () -> Self in
 #if os(iOS)
-if #available(macOS 13.0,watchOS 9.0,iOS 16.0,tvOS 16.0, *) {
+if #available(iOS 16.0,macOS 13.0,tvOS 16.0,watchOS 9.0, *) {
     return Self.browser
 } else { fatalError("'browser' is not available in this OS version") }
 #else
@@ -14070,7 +14085,7 @@ fatalError("'browser' is not available on this OS")
 })
 ConstantAtomLiteral("editor").map({ () -> Self in
 #if os(iOS) || os(macOS)
-if #available(tvOS 16.0,iOS 16.0,macOS 13.0,watchOS 9.0, *) {
+if #available(iOS 16.0,macOS 13.0,tvOS 16.0,watchOS 9.0, *) {
     return Self.editor
 } else { fatalError("'editor' is not available in this OS version") }
 #else
@@ -14082,14 +14097,14 @@ fatalError("'editor' is not available on this OS")
     }
 }
 
-#if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
-@available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0, *)
+#if os(watchOS) || os(iOS) || os(macOS) || os(tvOS)
+@available(watchOS 10.0,iOS 17.0,macOS 14.0,tvOS 17.0, *)
 extension ToolbarTitleDisplayMode: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             ConstantAtomLiteral("automatic").map({ () -> Self in
-#if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
+#if os(watchOS) || os(iOS) || os(macOS) || os(tvOS)
 
     return Self.automatic
 
@@ -14098,7 +14113,7 @@ fatalError("'automatic' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("large").map({ () -> Self in
-#if os(iOS) || os(watchOS)
+#if os(watchOS) || os(iOS)
 
     return Self.large
 
@@ -14116,7 +14131,7 @@ fatalError("'inlineLarge' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("inline").map({ () -> Self in
-#if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
+#if os(watchOS) || os(iOS) || os(macOS) || os(tvOS)
 
     return Self.inline
 

--- a/Sources/LiveViewNativeMacros/LiveViewMacro.swift
+++ b/Sources/LiveViewNativeMacros/LiveViewMacro.swift
@@ -67,7 +67,6 @@ extension LiveViewMacro: ExpressionMacro {
         { () -> AnyView in
             enum \(registryName): AggregateRegistry {
                 \(registries)
-                typealias CustomModifier = Registries.CustomModifier
             }
         
             return AnyView(LiveView<\(registryName)>(\(liveViewArguments)))

--- a/Sources/LiveViewNativeMacros/LiveViewMacro.swift
+++ b/Sources/LiveViewNativeMacros/LiveViewMacro.swift
@@ -67,6 +67,7 @@ extension LiveViewMacro: ExpressionMacro {
         { () -> AnyView in
             enum \(registryName): AggregateRegistry {
                 \(registries)
+                typealias CustomModifier = Registries.CustomModifier
             }
         
             return AnyView(LiveView<\(registryName)>(\(liveViewArguments)))

--- a/Sources/LiveViewNativeStylesheet/Parsing/External/ParseableModifier.swift
+++ b/Sources/LiveViewNativeStylesheet/Parsing/External/ParseableModifier.swift
@@ -299,16 +299,9 @@ public struct _ConditionalModifier<TrueModifier, FalseModifier>: ViewModifier, P
     }
 }
 
-extension EmptyModifier: ParseableExpressionProtocol {
-    public static var name: String { "" }
-    public static func arguments(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
-        Always(Self.identity)
-    }
-    public init(_ arguments: ()) {
-        fatalError()
-    }
-    
+extension EmptyModifier: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
-        Parse({ Self.identity }) {}
+        ASTNode("__never__", in: context) {}
+            .map({ _ in Self.identity })
     }
 }

--- a/Sources/LiveViewNativeStylesheet/Parsing/External/ParseableModifier.swift
+++ b/Sources/LiveViewNativeStylesheet/Parsing/External/ParseableModifier.swift
@@ -135,6 +135,23 @@ public struct AtomString: ParseableModifierValue {
     }
 }
 
+extension Date: ParseableModifierValue {
+    public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
+        ParseableDate.parser(in: context).map(\.value)
+    }
+    
+    @ParseableExpression
+    struct ParseableDate {
+        static let name = "Date"
+        
+        let value: Date
+        
+        init(timeIntervalSince1970: Double) {
+            self.value = .init(timeIntervalSince1970: timeIntervalSince1970)
+        }
+    }
+}
+
 extension Array: ParseableModifierValue where Element: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ListLiteral {

--- a/Sources/ModifierGenerator/ModifierGenerator.swift
+++ b/Sources/ModifierGenerator/ModifierGenerator.swift
@@ -370,20 +370,27 @@ struct ModifierGenerator: ParsableCommand {
                             Metadata.parser()
                         }.parse(&copy)
                         
+                        copy = input
+                        
                         // attempt to parse the built-in modifiers first.
-                        if let parser = parsers[modifierName] {
-                            return try parser.parse(&input)
-                        } else {
-                            // if the modifier name is not a known built-in, try to parse as a custom modifier
+                        do {
+                            if let parser = parsers[modifierName] {
+                                return try parser.parse(&input)
+                            } else {
+                                throw ModifierParseError(
+                                    error: .unknownModifier(modifierName),
+                                    metadata: metadata
+                                )
+                            }
+                        } catch let builtinError {
+                            // if the modifier name is not a known built-in, backtrack and try to parse as a custom modifier
+                            input = copy
                             do {
                                 return try ._customRegistryModifier(R.parseModifier(&input, in: context))
                             } catch let error as ModifierParseError {
                                 throw error
                             } catch {
-                                throw ModifierParseError(
-                                    error: .unknownModifier(modifierName),
-                                    metadata: metadata
-                                )
+                                throw builtinError
                             }
                         }
                     }


### PR DESCRIPTION
This PR deals with modifiers in multiple contexts which I'll refer to as:
* "root context" - the main app, uses SwiftUI Views
* "content builder context" - custom element types in a specific View. For example, `MapContent` or `ChartContent` instead of View types.

Changes:

* `AggregateRegistry` now properly collects modifiers from addons. This also fixes the `#LiveView(_:addons:)` macro, which used `AggregateRegistry` internally.
* Custom modifiers from the registry will now be parsed after built-in modifiers (were previously ignored).
* `ContentBuilder` can declare custom modifiers and use classes on its elements. These should also be included in the `CustomRegistry` for the add-on to avoid parsing errors.
* `LiveViewNativeStylesheet` was made available to external packages for use in add-ons.
* `@ContentBuilderContext` now accepts the `ContentBuilder` type as a second generic argument. This is necessary for efficient stylesheet parsing.

> [!NOTE]
> Content builders parse stylesheets separate from the rest of the app. This is done on-demand, and does not impact screens without them.

Here's an example of using custom modifiers both in the root context, and in a content builder context:

```ex
"marker-blue" do
  tint(.blue) # uses the `MapContentBuilder` tint modifier when in that context.
end

"look-around" do
  # custom modifier that applies to Views
  lookAroundViewer(isPresented: attr("is-on"), initialScene: CLLocationCoordinate2D(latitude: 0, longitude: 0))
end
```

```html
<Map>
  <!-- children of `Map` use the `MapContentBuilder` -->
  <Marker class="marker-blue" latitude={38.8951} longitude={-77.0364}>
    Washington, D.C.
  </Marker>
</Map>
<Toggle phx-change="toggle-changed" is-on={@toggle} class="look-around">
  Show Look Around Viewer
</Toggle>
```

Here's what a modifier in a `ContentBuilder` looks like:

### Declare the modifier type
```swift
import SwiftUI
import MapKit
import LiveViewNative
import LiveViewNativeStylesheet

@ParseableExpression
struct TintModifier: ContentModifier {
    typealias Builder = MapContentBuilder
    
    static let name = "tint"
    
    let color: Color
    
    init(_ color: Color) {
        self.color = color
    }
    
    func apply<R: RootRegistry>(
        to content: Builder.Content,
        on element: ElementNode,
        in context: Builder.Context<R>
    ) -> Builder.Content {
        content.tint(color)
    }
}
```

> [!NOTE]
> Name collisions with built-in modifiers are ok in a `ContentBuilder`. In the root context, the built-in modifiers are always given priority. In a content builder's context, any built-in modifiers will be ignored.

### Use an enum in the `ContentBuilder` to parse all supported modifiers
```swift
enum MapContentBuilder: ContentBuilder {
    enum ModifierType: ContentModifier {
        typealias Builder = MapContentBuilder
        
        case tint(TintModifier)
        // ...
        
        static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
            OneOf {
                TintModifier.parser(in: context).map(Self.tint)
                // ...
            }
        }
        
        func apply<R>(
            to content: Builder.Content,
            on element: ElementNode,
            in context: Builder.Context<R>
        ) -> Builder.Content where R : RootRegistry {
            switch self {
            case .tint(let modifier):
                return modifier.apply(to: content, on: element, in: context)
                // ...
            }
        }
    }

    // ...
}
```

### Add to the `CustomRegistry`
It is recommended to declare content builder modifiers in the `CustomRegistry` as well. This will avoid parsing errors, and can catch errors the content builder might miss.
```swift
import LiveViewNative
import LiveViewNativeStylesheet
import SwiftUI

public enum MapKitRegistry<Root: RootRegistry>: CustomRegistry {
    // ...

    public struct CustomModifier: ViewModifier, ParseableModifierValue {
        enum Storage {
            // ...
            case noop
        }
        
        let storage: Storage
        
        public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
            OneOf {
                // ...
                // This line will catch any ContentBuilder modifiers, and map them to a `noop` type.
                MapContentBuilder.ModifierType.parser(in: context).map({ _ in Self(storage: .noop) })
            }
        }
        
        public func body(content: Content) -> some View {
            switch storage {
            // ...
            case .noop:
                content
            }
        }
    }
}
```