### PR TITLE
Re-order `Alignment` cases

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -148,7 +148,7 @@ let package = Package(
         ),
         .testTarget(
             name: "LiveViewNativeStylesheetTests",
-            dependencies: ["LiveViewNativeStylesheet"]
+            dependencies: ["LiveViewNativeStylesheet", "LiveViewNative"]
         ),
         .testTarget(
             name: "LiveViewNativeStylesheetMacrosTests",

--- a/Sources/LiveViewNative/Stylesheets/ParseableTypes/Alignment+ParseableModifierValue.swift
+++ b/Sources/LiveViewNative/Stylesheets/ParseableTypes/Alignment+ParseableModifierValue.swift
@@ -12,24 +12,26 @@ extension Alignment: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
-                ConstantAtomLiteral("top").map({ Self.top })
+                ConstantAtomLiteral("centerFirstTextBaseline").map({ Self.centerFirstTextBaseline })
+                ConstantAtomLiteral("centerLastTextBaseline").map({ Self.centerLastTextBaseline })
+                
+                ConstantAtomLiteral("leadingFirstTextBaseline").map({ Self.leadingFirstTextBaseline })
+                ConstantAtomLiteral("leadingLastTextBaseline").map({ Self.leadingLastTextBaseline })
+                
+                ConstantAtomLiteral("trailingFirstTextBaseline").map({ Self.trailingFirstTextBaseline })
+                ConstantAtomLiteral("trailingLastTextBaseline").map({ Self.trailingLastTextBaseline })
+                
                 ConstantAtomLiteral("topLeading").map({ Self.topLeading })
                 ConstantAtomLiteral("topTrailing").map({ Self.topTrailing })
                 
-                ConstantAtomLiteral("center").map({ Self.center })
-                ConstantAtomLiteral("leading").map({ Self.leading })
-                ConstantAtomLiteral("trailing").map({ Self.trailing })
-                
-                ConstantAtomLiteral("bottom").map({ Self.bottom })
                 ConstantAtomLiteral("bottomLeading").map({ Self.bottomLeading })
                 ConstantAtomLiteral("bottomTrailing").map({ Self.bottomTrailing })
                 
-                ConstantAtomLiteral("centerFirstTextBaseline").map({ Self.centerFirstTextBaseline })
-                ConstantAtomLiteral("centerLastTextBaseline").map({ Self.centerLastTextBaseline })
-                ConstantAtomLiteral("leadingFirstTextBaseline").map({ Self.leadingFirstTextBaseline })
-                ConstantAtomLiteral("leadingLastTextBaseline").map({ Self.leadingLastTextBaseline })
-                ConstantAtomLiteral("trailingFirstTextBaseline").map({ Self.trailingFirstTextBaseline })
-                ConstantAtomLiteral("trailingLastTextBaseline").map({ Self.trailingLastTextBaseline })
+                ConstantAtomLiteral("top").map({ Self.top })
+                ConstantAtomLiteral("bottom").map({ Self.bottom })
+                ConstantAtomLiteral("center").map({ Self.center })
+                ConstantAtomLiteral("leading").map({ Self.leading })
+                ConstantAtomLiteral("trailing").map({ Self.trailing })
             }
         }
     }

--- a/Tests/LiveViewNativeStylesheetTests/LiveViewNativeStylesheetTests.swift
+++ b/Tests/LiveViewNativeStylesheetTests/LiveViewNativeStylesheetTests.swift
@@ -1,7 +1,11 @@
 import XCTest
 import SwiftUI
 @testable import LiveViewNativeStylesheet
+@testable import LiveViewNative
 
 final class LiveViewNativeStylesheetTests: XCTestCase {
-    
+    func testAlignment() throws {
+        XCTAssertEqual(try Alignment.parser(in: .init()).parse("{:., [], [nil, :topLeading]}"), Alignment.topLeading)
+        XCTAssertEqual(try Alignment.parser(in: .init()).parse("{:., [], [nil, :top]}"), Alignment.top)
+    }
 }

--- a/Tests/LiveViewNativeStylesheetTests/LiveViewNativeStylesheetTests.swift
+++ b/Tests/LiveViewNativeStylesheetTests/LiveViewNativeStylesheetTests.swift
@@ -7,5 +7,20 @@ final class LiveViewNativeStylesheetTests: XCTestCase {
     func testAlignment() throws {
         XCTAssertEqual(try Alignment.parser(in: .init()).parse("{:., [], [nil, :topLeading]}"), Alignment.topLeading)
         XCTAssertEqual(try Alignment.parser(in: .init()).parse("{:., [], [nil, :top]}"), Alignment.top)
+        XCTAssertEqual(try Alignment.parser(in: .init()).parse("{:., [], [nil, :centerFirstTextBaseline]}"), Alignment.centerFirstTextBaseline)
+        XCTAssertEqual(try Alignment.parser(in: .init()).parse("{:., [], [nil, :centerLastTextBaseline]}"), Alignment.centerLastTextBaseline)
+        XCTAssertEqual(try Alignment.parser(in: .init()).parse("{:., [], [nil, :leadingFirstTextBaseline]}"), Alignment.leadingFirstTextBaseline)
+        XCTAssertEqual(try Alignment.parser(in: .init()).parse("{:., [], [nil, :leadingLastTextBaseline]}"), Alignment.leadingLastTextBaseline)
+        XCTAssertEqual(try Alignment.parser(in: .init()).parse("{:., [], [nil, :trailingFirstTextBaseline]}"), Alignment.trailingFirstTextBaseline)
+        XCTAssertEqual(try Alignment.parser(in: .init()).parse("{:., [], [nil, :trailingLastTextBaseline]}"), Alignment.trailingLastTextBaseline)
+        XCTAssertEqual(try Alignment.parser(in: .init()).parse("{:., [], [nil, :topLeading]}"), Alignment.topLeading)
+        XCTAssertEqual(try Alignment.parser(in: .init()).parse("{:., [], [nil, :topTrailing]}"), Alignment.topTrailing)
+        XCTAssertEqual(try Alignment.parser(in: .init()).parse("{:., [], [nil, :bottomLeading]}"), Alignment.bottomLeading)
+        XCTAssertEqual(try Alignment.parser(in: .init()).parse("{:., [], [nil, :bottomTrailing]}"), Alignment.bottomTrailing)
+        XCTAssertEqual(try Alignment.parser(in: .init()).parse("{:., [], [nil, :top]}"), Alignment.top)
+        XCTAssertEqual(try Alignment.parser(in: .init()).parse("{:., [], [nil, :bottom]}"), Alignment.bottom)
+        XCTAssertEqual(try Alignment.parser(in: .init()).parse("{:., [], [nil, :center]}"), Alignment.center)
+        XCTAssertEqual(try Alignment.parser(in: .init()).parse("{:., [], [nil, :leading]}"), Alignment.leading)
+        XCTAssertEqual(try Alignment.parser(in: .init()).parse("{:., [], [nil, :trailing]}"), Alignment.trailing)
     }
 }


### PR DESCRIPTION
The ordering of the alignment cases caused parsing to fail for some compound cases, such as `topLeading`.

I have added a test for this type as well.