### PR TITLE
Add `--schema` flag to `ModifierGenerator`

### DIFF
--- a/Sources/LiveViewNative/_GeneratedModifiers.swift
+++ b/Sources/LiveViewNative/_GeneratedModifiers.swift
@@ -1687,10 +1687,10 @@ struct _containerRelativeFrameModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
+        #if os(watchOS) || os(iOS) || os(macOS) || os(tvOS)
         case _0(axes: Any,alignment: Any)
         #endif
-        #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
+        #if os(macOS) || os(watchOS) || os(iOS) || os(tvOS)
         case _1(axes: Any,count: Any,span: Any, spacing: Any,alignment: Any)
         #endif
     }
@@ -1705,15 +1705,15 @@ struct _containerRelativeFrameModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
-    @available(tvOS 17.0,iOS 17.0,watchOS 10.0,macOS 14.0, *)
+    #if os(watchOS) || os(iOS) || os(macOS) || os(tvOS)
+    @available(watchOS 10.0,iOS 17.0,macOS 14.0,tvOS 17.0, *)
     init(_ axes: SwiftUI.Axis.Set,alignment: AttributeReference<SwiftUI.Alignment> = .init(storage: .constant(.center)) ) {
         self.value = ._0(axes: axes, alignment: alignment)
         
     }
     #endif
-    #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
-    @available(tvOS 17.0,iOS 17.0,watchOS 10.0,macOS 14.0, *)
+    #if os(macOS) || os(watchOS) || os(iOS) || os(tvOS)
+    @available(macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0, *)
     init(_ axes: SwiftUI.Axis.Set,count: AttributeReference<Swift.Int>,span: AttributeReference<Swift.Int> = .init(storage: .constant(1)), spacing: AttributeReference<CoreFoundation.CGFloat>,alignment: AttributeReference<SwiftUI.Alignment> = .init(storage: .constant(.center)) ) {
         self.value = ._1(axes: axes, count: count, span: span, spacing: spacing, alignment: alignment)
         
@@ -1724,18 +1724,18 @@ struct _containerRelativeFrameModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
+        #if os(watchOS) || os(iOS) || os(macOS) || os(tvOS)
         case let ._0(axes, alignment):
-            if #available(tvOS 17.0,iOS 17.0,watchOS 10.0,macOS 14.0, *) {
+            if #available(watchOS 10.0,iOS 17.0,macOS 14.0,tvOS 17.0, *) {
             let axes = axes as! SwiftUI.Axis.Set
 let alignment = alignment as! AttributeReference<SwiftUI.Alignment>
             __content
                 .containerRelativeFrame(axes, alignment: alignment.resolve(on: element, in: context))
             } else { __content }
         #endif
-        #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
+        #if os(macOS) || os(watchOS) || os(iOS) || os(tvOS)
         case let ._1(axes, count, span, spacing, alignment):
-            if #available(tvOS 17.0,iOS 17.0,watchOS 10.0,macOS 14.0, *) {
+            if #available(macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0, *) {
             let axes = axes as! SwiftUI.Axis.Set
 let count = count as! AttributeReference<Swift.Int>
 let span = span as! AttributeReference<Swift.Int>
@@ -1900,10 +1900,10 @@ struct _contextMenuModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(macOS) || os(iOS) || os(tvOS)
+        #if os(macOS) || os(tvOS) || os(iOS)
         case _0(menuItems: Any)
         #endif
-        #if os(iOS) || os(tvOS) || os(macOS)
+        #if os(macOS) || os(tvOS) || os(iOS)
         case _1(menuItems: Any,preview: Any)
         #endif
     }
@@ -1918,15 +1918,15 @@ struct _contextMenuModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(macOS) || os(iOS) || os(tvOS)
-    @available(macOS 10.15,iOS 13.0,tvOS 14.0, *)
+    #if os(macOS) || os(tvOS) || os(iOS)
+    @available(macOS 10.15,tvOS 14.0,iOS 13.0, *)
     init(menuItems: ViewReference=ViewReference(value: [])) {
         self.value = ._0(menuItems: menuItems)
         
     }
     #endif
-    #if os(iOS) || os(tvOS) || os(macOS)
-    @available(iOS 16.0,tvOS 16.0,macOS 13.0, *)
+    #if os(macOS) || os(tvOS) || os(iOS)
+    @available(macOS 13.0,tvOS 16.0,iOS 16.0, *)
     init(menuItems: ViewReference=ViewReference(value: []),preview: ViewReference=ViewReference(value: [])) {
         self.value = ._1(menuItems: menuItems, preview: preview)
         
@@ -1937,17 +1937,17 @@ struct _contextMenuModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(macOS) || os(iOS) || os(tvOS)
+        #if os(macOS) || os(tvOS) || os(iOS)
         case let ._0(menuItems):
-            if #available(macOS 10.15,iOS 13.0,tvOS 14.0, *) {
+            if #available(macOS 10.15,tvOS 14.0,iOS 13.0, *) {
             let menuItems = menuItems as! ViewReference
             __content
                 .contextMenu(menuItems: { menuItems.resolve(on: element, in: context) })
             } else { __content }
         #endif
-        #if os(iOS) || os(tvOS) || os(macOS)
+        #if os(macOS) || os(tvOS) || os(iOS)
         case let ._1(menuItems, preview):
-            if #available(iOS 16.0,tvOS 16.0,macOS 13.0, *) {
+            if #available(macOS 13.0,tvOS 16.0,iOS 16.0, *) {
             let menuItems = menuItems as! ViewReference
 let preview = preview as! ViewReference
             __content
@@ -2005,7 +2005,7 @@ struct _controlGroupStyleModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(macOS) || os(tvOS)
+        #if os(iOS) || os(tvOS) || os(macOS)
         case _0(style: Any)
         #endif
     }
@@ -2018,8 +2018,8 @@ struct _controlGroupStyleModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(macOS) || os(tvOS)
-    @available(iOS 15.0,macOS 12.0,tvOS 17.0, *)
+    #if os(iOS) || os(tvOS) || os(macOS)
+    @available(iOS 15.0,tvOS 17.0,macOS 12.0, *)
     init(_ style: AnyControlGroupStyle) {
         self.value = ._0(style: style)
         
@@ -2030,9 +2030,9 @@ struct _controlGroupStyleModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(macOS) || os(tvOS)
+        #if os(iOS) || os(tvOS) || os(macOS)
         case let ._0(style):
-            if #available(iOS 15.0,macOS 12.0,tvOS 17.0, *) {
+            if #available(iOS 15.0,tvOS 17.0,macOS 12.0, *) {
             let style = style as! AnyControlGroupStyle
             __content
                 .controlGroupStyle(style)
@@ -2047,7 +2047,7 @@ struct _controlSizeModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(watchOS) || os(iOS) || os(macOS)
+        #if os(iOS) || os(watchOS) || os(macOS)
         case _0(controlSize: Any)
         #endif
     }
@@ -2060,8 +2060,8 @@ struct _controlSizeModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(watchOS) || os(iOS) || os(macOS)
-    @available(watchOS 9.0,iOS 15.0,macOS 10.15, *)
+    #if os(iOS) || os(watchOS) || os(macOS)
+    @available(iOS 15.0,watchOS 9.0,macOS 10.15, *)
     init(_ controlSize: SwiftUI.ControlSize) {
         self.value = ._0(controlSize: controlSize)
         
@@ -2072,9 +2072,9 @@ struct _controlSizeModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(watchOS) || os(iOS) || os(macOS)
+        #if os(iOS) || os(watchOS) || os(macOS)
         case let ._0(controlSize):
-            if #available(watchOS 9.0,iOS 15.0,macOS 10.15, *) {
+            if #available(iOS 15.0,watchOS 9.0,macOS 10.15, *) {
             let controlSize = controlSize as! SwiftUI.ControlSize
             __content
                 .controlSize(controlSize)
@@ -2089,7 +2089,7 @@ struct _coordinateSpaceModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(tvOS) || os(macOS) || os(watchOS) || os(iOS)
+        #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
         case _0(name: Any)
         #endif
     }
@@ -2102,8 +2102,8 @@ struct _coordinateSpaceModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(tvOS) || os(macOS) || os(watchOS) || os(iOS)
-    @available(tvOS 17.0,macOS 14.0,watchOS 10.0,iOS 17.0, *)
+    #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
+    @available(tvOS 17.0,iOS 17.0,watchOS 10.0,macOS 14.0, *)
     init(_ name: SwiftUI.NamedCoordinateSpace) {
         self.value = ._0(name: name)
         
@@ -2114,9 +2114,9 @@ struct _coordinateSpaceModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(tvOS) || os(macOS) || os(watchOS) || os(iOS)
+        #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
         case let ._0(name):
-            if #available(tvOS 17.0,macOS 14.0,watchOS 10.0,iOS 17.0, *) {
+            if #available(tvOS 17.0,iOS 17.0,watchOS 10.0,macOS 14.0, *) {
             let name = name as! SwiftUI.NamedCoordinateSpace
             __content
                 .coordinateSpace(name)
@@ -2173,7 +2173,7 @@ struct _defaultScrollAnchorModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
+        #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
         case _0(anchor: Any?)
         #endif
     }
@@ -2186,8 +2186,8 @@ struct _defaultScrollAnchorModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
-    @available(iOS 17.0,macOS 14.0,watchOS 10.0,tvOS 17.0, *)
+    #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
+    @available(tvOS 17.0,iOS 17.0,watchOS 10.0,macOS 14.0, *)
     init(_ anchor: AttributeReference<SwiftUI.UnitPoint?>?) {
         self.value = ._0(anchor: anchor)
         
@@ -2198,9 +2198,9 @@ struct _defaultScrollAnchorModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
+        #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
         case let ._0(anchor):
-            if #available(iOS 17.0,macOS 14.0,watchOS 10.0,tvOS 17.0, *) {
+            if #available(tvOS 17.0,iOS 17.0,watchOS 10.0,macOS 14.0, *) {
             let anchor = anchor as? AttributeReference<SwiftUI.UnitPoint?>
             __content
                 .defaultScrollAnchor(anchor?.resolve(on: element, in: context))
@@ -2341,16 +2341,16 @@ struct _dialogSuppressionToggleModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(tvOS) || os(watchOS) || os(iOS) || os(macOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
         case _0(titleKey: Any)
         #endif
-        #if os(tvOS) || os(watchOS) || os(iOS) || os(macOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
         case _1(title: Any)
         #endif
-        #if os(tvOS) || os(watchOS) || os(iOS) || os(macOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
         case _2(label: Any)
         #endif
-        #if os(tvOS) || os(watchOS) || os(iOS) || os(macOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
         case _3
         #endif
     }
@@ -2369,29 +2369,29 @@ struct _dialogSuppressionToggleModifier<R: RootRegistry>: ViewModifier {
 @ChangeTracked private var _3_isSuppressed: Swift.Bool
 
 
-    #if os(tvOS) || os(watchOS) || os(iOS) || os(macOS)
-    @available(tvOS 17.0,watchOS 10.0,iOS 17.0,macOS 14.0, *)
+    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+    @available(iOS 17.0,macOS 14.0,tvOS 17.0,watchOS 10.0, *)
     init(_ titleKey: SwiftUI.LocalizedStringKey,isSuppressed: ChangeTracked<Swift.Bool>) {
         self.value = ._0(titleKey: titleKey)
         self.__0_isSuppressed = isSuppressed
     }
     #endif
-    #if os(tvOS) || os(watchOS) || os(iOS) || os(macOS)
-    @available(tvOS 17.0,watchOS 10.0,iOS 17.0,macOS 14.0, *)
+    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+    @available(iOS 17.0,macOS 14.0,tvOS 17.0,watchOS 10.0, *)
     init(_ title: AttributeReference<String>,isSuppressed: ChangeTracked<Swift.Bool>) {
         self.value = ._1(title: title)
         self.__1_isSuppressed = isSuppressed
     }
     #endif
-    #if os(tvOS) || os(watchOS) || os(iOS) || os(macOS)
-    @available(tvOS 17.0,watchOS 10.0,iOS 17.0,macOS 14.0, *)
+    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+    @available(iOS 17.0,macOS 14.0,tvOS 17.0,watchOS 10.0, *)
     init(_ label: TextReference,isSuppressed: ChangeTracked<Swift.Bool>) {
         self.value = ._2(label: label)
         self.__2_isSuppressed = isSuppressed
     }
     #endif
-    #if os(tvOS) || os(watchOS) || os(iOS) || os(macOS)
-    @available(tvOS 17.0,watchOS 10.0,iOS 17.0,macOS 14.0, *)
+    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+    @available(iOS 17.0,macOS 14.0,tvOS 17.0,watchOS 10.0, *)
     init(isSuppressed: ChangeTracked<Swift.Bool>) {
         self.value = ._3
         self.__3_isSuppressed = isSuppressed
@@ -2402,33 +2402,33 @@ struct _dialogSuppressionToggleModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(tvOS) || os(watchOS) || os(iOS) || os(macOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
         case let ._0(titleKey):
-            if #available(tvOS 17.0,watchOS 10.0,iOS 17.0,macOS 14.0, *) {
+            if #available(iOS 17.0,macOS 14.0,tvOS 17.0,watchOS 10.0, *) {
             let titleKey = titleKey as! SwiftUI.LocalizedStringKey
             __content
                 .dialogSuppressionToggle(titleKey, isSuppressed: __0_isSuppressed.projectedValue)
             } else { __content }
         #endif
-        #if os(tvOS) || os(watchOS) || os(iOS) || os(macOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
         case let ._1(title):
-            if #available(tvOS 17.0,watchOS 10.0,iOS 17.0,macOS 14.0, *) {
+            if #available(iOS 17.0,macOS 14.0,tvOS 17.0,watchOS 10.0, *) {
             let title = title as! AttributeReference<String>
             __content
                 .dialogSuppressionToggle(title.resolve(on: element, in: context), isSuppressed: __1_isSuppressed.projectedValue)
             } else { __content }
         #endif
-        #if os(tvOS) || os(watchOS) || os(iOS) || os(macOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
         case let ._2(label):
-            if #available(tvOS 17.0,watchOS 10.0,iOS 17.0,macOS 14.0, *) {
+            if #available(iOS 17.0,macOS 14.0,tvOS 17.0,watchOS 10.0, *) {
             let label = label as! TextReference
             __content
                 .dialogSuppressionToggle(label.resolve(on: element, in: context), isSuppressed: __2_isSuppressed.projectedValue)
             } else { __content }
         #endif
-        #if os(tvOS) || os(watchOS) || os(iOS) || os(macOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
         case ._3:
-            if #available(tvOS 17.0,watchOS 10.0,iOS 17.0,macOS 14.0, *) {
+            if #available(iOS 17.0,macOS 14.0,tvOS 17.0,watchOS 10.0, *) {
             
             __content
                 .dialogSuppressionToggle(isSuppressed: __3_isSuppressed.projectedValue)
@@ -2651,7 +2651,7 @@ struct _fileDialogCustomizationIDModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(macOS)
+        #if os(macOS) || os(iOS)
         case _0(id: Any)
         #endif
     }
@@ -2664,8 +2664,8 @@ struct _fileDialogCustomizationIDModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(macOS)
-    @available(iOS 17.0,macOS 14.0, *)
+    #if os(macOS) || os(iOS)
+    @available(macOS 14.0,iOS 17.0, *)
     init(_ id: AttributeReference<Swift.String>) {
         self.value = ._0(id: id)
         
@@ -2676,9 +2676,9 @@ struct _fileDialogCustomizationIDModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(macOS)
+        #if os(macOS) || os(iOS)
         case let ._0(id):
-            if #available(iOS 17.0,macOS 14.0, *) {
+            if #available(macOS 14.0,iOS 17.0, *) {
             let id = id as! AttributeReference<Swift.String>
             __content
                 .fileDialogCustomizationID(id.resolve(on: element, in: context))
@@ -2693,7 +2693,7 @@ struct _fileDialogImportsUnresolvedAliasesModifier<R: RootRegistry>: ViewModifie
 
     enum Value {
         case _never
-        #if os(iOS) || os(macOS)
+        #if os(macOS) || os(iOS)
         case _0(imports: Any)
         #endif
     }
@@ -2706,8 +2706,8 @@ struct _fileDialogImportsUnresolvedAliasesModifier<R: RootRegistry>: ViewModifie
 
 
 
-    #if os(iOS) || os(macOS)
-    @available(iOS 17.0,macOS 14.0, *)
+    #if os(macOS) || os(iOS)
+    @available(macOS 14.0,iOS 17.0, *)
     init(_ imports: AttributeReference<Swift.Bool>) {
         self.value = ._0(imports: imports)
         
@@ -2718,9 +2718,9 @@ struct _fileDialogImportsUnresolvedAliasesModifier<R: RootRegistry>: ViewModifie
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(macOS)
+        #if os(macOS) || os(iOS)
         case let ._0(imports):
-            if #available(iOS 17.0,macOS 14.0, *) {
+            if #available(macOS 14.0,iOS 17.0, *) {
             let imports = imports as! AttributeReference<Swift.Bool>
             __content
                 .fileDialogImportsUnresolvedAliases(imports.resolve(on: element, in: context))
@@ -2923,7 +2923,7 @@ struct _focusEffectDisabledModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
+        #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
         case _0(disabled: Any)
         #endif
     }
@@ -2936,8 +2936,8 @@ struct _focusEffectDisabledModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
-    @available(iOS 17.0,macOS 14.0,watchOS 10.0,tvOS 17.0, *)
+    #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+    @available(macOS 14.0,iOS 17.0,watchOS 10.0,tvOS 17.0, *)
     init(_ disabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(disabled: disabled)
         
@@ -2948,9 +2948,9 @@ struct _focusEffectDisabledModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
+        #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
         case let ._0(disabled):
-            if #available(iOS 17.0,macOS 14.0,watchOS 10.0,tvOS 17.0, *) {
+            if #available(macOS 14.0,iOS 17.0,watchOS 10.0,tvOS 17.0, *) {
             let disabled = disabled as! AttributeReference<Swift.Bool>
             __content
                 .focusEffectDisabled(disabled.resolve(on: element, in: context))
@@ -3007,10 +3007,10 @@ struct _focusableModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
+        #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
         case _0(isFocusable: Any)
         #endif
-        #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
+        #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
         case _1(isFocusable: Any, interactions: Any)
         #endif
     }
@@ -3025,15 +3025,15 @@ struct _focusableModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
-    @available(tvOS 15.0,iOS 17.0,watchOS 8.0,macOS 12.0, *)
+    #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+    @available(macOS 12.0,iOS 17.0,watchOS 8.0,tvOS 15.0, *)
     init(_ isFocusable: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(isFocusable: isFocusable)
         
     }
     #endif
-    #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
-    @available(tvOS 17.0,iOS 17.0,watchOS 10.0,macOS 14.0, *)
+    #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+    @available(macOS 14.0,iOS 17.0,watchOS 10.0,tvOS 17.0, *)
     init(_ isFocusable: AttributeReference<Swift.Bool> = .init(storage: .constant(true)), interactions: SwiftUI.FocusInteractions) {
         self.value = ._1(isFocusable: isFocusable, interactions: interactions)
         
@@ -3044,17 +3044,17 @@ struct _focusableModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
+        #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
         case let ._0(isFocusable):
-            if #available(tvOS 15.0,iOS 17.0,watchOS 8.0,macOS 12.0, *) {
+            if #available(macOS 12.0,iOS 17.0,watchOS 8.0,tvOS 15.0, *) {
             let isFocusable = isFocusable as! AttributeReference<Swift.Bool>
             __content
                 .focusable(isFocusable.resolve(on: element, in: context))
             } else { __content }
         #endif
-        #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
+        #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
         case let ._1(isFocusable, interactions):
-            if #available(tvOS 17.0,iOS 17.0,watchOS 10.0,macOS 14.0, *) {
+            if #available(macOS 14.0,iOS 17.0,watchOS 10.0,tvOS 17.0, *) {
             let isFocusable = isFocusable as! AttributeReference<Swift.Bool>
 let interactions = interactions as! SwiftUI.FocusInteractions
             __content
@@ -3112,7 +3112,7 @@ struct _fontDesignModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(tvOS) || os(macOS) || os(watchOS) || os(iOS)
+        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
         case _0(design: Any?)
         #endif
     }
@@ -3125,8 +3125,8 @@ struct _fontDesignModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(tvOS) || os(macOS) || os(watchOS) || os(iOS)
-    @available(tvOS 16.1,macOS 13.0,watchOS 9.1,iOS 16.1, *)
+    #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
+    @available(iOS 16.1,watchOS 9.1,macOS 13.0,tvOS 16.1, *)
     init(_ design: SwiftUI.Font.Design?) {
         self.value = ._0(design: design)
         
@@ -3137,9 +3137,9 @@ struct _fontDesignModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(tvOS) || os(macOS) || os(watchOS) || os(iOS)
+        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
         case let ._0(design):
-            if #available(tvOS 16.1,macOS 13.0,watchOS 9.1,iOS 16.1, *) {
+            if #available(iOS 16.1,watchOS 9.1,macOS 13.0,tvOS 16.1, *) {
             let design = design as? SwiftUI.Font.Design
             __content
                 .fontDesign(design)
@@ -3444,7 +3444,7 @@ struct _fullScreenCoverModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(watchOS) || os(iOS) || os(tvOS)
+        #if os(iOS) || os(watchOS) || os(tvOS)
         case _0(content: Any)
         #endif
     }
@@ -3457,8 +3457,8 @@ struct _fullScreenCoverModifier<R: RootRegistry>: ViewModifier {
 @ChangeTracked private var _0_isPresented: Swift.Bool
 @Event private var _0_onDismiss__0: Event.EventHandler
 
-    #if os(watchOS) || os(iOS) || os(tvOS)
-    @available(watchOS 7.0,iOS 14.0,tvOS 14.0, *)
+    #if os(iOS) || os(watchOS) || os(tvOS)
+    @available(iOS 14.0,watchOS 7.0,tvOS 14.0, *)
     init(isPresented: ChangeTracked<Swift.Bool>,onDismiss onDismiss__0: Event=Event(), content: ViewReference=ViewReference(value: [])) {
         self.value = ._0(content: content)
         self.__0_isPresented = isPresented
@@ -3470,9 +3470,9 @@ self.__0_onDismiss__0 = onDismiss__0
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(watchOS) || os(iOS) || os(tvOS)
+        #if os(iOS) || os(watchOS) || os(tvOS)
         case let ._0(content):
-            if #available(watchOS 7.0,iOS 14.0,tvOS 14.0, *) {
+            if #available(iOS 14.0,watchOS 7.0,tvOS 14.0, *) {
             let content = content as! ViewReference
             __content
                 .fullScreenCover(isPresented: __0_isPresented.projectedValue, onDismiss: { __0_onDismiss__0.wrappedValue() }, content: { content.resolve(on: element, in: context) })
@@ -3487,7 +3487,7 @@ struct _gaugeStyleModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(macOS) || os(watchOS)
+        #if os(iOS) || os(watchOS) || os(macOS)
         case _0(style: Any)
         #endif
     }
@@ -3500,8 +3500,8 @@ struct _gaugeStyleModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(macOS) || os(watchOS)
-    @available(iOS 16.0,macOS 13.0,watchOS 7.0, *)
+    #if os(iOS) || os(watchOS) || os(macOS)
+    @available(iOS 16.0,watchOS 7.0,macOS 13.0, *)
     init(_ style: AnyGaugeStyle) {
         self.value = ._0(style: style)
         
@@ -3512,9 +3512,9 @@ struct _gaugeStyleModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(macOS) || os(watchOS)
+        #if os(iOS) || os(watchOS) || os(macOS)
         case let ._0(style):
-            if #available(iOS 16.0,macOS 13.0,watchOS 7.0, *) {
+            if #available(iOS 16.0,watchOS 7.0,macOS 13.0, *) {
             let style = style as! AnyGaugeStyle
             __content
                 .gaugeStyle(style)
@@ -3529,7 +3529,7 @@ struct _geometryGroupModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(tvOS) || os(watchOS) || os(iOS) || os(macOS)
+        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
         case _0
         #endif
     }
@@ -3542,8 +3542,8 @@ struct _geometryGroupModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(tvOS) || os(watchOS) || os(iOS) || os(macOS)
-    @available(tvOS 17.0,watchOS 10.0,iOS 17.0,macOS 14.0, *)
+    #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
+    @available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0, *)
     init() {
         self.value = ._0
         
@@ -3554,9 +3554,9 @@ struct _geometryGroupModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(tvOS) || os(watchOS) || os(iOS) || os(macOS)
+        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
         case ._0:
-            if #available(tvOS 17.0,watchOS 10.0,iOS 17.0,macOS 14.0, *) {
+            if #available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0, *) {
             
             __content
                 .geometryGroup()
@@ -4115,10 +4115,10 @@ struct _hoverEffectModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(tvOS) || os(iOS) || os(visionOS)
+        #if os(visionOS) || os(iOS) || os(tvOS)
         case _0(effect: Any)
         #endif
-        #if os(tvOS) || os(iOS) || os(visionOS)
+        #if os(tvOS) || os(visionOS) || os(iOS)
         case _1(effect: Any, isEnabled: Any)
         #endif
     }
@@ -4133,15 +4133,15 @@ struct _hoverEffectModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(tvOS) || os(iOS) || os(visionOS)
-    @available(tvOS 16.0,iOS 13.4,visionOS 1.0, *)
+    #if os(visionOS) || os(iOS) || os(tvOS)
+    @available(visionOS 1.0,iOS 13.4,tvOS 16.0, *)
     init(_ effect: SwiftUI.HoverEffect = .automatic ) {
         self.value = ._0(effect: effect)
         
     }
     #endif
-    #if os(tvOS) || os(iOS) || os(visionOS)
-    @available(tvOS 17.0,iOS 17.0,visionOS 1.0, *)
+    #if os(tvOS) || os(visionOS) || os(iOS)
+    @available(tvOS 17.0,visionOS 1.0,iOS 17.0, *)
     init(_ effect: SwiftUI.HoverEffect = .automatic, isEnabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._1(effect: effect, isEnabled: isEnabled)
         
@@ -4152,17 +4152,17 @@ struct _hoverEffectModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(tvOS) || os(iOS) || os(visionOS)
+        #if os(visionOS) || os(iOS) || os(tvOS)
         case let ._0(effect):
-            if #available(tvOS 16.0,iOS 13.4,visionOS 1.0, *) {
+            if #available(visionOS 1.0,iOS 13.4,tvOS 16.0, *) {
             let effect = effect as! SwiftUI.HoverEffect 
             __content
                 .hoverEffect(effect)
             } else { __content }
         #endif
-        #if os(tvOS) || os(iOS) || os(visionOS)
+        #if os(tvOS) || os(visionOS) || os(iOS)
         case let ._1(effect, isEnabled):
-            if #available(tvOS 17.0,iOS 17.0,visionOS 1.0, *) {
+            if #available(tvOS 17.0,visionOS 1.0,iOS 17.0, *) {
             let effect = effect as! SwiftUI.HoverEffect 
 let isEnabled = isEnabled as! AttributeReference<Swift.Bool>
             __content
@@ -4178,7 +4178,7 @@ struct _hoverEffectDisabledModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(tvOS) || os(iOS) || os(visionOS)
+        #if os(tvOS) || os(visionOS) || os(iOS)
         case _0(disabled: Any)
         #endif
     }
@@ -4191,8 +4191,8 @@ struct _hoverEffectDisabledModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(tvOS) || os(iOS) || os(visionOS)
-    @available(tvOS 17.0,iOS 17.0,visionOS 1.0, *)
+    #if os(tvOS) || os(visionOS) || os(iOS)
+    @available(tvOS 17.0,visionOS 1.0,iOS 17.0, *)
     init(_ disabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(disabled: disabled)
         
@@ -4203,9 +4203,9 @@ struct _hoverEffectDisabledModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(tvOS) || os(iOS) || os(visionOS)
+        #if os(tvOS) || os(visionOS) || os(iOS)
         case let ._0(disabled):
-            if #available(tvOS 17.0,iOS 17.0,visionOS 1.0, *) {
+            if #available(tvOS 17.0,visionOS 1.0,iOS 17.0, *) {
             let disabled = disabled as! AttributeReference<Swift.Bool>
             __content
                 .hoverEffectDisabled(disabled.resolve(on: element, in: context))
@@ -4346,7 +4346,7 @@ struct _indexViewStyleModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(tvOS) || os(watchOS)
+        #if os(watchOS) || os(iOS) || os(tvOS)
         case _0(style: Any)
         #endif
     }
@@ -4359,8 +4359,8 @@ struct _indexViewStyleModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(tvOS) || os(watchOS)
-    @available(iOS 14.0,tvOS 14.0,watchOS 8.0, *)
+    #if os(watchOS) || os(iOS) || os(tvOS)
+    @available(watchOS 8.0,iOS 14.0,tvOS 14.0, *)
     init(_ style: AnyIndexViewStyle) {
         self.value = ._0(style: style)
         
@@ -4371,9 +4371,9 @@ struct _indexViewStyleModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(tvOS) || os(watchOS)
+        #if os(watchOS) || os(iOS) || os(tvOS)
         case let ._0(style):
-            if #available(iOS 14.0,tvOS 14.0,watchOS 8.0, *) {
+            if #available(watchOS 8.0,iOS 14.0,tvOS 14.0, *) {
             let style = style as! AnyIndexViewStyle
             __content
                 .indexViewStyle(style)
@@ -4578,7 +4578,7 @@ struct _invalidatableContentModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
+        #if os(macOS) || os(watchOS) || os(iOS) || os(tvOS)
         case _0(invalidatable: Any)
         #endif
     }
@@ -4591,8 +4591,8 @@ struct _invalidatableContentModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
-    @available(tvOS 17.0,iOS 17.0,watchOS 10.0,macOS 14.0, *)
+    #if os(macOS) || os(watchOS) || os(iOS) || os(tvOS)
+    @available(macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0, *)
     init(_ invalidatable: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(invalidatable: invalidatable)
         
@@ -4603,9 +4603,9 @@ struct _invalidatableContentModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
+        #if os(macOS) || os(watchOS) || os(iOS) || os(tvOS)
         case let ._0(invalidatable):
-            if #available(tvOS 17.0,iOS 17.0,watchOS 10.0,macOS 14.0, *) {
+            if #available(macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0, *) {
             let invalidatable = invalidatable as! AttributeReference<Swift.Bool>
             __content
                 .invalidatableContent(invalidatable.resolve(on: element, in: context))
@@ -4704,16 +4704,16 @@ struct _keyboardShortcutModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS)
         case _0(key: Any,modifiers: Any)
         #endif
-        #if os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS)
         case _1(shortcut: Any)
         #endif
-        #if os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS)
         case _2(shortcut: Any?)
         #endif
-        #if os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS)
         case _3(key: Any,modifiers: Any, localization: Any)
         #endif
     }
@@ -4732,29 +4732,29 @@ struct _keyboardShortcutModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(macOS) || os(iOS)
-    @available(macOS 11.0,iOS 14.0, *)
+    #if os(iOS) || os(macOS)
+    @available(iOS 14.0,macOS 11.0, *)
     init(_ key: SwiftUI.KeyEquivalent,modifiers: SwiftUI.EventModifiers = .command ) {
         self.value = ._0(key: key, modifiers: modifiers)
         
     }
     #endif
-    #if os(macOS) || os(iOS)
-    @available(macOS 11.0,iOS 14.0, *)
+    #if os(iOS) || os(macOS)
+    @available(iOS 14.0,macOS 11.0, *)
     init(_ shortcut: SwiftUI.KeyboardShortcut) {
         self.value = ._1(shortcut: shortcut)
         
     }
     #endif
-    #if os(macOS) || os(iOS)
-    @available(macOS 12.3,iOS 15.4, *)
+    #if os(iOS) || os(macOS)
+    @available(iOS 15.4,macOS 12.3, *)
     init(_ shortcut: SwiftUI.KeyboardShortcut?) {
         self.value = ._2(shortcut: shortcut)
         
     }
     #endif
-    #if os(macOS) || os(iOS)
-    @available(macOS 12.0,iOS 15.0, *)
+    #if os(iOS) || os(macOS)
+    @available(iOS 15.0,macOS 12.0, *)
     init(_ key: SwiftUI.KeyEquivalent,modifiers: SwiftUI.EventModifiers = .command, localization: SwiftUI.KeyboardShortcut.Localization) {
         self.value = ._3(key: key, modifiers: modifiers, localization: localization)
         
@@ -4765,34 +4765,34 @@ struct _keyboardShortcutModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS)
         case let ._0(key, modifiers):
-            if #available(macOS 11.0,iOS 14.0, *) {
+            if #available(iOS 14.0,macOS 11.0, *) {
             let key = key as! SwiftUI.KeyEquivalent
 let modifiers = modifiers as! SwiftUI.EventModifiers 
             __content
                 .keyboardShortcut(key, modifiers: modifiers)
             } else { __content }
         #endif
-        #if os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS)
         case let ._1(shortcut):
-            if #available(macOS 11.0,iOS 14.0, *) {
+            if #available(iOS 14.0,macOS 11.0, *) {
             let shortcut = shortcut as! SwiftUI.KeyboardShortcut
             __content
                 .keyboardShortcut(shortcut)
             } else { __content }
         #endif
-        #if os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS)
         case let ._2(shortcut):
-            if #available(macOS 12.3,iOS 15.4, *) {
+            if #available(iOS 15.4,macOS 12.3, *) {
             let shortcut = shortcut as? SwiftUI.KeyboardShortcut
             __content
                 .keyboardShortcut(shortcut)
             } else { __content }
         #endif
-        #if os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS)
         case let ._3(key, modifiers, localization):
-            if #available(macOS 12.0,iOS 15.0, *) {
+            if #available(iOS 15.0,macOS 12.0, *) {
             let key = key as! SwiftUI.KeyEquivalent
 let modifiers = modifiers as! SwiftUI.EventModifiers 
 let localization = localization as! SwiftUI.KeyboardShortcut.Localization
@@ -5456,7 +5456,7 @@ struct _listRowSeparatorTintModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(macOS)
+        #if os(macOS) || os(iOS)
         case _0(color: Any?,edges: Any)
         #endif
     }
@@ -5469,8 +5469,8 @@ struct _listRowSeparatorTintModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(macOS)
-    @available(iOS 15.0,macOS 13.0, *)
+    #if os(macOS) || os(iOS)
+    @available(macOS 13.0,iOS 15.0, *)
     init(_ color: AttributeReference<SwiftUI.Color?>?,edges: SwiftUI.VerticalEdge.Set = .all ) {
         self.value = ._0(color: color, edges: edges)
         
@@ -5481,9 +5481,9 @@ struct _listRowSeparatorTintModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(macOS)
+        #if os(macOS) || os(iOS)
         case let ._0(color, edges):
-            if #available(iOS 15.0,macOS 13.0, *) {
+            if #available(macOS 13.0,iOS 15.0, *) {
             let color = color as? AttributeReference<SwiftUI.Color?>
 let edges = edges as! SwiftUI.VerticalEdge.Set 
             __content
@@ -5541,7 +5541,7 @@ struct _listSectionSeparatorModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(macOS)
+        #if os(macOS) || os(iOS)
         case _0(visibility: Any,edges: Any)
         #endif
     }
@@ -5554,8 +5554,8 @@ struct _listSectionSeparatorModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(macOS)
-    @available(iOS 15.0,macOS 13.0, *)
+    #if os(macOS) || os(iOS)
+    @available(macOS 13.0,iOS 15.0, *)
     init(_ visibility: AttributeReference<SwiftUI.Visibility>,edges: SwiftUI.VerticalEdge.Set = .all ) {
         self.value = ._0(visibility: visibility, edges: edges)
         
@@ -5566,9 +5566,9 @@ struct _listSectionSeparatorModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(macOS)
+        #if os(macOS) || os(iOS)
         case let ._0(visibility, edges):
-            if #available(iOS 15.0,macOS 13.0, *) {
+            if #available(macOS 13.0,iOS 15.0, *) {
             let visibility = visibility as! AttributeReference<SwiftUI.Visibility>
 let edges = edges as! SwiftUI.VerticalEdge.Set 
             __content
@@ -5584,7 +5584,7 @@ struct _listSectionSeparatorTintModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(macOS)
+        #if os(macOS) || os(iOS)
         case _0(color: Any?,edges: Any)
         #endif
     }
@@ -5597,8 +5597,8 @@ struct _listSectionSeparatorTintModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(macOS)
-    @available(iOS 15.0,macOS 13.0, *)
+    #if os(macOS) || os(iOS)
+    @available(macOS 13.0,iOS 15.0, *)
     init(_ color: AttributeReference<SwiftUI.Color?>?,edges: SwiftUI.VerticalEdge.Set = .all ) {
         self.value = ._0(color: color, edges: edges)
         
@@ -5609,9 +5609,9 @@ struct _listSectionSeparatorTintModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(macOS)
+        #if os(macOS) || os(iOS)
         case let ._0(color, edges):
-            if #available(iOS 15.0,macOS 13.0, *) {
+            if #available(macOS 13.0,iOS 15.0, *) {
             let color = color as? AttributeReference<SwiftUI.Color?>
 let edges = edges as! SwiftUI.VerticalEdge.Set 
             __content
@@ -5627,10 +5627,10 @@ struct _listSectionSpacingModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(watchOS) || os(iOS)
+        #if os(iOS) || os(watchOS)
         case _0(spacing: Any)
         #endif
-        #if os(watchOS) || os(iOS)
+        #if os(iOS) || os(watchOS)
         case _1(spacing: Any)
         #endif
     }
@@ -5645,15 +5645,15 @@ struct _listSectionSpacingModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(watchOS) || os(iOS)
-    @available(watchOS 10.0,iOS 17.0, *)
+    #if os(iOS) || os(watchOS)
+    @available(iOS 17.0,watchOS 10.0, *)
     init(_ spacing: SwiftUI.ListSectionSpacing) {
         self.value = ._0(spacing: spacing)
         
     }
     #endif
-    #if os(watchOS) || os(iOS)
-    @available(watchOS 10.0,iOS 17.0, *)
+    #if os(iOS) || os(watchOS)
+    @available(iOS 17.0,watchOS 10.0, *)
     init(_ spacing: AttributeReference<CoreFoundation.CGFloat>) {
         self.value = ._1(spacing: spacing)
         
@@ -5664,17 +5664,17 @@ struct _listSectionSpacingModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(watchOS) || os(iOS)
+        #if os(iOS) || os(watchOS)
         case let ._0(spacing):
-            if #available(watchOS 10.0,iOS 17.0, *) {
+            if #available(iOS 17.0,watchOS 10.0, *) {
             let spacing = spacing as! SwiftUI.ListSectionSpacing
             __content
                 .listSectionSpacing(spacing)
             } else { __content }
         #endif
-        #if os(watchOS) || os(iOS)
+        #if os(iOS) || os(watchOS)
         case let ._1(spacing):
-            if #available(watchOS 10.0,iOS 17.0, *) {
+            if #available(iOS 17.0,watchOS 10.0, *) {
             let spacing = spacing as! AttributeReference<CoreFoundation.CGFloat>
             __content
                 .listSectionSpacing(spacing.resolve(on: element, in: context))
@@ -5773,7 +5773,7 @@ struct _menuIndicatorModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(tvOS) || os(macOS)
+        #if os(macOS) || os(tvOS) || os(iOS)
         case _0(visibility: Any)
         #endif
     }
@@ -5786,8 +5786,8 @@ struct _menuIndicatorModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(tvOS) || os(macOS)
-    @available(iOS 15.0,tvOS 17.0,macOS 12.0, *)
+    #if os(macOS) || os(tvOS) || os(iOS)
+    @available(macOS 12.0,tvOS 17.0,iOS 15.0, *)
     init(_ visibility: AttributeReference<SwiftUI.Visibility>) {
         self.value = ._0(visibility: visibility)
         
@@ -5798,9 +5798,9 @@ struct _menuIndicatorModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(tvOS) || os(macOS)
+        #if os(macOS) || os(tvOS) || os(iOS)
         case let ._0(visibility):
-            if #available(iOS 15.0,tvOS 17.0,macOS 12.0, *) {
+            if #available(macOS 12.0,tvOS 17.0,iOS 15.0, *) {
             let visibility = visibility as! AttributeReference<SwiftUI.Visibility>
             __content
                 .menuIndicator(visibility.resolve(on: element, in: context))
@@ -5857,7 +5857,7 @@ struct _menuStyleModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(macOS) || os(iOS) || os(tvOS)
+        #if os(iOS) || os(tvOS) || os(macOS)
         case _0(style: Any)
         #endif
     }
@@ -5870,8 +5870,8 @@ struct _menuStyleModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(macOS) || os(iOS) || os(tvOS)
-    @available(macOS 11.0,iOS 14.0,tvOS 17.0, *)
+    #if os(iOS) || os(tvOS) || os(macOS)
+    @available(iOS 14.0,tvOS 17.0,macOS 11.0, *)
     init(_ style: AnyMenuStyle) {
         self.value = ._0(style: style)
         
@@ -5882,9 +5882,9 @@ struct _menuStyleModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(macOS) || os(iOS) || os(tvOS)
+        #if os(iOS) || os(tvOS) || os(macOS)
         case let ._0(style):
-            if #available(macOS 11.0,iOS 14.0,tvOS 17.0, *) {
+            if #available(iOS 14.0,tvOS 17.0,macOS 11.0, *) {
             let style = style as! AnyMenuStyle
             __content
                 .menuStyle(style)
@@ -6151,7 +6151,7 @@ struct _navigationBarTitleDisplayModeModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(watchOS) || os(iOS)
+        #if os(iOS) || os(watchOS)
         case _0(displayMode: Any)
         #endif
     }
@@ -6164,8 +6164,8 @@ struct _navigationBarTitleDisplayModeModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(watchOS) || os(iOS)
-    @available(watchOS 8.0,iOS 14.0, *)
+    #if os(iOS) || os(watchOS)
+    @available(iOS 14.0,watchOS 8.0, *)
     init(_ displayMode: SwiftUI.NavigationBarItem.TitleDisplayMode) {
         self.value = ._0(displayMode: displayMode)
         
@@ -6176,9 +6176,9 @@ struct _navigationBarTitleDisplayModeModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(watchOS) || os(iOS)
+        #if os(iOS) || os(watchOS)
         case let ._0(displayMode):
-            if #available(watchOS 8.0,iOS 14.0, *) {
+            if #available(iOS 14.0,watchOS 8.0, *) {
             let displayMode = displayMode as! SwiftUI.NavigationBarItem.TitleDisplayMode
             __content
                 .navigationBarTitleDisplayMode(displayMode)
@@ -6476,7 +6476,7 @@ struct _navigationTitleModifier<R: RootRegistry>: ViewModifier {
     }
     
     #if os(watchOS)
-    @available(macOS 11.0,watchOS 7.0,tvOS 14.0,iOS 14.0, *)
+    @available(tvOS 14.0,iOS 14.0,watchOS 7.0,macOS 11.0, *)
     init(_ title: ViewReference=ViewReference(value: [])) {
         self.value = ._3(title: title)
         
@@ -6520,7 +6520,7 @@ struct _navigationTitleModifier<R: RootRegistry>: ViewModifier {
         
         #if os(watchOS)
         case let ._3(title):
-            if #available(macOS 11.0,watchOS 7.0,tvOS 14.0,iOS 14.0, *) {
+            if #available(tvOS 14.0,iOS 14.0,watchOS 7.0,macOS 11.0, *) {
             let title = title as! ViewReference
             __content
                 .navigationTitle({ title.resolve(on: element, in: context) })
@@ -6815,7 +6815,7 @@ struct _onLongPressGestureModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(watchOS) || os(iOS) || os(macOS)
+        #if os(macOS) || os(watchOS) || os(iOS)
         case _0(minimumDuration: Any, maximumDistance: Any)
         #endif
         #if os(tvOS)
@@ -6835,8 +6835,8 @@ struct _onLongPressGestureModifier<R: RootRegistry>: ViewModifier {
 @Event private var _1_action__0: Event.EventHandler
 @Event private var _1_onPressingChanged__1: Event.EventHandler
 
-    #if os(watchOS) || os(iOS) || os(macOS)
-    @available(tvOS 14.0,watchOS 6.0,iOS 13.0,macOS 10.15, *)
+    #if os(macOS) || os(watchOS) || os(iOS)
+    @available(macOS 10.15,watchOS 6.0,iOS 13.0,tvOS 14.0, *)
     init(minimumDuration: AttributeReference<Swift.Double> = .init(storage: .constant(0.5)), maximumDistance: AttributeReference<CoreFoundation.CGFloat> = .init(storage: .constant(10)), perform action__0: Event,onPressingChanged onPressingChanged__1: Event=Event() ) {
         self.value = ._0(minimumDuration: minimumDuration, maximumDistance: maximumDistance)
         self.__0_action__0 = action__0
@@ -6844,7 +6844,7 @@ self.__0_onPressingChanged__1 = onPressingChanged__1
     }
     #endif
     #if os(tvOS)
-    @available(tvOS 14.0,watchOS 6.0,iOS 13.0,macOS 10.15, *)
+    @available(macOS 10.15,watchOS 6.0,iOS 13.0,tvOS 14.0, *)
     init(minimumDuration: AttributeReference<Swift.Double> = .init(storage: .constant(0.5)), perform action__0: Event,onPressingChanged onPressingChanged__1: Event=Event() ) {
         self.value = ._1(minimumDuration: minimumDuration)
         self.__1_action__0 = action__0
@@ -6856,9 +6856,9 @@ self.__1_onPressingChanged__1 = onPressingChanged__1
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(watchOS) || os(iOS) || os(macOS)
+        #if os(macOS) || os(watchOS) || os(iOS)
         case let ._0(minimumDuration, maximumDistance):
-            if #available(tvOS 14.0,watchOS 6.0,iOS 13.0,macOS 10.15, *) {
+            if #available(macOS 10.15,watchOS 6.0,iOS 13.0,tvOS 14.0, *) {
             let minimumDuration = minimumDuration as! AttributeReference<Swift.Double>
 let maximumDistance = maximumDistance as! AttributeReference<CoreFoundation.CGFloat>
             __content
@@ -6867,7 +6867,7 @@ let maximumDistance = maximumDistance as! AttributeReference<CoreFoundation.CGFl
         #endif
         #if os(tvOS)
         case let ._1(minimumDuration):
-            if #available(tvOS 14.0,watchOS 6.0,iOS 13.0,macOS 10.15, *) {
+            if #available(macOS 10.15,watchOS 6.0,iOS 13.0,tvOS 14.0, *) {
             let minimumDuration = minimumDuration as! AttributeReference<Swift.Double>
             __content
                 .onLongPressGesture(minimumDuration: minimumDuration.resolve(on: element, in: context), perform: { __1_action__0.wrappedValue() }, onPressingChanged: { __1_onPressingChanged__1.wrappedValue(value: $0) })
@@ -7013,7 +7013,7 @@ struct _onTapGestureModifier<R: RootRegistry>: ViewModifier {
         
         case _0(count: AttributeReference<Swift.Int> = .init(storage: .constant(1)))
         
-        #if os(iOS) || os(macOS) || os(watchOS)
+        #if os(watchOS) || os(iOS) || os(macOS)
         case _1(count: Any, coordinateSpace: Any)
         #endif
     }
@@ -7035,8 +7035,8 @@ struct _onTapGestureModifier<R: RootRegistry>: ViewModifier {
         self.__0_action__0 = action__0
     }
     
-    #if os(iOS) || os(macOS) || os(watchOS)
-    @available(iOS 17.0,macOS 14.0,watchOS 10.0, *)
+    #if os(watchOS) || os(iOS) || os(macOS)
+    @available(watchOS 10.0,iOS 17.0,macOS 14.0, *)
     init(count: AttributeReference<Swift.Int> = .init(storage: .constant(1)), coordinateSpace: AnyCoordinateSpaceProtocol = .local, perform action__1: Event) {
         self.value = ._1(count: count, coordinateSpace: coordinateSpace)
         self.__1_action__1 = action__1
@@ -7055,9 +7055,9 @@ struct _onTapGestureModifier<R: RootRegistry>: ViewModifier {
                 .onTapGesture(count: count.resolve(on: element, in: context), perform: { __0_action__0.wrappedValue() })
             
         
-        #if os(iOS) || os(macOS) || os(watchOS)
+        #if os(watchOS) || os(iOS) || os(macOS)
         case let ._1(count, coordinateSpace):
-            if #available(iOS 17.0,macOS 14.0,watchOS 10.0, *) {
+            if #available(watchOS 10.0,iOS 17.0,macOS 14.0, *) {
             let count = count as! AttributeReference<Swift.Int>
 let coordinateSpace = coordinateSpace as! AnyCoordinateSpaceProtocol 
             __content
@@ -7511,10 +7511,10 @@ struct _presentationBackgroundModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
+        #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
         case _0(style: Any)
         #endif
-        #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
+        #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
         case _1(alignment: Any, content: Any)
         #endif
     }
@@ -7529,15 +7529,15 @@ struct _presentationBackgroundModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
-    @available(tvOS 16.4,iOS 16.4,watchOS 9.4,macOS 13.3, *)
+    #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+    @available(macOS 13.3,iOS 16.4,tvOS 16.4,watchOS 9.4, *)
     init(_ style: AnyShapeStyle) {
         self.value = ._0(style: style)
         
     }
     #endif
-    #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
-    @available(tvOS 16.4,iOS 16.4,watchOS 9.4,macOS 13.3, *)
+    #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+    @available(macOS 13.3,iOS 16.4,tvOS 16.4,watchOS 9.4, *)
     init(alignment: AttributeReference<SwiftUI.Alignment> = .init(storage: .constant(.center)), content: ViewReference=ViewReference(value: [])) {
         self.value = ._1(alignment: alignment, content: content)
         
@@ -7548,17 +7548,17 @@ struct _presentationBackgroundModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
+        #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
         case let ._0(style):
-            if #available(tvOS 16.4,iOS 16.4,watchOS 9.4,macOS 13.3, *) {
+            if #available(macOS 13.3,iOS 16.4,tvOS 16.4,watchOS 9.4, *) {
             let style = style as! AnyShapeStyle
             __content
                 .presentationBackground(style)
             } else { __content }
         #endif
-        #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
+        #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
         case let ._1(alignment, content):
-            if #available(tvOS 16.4,iOS 16.4,watchOS 9.4,macOS 13.3, *) {
+            if #available(macOS 13.3,iOS 16.4,tvOS 16.4,watchOS 9.4, *) {
             let alignment = alignment as! AttributeReference<SwiftUI.Alignment>
 let content = content as! ViewReference
             __content
@@ -7574,7 +7574,7 @@ struct _presentationBackgroundInteractionModifier<R: RootRegistry>: ViewModifier
 
     enum Value {
         case _never
-        #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
+        #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
         case _0(interaction: Any)
         #endif
     }
@@ -7587,8 +7587,8 @@ struct _presentationBackgroundInteractionModifier<R: RootRegistry>: ViewModifier
 
 
 
-    #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
-    @available(tvOS 16.4,iOS 16.4,watchOS 9.4,macOS 13.3, *)
+    #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+    @available(macOS 13.3,iOS 16.4,watchOS 9.4,tvOS 16.4, *)
     init(_ interaction: SwiftUI.PresentationBackgroundInteraction) {
         self.value = ._0(interaction: interaction)
         
@@ -7599,9 +7599,9 @@ struct _presentationBackgroundInteractionModifier<R: RootRegistry>: ViewModifier
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
+        #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
         case let ._0(interaction):
-            if #available(tvOS 16.4,iOS 16.4,watchOS 9.4,macOS 13.3, *) {
+            if #available(macOS 13.3,iOS 16.4,watchOS 9.4,tvOS 16.4, *) {
             let interaction = interaction as! SwiftUI.PresentationBackgroundInteraction
             __content
                 .presentationBackgroundInteraction(interaction)
@@ -7616,10 +7616,10 @@ struct _presentationCompactAdaptationModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(tvOS) || os(watchOS) || os(macOS) || os(iOS)
+        #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
         case _0(adaptation: Any)
         #endif
-        #if os(tvOS) || os(watchOS) || os(macOS) || os(iOS)
+        #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
         case _1(horizontalAdaptation: Any,verticalAdaptation: Any)
         #endif
     }
@@ -7634,15 +7634,15 @@ struct _presentationCompactAdaptationModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(tvOS) || os(watchOS) || os(macOS) || os(iOS)
-    @available(tvOS 16.4,watchOS 9.4,macOS 13.3,iOS 16.4, *)
+    #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+    @available(macOS 13.3,iOS 16.4,watchOS 9.4,tvOS 16.4, *)
     init(_ adaptation: SwiftUI.PresentationAdaptation) {
         self.value = ._0(adaptation: adaptation)
         
     }
     #endif
-    #if os(tvOS) || os(watchOS) || os(macOS) || os(iOS)
-    @available(tvOS 16.4,watchOS 9.4,macOS 13.3,iOS 16.4, *)
+    #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+    @available(macOS 13.3,iOS 16.4,watchOS 9.4,tvOS 16.4, *)
     init(horizontal horizontalAdaptation: SwiftUI.PresentationAdaptation,vertical verticalAdaptation: SwiftUI.PresentationAdaptation) {
         self.value = ._1(horizontalAdaptation: horizontalAdaptation, verticalAdaptation: verticalAdaptation)
         
@@ -7653,17 +7653,17 @@ struct _presentationCompactAdaptationModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(tvOS) || os(watchOS) || os(macOS) || os(iOS)
+        #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
         case let ._0(adaptation):
-            if #available(tvOS 16.4,watchOS 9.4,macOS 13.3,iOS 16.4, *) {
+            if #available(macOS 13.3,iOS 16.4,watchOS 9.4,tvOS 16.4, *) {
             let adaptation = adaptation as! SwiftUI.PresentationAdaptation
             __content
                 .presentationCompactAdaptation(adaptation)
             } else { __content }
         #endif
-        #if os(tvOS) || os(watchOS) || os(macOS) || os(iOS)
+        #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
         case let ._1(horizontalAdaptation, verticalAdaptation):
-            if #available(tvOS 16.4,watchOS 9.4,macOS 13.3,iOS 16.4, *) {
+            if #available(macOS 13.3,iOS 16.4,watchOS 9.4,tvOS 16.4, *) {
             let horizontalAdaptation = horizontalAdaptation as! SwiftUI.PresentationAdaptation
 let verticalAdaptation = verticalAdaptation as! SwiftUI.PresentationAdaptation
             __content
@@ -7679,7 +7679,7 @@ struct _presentationContentInteractionModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(tvOS) || os(watchOS) || os(macOS) || os(iOS)
+        #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
         case _0(behavior: Any)
         #endif
     }
@@ -7692,8 +7692,8 @@ struct _presentationContentInteractionModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(tvOS) || os(watchOS) || os(macOS) || os(iOS)
-    @available(tvOS 16.4,watchOS 9.4,macOS 13.3,iOS 16.4, *)
+    #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+    @available(macOS 13.3,iOS 16.4,watchOS 9.4,tvOS 16.4, *)
     init(_ behavior: SwiftUI.PresentationContentInteraction) {
         self.value = ._0(behavior: behavior)
         
@@ -7704,9 +7704,9 @@ struct _presentationContentInteractionModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(tvOS) || os(watchOS) || os(macOS) || os(iOS)
+        #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
         case let ._0(behavior):
-            if #available(tvOS 16.4,watchOS 9.4,macOS 13.3,iOS 16.4, *) {
+            if #available(macOS 13.3,iOS 16.4,watchOS 9.4,tvOS 16.4, *) {
             let behavior = behavior as! SwiftUI.PresentationContentInteraction
             __content
                 .presentationContentInteraction(behavior)
@@ -7721,7 +7721,7 @@ struct _presentationCornerRadiusModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(tvOS) || os(watchOS) || os(macOS) || os(iOS)
+        #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
         case _0(cornerRadius: Any?)
         #endif
     }
@@ -7734,8 +7734,8 @@ struct _presentationCornerRadiusModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(tvOS) || os(watchOS) || os(macOS) || os(iOS)
-    @available(tvOS 16.4,watchOS 9.4,macOS 13.3,iOS 16.4, *)
+    #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+    @available(macOS 13.3,iOS 16.4,watchOS 9.4,tvOS 16.4, *)
     init(_ cornerRadius: AttributeReference<CoreFoundation.CGFloat?>?) {
         self.value = ._0(cornerRadius: cornerRadius)
         
@@ -7746,9 +7746,9 @@ struct _presentationCornerRadiusModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(tvOS) || os(watchOS) || os(macOS) || os(iOS)
+        #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
         case let ._0(cornerRadius):
-            if #available(tvOS 16.4,watchOS 9.4,macOS 13.3,iOS 16.4, *) {
+            if #available(macOS 13.3,iOS 16.4,watchOS 9.4,tvOS 16.4, *) {
             let cornerRadius = cornerRadius as? AttributeReference<CoreFoundation.CGFloat?>
             __content
                 .presentationCornerRadius(cornerRadius?.resolve(on: element, in: context))
@@ -8515,7 +8515,7 @@ struct _scrollBounceBehaviorModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
+        #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
         case _0(behavior: Any,axes: Any)
         #endif
     }
@@ -8528,8 +8528,8 @@ struct _scrollBounceBehaviorModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
-    @available(iOS 16.4,macOS 13.3,watchOS 9.4,tvOS 16.4, *)
+    #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
+    @available(tvOS 16.4,iOS 16.4,watchOS 9.4,macOS 13.3, *)
     init(_ behavior: SwiftUI.ScrollBounceBehavior,axes: SwiftUI.Axis.Set = [.vertical] ) {
         self.value = ._0(behavior: behavior, axes: axes)
         
@@ -8540,9 +8540,9 @@ struct _scrollBounceBehaviorModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
+        #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
         case let ._0(behavior, axes):
-            if #available(iOS 16.4,macOS 13.3,watchOS 9.4,tvOS 16.4, *) {
+            if #available(tvOS 16.4,iOS 16.4,watchOS 9.4,macOS 13.3, *) {
             let behavior = behavior as! SwiftUI.ScrollBounceBehavior
 let axes = axes as! SwiftUI.Axis.Set 
             __content
@@ -8558,7 +8558,7 @@ struct _scrollClipDisabledModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
+        #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
         case _0(disabled: Any)
         #endif
     }
@@ -8571,8 +8571,8 @@ struct _scrollClipDisabledModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
-    @available(iOS 17.0,macOS 14.0,watchOS 10.0,tvOS 17.0, *)
+    #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
+    @available(tvOS 17.0,iOS 17.0,watchOS 10.0,macOS 14.0, *)
     init(_ disabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(disabled: disabled)
         
@@ -8583,9 +8583,9 @@ struct _scrollClipDisabledModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
+        #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
         case let ._0(disabled):
-            if #available(iOS 17.0,macOS 14.0,watchOS 10.0,tvOS 17.0, *) {
+            if #available(tvOS 17.0,iOS 17.0,watchOS 10.0,macOS 14.0, *) {
             let disabled = disabled as! AttributeReference<Swift.Bool>
             __content
                 .scrollClipDisabled(disabled.resolve(on: element, in: context))
@@ -8600,7 +8600,7 @@ struct _scrollContentBackgroundModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(watchOS) || os(iOS) || os(macOS)
+        #if os(iOS) || os(macOS) || os(watchOS)
         case _0(visibility: Any)
         #endif
     }
@@ -8613,8 +8613,8 @@ struct _scrollContentBackgroundModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(watchOS) || os(iOS) || os(macOS)
-    @available(watchOS 9.0,iOS 16.0,macOS 13.0, *)
+    #if os(iOS) || os(macOS) || os(watchOS)
+    @available(iOS 16.0,macOS 13.0,watchOS 9.0, *)
     init(_ visibility: AttributeReference<SwiftUI.Visibility>) {
         self.value = ._0(visibility: visibility)
         
@@ -8625,9 +8625,9 @@ struct _scrollContentBackgroundModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(watchOS) || os(iOS) || os(macOS)
+        #if os(iOS) || os(macOS) || os(watchOS)
         case let ._0(visibility):
-            if #available(watchOS 9.0,iOS 16.0,macOS 13.0, *) {
+            if #available(iOS 16.0,macOS 13.0,watchOS 9.0, *) {
             let visibility = visibility as! AttributeReference<SwiftUI.Visibility>
             __content
                 .scrollContentBackground(visibility.resolve(on: element, in: context))
@@ -8684,7 +8684,7 @@ struct _scrollDismissesKeyboardModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(tvOS) || os(watchOS) || os(iOS) || os(macOS)
+        #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
         case _0(mode: Any)
         #endif
     }
@@ -8697,8 +8697,8 @@ struct _scrollDismissesKeyboardModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(tvOS) || os(watchOS) || os(iOS) || os(macOS)
-    @available(tvOS 16.0,watchOS 9.0,iOS 16.0,macOS 13.0, *)
+    #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
+    @available(tvOS 16.0,iOS 16.0,watchOS 9.0,macOS 13.0, *)
     init(_ mode: SwiftUI.ScrollDismissesKeyboardMode) {
         self.value = ._0(mode: mode)
         
@@ -8709,9 +8709,9 @@ struct _scrollDismissesKeyboardModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(tvOS) || os(watchOS) || os(iOS) || os(macOS)
+        #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
         case let ._0(mode):
-            if #available(tvOS 16.0,watchOS 9.0,iOS 16.0,macOS 13.0, *) {
+            if #available(tvOS 16.0,iOS 16.0,watchOS 9.0,macOS 13.0, *) {
             let mode = mode as! SwiftUI.ScrollDismissesKeyboardMode
             __content
                 .scrollDismissesKeyboard(mode)
@@ -8768,10 +8768,10 @@ struct _scrollIndicatorsFlashModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
+        #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
         case _0(value: Any)
         #endif
-        #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
+        #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
         case _1(onAppear: Any)
         #endif
     }
@@ -8786,15 +8786,15 @@ struct _scrollIndicatorsFlashModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
-    @available(iOS 17.0,macOS 14.0,watchOS 10.0,tvOS 17.0, *)
+    #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
+    @available(tvOS 17.0,iOS 17.0,watchOS 10.0,macOS 14.0, *)
     init(trigger value: AttributeReference<String>) {
         self.value = ._0(value: value)
         
     }
     #endif
-    #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
-    @available(iOS 17.0,macOS 14.0,watchOS 10.0,tvOS 17.0, *)
+    #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
+    @available(tvOS 17.0,iOS 17.0,watchOS 10.0,macOS 14.0, *)
     init(onAppear: AttributeReference<Swift.Bool>) {
         self.value = ._1(onAppear: onAppear)
         
@@ -8805,17 +8805,17 @@ struct _scrollIndicatorsFlashModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
+        #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
         case let ._0(value):
-            if #available(iOS 17.0,macOS 14.0,watchOS 10.0,tvOS 17.0, *) {
+            if #available(tvOS 17.0,iOS 17.0,watchOS 10.0,macOS 14.0, *) {
             let value = value as! AttributeReference<String>
             __content
                 .scrollIndicatorsFlash(trigger: value.resolve(on: element, in: context))
             } else { __content }
         #endif
-        #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
+        #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
         case let ._1(onAppear):
-            if #available(iOS 17.0,macOS 14.0,watchOS 10.0,tvOS 17.0, *) {
+            if #available(tvOS 17.0,iOS 17.0,watchOS 10.0,macOS 14.0, *) {
             let onAppear = onAppear as! AttributeReference<Swift.Bool>
             __content
                 .scrollIndicatorsFlash(onAppear: onAppear.resolve(on: element, in: context))
@@ -8830,7 +8830,7 @@ struct _scrollPositionModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
+        #if os(watchOS) || os(iOS) || os(macOS) || os(tvOS)
         case _0(anchor: Any?)
         #endif
     }
@@ -8843,8 +8843,8 @@ struct _scrollPositionModifier<R: RootRegistry>: ViewModifier {
 @ChangeTracked private var _0_id: String?
 
 
-    #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
-    @available(iOS 17.0,macOS 14.0,watchOS 10.0,tvOS 17.0, *)
+    #if os(watchOS) || os(iOS) || os(macOS) || os(tvOS)
+    @available(watchOS 10.0,iOS 17.0,macOS 14.0,tvOS 17.0, *)
     init(id: ChangeTracked<String?>,anchor: AttributeReference<SwiftUI.UnitPoint?>? = .init(storage: .constant(nil)) ) {
         self.value = ._0(anchor: anchor)
         self.__0_id = id
@@ -8855,9 +8855,9 @@ struct _scrollPositionModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
+        #if os(watchOS) || os(iOS) || os(macOS) || os(tvOS)
         case let ._0(anchor):
-            if #available(iOS 17.0,macOS 14.0,watchOS 10.0,tvOS 17.0, *) {
+            if #available(watchOS 10.0,iOS 17.0,macOS 14.0,tvOS 17.0, *) {
             let anchor = anchor as? AttributeReference<SwiftUI.UnitPoint?>
             __content
                 .scrollPosition(id: __0_id.projectedValue, anchor: anchor?.resolve(on: element, in: context))
@@ -8998,7 +8998,7 @@ struct _searchPresentationToolbarBehaviorModifier<R: RootRegistry>: ViewModifier
 
     enum Value {
         case _never
-        #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
+        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
         case _0(behavior: Any)
         #endif
     }
@@ -9011,8 +9011,8 @@ struct _searchPresentationToolbarBehaviorModifier<R: RootRegistry>: ViewModifier
 
 
 
-    #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
-    @available(tvOS 17.1,iOS 17.1,watchOS 10.1,macOS 14.1, *)
+    #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
+    @available(iOS 17.1,watchOS 10.1,macOS 14.1,tvOS 17.1, *)
     init(_ behavior: SwiftUI.SearchPresentationToolbarBehavior) {
         self.value = ._0(behavior: behavior)
         
@@ -9023,9 +9023,9 @@ struct _searchPresentationToolbarBehaviorModifier<R: RootRegistry>: ViewModifier
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
+        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
         case let ._0(behavior):
-            if #available(tvOS 17.1,iOS 17.1,watchOS 10.1,macOS 14.1, *) {
+            if #available(iOS 17.1,watchOS 10.1,macOS 14.1,tvOS 17.1, *) {
             let behavior = behavior as! SwiftUI.SearchPresentationToolbarBehavior
             __content
                 .searchPresentationToolbarBehavior(behavior)
@@ -9111,13 +9111,13 @@ struct _searchableModifier<R: RootRegistry>: ViewModifier {
         
         case _2(placement: SwiftUI.SearchFieldPlacement = .automatic, prompt: AttributeReference<String>)
         
-        #if os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS)
         case _3(placement: Any, prompt: Any?)
         #endif
-        #if os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS)
         case _4(placement: Any, prompt: Any)
         #endif
-        #if os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS)
         case _5(placement: Any, prompt: Any)
         #endif
     }
@@ -9164,24 +9164,24 @@ struct _searchableModifier<R: RootRegistry>: ViewModifier {
         self.__2_text = text
     }
     
-    #if os(macOS) || os(iOS)
-    @available(macOS 14.0,iOS 17.0, *)
+    #if os(iOS) || os(macOS)
+    @available(iOS 17.0,macOS 14.0, *)
     init(text: ChangeTracked<Swift.String>,isPresented: ChangeTracked<Swift.Bool>,placement: SwiftUI.SearchFieldPlacement = .automatic, prompt: TextReference? = nil ) {
         self.value = ._3(placement: placement, prompt: prompt)
         self.__3_text = text
 self.__3_isPresented = isPresented
     }
     #endif
-    #if os(macOS) || os(iOS)
-    @available(macOS 14.0,iOS 17.0, *)
+    #if os(iOS) || os(macOS)
+    @available(iOS 17.0,macOS 14.0, *)
     init(text: ChangeTracked<Swift.String>,isPresented: ChangeTracked<Swift.Bool>,placement: SwiftUI.SearchFieldPlacement = .automatic, prompt: SwiftUI.LocalizedStringKey) {
         self.value = ._4(placement: placement, prompt: prompt)
         self.__4_text = text
 self.__4_isPresented = isPresented
     }
     #endif
-    #if os(macOS) || os(iOS)
-    @available(macOS 14.0,iOS 17.0, *)
+    #if os(iOS) || os(macOS)
+    @available(iOS 17.0,macOS 14.0, *)
     init(text: ChangeTracked<Swift.String>,isPresented: ChangeTracked<Swift.Bool>,placement: SwiftUI.SearchFieldPlacement = .automatic, prompt: AttributeReference<String>) {
         self.value = ._5(placement: placement, prompt: prompt)
         self.__5_text = text
@@ -9217,27 +9217,27 @@ self.__5_isPresented = isPresented
                 .searchable(text: __2_text.projectedValue, placement: placement, prompt: prompt.resolve(on: element, in: context))
             
         
-        #if os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS)
         case let ._3(placement, prompt):
-            if #available(macOS 14.0,iOS 17.0, *) {
+            if #available(iOS 17.0,macOS 14.0, *) {
             let placement = placement as! SwiftUI.SearchFieldPlacement 
 let prompt = prompt as? TextReference
             __content
                 .searchable(text: __3_text.projectedValue, isPresented: __3_isPresented.projectedValue, placement: placement, prompt: prompt?.resolve(on: element, in: context))
             } else { __content }
         #endif
-        #if os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS)
         case let ._4(placement, prompt):
-            if #available(macOS 14.0,iOS 17.0, *) {
+            if #available(iOS 17.0,macOS 14.0, *) {
             let placement = placement as! SwiftUI.SearchFieldPlacement 
 let prompt = prompt as! SwiftUI.LocalizedStringKey
             __content
                 .searchable(text: __4_text.projectedValue, isPresented: __4_isPresented.projectedValue, placement: placement, prompt: prompt)
             } else { __content }
         #endif
-        #if os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS)
         case let ._5(placement, prompt):
-            if #available(macOS 14.0,iOS 17.0, *) {
+            if #available(iOS 17.0,macOS 14.0, *) {
             let placement = placement as! SwiftUI.SearchFieldPlacement 
 let prompt = prompt as! AttributeReference<String>
             __content
@@ -9253,7 +9253,7 @@ struct _selectionDisabledModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(tvOS) || os(macOS) || os(watchOS) || os(iOS)
+        #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
         case _0(isDisabled: Any)
         #endif
     }
@@ -9266,8 +9266,8 @@ struct _selectionDisabledModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(tvOS) || os(macOS) || os(watchOS) || os(iOS)
-    @available(tvOS 17.0,macOS 14.0,watchOS 10.0,iOS 17.0, *)
+    #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
+    @available(iOS 17.0,macOS 14.0,watchOS 10.0,tvOS 17.0, *)
     init(_ isDisabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(isDisabled: isDisabled)
         
@@ -9278,9 +9278,9 @@ struct _selectionDisabledModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(tvOS) || os(macOS) || os(watchOS) || os(iOS)
+        #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
         case let ._0(isDisabled):
-            if #available(tvOS 17.0,macOS 14.0,watchOS 10.0,iOS 17.0, *) {
+            if #available(iOS 17.0,macOS 14.0,watchOS 10.0,tvOS 17.0, *) {
             let isDisabled = isDisabled as! AttributeReference<Swift.Bool>
             __content
                 .selectionDisabled(isDisabled.resolve(on: element, in: context))
@@ -9758,7 +9758,7 @@ struct _swipeActionsModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(macOS) || os(watchOS)
+        #if os(watchOS) || os(iOS) || os(macOS)
         case _0(edge: Any, allowsFullSwipe: Any, content: Any)
         #endif
     }
@@ -9771,8 +9771,8 @@ struct _swipeActionsModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(macOS) || os(watchOS)
-    @available(iOS 15.0,macOS 12.0,watchOS 8.0, *)
+    #if os(watchOS) || os(iOS) || os(macOS)
+    @available(watchOS 8.0,iOS 15.0,macOS 12.0, *)
     init(edge: SwiftUI.HorizontalEdge = .trailing, allowsFullSwipe: AttributeReference<Swift.Bool> = .init(storage: .constant(true)), content: ViewReference=ViewReference(value: [])) {
         self.value = ._0(edge: edge, allowsFullSwipe: allowsFullSwipe, content: content)
         
@@ -9783,9 +9783,9 @@ struct _swipeActionsModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(macOS) || os(watchOS)
+        #if os(watchOS) || os(iOS) || os(macOS)
         case let ._0(edge, allowsFullSwipe, content):
-            if #available(iOS 15.0,macOS 12.0,watchOS 8.0, *) {
+            if #available(watchOS 8.0,iOS 15.0,macOS 12.0, *) {
             let edge = edge as! SwiftUI.HorizontalEdge 
 let allowsFullSwipe = allowsFullSwipe as! AttributeReference<Swift.Bool>
 let content = content as! ViewReference
@@ -9802,7 +9802,7 @@ struct _symbolEffectsRemovedModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(tvOS) || os(macOS) || os(watchOS) || os(iOS)
+        #if os(watchOS) || os(iOS) || os(macOS) || os(tvOS)
         case _0(isEnabled: Any)
         #endif
     }
@@ -9815,8 +9815,8 @@ struct _symbolEffectsRemovedModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(tvOS) || os(macOS) || os(watchOS) || os(iOS)
-    @available(tvOS 17.0,macOS 14.0,watchOS 10.0,iOS 17.0, *)
+    #if os(watchOS) || os(iOS) || os(macOS) || os(tvOS)
+    @available(watchOS 10.0,iOS 17.0,macOS 14.0,tvOS 17.0, *)
     init(_ isEnabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(isEnabled: isEnabled)
         
@@ -9827,9 +9827,9 @@ struct _symbolEffectsRemovedModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(tvOS) || os(macOS) || os(watchOS) || os(iOS)
+        #if os(watchOS) || os(iOS) || os(macOS) || os(tvOS)
         case let ._0(isEnabled):
-            if #available(tvOS 17.0,macOS 14.0,watchOS 10.0,iOS 17.0, *) {
+            if #available(watchOS 10.0,iOS 17.0,macOS 14.0,tvOS 17.0, *) {
             let isEnabled = isEnabled as! AttributeReference<Swift.Bool>
             __content
                 .symbolEffectsRemoved(isEnabled.resolve(on: element, in: context))
@@ -10096,7 +10096,7 @@ struct _textContentTypeModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(tvOS)
+        #if os(tvOS) || os(iOS)
         case _0(textContentType: Any?)
         #endif
     }
@@ -10109,8 +10109,8 @@ struct _textContentTypeModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(tvOS)
-    @available(iOS 13.0,tvOS 13.0, *)
+    #if os(tvOS) || os(iOS)
+    @available(tvOS 13.0,iOS 13.0, *)
     init(_ textContentType: UIKit.UITextContentType?) {
         self.value = ._0(textContentType: textContentType)
         
@@ -10121,9 +10121,9 @@ struct _textContentTypeModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(tvOS)
+        #if os(tvOS) || os(iOS)
         case let ._0(textContentType):
-            if #available(iOS 13.0,tvOS 13.0, *) {
+            if #available(tvOS 13.0,iOS 13.0, *) {
             let textContentType = textContentType as? UIKit.UITextContentType
             __content
                 .textContentType(textContentType)
@@ -10222,7 +10222,7 @@ struct _textInputAutocapitalizationModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(watchOS) || os(iOS) || os(tvOS)
+        #if os(iOS) || os(watchOS) || os(tvOS)
         case _0(autocapitalization: Any?)
         #endif
     }
@@ -10235,8 +10235,8 @@ struct _textInputAutocapitalizationModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(watchOS) || os(iOS) || os(tvOS)
-    @available(watchOS 8.0,iOS 15.0,tvOS 15.0, *)
+    #if os(iOS) || os(watchOS) || os(tvOS)
+    @available(iOS 15.0,watchOS 8.0,tvOS 15.0, *)
     init(_ autocapitalization: SwiftUI.TextInputAutocapitalization?) {
         self.value = ._0(autocapitalization: autocapitalization)
         
@@ -10247,9 +10247,9 @@ struct _textInputAutocapitalizationModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(watchOS) || os(iOS) || os(tvOS)
+        #if os(iOS) || os(watchOS) || os(tvOS)
         case let ._0(autocapitalization):
-            if #available(watchOS 8.0,iOS 15.0,tvOS 15.0, *) {
+            if #available(iOS 15.0,watchOS 8.0,tvOS 15.0, *) {
             let autocapitalization = autocapitalization as? SwiftUI.TextInputAutocapitalization
             __content
                 .textInputAutocapitalization(autocapitalization)
@@ -10264,7 +10264,7 @@ struct _textScaleModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(tvOS) || os(watchOS) || os(macOS) || os(iOS)
+        #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
         case _0(scale: Any,isEnabled: Any)
         #endif
     }
@@ -10277,8 +10277,8 @@ struct _textScaleModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(tvOS) || os(watchOS) || os(macOS) || os(iOS)
-    @available(tvOS 17.0,watchOS 10.0,macOS 14.0,iOS 17.0, *)
+    #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+    @available(macOS 14.0,iOS 17.0,watchOS 10.0,tvOS 17.0, *)
     init(_ scale: SwiftUI.Text.Scale,isEnabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(scale: scale, isEnabled: isEnabled)
         
@@ -10289,9 +10289,9 @@ struct _textScaleModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(tvOS) || os(watchOS) || os(macOS) || os(iOS)
+        #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
         case let ._0(scale, isEnabled):
-            if #available(tvOS 17.0,watchOS 10.0,macOS 14.0,iOS 17.0, *) {
+            if #available(macOS 14.0,iOS 17.0,watchOS 10.0,tvOS 17.0, *) {
             let scale = scale as! SwiftUI.Text.Scale
 let isEnabled = isEnabled as! AttributeReference<Swift.Bool>
             __content
@@ -10307,7 +10307,7 @@ struct _textSelectionModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS)
         case _0(selectability: Any)
         #endif
     }
@@ -10320,8 +10320,8 @@ struct _textSelectionModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(macOS) || os(iOS)
-    @available(macOS 12.0,iOS 15.0, *)
+    #if os(iOS) || os(macOS)
+    @available(iOS 15.0,macOS 12.0, *)
     init(_ selectability: AnyTextSelectability) {
         self.value = ._0(selectability: selectability)
         
@@ -10332,9 +10332,9 @@ struct _textSelectionModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS)
         case let ._0(selectability):
-            if #available(macOS 12.0,iOS 15.0, *) {
+            if #available(iOS 15.0,macOS 12.0, *) {
             let selectability = selectability as! AnyTextSelectability
             __content
                 .textSelection(selectability)
@@ -10456,7 +10456,7 @@ struct _toolbarModifier<R: RootRegistry>: ViewModifier {
         
         case _0(visibility: AttributeReference<SwiftUI.Visibility>,bars: SwiftUI.ToolbarPlacement)
         
-        #if os(tvOS) || os(watchOS) || os(iOS) || os(macOS)
+        #if os(macOS) || os(watchOS) || os(iOS) || os(tvOS)
         case _1(defaultItemKind: Any?)
         #endif
         
@@ -10488,8 +10488,8 @@ struct _toolbarModifier<R: RootRegistry>: ViewModifier {
         
     }
     
-    #if os(tvOS) || os(watchOS) || os(iOS) || os(macOS)
-    @available(tvOS 17.0,watchOS 10.0,iOS 17.0,macOS 14.0, *)
+    #if os(macOS) || os(watchOS) || os(iOS) || os(tvOS)
+    @available(macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0, *)
     init(removing defaultItemKind: SwiftUI.ToolbarDefaultItemKind?) {
         self.value = ._1(defaultItemKind: defaultItemKind)
         
@@ -10522,9 +10522,9 @@ struct _toolbarModifier<R: RootRegistry>: ViewModifier {
                 .toolbar(visibility.resolve(on: element, in: context), for: bars)
             
         
-        #if os(tvOS) || os(watchOS) || os(iOS) || os(macOS)
+        #if os(macOS) || os(watchOS) || os(iOS) || os(tvOS)
         case let ._1(defaultItemKind):
-            if #available(tvOS 17.0,watchOS 10.0,iOS 17.0,macOS 14.0, *) {
+            if #available(macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0, *) {
             let defaultItemKind = defaultItemKind as? SwiftUI.ToolbarDefaultItemKind
             __content
                 .toolbar(removing: defaultItemKind)
@@ -10701,7 +10701,7 @@ struct _toolbarTitleDisplayModeModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(tvOS) || os(watchOS) || os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
         case _0(mode: Any)
         #endif
     }
@@ -10714,8 +10714,8 @@ struct _toolbarTitleDisplayModeModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(tvOS) || os(watchOS) || os(macOS) || os(iOS)
-    @available(tvOS 17.0,watchOS 10.0,macOS 14.0,iOS 17.0, *)
+    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+    @available(iOS 17.0,macOS 14.0,tvOS 17.0,watchOS 10.0, *)
     init(_ mode: SwiftUI.ToolbarTitleDisplayMode) {
         self.value = ._0(mode: mode)
         
@@ -10726,9 +10726,9 @@ struct _toolbarTitleDisplayModeModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(tvOS) || os(watchOS) || os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
         case let ._0(mode):
-            if #available(tvOS 17.0,watchOS 10.0,macOS 14.0,iOS 17.0, *) {
+            if #available(iOS 17.0,macOS 14.0,tvOS 17.0,watchOS 10.0, *) {
             let mode = mode as! SwiftUI.ToolbarTitleDisplayMode
             __content
                 .toolbarTitleDisplayMode(mode)
@@ -11385,28 +11385,28 @@ case truncationMode(_truncationModeModifier<R>)
 case underline(_underlineModifier<R>)
 case unredacted(_unredactedModifier<R>)
 case zIndex(_zIndexModifier<R>)
-        case _PrefersDefaultFocusModifier(LiveViewNative._PrefersDefaultFocusModifier<R>)
+        case _IntersectionModifier(LiveViewNative._IntersectionModifier)
+case _UnionModifier(LiveViewNative._UnionModifier)
+case _ScaleModifier(LiveViewNative._ScaleModifier<R>)
+case _LineIntersectionModifier(LiveViewNative._LineIntersectionModifier)
+case _FillModifier(LiveViewNative._FillModifier)
+case _LineSubtractionModifier(LiveViewNative._LineSubtractionModifier)
+case _OnSubmitModifier(LiveViewNative._OnSubmitModifier)
+case _StrokeModifier(LiveViewNative._StrokeModifier<R>)
+case _PrefersDefaultFocusModifier(LiveViewNative._PrefersDefaultFocusModifier<R>)
+case _SymmetricDifferenceModifier(LiveViewNative._SymmetricDifferenceModifier)
 case _MaskModifier(LiveViewNative._MaskModifier<R>)
-case _RotationModifier(LiveViewNative._RotationModifier)
+case _SubtractingModifier(LiveViewNative._SubtractingModifier)
+case _Rotation3DEffectModifier(LiveViewNative._Rotation3DEffectModifier<R>)
 case _TransformModifier(LiveViewNative._TransformModifier)
 case _SearchCompletionModifier(LiveViewNative._SearchCompletionModifier<R>)
-case _UnionModifier(LiveViewNative._UnionModifier)
-case _LineIntersectionModifier(LiveViewNative._LineIntersectionModifier)
-case _StrokeModifier(LiveViewNative._StrokeModifier<R>)
-case _IntersectionModifier(LiveViewNative._IntersectionModifier)
+case _RotationModifier(LiveViewNative._RotationModifier)
+case _RenderingModeModifier(LiveViewNative._RenderingModeModifier)
+case _FocusScopeModifier(LiveViewNative._FocusScopeModifier<R>)
+case _PresentationDetentsModifier(LiveViewNative._PresentationDetentsModifier)
 case _ResizableModifier(LiveViewNative._ResizableModifier)
 case _SearchScopesModifier(LiveViewNative._SearchScopesModifier<R>)
 case _MatchedGeometryEffectModifier(LiveViewNative._MatchedGeometryEffectModifier<R>)
-case _OnSubmitModifier(LiveViewNative._OnSubmitModifier)
-case _ScaleModifier(LiveViewNative._ScaleModifier<R>)
-case _FillModifier(LiveViewNative._FillModifier)
-case _LineSubtractionModifier(LiveViewNative._LineSubtractionModifier)
-case _RenderingModeModifier(LiveViewNative._RenderingModeModifier)
-case _Rotation3DEffectModifier(LiveViewNative._Rotation3DEffectModifier<R>)
-case _PresentationDetentsModifier(LiveViewNative._PresentationDetentsModifier)
-case _SubtractingModifier(LiveViewNative._SubtractingModifier)
-case _SymmetricDifferenceModifier(LiveViewNative._SymmetricDifferenceModifier)
-case _FocusScopeModifier(LiveViewNative._FocusScopeModifier<R>)
         case _customRegistryModifier(R.CustomModifier)
         
         func body(content: Content) -> some View {
@@ -11861,49 +11861,49 @@ case let .unredacted(modifier):
     content.modifier(modifier)
 case let .zIndex(modifier):
     content.modifier(modifier)
-            case let ._PrefersDefaultFocusModifier(modifier):
+            case let ._IntersectionModifier(modifier):
+    content.modifier(modifier)
+case let ._UnionModifier(modifier):
+    content.modifier(modifier)
+case let ._ScaleModifier(modifier):
+    content.modifier(modifier)
+case let ._LineIntersectionModifier(modifier):
+    content.modifier(modifier)
+case let ._FillModifier(modifier):
+    content.modifier(modifier)
+case let ._LineSubtractionModifier(modifier):
+    content.modifier(modifier)
+case let ._OnSubmitModifier(modifier):
+    content.modifier(modifier)
+case let ._StrokeModifier(modifier):
+    content.modifier(modifier)
+case let ._PrefersDefaultFocusModifier(modifier):
+    content.modifier(modifier)
+case let ._SymmetricDifferenceModifier(modifier):
     content.modifier(modifier)
 case let ._MaskModifier(modifier):
     content.modifier(modifier)
-case let ._RotationModifier(modifier):
+case let ._SubtractingModifier(modifier):
+    content.modifier(modifier)
+case let ._Rotation3DEffectModifier(modifier):
     content.modifier(modifier)
 case let ._TransformModifier(modifier):
     content.modifier(modifier)
 case let ._SearchCompletionModifier(modifier):
     content.modifier(modifier)
-case let ._UnionModifier(modifier):
+case let ._RotationModifier(modifier):
     content.modifier(modifier)
-case let ._LineIntersectionModifier(modifier):
+case let ._RenderingModeModifier(modifier):
     content.modifier(modifier)
-case let ._StrokeModifier(modifier):
+case let ._FocusScopeModifier(modifier):
     content.modifier(modifier)
-case let ._IntersectionModifier(modifier):
+case let ._PresentationDetentsModifier(modifier):
     content.modifier(modifier)
 case let ._ResizableModifier(modifier):
     content.modifier(modifier)
 case let ._SearchScopesModifier(modifier):
     content.modifier(modifier)
 case let ._MatchedGeometryEffectModifier(modifier):
-    content.modifier(modifier)
-case let ._OnSubmitModifier(modifier):
-    content.modifier(modifier)
-case let ._ScaleModifier(modifier):
-    content.modifier(modifier)
-case let ._FillModifier(modifier):
-    content.modifier(modifier)
-case let ._LineSubtractionModifier(modifier):
-    content.modifier(modifier)
-case let ._RenderingModeModifier(modifier):
-    content.modifier(modifier)
-case let ._Rotation3DEffectModifier(modifier):
-    content.modifier(modifier)
-case let ._PresentationDetentsModifier(modifier):
-    content.modifier(modifier)
-case let ._SubtractingModifier(modifier):
-    content.modifier(modifier)
-case let ._SymmetricDifferenceModifier(modifier):
-    content.modifier(modifier)
-case let ._FocusScopeModifier(modifier):
     content.modifier(modifier)
             case let ._customRegistryModifier(modifier):
                 content.modifier(modifier)
@@ -12147,28 +12147,28 @@ _truncationModeModifier<R>.name: _truncationModeModifier<R>.parser(in: context).
 _underlineModifier<R>.name: _underlineModifier<R>.parser(in: context).map(Output.underline).eraseToAnyParser(),
 _unredactedModifier<R>.name: _unredactedModifier<R>.parser(in: context).map(Output.unredacted).eraseToAnyParser(),
 _zIndexModifier<R>.name: _zIndexModifier<R>.parser(in: context).map(Output.zIndex).eraseToAnyParser(),
-                    LiveViewNative._PrefersDefaultFocusModifier<R>.name: LiveViewNative._PrefersDefaultFocusModifier<R>.parser(in: context).map(Output._PrefersDefaultFocusModifier).eraseToAnyParser(),
+                    LiveViewNative._IntersectionModifier.name: LiveViewNative._IntersectionModifier.parser(in: context).map(Output._IntersectionModifier).eraseToAnyParser(),
+LiveViewNative._UnionModifier.name: LiveViewNative._UnionModifier.parser(in: context).map(Output._UnionModifier).eraseToAnyParser(),
+LiveViewNative._ScaleModifier<R>.name: LiveViewNative._ScaleModifier<R>.parser(in: context).map(Output._ScaleModifier).eraseToAnyParser(),
+LiveViewNative._LineIntersectionModifier.name: LiveViewNative._LineIntersectionModifier.parser(in: context).map(Output._LineIntersectionModifier).eraseToAnyParser(),
+LiveViewNative._FillModifier.name: LiveViewNative._FillModifier.parser(in: context).map(Output._FillModifier).eraseToAnyParser(),
+LiveViewNative._LineSubtractionModifier.name: LiveViewNative._LineSubtractionModifier.parser(in: context).map(Output._LineSubtractionModifier).eraseToAnyParser(),
+LiveViewNative._OnSubmitModifier.name: LiveViewNative._OnSubmitModifier.parser(in: context).map(Output._OnSubmitModifier).eraseToAnyParser(),
+LiveViewNative._StrokeModifier<R>.name: LiveViewNative._StrokeModifier<R>.parser(in: context).map(Output._StrokeModifier).eraseToAnyParser(),
+LiveViewNative._PrefersDefaultFocusModifier<R>.name: LiveViewNative._PrefersDefaultFocusModifier<R>.parser(in: context).map(Output._PrefersDefaultFocusModifier).eraseToAnyParser(),
+LiveViewNative._SymmetricDifferenceModifier.name: LiveViewNative._SymmetricDifferenceModifier.parser(in: context).map(Output._SymmetricDifferenceModifier).eraseToAnyParser(),
 LiveViewNative._MaskModifier<R>.name: LiveViewNative._MaskModifier<R>.parser(in: context).map(Output._MaskModifier).eraseToAnyParser(),
-LiveViewNative._RotationModifier.name: LiveViewNative._RotationModifier.parser(in: context).map(Output._RotationModifier).eraseToAnyParser(),
+LiveViewNative._SubtractingModifier.name: LiveViewNative._SubtractingModifier.parser(in: context).map(Output._SubtractingModifier).eraseToAnyParser(),
+LiveViewNative._Rotation3DEffectModifier<R>.name: LiveViewNative._Rotation3DEffectModifier<R>.parser(in: context).map(Output._Rotation3DEffectModifier).eraseToAnyParser(),
 LiveViewNative._TransformModifier.name: LiveViewNative._TransformModifier.parser(in: context).map(Output._TransformModifier).eraseToAnyParser(),
 LiveViewNative._SearchCompletionModifier<R>.name: LiveViewNative._SearchCompletionModifier<R>.parser(in: context).map(Output._SearchCompletionModifier).eraseToAnyParser(),
-LiveViewNative._UnionModifier.name: LiveViewNative._UnionModifier.parser(in: context).map(Output._UnionModifier).eraseToAnyParser(),
-LiveViewNative._LineIntersectionModifier.name: LiveViewNative._LineIntersectionModifier.parser(in: context).map(Output._LineIntersectionModifier).eraseToAnyParser(),
-LiveViewNative._StrokeModifier<R>.name: LiveViewNative._StrokeModifier<R>.parser(in: context).map(Output._StrokeModifier).eraseToAnyParser(),
-LiveViewNative._IntersectionModifier.name: LiveViewNative._IntersectionModifier.parser(in: context).map(Output._IntersectionModifier).eraseToAnyParser(),
+LiveViewNative._RotationModifier.name: LiveViewNative._RotationModifier.parser(in: context).map(Output._RotationModifier).eraseToAnyParser(),
+LiveViewNative._RenderingModeModifier.name: LiveViewNative._RenderingModeModifier.parser(in: context).map(Output._RenderingModeModifier).eraseToAnyParser(),
+LiveViewNative._FocusScopeModifier<R>.name: LiveViewNative._FocusScopeModifier<R>.parser(in: context).map(Output._FocusScopeModifier).eraseToAnyParser(),
+LiveViewNative._PresentationDetentsModifier.name: LiveViewNative._PresentationDetentsModifier.parser(in: context).map(Output._PresentationDetentsModifier).eraseToAnyParser(),
 LiveViewNative._ResizableModifier.name: LiveViewNative._ResizableModifier.parser(in: context).map(Output._ResizableModifier).eraseToAnyParser(),
 LiveViewNative._SearchScopesModifier<R>.name: LiveViewNative._SearchScopesModifier<R>.parser(in: context).map(Output._SearchScopesModifier).eraseToAnyParser(),
 LiveViewNative._MatchedGeometryEffectModifier<R>.name: LiveViewNative._MatchedGeometryEffectModifier<R>.parser(in: context).map(Output._MatchedGeometryEffectModifier).eraseToAnyParser(),
-LiveViewNative._OnSubmitModifier.name: LiveViewNative._OnSubmitModifier.parser(in: context).map(Output._OnSubmitModifier).eraseToAnyParser(),
-LiveViewNative._ScaleModifier<R>.name: LiveViewNative._ScaleModifier<R>.parser(in: context).map(Output._ScaleModifier).eraseToAnyParser(),
-LiveViewNative._FillModifier.name: LiveViewNative._FillModifier.parser(in: context).map(Output._FillModifier).eraseToAnyParser(),
-LiveViewNative._LineSubtractionModifier.name: LiveViewNative._LineSubtractionModifier.parser(in: context).map(Output._LineSubtractionModifier).eraseToAnyParser(),
-LiveViewNative._RenderingModeModifier.name: LiveViewNative._RenderingModeModifier.parser(in: context).map(Output._RenderingModeModifier).eraseToAnyParser(),
-LiveViewNative._Rotation3DEffectModifier<R>.name: LiveViewNative._Rotation3DEffectModifier<R>.parser(in: context).map(Output._Rotation3DEffectModifier).eraseToAnyParser(),
-LiveViewNative._PresentationDetentsModifier.name: LiveViewNative._PresentationDetentsModifier.parser(in: context).map(Output._PresentationDetentsModifier).eraseToAnyParser(),
-LiveViewNative._SubtractingModifier.name: LiveViewNative._SubtractingModifier.parser(in: context).map(Output._SubtractingModifier).eraseToAnyParser(),
-LiveViewNative._SymmetricDifferenceModifier.name: LiveViewNative._SymmetricDifferenceModifier.parser(in: context).map(Output._SymmetricDifferenceModifier).eraseToAnyParser(),
-LiveViewNative._FocusScopeModifier<R>.name: LiveViewNative._FocusScopeModifier<R>.parser(in: context).map(Output._FocusScopeModifier).eraseToAnyParser(),
                 ]
                 
                 var copy = input
@@ -12581,14 +12581,14 @@ ConstantAtomLiteral("plusLighter").map({ () -> Self in
     }
 }
 
-#if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
-@available(iOS 17.0,macOS 14.0,watchOS 10.0,tvOS 17.0, *)
+#if os(tvOS) || os(iOS) || os(macOS) || os(watchOS)
+@available(tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0, *)
 extension ButtonRepeatBehavior: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             ConstantAtomLiteral("automatic").map({ () -> Self in
-#if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
+#if os(tvOS) || os(iOS) || os(macOS) || os(watchOS)
 
     return Self.automatic
 
@@ -12597,7 +12597,7 @@ fatalError("'automatic' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("enabled").map({ () -> Self in
-#if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
+#if os(tvOS) || os(iOS) || os(macOS) || os(watchOS)
 
     return Self.enabled
 
@@ -12606,7 +12606,7 @@ fatalError("'enabled' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("disabled").map({ () -> Self in
-#if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
+#if os(tvOS) || os(iOS) || os(macOS) || os(watchOS)
 
     return Self.disabled
 
@@ -12686,8 +12686,8 @@ ConstantAtomLiteral("dark").map({ () -> Self in
     }
 }
 
-#if os(tvOS) || os(macOS) || os(watchOS) || os(iOS)
-@available(tvOS 17.0,macOS 14.0,watchOS 10.0,iOS 17.0, *)
+#if os(tvOS) || os(iOS) || os(macOS) || os(watchOS)
+@available(tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0, *)
 extension ContainerBackgroundPlacement: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -12715,14 +12715,14 @@ fatalError("'navigation' is not available on this OS")
     }
 }
 #endif
-#if os(watchOS) || os(iOS) || os(tvOS) || os(macOS)
-@available(watchOS 10.0,iOS 17.0,tvOS 17.0,macOS 14.0, *)
+#if os(tvOS) || os(iOS) || os(macOS) || os(watchOS)
+@available(tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0, *)
 extension ContentMarginPlacement: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             ConstantAtomLiteral("automatic").map({ () -> Self in
-#if os(watchOS) || os(iOS) || os(tvOS) || os(macOS)
+#if os(tvOS) || os(iOS) || os(macOS) || os(watchOS)
 
     return Self.automatic
 
@@ -12731,7 +12731,7 @@ fatalError("'automatic' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("scrollContent").map({ () -> Self in
-#if os(watchOS) || os(iOS) || os(tvOS) || os(macOS)
+#if os(tvOS) || os(iOS) || os(macOS) || os(watchOS)
 
     return Self.scrollContent
 
@@ -12740,7 +12740,7 @@ fatalError("'scrollContent' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("scrollIndicators").map({ () -> Self in
-#if os(watchOS) || os(iOS) || os(tvOS) || os(macOS)
+#if os(tvOS) || os(iOS) || os(macOS) || os(watchOS)
 
     return Self.scrollIndicators
 
@@ -12769,8 +12769,8 @@ extension ContentShapeKinds: ParseableModifierValue {
 
 })
 ConstantAtomLiteral("dragPreview").map({ () -> Self in
-#if os(macOS) || os(iOS)
-if #available(tvOS 15.0,macOS 12.0,watchOS 8.0,iOS 15.0, *) {
+#if os(iOS) || os(macOS)
+if #available(tvOS 15.0,iOS 15.0,macOS 12.0,watchOS 8.0, *) {
     return Self.dragPreview
 } else { fatalError("'dragPreview' is not available in this OS version") }
 #else
@@ -12779,7 +12779,7 @@ fatalError("'dragPreview' is not available on this OS")
 })
 ConstantAtomLiteral("contextMenuPreview").map({ () -> Self in
 #if os(tvOS) || os(iOS)
-if #available(tvOS 17.0,macOS 12.0,watchOS 8.0,iOS 15.0, *) {
+if #available(tvOS 17.0,iOS 15.0,macOS 12.0,watchOS 8.0, *) {
     return Self.contextMenuPreview
 } else { fatalError("'contextMenuPreview' is not available in this OS version") }
 #else
@@ -12788,7 +12788,7 @@ fatalError("'contextMenuPreview' is not available on this OS")
 })
 ConstantAtomLiteral("hoverEffect").map({ () -> Self in
 #if os(iOS)
-if #available(tvOS 15.0,macOS 12.0,watchOS 8.0,iOS 15.0, *) {
+if #available(tvOS 15.0,iOS 15.0,macOS 12.0,watchOS 8.0, *) {
     return Self.hoverEffect
 } else { fatalError("'hoverEffect' is not available in this OS version") }
 #else
@@ -12797,7 +12797,7 @@ fatalError("'hoverEffect' is not available on this OS")
 })
 ConstantAtomLiteral("focusEffect").map({ () -> Self in
 #if os(macOS) || os(watchOS)
-if #available(tvOS 15.0,macOS 12.0,watchOS 8.0,iOS 15.0, *) {
+if #available(tvOS 15.0,iOS 15.0,macOS 12.0,watchOS 8.0, *) {
     return Self.focusEffect
 } else { fatalError("'focusEffect' is not available in this OS version") }
 #else
@@ -12805,8 +12805,8 @@ fatalError("'focusEffect' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("accessibility").map({ () -> Self in
-#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-if #available(iOS 17.0,macOS 14.0,tvOS 17.0,watchOS 10.0, *) {
+#if os(watchOS) || os(macOS) || os(tvOS) || os(iOS)
+if #available(watchOS 10.0,macOS 14.0,tvOS 17.0,iOS 17.0, *) {
     return Self.accessibility
 } else { fatalError("'accessibility' is not available in this OS version") }
 #else
@@ -12818,14 +12818,14 @@ fatalError("'accessibility' is not available on this OS")
     }
 }
 
-#if os(macOS) || os(iOS) || os(watchOS)
-@available(macOS 10.15,iOS 15.0,watchOS 9.0, *)
+#if os(iOS) || os(watchOS) || os(macOS)
+@available(iOS 15.0,watchOS 9.0,macOS 10.15, *)
 extension ControlSize: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             ConstantAtomLiteral("mini").map({ () -> Self in
-#if os(macOS) || os(iOS) || os(watchOS)
+#if os(iOS) || os(watchOS) || os(macOS)
 
     return Self.mini
 
@@ -12834,7 +12834,7 @@ fatalError("'mini' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("small").map({ () -> Self in
-#if os(macOS) || os(iOS) || os(watchOS)
+#if os(iOS) || os(watchOS) || os(macOS)
 
     return Self.small
 
@@ -12843,7 +12843,7 @@ fatalError("'small' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("regular").map({ () -> Self in
-#if os(macOS) || os(iOS) || os(watchOS)
+#if os(iOS) || os(watchOS) || os(macOS)
 
     return Self.regular
 
@@ -12852,8 +12852,8 @@ fatalError("'regular' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("large").map({ () -> Self in
-#if os(macOS) || os(iOS) || os(watchOS)
-if #available(macOS 11.0,iOS 15.0,watchOS 9.0, *) {
+#if os(iOS) || os(watchOS) || os(macOS)
+if #available(iOS 15.0,watchOS 9.0,macOS 11.0, *) {
     return Self.large
 } else { fatalError("'large' is not available in this OS version") }
 #else
@@ -12861,8 +12861,8 @@ fatalError("'large' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("extraLarge").map({ () -> Self in
-#if os(visionOS) || os(macOS) || os(watchOS) || os(iOS)
-if #available(visionOS 1.0,macOS 14.0,watchOS 10.0,iOS 17.0, *) {
+#if os(watchOS) || os(macOS) || os(iOS) || os(visionOS)
+if #available(watchOS 10.0,macOS 14.0,iOS 17.0,visionOS 1.0, *) {
     return Self.extraLarge
 } else { fatalError("'extraLarge' is not available in this OS version") }
 #else
@@ -12903,14 +12903,14 @@ ConstantAtomLiteral("userInitiated").map({ () -> Self in
     }
 }
 
-#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-@available(iOS 17.0,macOS 13.0,tvOS 17.0,watchOS 10.0, *)
+#if os(watchOS) || os(macOS) || os(tvOS) || os(iOS)
+@available(watchOS 10.0,macOS 13.0,tvOS 17.0,iOS 17.0, *)
 extension DialogSeverity: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             ConstantAtomLiteral("automatic").map({ () -> Self in
-#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+#if os(watchOS) || os(macOS) || os(tvOS) || os(iOS)
 
     return Self.automatic
 
@@ -12919,7 +12919,7 @@ fatalError("'automatic' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("critical").map({ () -> Self in
-#if os(watchOS) || os(iOS) || os(tvOS) || os(macOS)
+#if os(watchOS) || os(macOS) || os(tvOS) || os(iOS)
 
     return Self.critical
 
@@ -12928,8 +12928,8 @@ fatalError("'critical' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("standard").map({ () -> Self in
-#if os(watchOS) || os(iOS) || os(tvOS) || os(macOS)
-if #available(watchOS 10.0,iOS 17.0,tvOS 17.0,macOS 14.0, *) {
+#if os(watchOS) || os(macOS) || os(tvOS) || os(iOS)
+if #available(watchOS 10.0,macOS 14.0,tvOS 17.0,iOS 17.0, *) {
     return Self.standard
 } else { fatalError("'standard' is not available in this OS version") }
 #else
@@ -13062,14 +13062,14 @@ ConstantAtomLiteral("all").map({ () -> Self in
     }
 }
 
-#if os(macOS) || os(iOS)
-@available(macOS 14.0,iOS 17.0, *)
+#if os(iOS) || os(macOS)
+@available(iOS 17.0,macOS 14.0, *)
 extension FileDialogBrowserOptions: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             ConstantAtomLiteral("enumeratePackages").map({ () -> Self in
-#if os(macOS) || os(iOS)
+#if os(iOS) || os(macOS)
 
     return Self.enumeratePackages
 
@@ -13078,7 +13078,7 @@ fatalError("'enumeratePackages' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("includeHiddenFiles").map({ () -> Self in
-#if os(macOS) || os(iOS)
+#if os(iOS) || os(macOS)
 
     return Self.includeHiddenFiles
 
@@ -13087,7 +13087,7 @@ fatalError("'includeHiddenFiles' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("displayFileExtensions").map({ () -> Self in
-#if os(macOS) || os(iOS)
+#if os(iOS) || os(macOS)
 
     return Self.displayFileExtensions
 
@@ -13100,14 +13100,14 @@ fatalError("'displayFileExtensions' is not available on this OS")
     }
 }
 #endif
-#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-@available(iOS 17.0,macOS 14.0,tvOS 17.0,watchOS 10.0, *)
+#if os(tvOS) || os(iOS) || os(macOS) || os(watchOS)
+@available(tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0, *)
 extension FocusInteractions: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             ConstantAtomLiteral("activate").map({ () -> Self in
-#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+#if os(tvOS) || os(iOS) || os(macOS) || os(watchOS)
 
     return Self.activate
 
@@ -13116,7 +13116,7 @@ fatalError("'activate' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("edit").map({ () -> Self in
-#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+#if os(tvOS) || os(iOS) || os(macOS) || os(watchOS)
 
     return Self.edit
 
@@ -13125,7 +13125,7 @@ fatalError("'edit' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("automatic").map({ () -> Self in
-#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+#if os(tvOS) || os(iOS) || os(macOS) || os(watchOS)
 
     return Self.automatic
 
@@ -13219,8 +13219,8 @@ ConstantAtomLiteral("trailing").map({ () -> Self in
 
 })
 ConstantAtomLiteral("listRowSeparatorLeading").map({ () -> Self in
-#if os(macOS) || os(iOS)
-if #available(macOS 13.0,iOS 16.0, *) {
+#if os(iOS) || os(macOS)
+if #available(iOS 16.0,macOS 13.0, *) {
     return Self.listRowSeparatorLeading
 } else { fatalError("'listRowSeparatorLeading' is not available in this OS version") }
 #else
@@ -13228,8 +13228,8 @@ fatalError("'listRowSeparatorLeading' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("listRowSeparatorTrailing").map({ () -> Self in
-#if os(macOS) || os(iOS)
-if #available(macOS 13.0,iOS 16.0, *) {
+#if os(iOS) || os(macOS)
+if #available(iOS 16.0,macOS 13.0, *) {
     return Self.listRowSeparatorTrailing
 } else { fatalError("'listRowSeparatorTrailing' is not available in this OS version") }
 #else
@@ -13270,14 +13270,14 @@ ConstantAtomLiteral("trailing").map({ () -> Self in
     }
 }
 
-#if os(tvOS) || os(iOS)
-@available(tvOS 16.0,iOS 13.4, *)
+#if os(iOS) || os(tvOS)
+@available(iOS 13.4,tvOS 16.0, *)
 extension HoverEffect: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             ConstantAtomLiteral("automatic").map({ () -> Self in
-#if os(tvOS) || os(iOS)
+#if os(iOS) || os(tvOS)
 
     return Self.automatic
 
@@ -13286,8 +13286,8 @@ fatalError("'automatic' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("highlight").map({ () -> Self in
-#if os(tvOS) || os(iOS)
-if #available(tvOS 17.0,iOS 13.4, *) {
+#if os(iOS) || os(tvOS)
+if #available(iOS 13.4,tvOS 17.0, *) {
     return Self.highlight
 } else { fatalError("'highlight' is not available in this OS version") }
 #else
@@ -13295,7 +13295,7 @@ fatalError("'highlight' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("lift").map({ () -> Self in
-#if os(tvOS) || os(iOS)
+#if os(iOS) || os(tvOS)
 
     return Self.lift
 
@@ -13308,14 +13308,14 @@ fatalError("'lift' is not available on this OS")
     }
 }
 #endif
-#if os(macOS) || os(iOS)
-@available(macOS 11.0,iOS 14.0, *)
+#if os(iOS) || os(macOS)
+@available(iOS 14.0,macOS 11.0, *)
 extension KeyboardShortcut: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             ConstantAtomLiteral("defaultAction").map({ () -> Self in
-#if os(macOS) || os(iOS)
+#if os(iOS) || os(macOS)
 
     return Self.defaultAction
 
@@ -13324,7 +13324,7 @@ fatalError("'defaultAction' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("cancelAction").map({ () -> Self in
-#if os(macOS) || os(iOS)
+#if os(iOS) || os(macOS)
 
     return Self.cancelAction
 
@@ -13392,7 +13392,7 @@ extension MenuOrder: ParseableModifierValue {
 })
 ConstantAtomLiteral("priority").map({ () -> Self in
 #if os(iOS)
-if #available(tvOS 16.0,iOS 16.0,watchOS 9.0,macOS 13.0, *) {
+if #available(iOS 16.0,macOS 13.0,watchOS 9.0,tvOS 16.0, *) {
     return Self.priority
 } else { fatalError("'priority' is not available in this OS version") }
 #else
@@ -13413,14 +13413,14 @@ ConstantAtomLiteral("fixed").map({ () -> Self in
     }
 }
 
-#if os(tvOS) || os(watchOS) || os(iOS) || os(macOS)
-@available(tvOS 16.4,watchOS 9.4,iOS 16.4,macOS 13.3, *)
+#if os(tvOS) || os(macOS) || os(iOS) || os(watchOS)
+@available(tvOS 16.4,macOS 13.3,iOS 16.4,watchOS 9.4, *)
 extension PresentationAdaptation: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             ConstantAtomLiteral("automatic").map({ () -> Self in
-#if os(tvOS) || os(watchOS) || os(iOS) || os(macOS)
+#if os(tvOS) || os(macOS) || os(iOS) || os(watchOS)
 
     return Self.automatic
 
@@ -13429,7 +13429,7 @@ fatalError("'automatic' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("none").map({ () -> Self in
-#if os(tvOS) || os(watchOS) || os(iOS) || os(macOS)
+#if os(tvOS) || os(macOS) || os(iOS) || os(watchOS)
 
     return Self.none
 
@@ -13438,7 +13438,7 @@ fatalError("'none' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("popover").map({ () -> Self in
-#if os(tvOS) || os(watchOS) || os(iOS) || os(macOS)
+#if os(tvOS) || os(macOS) || os(iOS) || os(watchOS)
 
     return Self.popover
 
@@ -13447,7 +13447,7 @@ fatalError("'popover' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("sheet").map({ () -> Self in
-#if os(tvOS) || os(watchOS) || os(iOS) || os(macOS)
+#if os(tvOS) || os(macOS) || os(iOS) || os(watchOS)
 
     return Self.sheet
 
@@ -13456,7 +13456,7 @@ fatalError("'sheet' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("fullScreenCover").map({ () -> Self in
-#if os(tvOS) || os(watchOS) || os(iOS) || os(macOS)
+#if os(tvOS) || os(macOS) || os(iOS) || os(watchOS)
 
     return Self.fullScreenCover
 
@@ -13469,14 +13469,14 @@ fatalError("'fullScreenCover' is not available on this OS")
     }
 }
 #endif
-#if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
-@available(iOS 16.4,macOS 13.3,watchOS 9.4,tvOS 16.4, *)
+#if os(tvOS) || os(iOS) || os(macOS) || os(watchOS)
+@available(tvOS 16.4,iOS 16.4,macOS 13.3,watchOS 9.4, *)
 extension PresentationContentInteraction: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             ConstantAtomLiteral("automatic").map({ () -> Self in
-#if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
+#if os(tvOS) || os(iOS) || os(macOS) || os(watchOS)
 
     return Self.automatic
 
@@ -13485,7 +13485,7 @@ fatalError("'automatic' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("resizes").map({ () -> Self in
-#if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
+#if os(tvOS) || os(iOS) || os(macOS) || os(watchOS)
 
     return Self.resizes
 
@@ -13494,7 +13494,7 @@ fatalError("'resizes' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("scrolls").map({ () -> Self in
-#if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
+#if os(tvOS) || os(iOS) || os(macOS) || os(watchOS)
 
     return Self.scrolls
 
@@ -13561,8 +13561,8 @@ ConstantAtomLiteral("privacy").map({ () -> Self in
 
 })
 ConstantAtomLiteral("invalidated").map({ () -> Self in
-#if os(tvOS) || os(watchOS) || os(iOS) || os(macOS)
-if #available(tvOS 17.0,watchOS 10.0,iOS 17.0,macOS 14.0, *) {
+#if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
+if #available(iOS 17.0,macOS 14.0,watchOS 10.0,tvOS 17.0, *) {
     return Self.invalidated
 } else { fatalError("'invalidated' is not available in this OS version") }
 #else
@@ -13658,7 +13658,7 @@ extension ScenePadding: ParseableModifierValue {
 })
 ConstantAtomLiteral("navigationBar").map({ () -> Self in
 #if os(watchOS)
-if #available(watchOS 9.0,tvOS 16.0,macOS 13.0,iOS 16.0, *) {
+if #available(tvOS 16.0,iOS 16.0,macOS 13.0,watchOS 9.0, *) {
     return Self.navigationBar
 } else { fatalError("'navigationBar' is not available in this OS version") }
 #else
@@ -13670,14 +13670,14 @@ fatalError("'navigationBar' is not available on this OS")
     }
 }
 
-#if os(tvOS) || os(macOS) || os(watchOS) || os(iOS)
-@available(tvOS 16.4,macOS 13.3,watchOS 9.4,iOS 16.4, *)
+#if os(tvOS) || os(iOS) || os(macOS) || os(watchOS)
+@available(tvOS 16.4,iOS 16.4,macOS 13.3,watchOS 9.4, *)
 extension ScrollBounceBehavior: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             ConstantAtomLiteral("automatic").map({ () -> Self in
-#if os(tvOS) || os(macOS) || os(watchOS) || os(iOS)
+#if os(tvOS) || os(iOS) || os(macOS) || os(watchOS)
 
     return Self.automatic
 
@@ -13686,7 +13686,7 @@ fatalError("'automatic' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("always").map({ () -> Self in
-#if os(tvOS) || os(macOS) || os(watchOS) || os(iOS)
+#if os(tvOS) || os(iOS) || os(macOS) || os(watchOS)
 
     return Self.always
 
@@ -13695,7 +13695,7 @@ fatalError("'always' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("basedOnSize").map({ () -> Self in
-#if os(tvOS) || os(macOS) || os(watchOS) || os(iOS)
+#if os(tvOS) || os(iOS) || os(macOS) || os(watchOS)
 
     return Self.basedOnSize
 
@@ -13708,8 +13708,8 @@ fatalError("'basedOnSize' is not available on this OS")
     }
 }
 #endif
-#if os(tvOS) || os(macOS) || os(watchOS) || os(iOS)
-@available(tvOS 16.0,macOS 13.0,watchOS 9.0,iOS 16.0, *)
+#if os(tvOS) || os(iOS) || os(macOS) || os(watchOS)
+@available(tvOS 16.0,iOS 16.0,macOS 13.0,watchOS 9.0, *)
 extension ScrollDismissesKeyboardMode: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -13802,14 +13802,14 @@ ConstantAtomLiteral("never").map({ () -> Self in
     }
 }
 
-#if os(watchOS) || os(iOS) || os(tvOS) || os(macOS)
-@available(watchOS 9.4,iOS 16.4,tvOS 16.4,macOS 13.3, *)
+#if os(tvOS) || os(iOS) || os(macOS) || os(watchOS)
+@available(tvOS 16.4,iOS 16.4,macOS 13.3,watchOS 9.4, *)
 extension SearchScopeActivation: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             ConstantAtomLiteral("automatic").map({ () -> Self in
-#if os(watchOS) || os(iOS) || os(tvOS) || os(macOS)
+#if os(tvOS) || os(iOS) || os(macOS) || os(watchOS)
 
     return Self.automatic
 
@@ -13818,7 +13818,7 @@ fatalError("'automatic' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("onTextEntry").map({ () -> Self in
-#if os(watchOS) || os(iOS) || os(macOS)
+#if os(iOS) || os(macOS) || os(watchOS)
 
     return Self.onTextEntry
 
@@ -13827,7 +13827,7 @@ fatalError("'onTextEntry' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("onSearchPresentation").map({ () -> Self in
-#if os(watchOS) || os(iOS) || os(macOS)
+#if os(iOS) || os(macOS) || os(watchOS)
 
     return Self.onSearchPresentation
 
@@ -14037,14 +14037,14 @@ ConstantAtomLiteral("search").map({ () -> Self in
     }
 }
 
-#if os(watchOS) || os(iOS) || os(tvOS) || os(macOS)
-@available(watchOS 10.0,iOS 17.0,tvOS 17.0,macOS 14.0, *)
+#if os(watchOS) || os(macOS) || os(tvOS) || os(iOS)
+@available(watchOS 10.0,macOS 14.0,tvOS 17.0,iOS 17.0, *)
 extension ToolbarDefaultItemKind: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             ConstantAtomLiteral("sidebarToggle").map({ () -> Self in
-#if os(watchOS) || os(iOS) || os(tvOS) || os(macOS)
+#if os(watchOS) || os(macOS) || os(tvOS) || os(iOS)
 
     return Self.sidebarToggle
 
@@ -14073,8 +14073,8 @@ extension ToolbarRole: ParseableModifierValue {
 
 })
 ConstantAtomLiteral("navigationStack").map({ () -> Self in
-#if os(iOS) || os(tvOS) || os(watchOS)
-if #available(iOS 16.0,macOS 13.0,tvOS 16.0,watchOS 9.0, *) {
+#if os(tvOS) || os(iOS) || os(watchOS)
+if #available(tvOS 16.0,iOS 16.0,macOS 13.0,watchOS 9.0, *) {
     return Self.navigationStack
 } else { fatalError("'navigationStack' is not available in this OS version") }
 #else
@@ -14083,7 +14083,7 @@ fatalError("'navigationStack' is not available on this OS")
 })
 ConstantAtomLiteral("browser").map({ () -> Self in
 #if os(iOS)
-if #available(iOS 16.0,macOS 13.0,tvOS 16.0,watchOS 9.0, *) {
+if #available(tvOS 16.0,iOS 16.0,macOS 13.0,watchOS 9.0, *) {
     return Self.browser
 } else { fatalError("'browser' is not available in this OS version") }
 #else
@@ -14092,7 +14092,7 @@ fatalError("'browser' is not available on this OS")
 })
 ConstantAtomLiteral("editor").map({ () -> Self in
 #if os(iOS) || os(macOS)
-if #available(iOS 16.0,macOS 13.0,tvOS 16.0,watchOS 9.0, *) {
+if #available(tvOS 16.0,iOS 16.0,macOS 13.0,watchOS 9.0, *) {
     return Self.editor
 } else { fatalError("'editor' is not available in this OS version") }
 #else
@@ -14104,14 +14104,14 @@ fatalError("'editor' is not available on this OS")
     }
 }
 
-#if os(watchOS) || os(iOS) || os(macOS) || os(tvOS)
-@available(watchOS 10.0,iOS 17.0,macOS 14.0,tvOS 17.0, *)
+#if os(tvOS) || os(macOS) || os(iOS) || os(watchOS)
+@available(tvOS 17.0,macOS 14.0,iOS 17.0,watchOS 10.0, *)
 extension ToolbarTitleDisplayMode: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             ConstantAtomLiteral("automatic").map({ () -> Self in
-#if os(watchOS) || os(iOS) || os(macOS) || os(tvOS)
+#if os(tvOS) || os(macOS) || os(iOS) || os(watchOS)
 
     return Self.automatic
 
@@ -14120,7 +14120,7 @@ fatalError("'automatic' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("large").map({ () -> Self in
-#if os(watchOS) || os(iOS)
+#if os(iOS) || os(watchOS)
 
     return Self.large
 
@@ -14129,7 +14129,7 @@ fatalError("'large' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("inlineLarge").map({ () -> Self in
-#if os(iOS) || os(macOS)
+#if os(macOS) || os(iOS)
 
     return Self.inlineLarge
 
@@ -14138,7 +14138,7 @@ fatalError("'inlineLarge' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("inline").map({ () -> Self in
-#if os(watchOS) || os(iOS) || os(macOS) || os(tvOS)
+#if os(tvOS) || os(macOS) || os(iOS) || os(watchOS)
 
     return Self.inline
 

--- a/Sources/ModifierGenerator/ModifierGenerator.swift
+++ b/Sources/ModifierGenerator/ModifierGenerator.swift
@@ -11,6 +11,8 @@ struct ModifierGenerator: ParsableCommand {
         transform: { URL(filePath: $0) }
     )
     private var interface: URL
+    
+    @Flag private var schema = false
 
     static let extraModifierTypes: Set<String> = [
         // Image modifiers
@@ -220,18 +222,21 @@ struct ModifierGenerator: ParsableCommand {
         let visitor = ModifierVisitor(viewMode: SyntaxTreeViewMode.all)
         visitor.walk(sourceFile)
 
-        FileHandle.standardOutput.write(Data(
-            #"""
-            // File generated with `swift run ModifierGenerator "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/System/Library/Frameworks/SwiftUI.framework/Modules/SwiftUI.swiftmodule/arm64-apple-ios.swiftinterface" > Sources/LiveViewNative/_GeneratedModifiers.swift`
-            
-            import SwiftUI
-            import LiveViewNativeStylesheet
+        if !schema {
+            FileHandle.standardOutput.write(Data(
+                #"""
+                // File generated with `swift run ModifierGenerator "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/System/Library/Frameworks/SwiftUI.framework/Modules/SwiftUI.swiftmodule/arm64-apple-ios.swiftinterface" > Sources/LiveViewNative/_GeneratedModifiers.swift`
+                
+                import SwiftUI
+                import LiveViewNativeStylesheet
 
 
-            """#.utf8
-        ))
+                """#.utf8
+            ))
+        }
 
         var modifierList = [String]()
+        var generatedSchema = Schema()
 
         for (modifier, signatures) in visitor.modifiers.sorted(by: { $0.key < $1.key }) {
             guard !modifier.starts(with: "_"),
@@ -283,195 +288,213 @@ struct ModifierGenerator: ParsableCommand {
                 })
             })
             
-            FileHandle.standardOutput.write(Data(
-                #"""
-                @ParseableExpression
-                struct _\#(modifier)Modifier<R: RootRegistry>: ViewModifier {
-                    static var name: String { "\#(modifier)" }
+            if schema {
+                generatedSchema.modifiers[modifier] = signatures.map({
+                    .init(parameters: $0.parameters.map({
+                        .init(
+                            firstName: $0.firstName.text,
+                            secondName: $0.secondName?.text,
+                            type: $0.type.trimmed.description
+                        )
+                    }))
+                })
+            } else {
+                FileHandle.standardOutput.write(Data(
+                    #"""
+                    @ParseableExpression
+                    struct _\#(modifier)Modifier<R: RootRegistry>: ViewModifier {
+                        static var name: String { "\#(modifier)" }
 
-                    enum Value {
-                        case _never
-                \#(signatures.map(\.case).joined(separator: "\n"))
-                    }
+                        enum Value {
+                            case _never
+                    \#(signatures.map(\.case).joined(separator: "\n"))
+                        }
 
-                    let value: Value
+                        let value: Value
 
-                    \#(requiresContext ? "@ObservedElement private var element" : "")
-                    \#(requiresContext ? "@LiveContext<R> private var context" : "")
-                
-                \#(signatures.compactMap(\.properties).joined(separator: "\n"))
+                        \#(requiresContext ? "@ObservedElement private var element" : "")
+                        \#(requiresContext ? "@LiveContext<R> private var context" : "")
+                    
+                    \#(signatures.compactMap(\.properties).joined(separator: "\n"))
 
-                \#(signatures.map(\.`init`).joined(separator: "\n"))
+                    \#(signatures.map(\.`init`).joined(separator: "\n"))
 
-                    func body(content __content: Content) -> some View {
-                        switch value {
-                        case ._never:
-                            fatalError("unreachable")
-                \#(signatures.map(\.content).joined(separator: "\n"))
+                        func body(content __content: Content) -> some View {
+                            switch value {
+                            case ._never:
+                                fatalError("unreachable")
+                    \#(signatures.map(\.content).joined(separator: "\n"))
+                            }
                         }
                     }
-                }
 
-                """#.utf8
-            ))
+                    """#.utf8
+                ))
+            }
         }
 
-        FileHandle.standardOutput.write(Data(#"""
-
-        extension BuiltinRegistry {
-            enum BuiltinModifier: ViewModifier, ParseableModifierValue {
-                \#(modifierList.map({ "case \($0)(_\($0)Modifier<R>)" }).joined(separator: "\n"))
-                \#(Self.extraModifierTypes.map({ "case \($0.split(separator: "<").first!)(LiveViewNative.\($0))" }).joined(separator: "\n"))
-                case _customRegistryModifier(R.CustomModifier)
-                
-                func body(content: Content) -> some View {
-                    switch self {
-                    \#(modifierList.map({
-                        """
-                        case let .\($0)(modifier):
+        if !schema {
+            FileHandle.standardOutput.write(Data(#"""
+            
+            extension BuiltinRegistry {
+                enum BuiltinModifier: ViewModifier, ParseableModifierValue {
+                    \#(modifierList.map({ "case \($0)(_\($0)Modifier<R>)" }).joined(separator: "\n"))
+                    \#(Self.extraModifierTypes.map({ "case \($0.split(separator: "<").first!)(LiveViewNative.\($0))" }).joined(separator: "\n"))
+                    case _customRegistryModifier(R.CustomModifier)
+                    
+                    func body(content: Content) -> some View {
+                        switch self {
+                        \#(modifierList.map({
+                            """
+                            case let .\($0)(modifier):
+                                content.modifier(modifier)
+                            """
+                        }).joined(separator: "\n"))
+                        \#(Self.extraModifierTypes.map({
+                            """
+                            case let .\($0.split(separator: "<").first!)(modifier):
+                                content.modifier(modifier)
+                            """
+                        }).joined(separator: "\n"))
+                        case let ._customRegistryModifier(modifier):
                             content.modifier(modifier)
-                        """
-                    }).joined(separator: "\n"))
-                    \#(Self.extraModifierTypes.map({
-                        """
-                        case let .\($0.split(separator: "<").first!)(modifier):
-                            content.modifier(modifier)
-                        """
-                    }).joined(separator: "\n"))
-                    case let ._customRegistryModifier(modifier):
-                        content.modifier(modifier)
+                        }
                     }
-                }
-                
-                static func parser(in context: ParseableModifierContext) -> _ParserType {
-                    .init(context: context)
-                }
+                    
+                    static func parser(in context: ParseableModifierContext) -> _ParserType {
+                        .init(context: context)
+                    }
 
-                struct _ParserType: Parser {
-                    typealias Input = Substring.UTF8View
-                    typealias Output = BuiltinModifier
-                    
-                    let context: ParseableModifierContext
-                    
-                    func parse(_ input: inout Substring.UTF8View) throws -> Output {
-                        let parsers = [
-                            \#(modifierList.map({ "_\($0)Modifier<R>.name: _\($0)Modifier<R>.parser(in: context).map(Output.\($0)).eraseToAnyParser()," }).joined(separator: "\n"))
-                            \#(Self.extraModifierTypes.map({ "LiveViewNative.\($0).name: LiveViewNative.\($0).parser(in: context).map(Output.\($0.split(separator: "<").first!)).eraseToAnyParser()," }).joined(separator: "\n"))
-                        ]
+                    struct _ParserType: Parser {
+                        typealias Input = Substring.UTF8View
+                        typealias Output = BuiltinModifier
                         
-                        var copy = input
-                        let (modifierName, metadata) = try Parse {
-                            "{".utf8
-                            Whitespace()
-                            AtomLiteral()
-                            Whitespace()
-                            ",".utf8
-                            Whitespace()
-                            Metadata.parser()
-                        }.parse(&copy)
+                        let context: ParseableModifierContext
                         
-                        copy = input
-                        
-                        // attempt to parse the built-in modifiers first.
-                        do {
-                            if let parser = parsers[modifierName] {
-                                return try parser.parse(&input)
-                            } else {
-                                throw ModifierParseError(
-                                    error: .unknownModifier(modifierName),
-                                    metadata: metadata
-                                )
-                            }
-                        } catch let builtinError {
-                            // if the modifier name is not a known built-in, backtrack and try to parse as a custom modifier
-                            input = copy
+                        func parse(_ input: inout Substring.UTF8View) throws -> Output {
+                            let parsers = [
+                                \#(modifierList.map({ "_\($0)Modifier<R>.name: _\($0)Modifier<R>.parser(in: context).map(Output.\($0)).eraseToAnyParser()," }).joined(separator: "\n"))
+                                \#(Self.extraModifierTypes.map({ "LiveViewNative.\($0).name: LiveViewNative.\($0).parser(in: context).map(Output.\($0.split(separator: "<").first!)).eraseToAnyParser()," }).joined(separator: "\n"))
+                            ]
+                            
+                            var copy = input
+                            let (modifierName, metadata) = try Parse {
+                                "{".utf8
+                                Whitespace()
+                                AtomLiteral()
+                                Whitespace()
+                                ",".utf8
+                                Whitespace()
+                                Metadata.parser()
+                            }.parse(&copy)
+                            
+                            copy = input
+                            
+                            // attempt to parse the built-in modifiers first.
                             do {
-                                return try ._customRegistryModifier(R.parseModifier(&input, in: context))
-                            } catch let error as ModifierParseError {
-                                throw error
-                            } catch {
-                                throw builtinError
+                                if let parser = parsers[modifierName] {
+                                    return try parser.parse(&input)
+                                } else {
+                                    throw ModifierParseError(
+                                        error: .unknownModifier(modifierName),
+                                        metadata: metadata
+                                    )
+                                }
+                            } catch let builtinError {
+                                // if the modifier name is not a known built-in, backtrack and try to parse as a custom modifier
+                                input = copy
+                                do {
+                                    return try ._customRegistryModifier(R.parseModifier(&input, in: context))
+                                } catch let error as ModifierParseError {
+                                    throw error
+                                } catch {
+                                    throw builtinError
+                                }
                             }
                         }
                     }
                 }
             }
-        }
-
-        """#.utf8))
-
-        let typeVisitor = EnumTypeVisitor(typeNames: Self.requiredTypes)
-        typeVisitor.walk(sourceFile)
-
-        for (type, cases) in typeVisitor.types.sorted(by: { $0.key < $1.key }) {
-            let (availability, unavailable) = typeVisitor.availability[type]!
-            FileHandle.standardOutput.write(Data(
-                """
-                \(
-                    availability.isEmpty
-                    ? ""
-                    : """
-                    #if \(
-                        availability
-                            .compactMap({ $0.argument.as(PlatformVersionSyntax.self)?.platform.text })
-                            .filter({ !unavailable.contains($0) })
-                            .map({ $0 == "macCatalyst" ? "targetEnvironment(macCatalyst)" : "os(\($0))" })
-                            .joined(separator: " || ")
-                    )
+            
+            """#.utf8))
+            
+            let typeVisitor = EnumTypeVisitor(typeNames: Self.requiredTypes)
+            typeVisitor.walk(sourceFile)
+            
+            for (type, cases) in typeVisitor.types.sorted(by: { $0.key < $1.key }) {
+                let (availability, unavailable) = typeVisitor.availability[type]!
+                FileHandle.standardOutput.write(Data(
                     """
-                )
-                \(availability.isEmpty ? "" : "@available(\(availability), *)")
-                extension \(type): ParseableModifierValue {
-                    public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
-                        ImplicitStaticMember {
-                            OneOf {
-                            \(cases.map({
-                                let (`case`, (memberAvailability, memberUnavailable)) = $0
-                                let availability = (
-                                    (
-                                        memberAvailability
-                                            .compactMap({ $0.argument.as(PlatformVersionSyntax.self) })
-                                            .map({ "\($0.platform.text) \($0.version?.description ?? "")" })
-                                            .sorted() ==
-                                        availability
-                                            .compactMap({ $0.argument.as(PlatformVersionSyntax.self) })
-                                            .map({ "\($0.platform.text) \($0.version?.description ?? "")" })
-                                            .sorted()
+                    \(
+                        availability.isEmpty
+                        ? ""
+                        : """
+                        #if \(
+                            availability
+                                .compactMap({ $0.argument.as(PlatformVersionSyntax.self)?.platform.text })
+                                .filter({ !unavailable.contains($0) })
+                                .map({ $0 == "macCatalyst" ? "targetEnvironment(macCatalyst)" : "os(\($0))" })
+                                .joined(separator: " || ")
+                        )
+                        """
+                    )
+                    \(availability.isEmpty ? "" : "@available(\(availability), *)")
+                    extension \(type): ParseableModifierValue {
+                        public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
+                            ImplicitStaticMember {
+                                OneOf {
+                                \(cases.map({
+                                    let (`case`, (memberAvailability, memberUnavailable)) = $0
+                                    let availability = (
+                                        (
+                                            memberAvailability
+                                                .compactMap({ $0.argument.as(PlatformVersionSyntax.self) })
+                                                .map({ "\($0.platform.text) \($0.version?.description ?? "")" })
+                                                .sorted() ==
+                                            availability
+                                                .compactMap({ $0.argument.as(PlatformVersionSyntax.self) })
+                                                .map({ "\($0.platform.text) \($0.version?.description ?? "")" })
+                                                .sorted()
+                                        )
                                     )
-                                )
-                                    ? AvailabilityArgumentListSyntax([])
-                                    : memberAvailability
-                                return #"""
-                                ConstantAtomLiteral("\#(`case`)").map({ () -> Self in
-                                \#(
-                                    memberAvailability.isEmpty
-                                    ? ""
-                                    : """
-                                    #if \(
-                                        memberAvailability
-                                            .compactMap({ $0.argument.as(PlatformVersionSyntax.self)?.platform.text })
-                                            .filter({ !memberUnavailable.contains($0) })
-                                            .map({ $0 == "macCatalyst" ? "targetEnvironment(macCatalyst)" : "os(\($0))" })
-                                            .joined(separator: " || "))
-                                    """
-                                )
-                                \#(availability.isEmpty ? "" : "if #available(\(availability), *) {")
-                                    return Self.\#(`case`)
-                                \#(availability.isEmpty ? "" : #"} else { fatalError("'\#(`case`)' is not available in this OS version") }"#)
-                                \#(memberAvailability.isEmpty ? "" : "#else")
-                                \#(memberAvailability.isEmpty ? "" : #"fatalError("'\#(`case`)' is not available on this OS")"#)
-                                \#(memberAvailability.isEmpty ? "" : "#endif")
-                                })
-                                """#
-                            }).joined(separator: "\n"))
+                                        ? AvailabilityArgumentListSyntax([])
+                                        : memberAvailability
+                                    return #"""
+                                    ConstantAtomLiteral("\#(`case`)").map({ () -> Self in
+                                    \#(
+                                        memberAvailability.isEmpty
+                                        ? ""
+                                        : """
+                                        #if \(
+                                            memberAvailability
+                                                .compactMap({ $0.argument.as(PlatformVersionSyntax.self)?.platform.text })
+                                                .filter({ !memberUnavailable.contains($0) })
+                                                .map({ $0 == "macCatalyst" ? "targetEnvironment(macCatalyst)" : "os(\($0))" })
+                                                .joined(separator: " || "))
+                                        """
+                                    )
+                                    \#(availability.isEmpty ? "" : "if #available(\(availability), *) {")
+                                        return Self.\#(`case`)
+                                    \#(availability.isEmpty ? "" : #"} else { fatalError("'\#(`case`)' is not available in this OS version") }"#)
+                                    \#(memberAvailability.isEmpty ? "" : "#else")
+                                    \#(memberAvailability.isEmpty ? "" : #"fatalError("'\#(`case`)' is not available on this OS")"#)
+                                    \#(memberAvailability.isEmpty ? "" : "#endif")
+                                    })
+                                    """#
+                                }).joined(separator: "\n"))
+                                }
                             }
                         }
                     }
-                }
-                \(availability.isEmpty ? "" : "#endif")
-
-                """.utf8
-            ))
+                    \(availability.isEmpty ? "" : "#endif")
+                    
+                    """.utf8
+                ))
+            }
+        }
+        
+        if schema {
+            FileHandle.standardOutput.write(try JSONEncoder().encode(generatedSchema))
         }
     }
 

--- a/Sources/ModifierGenerator/ModifierGenerator.swift
+++ b/Sources/ModifierGenerator/ModifierGenerator.swift
@@ -12,7 +12,9 @@ struct ModifierGenerator: ParsableCommand {
     )
     private var interface: URL
     
-    @Flag private var schema = false
+    @Flag(
+        help: "Produce a JSON format read by the LiveView Native VS Code extension."
+    ) private var schema = false
 
     static let extraModifierTypes: Set<String> = [
         // Image modifiers

--- a/Sources/ModifierGenerator/Schema.swift
+++ b/Sources/ModifierGenerator/Schema.swift
@@ -1,0 +1,34 @@
+//
+//  Schema.swift
+//
+//
+//  Created by Carson Katri on 1/2/24.
+//
+
+import Foundation
+
+/// A JSON representation of the available modifiers.
+/// This structure is used by the LiveView Native VS Code extension to provide completions for modifiers.
+struct Schema: Encodable {
+    var modifiers: [String:[Signature]] = [:]
+    
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(modifiers)
+    }
+    
+    struct Signature: Encodable {
+        let parameters: [Parameter]
+        
+        func encode(to encoder: Encoder) throws {
+            var container = encoder.singleValueContainer()
+            try container.encode(parameters)
+        }
+        
+        struct Parameter: Encodable {
+            let firstName: String
+            let secondName: String?
+            let type: String
+        }
+    }
+}


### PR DESCRIPTION
This adds a `--schema` flag to the modifier generator. This changes the output to a JSON format that is read by the LiveView Native VS Code extension to provide code completion.

See https://github.com/liveview-native/liveview-native-vscode/pull/5 for an example output and use-case.