### PR TITLE
Remove documents when disconnecting socket

### DIFF
--- a/Sources/LiveViewNative/Coordinators/LiveSessionCoordinator.swift
+++ b/Sources/LiveViewNative/Coordinators/LiveSessionCoordinator.swift
@@ -180,6 +180,7 @@ public class LiveSessionCoordinator<R: RootRegistry>: ObservableObject {
     private func disconnect() async {
         for entry in self.navigationPath {
             await entry.coordinator.disconnect()
+            entry.coordinator.document = nil
         }
         self.navigationPath = [self.navigationPath.first!]
         self.socket?.disconnect()


### PR DESCRIPTION
Closes #1206 

Previously, the old document was left when disconnecting from the socket. This caused the diffing to break on live reload when the new document was sent.