### PR TITLE
Find modifier members inside `#if` conditionals

### DIFF
--- a/Sources/LiveViewNative/_GeneratedModifiers.swift
+++ b/Sources/LiveViewNative/_GeneratedModifiers.swift
@@ -883,10 +883,10 @@ struct _badgeModifier<R: RootRegistry>: ViewModifier {
         #if os(macOS) || os(iOS)
         case _1(label: Any?)
         #endif
-        #if os(iOS) || os(macOS)
+        #if os(macOS) || os(iOS)
         case _2(key: Any?)
         #endif
-        #if os(iOS) || os(macOS)
+        #if os(macOS) || os(iOS)
         case _3(label: Any)
         #endif
     }
@@ -919,15 +919,15 @@ struct _badgeModifier<R: RootRegistry>: ViewModifier {
         
     }
     #endif
-    #if os(iOS) || os(macOS)
-    @available(iOS 15.0,macOS 12.0, *)
+    #if os(macOS) || os(iOS)
+    @available(macOS 12.0,iOS 15.0, *)
     init(_ key: SwiftUI.LocalizedStringKey?) {
         self.value = ._2(key: key)
         
     }
     #endif
-    #if os(iOS) || os(macOS)
-    @available(iOS 15.0,macOS 12.0, *)
+    #if os(macOS) || os(iOS)
+    @available(macOS 12.0,iOS 15.0, *)
     init(_ label: AttributeReference<String>) {
         self.value = ._3(label: label)
         
@@ -954,17 +954,17 @@ struct _badgeModifier<R: RootRegistry>: ViewModifier {
                 .badge(label?.resolve(on: element, in: context))
             } else { __content }
         #endif
-        #if os(iOS) || os(macOS)
+        #if os(macOS) || os(iOS)
         case let ._2(key):
-            if #available(iOS 15.0,macOS 12.0, *) {
+            if #available(macOS 12.0,iOS 15.0, *) {
             let key = key as? SwiftUI.LocalizedStringKey
             __content
                 .badge(key)
             } else { __content }
         #endif
-        #if os(iOS) || os(macOS)
+        #if os(macOS) || os(iOS)
         case let ._3(label):
-            if #available(iOS 15.0,macOS 12.0, *) {
+            if #available(macOS 12.0,iOS 15.0, *) {
             let label = label as! AttributeReference<String>
             __content
                 .badge(label.resolve(on: element, in: context))
@@ -1687,10 +1687,10 @@ struct _containerRelativeFrameModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+        #if os(macOS) || os(watchOS) || os(iOS) || os(tvOS)
         case _0(axes: Any,alignment: Any)
         #endif
-        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
+        #if os(macOS) || os(watchOS) || os(iOS) || os(tvOS)
         case _1(axes: Any,count: Any,span: Any, spacing: Any,alignment: Any)
         #endif
     }
@@ -1705,15 +1705,15 @@ struct _containerRelativeFrameModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-    @available(iOS 17.0,macOS 14.0,tvOS 17.0,watchOS 10.0, *)
+    #if os(macOS) || os(watchOS) || os(iOS) || os(tvOS)
+    @available(macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0, *)
     init(_ axes: SwiftUI.Axis.Set,alignment: AttributeReference<SwiftUI.Alignment> = .init(storage: .constant(.center)) ) {
         self.value = ._0(axes: axes, alignment: alignment)
         
     }
     #endif
-    #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
-    @available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0, *)
+    #if os(macOS) || os(watchOS) || os(iOS) || os(tvOS)
+    @available(macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0, *)
     init(_ axes: SwiftUI.Axis.Set,count: AttributeReference<Swift.Int>,span: AttributeReference<Swift.Int> = .init(storage: .constant(1)), spacing: AttributeReference<CoreFoundation.CGFloat>,alignment: AttributeReference<SwiftUI.Alignment> = .init(storage: .constant(.center)) ) {
         self.value = ._1(axes: axes, count: count, span: span, spacing: spacing, alignment: alignment)
         
@@ -1724,18 +1724,18 @@ struct _containerRelativeFrameModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+        #if os(macOS) || os(watchOS) || os(iOS) || os(tvOS)
         case let ._0(axes, alignment):
-            if #available(iOS 17.0,macOS 14.0,tvOS 17.0,watchOS 10.0, *) {
+            if #available(macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0, *) {
             let axes = axes as! SwiftUI.Axis.Set
 let alignment = alignment as! AttributeReference<SwiftUI.Alignment>
             __content
                 .containerRelativeFrame(axes, alignment: alignment.resolve(on: element, in: context))
             } else { __content }
         #endif
-        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
+        #if os(macOS) || os(watchOS) || os(iOS) || os(tvOS)
         case let ._1(axes, count, span, spacing, alignment):
-            if #available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0, *) {
+            if #available(macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0, *) {
             let axes = axes as! SwiftUI.Axis.Set
 let count = count as! AttributeReference<Swift.Int>
 let span = span as! AttributeReference<Swift.Int>
@@ -1900,10 +1900,10 @@ struct _contextMenuModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(tvOS) || os(macOS) || os(iOS)
+        #if os(macOS) || os(tvOS) || os(iOS)
         case _0(menuItems: Any)
         #endif
-        #if os(macOS) || os(iOS) || os(tvOS)
+        #if os(macOS) || os(tvOS) || os(iOS)
         case _1(menuItems: Any,preview: Any)
         #endif
     }
@@ -1918,15 +1918,15 @@ struct _contextMenuModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(tvOS) || os(macOS) || os(iOS)
-    @available(tvOS 14.0,macOS 10.15,iOS 13.0, *)
+    #if os(macOS) || os(tvOS) || os(iOS)
+    @available(macOS 10.15,tvOS 14.0,iOS 13.0, *)
     init(menuItems: ViewReference=ViewReference(value: [])) {
         self.value = ._0(menuItems: menuItems)
         
     }
     #endif
-    #if os(macOS) || os(iOS) || os(tvOS)
-    @available(macOS 13.0,iOS 16.0,tvOS 16.0, *)
+    #if os(macOS) || os(tvOS) || os(iOS)
+    @available(macOS 13.0,tvOS 16.0,iOS 16.0, *)
     init(menuItems: ViewReference=ViewReference(value: []),preview: ViewReference=ViewReference(value: [])) {
         self.value = ._1(menuItems: menuItems, preview: preview)
         
@@ -1937,17 +1937,17 @@ struct _contextMenuModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(tvOS) || os(macOS) || os(iOS)
+        #if os(macOS) || os(tvOS) || os(iOS)
         case let ._0(menuItems):
-            if #available(tvOS 14.0,macOS 10.15,iOS 13.0, *) {
+            if #available(macOS 10.15,tvOS 14.0,iOS 13.0, *) {
             let menuItems = menuItems as! ViewReference
             __content
                 .contextMenu(menuItems: { menuItems.resolve(on: element, in: context) })
             } else { __content }
         #endif
-        #if os(macOS) || os(iOS) || os(tvOS)
+        #if os(macOS) || os(tvOS) || os(iOS)
         case let ._1(menuItems, preview):
-            if #available(macOS 13.0,iOS 16.0,tvOS 16.0, *) {
+            if #available(macOS 13.0,tvOS 16.0,iOS 16.0, *) {
             let menuItems = menuItems as! ViewReference
 let preview = preview as! ViewReference
             __content
@@ -2005,7 +2005,7 @@ struct _controlGroupStyleModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(macOS) || os(iOS) || os(tvOS)
+        #if os(macOS) || os(tvOS) || os(iOS)
         case _0(style: Any)
         #endif
     }
@@ -2018,8 +2018,8 @@ struct _controlGroupStyleModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(macOS) || os(iOS) || os(tvOS)
-    @available(macOS 12.0,iOS 15.0,tvOS 17.0, *)
+    #if os(macOS) || os(tvOS) || os(iOS)
+    @available(macOS 12.0,tvOS 17.0,iOS 15.0, *)
     init(_ style: AnyControlGroupStyle) {
         self.value = ._0(style: style)
         
@@ -2030,9 +2030,9 @@ struct _controlGroupStyleModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(macOS) || os(iOS) || os(tvOS)
+        #if os(macOS) || os(tvOS) || os(iOS)
         case let ._0(style):
-            if #available(macOS 12.0,iOS 15.0,tvOS 17.0, *) {
+            if #available(macOS 12.0,tvOS 17.0,iOS 15.0, *) {
             let style = style as! AnyControlGroupStyle
             __content
                 .controlGroupStyle(style)
@@ -2047,7 +2047,7 @@ struct _controlSizeModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(watchOS) || os(iOS) || os(macOS)
+        #if os(macOS) || os(watchOS) || os(iOS)
         case _0(controlSize: Any)
         #endif
     }
@@ -2060,8 +2060,8 @@ struct _controlSizeModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(watchOS) || os(iOS) || os(macOS)
-    @available(watchOS 9.0,iOS 15.0,macOS 10.15, *)
+    #if os(macOS) || os(watchOS) || os(iOS)
+    @available(macOS 10.15,watchOS 9.0,iOS 15.0, *)
     init(_ controlSize: SwiftUI.ControlSize) {
         self.value = ._0(controlSize: controlSize)
         
@@ -2072,9 +2072,9 @@ struct _controlSizeModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(watchOS) || os(iOS) || os(macOS)
+        #if os(macOS) || os(watchOS) || os(iOS)
         case let ._0(controlSize):
-            if #available(watchOS 9.0,iOS 15.0,macOS 10.15, *) {
+            if #available(macOS 10.15,watchOS 9.0,iOS 15.0, *) {
             let controlSize = controlSize as! SwiftUI.ControlSize
             __content
                 .controlSize(controlSize)
@@ -2089,7 +2089,7 @@ struct _coordinateSpaceModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(watchOS) || os(tvOS) || os(macOS)
+        #if os(watchOS) || os(macOS) || os(iOS) || os(tvOS)
         case _0(name: Any)
         #endif
     }
@@ -2102,8 +2102,8 @@ struct _coordinateSpaceModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(watchOS) || os(tvOS) || os(macOS)
-    @available(iOS 17.0,watchOS 10.0,tvOS 17.0,macOS 14.0, *)
+    #if os(watchOS) || os(macOS) || os(iOS) || os(tvOS)
+    @available(watchOS 10.0,macOS 14.0,iOS 17.0,tvOS 17.0, *)
     init(_ name: SwiftUI.NamedCoordinateSpace) {
         self.value = ._0(name: name)
         
@@ -2114,9 +2114,9 @@ struct _coordinateSpaceModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(watchOS) || os(tvOS) || os(macOS)
+        #if os(watchOS) || os(macOS) || os(iOS) || os(tvOS)
         case let ._0(name):
-            if #available(iOS 17.0,watchOS 10.0,tvOS 17.0,macOS 14.0, *) {
+            if #available(watchOS 10.0,macOS 14.0,iOS 17.0,tvOS 17.0, *) {
             let name = name as! SwiftUI.NamedCoordinateSpace
             __content
                 .coordinateSpace(name)
@@ -2131,7 +2131,7 @@ struct _datePickerStyleModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(macOS) || os(watchOS)
+        #if os(macOS) || os(watchOS) || os(iOS)
         case _0(style: Any)
         #endif
     }
@@ -2144,8 +2144,8 @@ struct _datePickerStyleModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(macOS) || os(watchOS)
-    @available(iOS 13.0,macOS 10.15,watchOS 10.0, *)
+    #if os(macOS) || os(watchOS) || os(iOS)
+    @available(macOS 10.15,watchOS 10.0,iOS 13.0, *)
     init(_ style: AnyDatePickerStyle) {
         self.value = ._0(style: style)
         
@@ -2156,9 +2156,9 @@ struct _datePickerStyleModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(macOS) || os(watchOS)
+        #if os(macOS) || os(watchOS) || os(iOS)
         case let ._0(style):
-            if #available(iOS 13.0,macOS 10.15,watchOS 10.0, *) {
+            if #available(macOS 10.15,watchOS 10.0,iOS 13.0, *) {
             let style = style as! AnyDatePickerStyle
             __content
                 .datePickerStyle(style)
@@ -2173,7 +2173,7 @@ struct _defaultScrollAnchorModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(watchOS) || os(iOS) || os(tvOS) || os(macOS)
+        #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
         case _0(anchor: Any?)
         #endif
     }
@@ -2186,8 +2186,8 @@ struct _defaultScrollAnchorModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(watchOS) || os(iOS) || os(tvOS) || os(macOS)
-    @available(watchOS 10.0,iOS 17.0,tvOS 17.0,macOS 14.0, *)
+    #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
+    @available(tvOS 17.0,iOS 17.0,watchOS 10.0,macOS 14.0, *)
     init(_ anchor: AttributeReference<SwiftUI.UnitPoint?>?) {
         self.value = ._0(anchor: anchor)
         
@@ -2198,9 +2198,9 @@ struct _defaultScrollAnchorModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(watchOS) || os(iOS) || os(tvOS) || os(macOS)
+        #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
         case let ._0(anchor):
-            if #available(watchOS 10.0,iOS 17.0,tvOS 17.0,macOS 14.0, *) {
+            if #available(tvOS 17.0,iOS 17.0,watchOS 10.0,macOS 14.0, *) {
             let anchor = anchor as? AttributeReference<SwiftUI.UnitPoint?>
             __content
                 .defaultScrollAnchor(anchor?.resolve(on: element, in: context))
@@ -2341,16 +2341,16 @@ struct _dialogSuppressionToggleModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(watchOS) || os(tvOS) || os(macOS) || os(iOS)
+        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
         case _0(titleKey: Any)
         #endif
-        #if os(tvOS) || os(iOS) || os(macOS) || os(watchOS)
+        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
         case _1(title: Any)
         #endif
-        #if os(iOS) || os(tvOS) || os(macOS) || os(watchOS)
+        #if os(tvOS) || os(macOS) || os(watchOS) || os(iOS)
         case _2(label: Any)
         #endif
-        #if os(iOS) || os(tvOS) || os(macOS) || os(watchOS)
+        #if os(tvOS) || os(macOS) || os(watchOS) || os(iOS)
         case _3
         #endif
     }
@@ -2369,29 +2369,29 @@ struct _dialogSuppressionToggleModifier<R: RootRegistry>: ViewModifier {
 @ChangeTracked private var _3_isSuppressed: Swift.Bool
 
 
-    #if os(watchOS) || os(tvOS) || os(macOS) || os(iOS)
-    @available(watchOS 10.0,tvOS 17.0,macOS 14.0,iOS 17.0, *)
+    #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
+    @available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0, *)
     init(_ titleKey: SwiftUI.LocalizedStringKey,isSuppressed: ChangeTracked<Swift.Bool>) {
         self.value = ._0(titleKey: titleKey)
         self.__0_isSuppressed = isSuppressed
     }
     #endif
-    #if os(tvOS) || os(iOS) || os(macOS) || os(watchOS)
-    @available(tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0, *)
+    #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
+    @available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0, *)
     init(_ title: AttributeReference<String>,isSuppressed: ChangeTracked<Swift.Bool>) {
         self.value = ._1(title: title)
         self.__1_isSuppressed = isSuppressed
     }
     #endif
-    #if os(iOS) || os(tvOS) || os(macOS) || os(watchOS)
-    @available(iOS 17.0,tvOS 17.0,macOS 14.0,watchOS 10.0, *)
+    #if os(tvOS) || os(macOS) || os(watchOS) || os(iOS)
+    @available(tvOS 17.0,macOS 14.0,watchOS 10.0,iOS 17.0, *)
     init(_ label: TextReference,isSuppressed: ChangeTracked<Swift.Bool>) {
         self.value = ._2(label: label)
         self.__2_isSuppressed = isSuppressed
     }
     #endif
-    #if os(iOS) || os(tvOS) || os(macOS) || os(watchOS)
-    @available(iOS 17.0,tvOS 17.0,macOS 14.0,watchOS 10.0, *)
+    #if os(tvOS) || os(macOS) || os(watchOS) || os(iOS)
+    @available(tvOS 17.0,macOS 14.0,watchOS 10.0,iOS 17.0, *)
     init(isSuppressed: ChangeTracked<Swift.Bool>) {
         self.value = ._3
         self.__3_isSuppressed = isSuppressed
@@ -2402,33 +2402,33 @@ struct _dialogSuppressionToggleModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(watchOS) || os(tvOS) || os(macOS) || os(iOS)
+        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
         case let ._0(titleKey):
-            if #available(watchOS 10.0,tvOS 17.0,macOS 14.0,iOS 17.0, *) {
+            if #available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0, *) {
             let titleKey = titleKey as! SwiftUI.LocalizedStringKey
             __content
                 .dialogSuppressionToggle(titleKey, isSuppressed: __0_isSuppressed.projectedValue)
             } else { __content }
         #endif
-        #if os(tvOS) || os(iOS) || os(macOS) || os(watchOS)
+        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
         case let ._1(title):
-            if #available(tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0, *) {
+            if #available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0, *) {
             let title = title as! AttributeReference<String>
             __content
                 .dialogSuppressionToggle(title.resolve(on: element, in: context), isSuppressed: __1_isSuppressed.projectedValue)
             } else { __content }
         #endif
-        #if os(iOS) || os(tvOS) || os(macOS) || os(watchOS)
+        #if os(tvOS) || os(macOS) || os(watchOS) || os(iOS)
         case let ._2(label):
-            if #available(iOS 17.0,tvOS 17.0,macOS 14.0,watchOS 10.0, *) {
+            if #available(tvOS 17.0,macOS 14.0,watchOS 10.0,iOS 17.0, *) {
             let label = label as! TextReference
             __content
                 .dialogSuppressionToggle(label.resolve(on: element, in: context), isSuppressed: __2_isSuppressed.projectedValue)
             } else { __content }
         #endif
-        #if os(iOS) || os(tvOS) || os(macOS) || os(watchOS)
+        #if os(tvOS) || os(macOS) || os(watchOS) || os(iOS)
         case ._3:
-            if #available(iOS 17.0,tvOS 17.0,macOS 14.0,watchOS 10.0, *) {
+            if #available(tvOS 17.0,macOS 14.0,watchOS 10.0,iOS 17.0, *) {
             
             __content
                 .dialogSuppressionToggle(isSuppressed: __3_isSuppressed.projectedValue)
@@ -2923,7 +2923,7 @@ struct _focusEffectDisabledModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
         case _0(disabled: Any)
         #endif
     }
@@ -2936,8 +2936,8 @@ struct _focusEffectDisabledModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
-    @available(macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0, *)
+    #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
+    @available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0, *)
     init(_ disabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(disabled: disabled)
         
@@ -2948,9 +2948,9 @@ struct _focusEffectDisabledModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
         case let ._0(disabled):
-            if #available(macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0, *) {
+            if #available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0, *) {
             let disabled = disabled as! AttributeReference<Swift.Bool>
             __content
                 .focusEffectDisabled(disabled.resolve(on: element, in: context))
@@ -2965,7 +2965,7 @@ struct _focusSectionModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(tvOS) || os(macOS)
+        #if os(macOS) || os(tvOS)
         case _0
         #endif
     }
@@ -2978,8 +2978,8 @@ struct _focusSectionModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(tvOS) || os(macOS)
-    @available(tvOS 15.0,macOS 13.0, *)
+    #if os(macOS) || os(tvOS)
+    @available(macOS 13.0,tvOS 15.0, *)
     init() {
         self.value = ._0
         
@@ -2990,9 +2990,9 @@ struct _focusSectionModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(tvOS) || os(macOS)
+        #if os(macOS) || os(tvOS)
         case ._0:
-            if #available(tvOS 15.0,macOS 13.0, *) {
+            if #available(macOS 13.0,tvOS 15.0, *) {
             
             __content
                 .focusSection()
@@ -3007,10 +3007,10 @@ struct _focusableModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+        #if os(watchOS) || os(iOS) || os(tvOS) || os(macOS)
         case _0(isFocusable: Any)
         #endif
-        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+        #if os(watchOS) || os(iOS) || os(tvOS) || os(macOS)
         case _1(isFocusable: Any, interactions: Any)
         #endif
     }
@@ -3025,15 +3025,15 @@ struct _focusableModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-    @available(iOS 17.0,macOS 12.0,tvOS 15.0,watchOS 8.0, *)
+    #if os(watchOS) || os(iOS) || os(tvOS) || os(macOS)
+    @available(watchOS 8.0,iOS 17.0,tvOS 15.0,macOS 12.0, *)
     init(_ isFocusable: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(isFocusable: isFocusable)
         
     }
     #endif
-    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-    @available(iOS 17.0,macOS 14.0,tvOS 17.0,watchOS 10.0, *)
+    #if os(watchOS) || os(iOS) || os(tvOS) || os(macOS)
+    @available(watchOS 10.0,iOS 17.0,tvOS 17.0,macOS 14.0, *)
     init(_ isFocusable: AttributeReference<Swift.Bool> = .init(storage: .constant(true)), interactions: SwiftUI.FocusInteractions) {
         self.value = ._1(isFocusable: isFocusable, interactions: interactions)
         
@@ -3044,17 +3044,17 @@ struct _focusableModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+        #if os(watchOS) || os(iOS) || os(tvOS) || os(macOS)
         case let ._0(isFocusable):
-            if #available(iOS 17.0,macOS 12.0,tvOS 15.0,watchOS 8.0, *) {
+            if #available(watchOS 8.0,iOS 17.0,tvOS 15.0,macOS 12.0, *) {
             let isFocusable = isFocusable as! AttributeReference<Swift.Bool>
             __content
                 .focusable(isFocusable.resolve(on: element, in: context))
             } else { __content }
         #endif
-        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+        #if os(watchOS) || os(iOS) || os(tvOS) || os(macOS)
         case let ._1(isFocusable, interactions):
-            if #available(iOS 17.0,macOS 14.0,tvOS 17.0,watchOS 10.0, *) {
+            if #available(watchOS 10.0,iOS 17.0,tvOS 17.0,macOS 14.0, *) {
             let isFocusable = isFocusable as! AttributeReference<Swift.Bool>
 let interactions = interactions as! SwiftUI.FocusInteractions
             __content
@@ -3112,7 +3112,7 @@ struct _fontDesignModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(macOS) || os(tvOS) || os(watchOS) || os(iOS)
+        #if os(watchOS) || os(macOS) || os(iOS) || os(tvOS)
         case _0(design: Any?)
         #endif
     }
@@ -3125,8 +3125,8 @@ struct _fontDesignModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(macOS) || os(tvOS) || os(watchOS) || os(iOS)
-    @available(macOS 13.0,tvOS 16.1,watchOS 9.1,iOS 16.1, *)
+    #if os(watchOS) || os(macOS) || os(iOS) || os(tvOS)
+    @available(watchOS 9.1,macOS 13.0,iOS 16.1,tvOS 16.1, *)
     init(_ design: SwiftUI.Font.Design?) {
         self.value = ._0(design: design)
         
@@ -3137,9 +3137,9 @@ struct _fontDesignModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(macOS) || os(tvOS) || os(watchOS) || os(iOS)
+        #if os(watchOS) || os(macOS) || os(iOS) || os(tvOS)
         case let ._0(design):
-            if #available(macOS 13.0,tvOS 16.1,watchOS 9.1,iOS 16.1, *) {
+            if #available(watchOS 9.1,macOS 13.0,iOS 16.1,tvOS 16.1, *) {
             let design = design as? SwiftUI.Font.Design
             __content
                 .fontDesign(design)
@@ -3444,7 +3444,7 @@ struct _fullScreenCoverModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(tvOS) || os(iOS) || os(watchOS)
+        #if os(watchOS) || os(tvOS) || os(iOS)
         case _0(content: Any)
         #endif
     }
@@ -3457,8 +3457,8 @@ struct _fullScreenCoverModifier<R: RootRegistry>: ViewModifier {
 @ChangeTracked private var _0_isPresented: Swift.Bool
 @Event private var _0_onDismiss__0: Event.EventHandler
 
-    #if os(tvOS) || os(iOS) || os(watchOS)
-    @available(tvOS 14.0,iOS 14.0,watchOS 7.0, *)
+    #if os(watchOS) || os(tvOS) || os(iOS)
+    @available(watchOS 7.0,tvOS 14.0,iOS 14.0, *)
     init(isPresented: ChangeTracked<Swift.Bool>,onDismiss onDismiss__0: Event=Event(), content: ViewReference=ViewReference(value: [])) {
         self.value = ._0(content: content)
         self.__0_isPresented = isPresented
@@ -3470,9 +3470,9 @@ self.__0_onDismiss__0 = onDismiss__0
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(tvOS) || os(iOS) || os(watchOS)
+        #if os(watchOS) || os(tvOS) || os(iOS)
         case let ._0(content):
-            if #available(tvOS 14.0,iOS 14.0,watchOS 7.0, *) {
+            if #available(watchOS 7.0,tvOS 14.0,iOS 14.0, *) {
             let content = content as! ViewReference
             __content
                 .fullScreenCover(isPresented: __0_isPresented.projectedValue, onDismiss: { __0_onDismiss__0.wrappedValue() }, content: { content.resolve(on: element, in: context) })
@@ -3487,7 +3487,7 @@ struct _gaugeStyleModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(macOS) || os(watchOS)
+        #if os(macOS) || os(watchOS) || os(iOS)
         case _0(style: Any)
         #endif
     }
@@ -3500,8 +3500,8 @@ struct _gaugeStyleModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(macOS) || os(watchOS)
-    @available(iOS 16.0,macOS 13.0,watchOS 7.0, *)
+    #if os(macOS) || os(watchOS) || os(iOS)
+    @available(macOS 13.0,watchOS 7.0,iOS 16.0, *)
     init(_ style: AnyGaugeStyle) {
         self.value = ._0(style: style)
         
@@ -3512,9 +3512,9 @@ struct _gaugeStyleModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(macOS) || os(watchOS)
+        #if os(macOS) || os(watchOS) || os(iOS)
         case let ._0(style):
-            if #available(iOS 16.0,macOS 13.0,watchOS 7.0, *) {
+            if #available(macOS 13.0,watchOS 7.0,iOS 16.0, *) {
             let style = style as! AnyGaugeStyle
             __content
                 .gaugeStyle(style)
@@ -3529,7 +3529,7 @@ struct _geometryGroupModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(tvOS) || os(macOS) || os(iOS) || os(watchOS)
+        #if os(watchOS) || os(tvOS) || os(iOS) || os(macOS)
         case _0
         #endif
     }
@@ -3542,8 +3542,8 @@ struct _geometryGroupModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(tvOS) || os(macOS) || os(iOS) || os(watchOS)
-    @available(tvOS 17.0,macOS 14.0,iOS 17.0,watchOS 10.0, *)
+    #if os(watchOS) || os(tvOS) || os(iOS) || os(macOS)
+    @available(watchOS 10.0,tvOS 17.0,iOS 17.0,macOS 14.0, *)
     init() {
         self.value = ._0
         
@@ -3554,9 +3554,9 @@ struct _geometryGroupModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(tvOS) || os(macOS) || os(iOS) || os(watchOS)
+        #if os(watchOS) || os(tvOS) || os(iOS) || os(macOS)
         case ._0:
-            if #available(tvOS 17.0,macOS 14.0,iOS 17.0,watchOS 10.0, *) {
+            if #available(watchOS 10.0,tvOS 17.0,iOS 17.0,macOS 14.0, *) {
             
             __content
                 .geometryGroup()
@@ -3823,7 +3823,7 @@ struct _groupBoxStyleModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(macOS)
+        #if os(macOS) || os(iOS)
         case _0(style: Any)
         #endif
     }
@@ -3836,8 +3836,8 @@ struct _groupBoxStyleModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(macOS)
-    @available(iOS 14.0,macOS 11.0, *)
+    #if os(macOS) || os(iOS)
+    @available(macOS 11.0,iOS 14.0, *)
     init(_ style: AnyGroupBoxStyle) {
         self.value = ._0(style: style)
         
@@ -3848,9 +3848,9 @@ struct _groupBoxStyleModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(macOS)
+        #if os(macOS) || os(iOS)
         case let ._0(style):
-            if #available(iOS 14.0,macOS 11.0, *) {
+            if #available(macOS 11.0,iOS 14.0, *) {
             let style = style as! AnyGroupBoxStyle
             __content
                 .groupBoxStyle(style)
@@ -4115,10 +4115,10 @@ struct _hoverEffectModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(tvOS) || os(visionOS)
+        #if os(iOS) || os(visionOS) || os(tvOS)
         case _0(effect: Any)
         #endif
-        #if os(iOS) || os(visionOS) || os(tvOS)
+        #if os(tvOS) || os(iOS) || os(visionOS)
         case _1(effect: Any, isEnabled: Any)
         #endif
     }
@@ -4133,15 +4133,15 @@ struct _hoverEffectModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(tvOS) || os(visionOS)
-    @available(iOS 13.4,tvOS 16.0,visionOS 1.0, *)
+    #if os(iOS) || os(visionOS) || os(tvOS)
+    @available(iOS 13.4,visionOS 1.0,tvOS 16.0, *)
     init(_ effect: SwiftUI.HoverEffect = .automatic ) {
         self.value = ._0(effect: effect)
         
     }
     #endif
-    #if os(iOS) || os(visionOS) || os(tvOS)
-    @available(iOS 17.0,visionOS 1.0,tvOS 17.0, *)
+    #if os(tvOS) || os(iOS) || os(visionOS)
+    @available(tvOS 17.0,iOS 17.0,visionOS 1.0, *)
     init(_ effect: SwiftUI.HoverEffect = .automatic, isEnabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._1(effect: effect, isEnabled: isEnabled)
         
@@ -4152,17 +4152,17 @@ struct _hoverEffectModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(tvOS) || os(visionOS)
+        #if os(iOS) || os(visionOS) || os(tvOS)
         case let ._0(effect):
-            if #available(iOS 13.4,tvOS 16.0,visionOS 1.0, *) {
+            if #available(iOS 13.4,visionOS 1.0,tvOS 16.0, *) {
             let effect = effect as! SwiftUI.HoverEffect 
             __content
                 .hoverEffect(effect)
             } else { __content }
         #endif
-        #if os(iOS) || os(visionOS) || os(tvOS)
+        #if os(tvOS) || os(iOS) || os(visionOS)
         case let ._1(effect, isEnabled):
-            if #available(iOS 17.0,visionOS 1.0,tvOS 17.0, *) {
+            if #available(tvOS 17.0,iOS 17.0,visionOS 1.0, *) {
             let effect = effect as! SwiftUI.HoverEffect 
 let isEnabled = isEnabled as! AttributeReference<Swift.Bool>
             __content
@@ -4178,7 +4178,7 @@ struct _hoverEffectDisabledModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(tvOS) || os(visionOS)
+        #if os(tvOS) || os(iOS) || os(visionOS)
         case _0(disabled: Any)
         #endif
     }
@@ -4191,8 +4191,8 @@ struct _hoverEffectDisabledModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(tvOS) || os(visionOS)
-    @available(iOS 17.0,tvOS 17.0,visionOS 1.0, *)
+    #if os(tvOS) || os(iOS) || os(visionOS)
+    @available(tvOS 17.0,iOS 17.0,visionOS 1.0, *)
     init(_ disabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(disabled: disabled)
         
@@ -4203,9 +4203,9 @@ struct _hoverEffectDisabledModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(tvOS) || os(visionOS)
+        #if os(tvOS) || os(iOS) || os(visionOS)
         case let ._0(disabled):
-            if #available(iOS 17.0,tvOS 17.0,visionOS 1.0, *) {
+            if #available(tvOS 17.0,iOS 17.0,visionOS 1.0, *) {
             let disabled = disabled as! AttributeReference<Swift.Bool>
             __content
                 .hoverEffectDisabled(disabled.resolve(on: element, in: context))
@@ -4388,7 +4388,7 @@ struct _inspectorModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(macOS)
+        #if os(macOS) || os(iOS)
         case _0(content: Any)
         #endif
     }
@@ -4401,8 +4401,8 @@ struct _inspectorModifier<R: RootRegistry>: ViewModifier {
 @ChangeTracked private var _0_isPresented: Swift.Bool
 
 
-    #if os(iOS) || os(macOS)
-    @available(iOS 17.0,macOS 14.0, *)
+    #if os(macOS) || os(iOS)
+    @available(macOS 14.0,iOS 17.0, *)
     init(isPresented: ChangeTracked<Swift.Bool>,content: ViewReference=ViewReference(value: [])) {
         self.value = ._0(content: content)
         self.__0_isPresented = isPresented
@@ -4413,9 +4413,9 @@ struct _inspectorModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(macOS)
+        #if os(macOS) || os(iOS)
         case let ._0(content):
-            if #available(iOS 17.0,macOS 14.0, *) {
+            if #available(macOS 14.0,iOS 17.0, *) {
             let content = content as! ViewReference
             __content
                 .inspector(isPresented: __0_isPresented.projectedValue, content: { content.resolve(on: element, in: context) })
@@ -4578,7 +4578,7 @@ struct _invalidatableContentModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(tvOS) || os(watchOS) || os(macOS)
+        #if os(macOS) || os(watchOS) || os(iOS) || os(tvOS)
         case _0(invalidatable: Any)
         #endif
     }
@@ -4591,8 +4591,8 @@ struct _invalidatableContentModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(tvOS) || os(watchOS) || os(macOS)
-    @available(iOS 17.0,tvOS 17.0,watchOS 10.0,macOS 14.0, *)
+    #if os(macOS) || os(watchOS) || os(iOS) || os(tvOS)
+    @available(macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0, *)
     init(_ invalidatable: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(invalidatable: invalidatable)
         
@@ -4603,9 +4603,9 @@ struct _invalidatableContentModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(tvOS) || os(watchOS) || os(macOS)
+        #if os(macOS) || os(watchOS) || os(iOS) || os(tvOS)
         case let ._0(invalidatable):
-            if #available(iOS 17.0,tvOS 17.0,watchOS 10.0,macOS 14.0, *) {
+            if #available(macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0, *) {
             let invalidatable = invalidatable as! AttributeReference<Swift.Bool>
             __content
                 .invalidatableContent(invalidatable.resolve(on: element, in: context))
@@ -4707,13 +4707,13 @@ struct _keyboardShortcutModifier<R: RootRegistry>: ViewModifier {
         #if os(macOS) || os(iOS)
         case _0(key: Any,modifiers: Any)
         #endif
-        #if os(iOS) || os(macOS)
+        #if os(macOS) || os(iOS)
         case _1(shortcut: Any)
         #endif
-        #if os(iOS) || os(macOS)
+        #if os(macOS) || os(iOS)
         case _2(shortcut: Any?)
         #endif
-        #if os(iOS) || os(macOS)
+        #if os(macOS) || os(iOS)
         case _3(key: Any,modifiers: Any, localization: Any)
         #endif
     }
@@ -4739,22 +4739,22 @@ struct _keyboardShortcutModifier<R: RootRegistry>: ViewModifier {
         
     }
     #endif
-    #if os(iOS) || os(macOS)
-    @available(iOS 14.0,macOS 11.0, *)
+    #if os(macOS) || os(iOS)
+    @available(macOS 11.0,iOS 14.0, *)
     init(_ shortcut: SwiftUI.KeyboardShortcut) {
         self.value = ._1(shortcut: shortcut)
         
     }
     #endif
-    #if os(iOS) || os(macOS)
-    @available(iOS 15.4,macOS 12.3, *)
+    #if os(macOS) || os(iOS)
+    @available(macOS 12.3,iOS 15.4, *)
     init(_ shortcut: SwiftUI.KeyboardShortcut?) {
         self.value = ._2(shortcut: shortcut)
         
     }
     #endif
-    #if os(iOS) || os(macOS)
-    @available(iOS 15.0,macOS 12.0, *)
+    #if os(macOS) || os(iOS)
+    @available(macOS 12.0,iOS 15.0, *)
     init(_ key: SwiftUI.KeyEquivalent,modifiers: SwiftUI.EventModifiers = .command, localization: SwiftUI.KeyboardShortcut.Localization) {
         self.value = ._3(key: key, modifiers: modifiers, localization: localization)
         
@@ -4774,25 +4774,25 @@ let modifiers = modifiers as! SwiftUI.EventModifiers
                 .keyboardShortcut(key, modifiers: modifiers)
             } else { __content }
         #endif
-        #if os(iOS) || os(macOS)
+        #if os(macOS) || os(iOS)
         case let ._1(shortcut):
-            if #available(iOS 14.0,macOS 11.0, *) {
+            if #available(macOS 11.0,iOS 14.0, *) {
             let shortcut = shortcut as! SwiftUI.KeyboardShortcut
             __content
                 .keyboardShortcut(shortcut)
             } else { __content }
         #endif
-        #if os(iOS) || os(macOS)
+        #if os(macOS) || os(iOS)
         case let ._2(shortcut):
-            if #available(iOS 15.4,macOS 12.3, *) {
+            if #available(macOS 12.3,iOS 15.4, *) {
             let shortcut = shortcut as? SwiftUI.KeyboardShortcut
             __content
                 .keyboardShortcut(shortcut)
             } else { __content }
         #endif
-        #if os(iOS) || os(macOS)
+        #if os(macOS) || os(iOS)
         case let ._3(key, modifiers, localization):
-            if #available(iOS 15.0,macOS 12.0, *) {
+            if #available(macOS 12.0,iOS 15.0, *) {
             let key = key as! SwiftUI.KeyEquivalent
 let modifiers = modifiers as! SwiftUI.EventModifiers 
 let localization = localization as! SwiftUI.KeyboardShortcut.Localization
@@ -4809,7 +4809,7 @@ struct _keyboardTypeModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(tvOS)
+        #if os(tvOS) || os(iOS)
         case _0(type: Any)
         #endif
     }
@@ -4822,8 +4822,8 @@ struct _keyboardTypeModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(tvOS)
-    @available(iOS 13.0,tvOS 13.0, *)
+    #if os(tvOS) || os(iOS)
+    @available(tvOS 13.0,iOS 13.0, *)
     init(_ type: UIKit.UIKeyboardType) {
         self.value = ._0(type: type)
         
@@ -4834,9 +4834,9 @@ struct _keyboardTypeModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(tvOS)
+        #if os(tvOS) || os(iOS)
         case let ._0(type):
-            if #available(iOS 13.0,tvOS 13.0, *) {
+            if #available(tvOS 13.0,iOS 13.0, *) {
             let type = type as! UIKit.UIKeyboardType
             __content
                 .keyboardType(type)
@@ -5584,7 +5584,7 @@ struct _listSectionSeparatorTintModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(macOS)
+        #if os(macOS) || os(iOS)
         case _0(color: Any?,edges: Any)
         #endif
     }
@@ -5597,8 +5597,8 @@ struct _listSectionSeparatorTintModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(macOS)
-    @available(iOS 15.0,macOS 13.0, *)
+    #if os(macOS) || os(iOS)
+    @available(macOS 13.0,iOS 15.0, *)
     init(_ color: AttributeReference<SwiftUI.Color?>?,edges: SwiftUI.VerticalEdge.Set = .all ) {
         self.value = ._0(color: color, edges: edges)
         
@@ -5609,9 +5609,9 @@ struct _listSectionSeparatorTintModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(macOS)
+        #if os(macOS) || os(iOS)
         case let ._0(color, edges):
-            if #available(iOS 15.0,macOS 13.0, *) {
+            if #available(macOS 13.0,iOS 15.0, *) {
             let color = color as? AttributeReference<SwiftUI.Color?>
 let edges = edges as! SwiftUI.VerticalEdge.Set 
             __content
@@ -5627,10 +5627,10 @@ struct _listSectionSpacingModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(watchOS)
+        #if os(watchOS) || os(iOS)
         case _0(spacing: Any)
         #endif
-        #if os(iOS) || os(watchOS)
+        #if os(watchOS) || os(iOS)
         case _1(spacing: Any)
         #endif
     }
@@ -5645,15 +5645,15 @@ struct _listSectionSpacingModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(watchOS)
-    @available(iOS 17.0,watchOS 10.0, *)
+    #if os(watchOS) || os(iOS)
+    @available(watchOS 10.0,iOS 17.0, *)
     init(_ spacing: SwiftUI.ListSectionSpacing) {
         self.value = ._0(spacing: spacing)
         
     }
     #endif
-    #if os(iOS) || os(watchOS)
-    @available(iOS 17.0,watchOS 10.0, *)
+    #if os(watchOS) || os(iOS)
+    @available(watchOS 10.0,iOS 17.0, *)
     init(_ spacing: AttributeReference<CoreFoundation.CGFloat>) {
         self.value = ._1(spacing: spacing)
         
@@ -5664,17 +5664,17 @@ struct _listSectionSpacingModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(watchOS)
+        #if os(watchOS) || os(iOS)
         case let ._0(spacing):
-            if #available(iOS 17.0,watchOS 10.0, *) {
+            if #available(watchOS 10.0,iOS 17.0, *) {
             let spacing = spacing as! SwiftUI.ListSectionSpacing
             __content
                 .listSectionSpacing(spacing)
             } else { __content }
         #endif
-        #if os(iOS) || os(watchOS)
+        #if os(watchOS) || os(iOS)
         case let ._1(spacing):
-            if #available(iOS 17.0,watchOS 10.0, *) {
+            if #available(watchOS 10.0,iOS 17.0, *) {
             let spacing = spacing as! AttributeReference<CoreFoundation.CGFloat>
             __content
                 .listSectionSpacing(spacing.resolve(on: element, in: context))
@@ -5773,7 +5773,7 @@ struct _menuIndicatorModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(macOS) || os(iOS) || os(tvOS)
+        #if os(tvOS) || os(iOS) || os(macOS)
         case _0(visibility: Any)
         #endif
     }
@@ -5786,8 +5786,8 @@ struct _menuIndicatorModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(macOS) || os(iOS) || os(tvOS)
-    @available(macOS 12.0,iOS 15.0,tvOS 17.0, *)
+    #if os(tvOS) || os(iOS) || os(macOS)
+    @available(tvOS 17.0,iOS 15.0,macOS 12.0, *)
     init(_ visibility: AttributeReference<SwiftUI.Visibility>) {
         self.value = ._0(visibility: visibility)
         
@@ -5798,9 +5798,9 @@ struct _menuIndicatorModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(macOS) || os(iOS) || os(tvOS)
+        #if os(tvOS) || os(iOS) || os(macOS)
         case let ._0(visibility):
-            if #available(macOS 12.0,iOS 15.0,tvOS 17.0, *) {
+            if #available(tvOS 17.0,iOS 15.0,macOS 12.0, *) {
             let visibility = visibility as! AttributeReference<SwiftUI.Visibility>
             __content
                 .menuIndicator(visibility.resolve(on: element, in: context))
@@ -5857,7 +5857,7 @@ struct _menuStyleModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(macOS) || os(tvOS)
+        #if os(tvOS) || os(iOS) || os(macOS)
         case _0(style: Any)
         #endif
     }
@@ -5870,8 +5870,8 @@ struct _menuStyleModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(macOS) || os(tvOS)
-    @available(iOS 14.0,macOS 11.0,tvOS 17.0, *)
+    #if os(tvOS) || os(iOS) || os(macOS)
+    @available(tvOS 17.0,iOS 14.0,macOS 11.0, *)
     init(_ style: AnyMenuStyle) {
         self.value = ._0(style: style)
         
@@ -5882,9 +5882,9 @@ struct _menuStyleModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(macOS) || os(tvOS)
+        #if os(tvOS) || os(iOS) || os(macOS)
         case let ._0(style):
-            if #available(iOS 14.0,macOS 11.0,tvOS 17.0, *) {
+            if #available(tvOS 17.0,iOS 14.0,macOS 11.0, *) {
             let style = style as! AnyMenuStyle
             __content
                 .menuStyle(style)
@@ -6339,13 +6339,13 @@ struct _navigationSubtitleModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if targetEnvironment(macCatalyst) || os(macOS)
+        #if os(macOS) || targetEnvironment(macCatalyst)
         case _0(subtitle: Any)
         #endif
-        #if targetEnvironment(macCatalyst) || os(macOS)
+        #if os(macOS) || targetEnvironment(macCatalyst)
         case _1(subtitleKey: Any)
         #endif
-        #if targetEnvironment(macCatalyst) || os(macOS)
+        #if os(macOS) || targetEnvironment(macCatalyst)
         case _2(subtitle: Any)
         #endif
     }
@@ -6362,22 +6362,22 @@ struct _navigationSubtitleModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if targetEnvironment(macCatalyst) || os(macOS)
-    @available(macCatalyst 14.0,macOS 11.0, *)
+    #if os(macOS) || targetEnvironment(macCatalyst)
+    @available(macOS 11.0,macCatalyst 14.0, *)
     init(_ subtitle: TextReference) {
         self.value = ._0(subtitle: subtitle)
         
     }
     #endif
-    #if targetEnvironment(macCatalyst) || os(macOS)
-    @available(macCatalyst 14.0,macOS 11.0, *)
+    #if os(macOS) || targetEnvironment(macCatalyst)
+    @available(macOS 11.0,macCatalyst 14.0, *)
     init(_ subtitleKey: SwiftUI.LocalizedStringKey) {
         self.value = ._1(subtitleKey: subtitleKey)
         
     }
     #endif
-    #if targetEnvironment(macCatalyst) || os(macOS)
-    @available(macCatalyst 14.0,macOS 11.0, *)
+    #if os(macOS) || targetEnvironment(macCatalyst)
+    @available(macOS 11.0,macCatalyst 14.0, *)
     init(_ subtitle: AttributeReference<String>) {
         self.value = ._2(subtitle: subtitle)
         
@@ -6388,25 +6388,25 @@ struct _navigationSubtitleModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if targetEnvironment(macCatalyst) || os(macOS)
+        #if os(macOS) || targetEnvironment(macCatalyst)
         case let ._0(subtitle):
-            if #available(macCatalyst 14.0,macOS 11.0, *) {
+            if #available(macOS 11.0,macCatalyst 14.0, *) {
             let subtitle = subtitle as! TextReference
             __content
                 .navigationSubtitle(subtitle.resolve(on: element, in: context))
             } else { __content }
         #endif
-        #if targetEnvironment(macCatalyst) || os(macOS)
+        #if os(macOS) || targetEnvironment(macCatalyst)
         case let ._1(subtitleKey):
-            if #available(macCatalyst 14.0,macOS 11.0, *) {
+            if #available(macOS 11.0,macCatalyst 14.0, *) {
             let subtitleKey = subtitleKey as! SwiftUI.LocalizedStringKey
             __content
                 .navigationSubtitle(subtitleKey)
             } else { __content }
         #endif
-        #if targetEnvironment(macCatalyst) || os(macOS)
+        #if os(macOS) || targetEnvironment(macCatalyst)
         case let ._2(subtitle):
-            if #available(macCatalyst 14.0,macOS 11.0, *) {
+            if #available(macOS 11.0,macCatalyst 14.0, *) {
             let subtitle = subtitle as! AttributeReference<String>
             __content
                 .navigationSubtitle(subtitle.resolve(on: element, in: context))
@@ -6476,7 +6476,7 @@ struct _navigationTitleModifier<R: RootRegistry>: ViewModifier {
     }
     
     #if os(watchOS)
-    @available(iOS 14.0,watchOS 7.0,tvOS 14.0,macOS 11.0, *)
+    @available(watchOS 7.0,macOS 11.0,iOS 14.0,tvOS 14.0, *)
     init(_ title: ViewReference=ViewReference(value: [])) {
         self.value = ._3(title: title)
         
@@ -6520,7 +6520,7 @@ struct _navigationTitleModifier<R: RootRegistry>: ViewModifier {
         
         #if os(watchOS)
         case let ._3(title):
-            if #available(iOS 14.0,watchOS 7.0,tvOS 14.0,macOS 11.0, *) {
+            if #available(watchOS 7.0,macOS 11.0,iOS 14.0,tvOS 14.0, *) {
             let title = title as! ViewReference
             __content
                 .navigationTitle({ title.resolve(on: element, in: context) })
@@ -6661,7 +6661,7 @@ struct _onDeleteCommandModifier<R: RootRegistry>: ViewModifier {
 @Event private var _0_action__0: Event.EventHandler
 
     #if os(macOS)
-    @available(macOS 10.15,tvOS 13.0, *)
+    @available(tvOS 13.0,macOS 10.15, *)
     init(perform action__0: Event=Event()) {
         self.value = ._0
         self.__0_action__0 = action__0
@@ -6674,7 +6674,7 @@ struct _onDeleteCommandModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(macOS)
         case ._0:
-            if #available(macOS 10.15,tvOS 13.0, *) {
+            if #available(tvOS 13.0,macOS 10.15, *) {
             
             __content
                 .onDeleteCommand(perform: { __0_action__0.wrappedValue() })
@@ -6731,7 +6731,7 @@ struct _onExitCommandModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(macOS) || os(tvOS)
+        #if os(tvOS) || os(macOS)
         case _0
         #endif
     }
@@ -6744,8 +6744,8 @@ struct _onExitCommandModifier<R: RootRegistry>: ViewModifier {
 
 @Event private var _0_action__0: Event.EventHandler
 
-    #if os(macOS) || os(tvOS)
-    @available(macOS 10.15,tvOS 13.0, *)
+    #if os(tvOS) || os(macOS)
+    @available(tvOS 13.0,macOS 10.15, *)
     init(perform action__0: Event=Event()) {
         self.value = ._0
         self.__0_action__0 = action__0
@@ -6756,9 +6756,9 @@ struct _onExitCommandModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(macOS) || os(tvOS)
+        #if os(tvOS) || os(macOS)
         case ._0:
-            if #available(macOS 10.15,tvOS 13.0, *) {
+            if #available(tvOS 13.0,macOS 10.15, *) {
             
             __content
                 .onExitCommand(perform: { __0_action__0.wrappedValue() })
@@ -6773,7 +6773,7 @@ struct _onHoverModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(macOS)
+        #if os(macOS) || os(iOS)
         case _0
         #endif
     }
@@ -6786,8 +6786,8 @@ struct _onHoverModifier<R: RootRegistry>: ViewModifier {
 
 @Event private var _0_action__1: Event.EventHandler
 
-    #if os(iOS) || os(macOS)
-    @available(iOS 13.4,macOS 10.15, *)
+    #if os(macOS) || os(iOS)
+    @available(macOS 10.15,iOS 13.4, *)
     init(perform action__1: Event) {
         self.value = ._0
         self.__0_action__1 = action__1
@@ -6798,9 +6798,9 @@ struct _onHoverModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(macOS)
+        #if os(macOS) || os(iOS)
         case ._0:
-            if #available(iOS 13.4,macOS 10.15, *) {
+            if #available(macOS 10.15,iOS 13.4, *) {
             
             __content
                 .onHover(perform: { __0_action__1.wrappedValue(value: $0) })
@@ -6815,7 +6815,7 @@ struct _onLongPressGestureModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(macOS) || os(watchOS) || os(iOS)
+        #if os(macOS) || os(iOS) || os(watchOS)
         case _0(minimumDuration: Any, maximumDistance: Any)
         #endif
         #if os(tvOS)
@@ -6835,8 +6835,8 @@ struct _onLongPressGestureModifier<R: RootRegistry>: ViewModifier {
 @Event private var _1_action__0: Event.EventHandler
 @Event private var _1_onPressingChanged__1: Event.EventHandler
 
-    #if os(macOS) || os(watchOS) || os(iOS)
-    @available(tvOS 14.0,macOS 10.15,watchOS 6.0,iOS 13.0, *)
+    #if os(macOS) || os(iOS) || os(watchOS)
+    @available(macOS 10.15,tvOS 14.0,iOS 13.0,watchOS 6.0, *)
     init(minimumDuration: AttributeReference<Swift.Double> = .init(storage: .constant(0.5)), maximumDistance: AttributeReference<CoreFoundation.CGFloat> = .init(storage: .constant(10)), perform action__0: Event,onPressingChanged onPressingChanged__1: Event=Event() ) {
         self.value = ._0(minimumDuration: minimumDuration, maximumDistance: maximumDistance)
         self.__0_action__0 = action__0
@@ -6844,7 +6844,7 @@ self.__0_onPressingChanged__1 = onPressingChanged__1
     }
     #endif
     #if os(tvOS)
-    @available(iOS 13.0,watchOS 6.0,macOS 10.15,tvOS 14.0, *)
+    @available(iOS 13.0,tvOS 14.0,watchOS 6.0,macOS 10.15, *)
     init(minimumDuration: AttributeReference<Swift.Double> = .init(storage: .constant(0.5)), perform action__0: Event,onPressingChanged onPressingChanged__1: Event=Event() ) {
         self.value = ._1(minimumDuration: minimumDuration)
         self.__1_action__0 = action__0
@@ -6856,9 +6856,9 @@ self.__1_onPressingChanged__1 = onPressingChanged__1
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(macOS) || os(watchOS) || os(iOS)
+        #if os(macOS) || os(iOS) || os(watchOS)
         case let ._0(minimumDuration, maximumDistance):
-            if #available(tvOS 14.0,macOS 10.15,watchOS 6.0,iOS 13.0, *) {
+            if #available(macOS 10.15,tvOS 14.0,iOS 13.0,watchOS 6.0, *) {
             let minimumDuration = minimumDuration as! AttributeReference<Swift.Double>
 let maximumDistance = maximumDistance as! AttributeReference<CoreFoundation.CGFloat>
             __content
@@ -6867,7 +6867,7 @@ let maximumDistance = maximumDistance as! AttributeReference<CoreFoundation.CGFl
         #endif
         #if os(tvOS)
         case let ._1(minimumDuration):
-            if #available(iOS 13.0,watchOS 6.0,macOS 10.15,tvOS 14.0, *) {
+            if #available(iOS 13.0,tvOS 14.0,watchOS 6.0,macOS 10.15, *) {
             let minimumDuration = minimumDuration as! AttributeReference<Swift.Double>
             __content
                 .onLongPressGesture(minimumDuration: minimumDuration.resolve(on: element, in: context), perform: { __1_action__0.wrappedValue() }, onPressingChanged: { __1_onPressingChanged__1.wrappedValue(value: $0) })
@@ -6926,7 +6926,7 @@ struct _onMoveCommandModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(macOS) || os(tvOS)
+        #if os(tvOS) || os(macOS)
         case _0
         #endif
     }
@@ -6939,8 +6939,8 @@ struct _onMoveCommandModifier<R: RootRegistry>: ViewModifier {
 
 @Event private var _0_action__1: Event.EventHandler
 
-    #if os(macOS) || os(tvOS)
-    @available(macOS 10.15,tvOS 13.0, *)
+    #if os(tvOS) || os(macOS)
+    @available(tvOS 13.0,macOS 10.15, *)
     init(perform action__1: Event=Event()) {
         self.value = ._0
         self.__0_action__1 = action__1
@@ -6951,9 +6951,9 @@ struct _onMoveCommandModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(macOS) || os(tvOS)
+        #if os(tvOS) || os(macOS)
         case ._0:
-            if #available(macOS 10.15,tvOS 13.0, *) {
+            if #available(tvOS 13.0,macOS 10.15, *) {
             
             __content
                 .onMoveCommand(perform: { __0_action__1.wrappedValue(value: $0) })
@@ -6982,7 +6982,7 @@ struct _onPlayPauseCommandModifier<R: RootRegistry>: ViewModifier {
 @Event private var _0_action__0: Event.EventHandler
 
     #if os(tvOS)
-    @available(macOS 10.15,tvOS 13.0, *)
+    @available(tvOS 13.0,macOS 10.15, *)
     init(perform action__0: Event=Event()) {
         self.value = ._0
         self.__0_action__0 = action__0
@@ -6995,7 +6995,7 @@ struct _onPlayPauseCommandModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(tvOS)
         case ._0:
-            if #available(macOS 10.15,tvOS 13.0, *) {
+            if #available(tvOS 13.0,macOS 10.15, *) {
             
             __content
                 .onPlayPauseCommand(perform: { __0_action__0.wrappedValue() })
@@ -7013,7 +7013,7 @@ struct _onTapGestureModifier<R: RootRegistry>: ViewModifier {
         
         case _0(count: AttributeReference<Swift.Int> = .init(storage: .constant(1)))
         
-        #if os(watchOS) || os(iOS) || os(macOS)
+        #if os(macOS) || os(watchOS) || os(iOS)
         case _1(count: Any, coordinateSpace: Any)
         #endif
     }
@@ -7035,8 +7035,8 @@ struct _onTapGestureModifier<R: RootRegistry>: ViewModifier {
         self.__0_action__0 = action__0
     }
     
-    #if os(watchOS) || os(iOS) || os(macOS)
-    @available(watchOS 10.0,iOS 17.0,macOS 14.0, *)
+    #if os(macOS) || os(watchOS) || os(iOS)
+    @available(macOS 14.0,watchOS 10.0,iOS 17.0, *)
     init(count: AttributeReference<Swift.Int> = .init(storage: .constant(1)), coordinateSpace: AnyCoordinateSpaceProtocol = .local, perform action__1: Event) {
         self.value = ._1(count: count, coordinateSpace: coordinateSpace)
         self.__1_action__1 = action__1
@@ -7055,9 +7055,9 @@ struct _onTapGestureModifier<R: RootRegistry>: ViewModifier {
                 .onTapGesture(count: count.resolve(on: element, in: context), perform: { __0_action__0.wrappedValue() })
             
         
-        #if os(watchOS) || os(iOS) || os(macOS)
+        #if os(macOS) || os(watchOS) || os(iOS)
         case let ._1(count, coordinateSpace):
-            if #available(watchOS 10.0,iOS 17.0,macOS 14.0, *) {
+            if #available(macOS 14.0,watchOS 10.0,iOS 17.0, *) {
             let count = count as! AttributeReference<Swift.Int>
 let coordinateSpace = coordinateSpace as! AnyCoordinateSpaceProtocol 
             __content
@@ -7511,10 +7511,10 @@ struct _presentationBackgroundModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
+        #if os(iOS) || os(watchOS) || os(tvOS) || os(macOS)
         case _0(style: Any)
         #endif
-        #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
+        #if os(iOS) || os(watchOS) || os(tvOS) || os(macOS)
         case _1(alignment: Any, content: Any)
         #endif
     }
@@ -7529,15 +7529,15 @@ struct _presentationBackgroundModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
-    @available(iOS 16.4,macOS 13.3,watchOS 9.4,tvOS 16.4, *)
+    #if os(iOS) || os(watchOS) || os(tvOS) || os(macOS)
+    @available(iOS 16.4,watchOS 9.4,tvOS 16.4,macOS 13.3, *)
     init(_ style: AnyShapeStyle) {
         self.value = ._0(style: style)
         
     }
     #endif
-    #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
-    @available(iOS 16.4,macOS 13.3,watchOS 9.4,tvOS 16.4, *)
+    #if os(iOS) || os(watchOS) || os(tvOS) || os(macOS)
+    @available(iOS 16.4,watchOS 9.4,tvOS 16.4,macOS 13.3, *)
     init(alignment: AttributeReference<SwiftUI.Alignment> = .init(storage: .constant(.center)), content: ViewReference=ViewReference(value: [])) {
         self.value = ._1(alignment: alignment, content: content)
         
@@ -7548,17 +7548,17 @@ struct _presentationBackgroundModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
+        #if os(iOS) || os(watchOS) || os(tvOS) || os(macOS)
         case let ._0(style):
-            if #available(iOS 16.4,macOS 13.3,watchOS 9.4,tvOS 16.4, *) {
+            if #available(iOS 16.4,watchOS 9.4,tvOS 16.4,macOS 13.3, *) {
             let style = style as! AnyShapeStyle
             __content
                 .presentationBackground(style)
             } else { __content }
         #endif
-        #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
+        #if os(iOS) || os(watchOS) || os(tvOS) || os(macOS)
         case let ._1(alignment, content):
-            if #available(iOS 16.4,macOS 13.3,watchOS 9.4,tvOS 16.4, *) {
+            if #available(iOS 16.4,watchOS 9.4,tvOS 16.4,macOS 13.3, *) {
             let alignment = alignment as! AttributeReference<SwiftUI.Alignment>
 let content = content as! ViewReference
             __content
@@ -7574,7 +7574,7 @@ struct _presentationBackgroundInteractionModifier<R: RootRegistry>: ViewModifier
 
     enum Value {
         case _never
-        #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
+        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
         case _0(interaction: Any)
         #endif
     }
@@ -7587,8 +7587,8 @@ struct _presentationBackgroundInteractionModifier<R: RootRegistry>: ViewModifier
 
 
 
-    #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
-    @available(tvOS 16.4,iOS 16.4,watchOS 9.4,macOS 13.3, *)
+    #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
+    @available(iOS 16.4,watchOS 9.4,macOS 13.3,tvOS 16.4, *)
     init(_ interaction: SwiftUI.PresentationBackgroundInteraction) {
         self.value = ._0(interaction: interaction)
         
@@ -7599,9 +7599,9 @@ struct _presentationBackgroundInteractionModifier<R: RootRegistry>: ViewModifier
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
+        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
         case let ._0(interaction):
-            if #available(tvOS 16.4,iOS 16.4,watchOS 9.4,macOS 13.3, *) {
+            if #available(iOS 16.4,watchOS 9.4,macOS 13.3,tvOS 16.4, *) {
             let interaction = interaction as! SwiftUI.PresentationBackgroundInteraction
             __content
                 .presentationBackgroundInteraction(interaction)
@@ -7616,10 +7616,10 @@ struct _presentationCompactAdaptationModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
+        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
         case _0(adaptation: Any)
         #endif
-        #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
         case _1(horizontalAdaptation: Any,verticalAdaptation: Any)
         #endif
     }
@@ -7634,15 +7634,15 @@ struct _presentationCompactAdaptationModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
-    @available(tvOS 16.4,iOS 16.4,watchOS 9.4,macOS 13.3, *)
+    #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
+    @available(iOS 16.4,watchOS 9.4,macOS 13.3,tvOS 16.4, *)
     init(_ adaptation: SwiftUI.PresentationAdaptation) {
         self.value = ._0(adaptation: adaptation)
         
     }
     #endif
-    #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
-    @available(macOS 13.3,iOS 16.4,tvOS 16.4,watchOS 9.4, *)
+    #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
+    @available(iOS 16.4,watchOS 9.4,macOS 13.3,tvOS 16.4, *)
     init(horizontal horizontalAdaptation: SwiftUI.PresentationAdaptation,vertical verticalAdaptation: SwiftUI.PresentationAdaptation) {
         self.value = ._1(horizontalAdaptation: horizontalAdaptation, verticalAdaptation: verticalAdaptation)
         
@@ -7653,17 +7653,17 @@ struct _presentationCompactAdaptationModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
+        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
         case let ._0(adaptation):
-            if #available(tvOS 16.4,iOS 16.4,watchOS 9.4,macOS 13.3, *) {
+            if #available(iOS 16.4,watchOS 9.4,macOS 13.3,tvOS 16.4, *) {
             let adaptation = adaptation as! SwiftUI.PresentationAdaptation
             __content
                 .presentationCompactAdaptation(adaptation)
             } else { __content }
         #endif
-        #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
         case let ._1(horizontalAdaptation, verticalAdaptation):
-            if #available(macOS 13.3,iOS 16.4,tvOS 16.4,watchOS 9.4, *) {
+            if #available(iOS 16.4,watchOS 9.4,macOS 13.3,tvOS 16.4, *) {
             let horizontalAdaptation = horizontalAdaptation as! SwiftUI.PresentationAdaptation
 let verticalAdaptation = verticalAdaptation as! SwiftUI.PresentationAdaptation
             __content
@@ -7679,7 +7679,7 @@ struct _presentationContentInteractionModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+        #if os(watchOS) || os(iOS) || os(tvOS) || os(macOS)
         case _0(behavior: Any)
         #endif
     }
@@ -7692,8 +7692,8 @@ struct _presentationContentInteractionModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-    @available(iOS 16.4,macOS 13.3,tvOS 16.4,watchOS 9.4, *)
+    #if os(watchOS) || os(iOS) || os(tvOS) || os(macOS)
+    @available(watchOS 9.4,iOS 16.4,tvOS 16.4,macOS 13.3, *)
     init(_ behavior: SwiftUI.PresentationContentInteraction) {
         self.value = ._0(behavior: behavior)
         
@@ -7704,9 +7704,9 @@ struct _presentationContentInteractionModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+        #if os(watchOS) || os(iOS) || os(tvOS) || os(macOS)
         case let ._0(behavior):
-            if #available(iOS 16.4,macOS 13.3,tvOS 16.4,watchOS 9.4, *) {
+            if #available(watchOS 9.4,iOS 16.4,tvOS 16.4,macOS 13.3, *) {
             let behavior = behavior as! SwiftUI.PresentationContentInteraction
             __content
                 .presentationContentInteraction(behavior)
@@ -7721,7 +7721,7 @@ struct _presentationCornerRadiusModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
         case _0(cornerRadius: Any?)
         #endif
     }
@@ -7734,8 +7734,8 @@ struct _presentationCornerRadiusModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-    @available(iOS 16.4,macOS 13.3,tvOS 16.4,watchOS 9.4, *)
+    #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
+    @available(iOS 16.4,watchOS 9.4,macOS 13.3,tvOS 16.4, *)
     init(_ cornerRadius: AttributeReference<CoreFoundation.CGFloat?>?) {
         self.value = ._0(cornerRadius: cornerRadius)
         
@@ -7746,9 +7746,9 @@ struct _presentationCornerRadiusModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
         case let ._0(cornerRadius):
-            if #available(iOS 16.4,macOS 13.3,tvOS 16.4,watchOS 9.4, *) {
+            if #available(iOS 16.4,watchOS 9.4,macOS 13.3,tvOS 16.4, *) {
             let cornerRadius = cornerRadius as? AttributeReference<CoreFoundation.CGFloat?>
             __content
                 .presentationCornerRadius(cornerRadius?.resolve(on: element, in: context))
@@ -8004,6 +8004,48 @@ struct _redactedModifier<R: RootRegistry>: ViewModifier {
             
             __content
                 .redacted(reason: reason)
+            
+        
+        }
+    }
+}
+@ParseableExpression
+struct _refreshableModifier<R: RootRegistry>: ViewModifier {
+    static var name: String { "refreshable" }
+
+    enum Value {
+        case _never
+        
+        case _0
+        
+    }
+
+    let value: Value
+
+    
+    
+
+
+@Event private var _0_action__0: Event.EventHandler
+
+    
+    
+    init(@_inheritActorContext action action__0: Event) {
+        self.value = ._0
+        self.__0_action__0 = action__0
+    }
+    
+
+    func body(content __content: Content) -> some View {
+        switch value {
+        case ._never:
+            fatalError("unreachable")
+        
+        case ._0:
+            
+            
+            __content
+                .refreshable(action: { __0_action__0.wrappedValue() })
             
         
         }
@@ -8473,7 +8515,7 @@ struct _scrollBounceBehaviorModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+        #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
         case _0(behavior: Any,axes: Any)
         #endif
     }
@@ -8486,8 +8528,8 @@ struct _scrollBounceBehaviorModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
-    @available(macOS 13.3,iOS 16.4,watchOS 9.4,tvOS 16.4, *)
+    #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
+    @available(tvOS 16.4,iOS 16.4,watchOS 9.4,macOS 13.3, *)
     init(_ behavior: SwiftUI.ScrollBounceBehavior,axes: SwiftUI.Axis.Set = [.vertical] ) {
         self.value = ._0(behavior: behavior, axes: axes)
         
@@ -8498,9 +8540,9 @@ struct _scrollBounceBehaviorModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+        #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
         case let ._0(behavior, axes):
-            if #available(macOS 13.3,iOS 16.4,watchOS 9.4,tvOS 16.4, *) {
+            if #available(tvOS 16.4,iOS 16.4,watchOS 9.4,macOS 13.3, *) {
             let behavior = behavior as! SwiftUI.ScrollBounceBehavior
 let axes = axes as! SwiftUI.Axis.Set 
             __content
@@ -8516,7 +8558,7 @@ struct _scrollClipDisabledModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(tvOS) || os(iOS) || os(macOS) || os(watchOS)
+        #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
         case _0(disabled: Any)
         #endif
     }
@@ -8529,8 +8571,8 @@ struct _scrollClipDisabledModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(tvOS) || os(iOS) || os(macOS) || os(watchOS)
-    @available(tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0, *)
+    #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
+    @available(tvOS 17.0,iOS 17.0,watchOS 10.0,macOS 14.0, *)
     init(_ disabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(disabled: disabled)
         
@@ -8541,9 +8583,9 @@ struct _scrollClipDisabledModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(tvOS) || os(iOS) || os(macOS) || os(watchOS)
+        #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
         case let ._0(disabled):
-            if #available(tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0, *) {
+            if #available(tvOS 17.0,iOS 17.0,watchOS 10.0,macOS 14.0, *) {
             let disabled = disabled as! AttributeReference<Swift.Bool>
             __content
                 .scrollClipDisabled(disabled.resolve(on: element, in: context))
@@ -8642,7 +8684,7 @@ struct _scrollDismissesKeyboardModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(tvOS) || os(iOS) || os(macOS) || os(watchOS)
+        #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
         case _0(mode: Any)
         #endif
     }
@@ -8655,8 +8697,8 @@ struct _scrollDismissesKeyboardModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(tvOS) || os(iOS) || os(macOS) || os(watchOS)
-    @available(tvOS 16.0,iOS 16.0,macOS 13.0,watchOS 9.0, *)
+    #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
+    @available(tvOS 16.0,iOS 16.0,watchOS 9.0,macOS 13.0, *)
     init(_ mode: SwiftUI.ScrollDismissesKeyboardMode) {
         self.value = ._0(mode: mode)
         
@@ -8667,9 +8709,9 @@ struct _scrollDismissesKeyboardModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(tvOS) || os(iOS) || os(macOS) || os(watchOS)
+        #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
         case let ._0(mode):
-            if #available(tvOS 16.0,iOS 16.0,macOS 13.0,watchOS 9.0, *) {
+            if #available(tvOS 16.0,iOS 16.0,watchOS 9.0,macOS 13.0, *) {
             let mode = mode as! SwiftUI.ScrollDismissesKeyboardMode
             __content
                 .scrollDismissesKeyboard(mode)
@@ -8726,10 +8768,10 @@ struct _scrollIndicatorsFlashModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(tvOS) || os(iOS) || os(macOS) || os(watchOS)
+        #if os(watchOS) || os(macOS) || os(iOS) || os(tvOS)
         case _0(value: Any)
         #endif
-        #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
+        #if os(watchOS) || os(tvOS) || os(iOS) || os(macOS)
         case _1(onAppear: Any)
         #endif
     }
@@ -8744,15 +8786,15 @@ struct _scrollIndicatorsFlashModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(tvOS) || os(iOS) || os(macOS) || os(watchOS)
-    @available(tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0, *)
+    #if os(watchOS) || os(macOS) || os(iOS) || os(tvOS)
+    @available(watchOS 10.0,macOS 14.0,iOS 17.0,tvOS 17.0, *)
     init(trigger value: AttributeReference<String>) {
         self.value = ._0(value: value)
         
     }
     #endif
-    #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
-    @available(iOS 17.0,macOS 14.0,watchOS 10.0,tvOS 17.0, *)
+    #if os(watchOS) || os(tvOS) || os(iOS) || os(macOS)
+    @available(watchOS 10.0,tvOS 17.0,iOS 17.0,macOS 14.0, *)
     init(onAppear: AttributeReference<Swift.Bool>) {
         self.value = ._1(onAppear: onAppear)
         
@@ -8763,17 +8805,17 @@ struct _scrollIndicatorsFlashModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(tvOS) || os(iOS) || os(macOS) || os(watchOS)
+        #if os(watchOS) || os(macOS) || os(iOS) || os(tvOS)
         case let ._0(value):
-            if #available(tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0, *) {
+            if #available(watchOS 10.0,macOS 14.0,iOS 17.0,tvOS 17.0, *) {
             let value = value as! AttributeReference<String>
             __content
                 .scrollIndicatorsFlash(trigger: value.resolve(on: element, in: context))
             } else { __content }
         #endif
-        #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
+        #if os(watchOS) || os(tvOS) || os(iOS) || os(macOS)
         case let ._1(onAppear):
-            if #available(iOS 17.0,macOS 14.0,watchOS 10.0,tvOS 17.0, *) {
+            if #available(watchOS 10.0,tvOS 17.0,iOS 17.0,macOS 14.0, *) {
             let onAppear = onAppear as! AttributeReference<Swift.Bool>
             __content
                 .scrollIndicatorsFlash(onAppear: onAppear.resolve(on: element, in: context))
@@ -8788,7 +8830,7 @@ struct _scrollPositionModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+        #if os(tvOS) || os(macOS) || os(iOS) || os(watchOS)
         case _0(anchor: Any?)
         #endif
     }
@@ -8801,8 +8843,8 @@ struct _scrollPositionModifier<R: RootRegistry>: ViewModifier {
 @ChangeTracked private var _0_id: String?
 
 
-    #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
-    @available(macOS 14.0,iOS 17.0,watchOS 10.0,tvOS 17.0, *)
+    #if os(tvOS) || os(macOS) || os(iOS) || os(watchOS)
+    @available(tvOS 17.0,macOS 14.0,iOS 17.0,watchOS 10.0, *)
     init(id: ChangeTracked<String?>,anchor: AttributeReference<SwiftUI.UnitPoint?>? = .init(storage: .constant(nil)) ) {
         self.value = ._0(anchor: anchor)
         self.__0_id = id
@@ -8813,9 +8855,9 @@ struct _scrollPositionModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+        #if os(tvOS) || os(macOS) || os(iOS) || os(watchOS)
         case let ._0(anchor):
-            if #available(macOS 14.0,iOS 17.0,watchOS 10.0,tvOS 17.0, *) {
+            if #available(tvOS 17.0,macOS 14.0,iOS 17.0,watchOS 10.0, *) {
             let anchor = anchor as? AttributeReference<SwiftUI.UnitPoint?>
             __content
                 .scrollPosition(id: __0_id.projectedValue, anchor: anchor?.resolve(on: element, in: context))
@@ -8872,7 +8914,7 @@ struct _scrollTargetLayoutModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(tvOS) || os(watchOS) || os(iOS) || os(macOS)
+        #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
         case _0(isEnabled: Any)
         #endif
     }
@@ -8885,8 +8927,8 @@ struct _scrollTargetLayoutModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(tvOS) || os(watchOS) || os(iOS) || os(macOS)
-    @available(tvOS 17.0,watchOS 10.0,iOS 17.0,macOS 14.0, *)
+    #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
+    @available(tvOS 17.0,iOS 17.0,watchOS 10.0,macOS 14.0, *)
     init(isEnabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(isEnabled: isEnabled)
         
@@ -8897,9 +8939,9 @@ struct _scrollTargetLayoutModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(tvOS) || os(watchOS) || os(iOS) || os(macOS)
+        #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
         case let ._0(isEnabled):
-            if #available(tvOS 17.0,watchOS 10.0,iOS 17.0,macOS 14.0, *) {
+            if #available(tvOS 17.0,iOS 17.0,watchOS 10.0,macOS 14.0, *) {
             let isEnabled = isEnabled as! AttributeReference<Swift.Bool>
             __content
                 .scrollTargetLayout(isEnabled: isEnabled.resolve(on: element, in: context))
@@ -8956,7 +8998,7 @@ struct _searchPresentationToolbarBehaviorModifier<R: RootRegistry>: ViewModifier
 
     enum Value {
         case _never
-        #if os(iOS) || os(watchOS) || os(tvOS) || os(macOS)
+        #if os(tvOS) || os(iOS) || os(macOS) || os(watchOS)
         case _0(behavior: Any)
         #endif
     }
@@ -8969,8 +9011,8 @@ struct _searchPresentationToolbarBehaviorModifier<R: RootRegistry>: ViewModifier
 
 
 
-    #if os(iOS) || os(watchOS) || os(tvOS) || os(macOS)
-    @available(iOS 17.1,watchOS 10.1,tvOS 17.1,macOS 14.1, *)
+    #if os(tvOS) || os(iOS) || os(macOS) || os(watchOS)
+    @available(tvOS 17.1,iOS 17.1,macOS 14.1,watchOS 10.1, *)
     init(_ behavior: SwiftUI.SearchPresentationToolbarBehavior) {
         self.value = ._0(behavior: behavior)
         
@@ -8981,9 +9023,9 @@ struct _searchPresentationToolbarBehaviorModifier<R: RootRegistry>: ViewModifier
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(watchOS) || os(tvOS) || os(macOS)
+        #if os(tvOS) || os(iOS) || os(macOS) || os(watchOS)
         case let ._0(behavior):
-            if #available(iOS 17.1,watchOS 10.1,tvOS 17.1,macOS 14.1, *) {
+            if #available(tvOS 17.1,iOS 17.1,macOS 14.1,watchOS 10.1, *) {
             let behavior = behavior as! SwiftUI.SearchPresentationToolbarBehavior
             __content
                 .searchPresentationToolbarBehavior(behavior)
@@ -9069,13 +9111,13 @@ struct _searchableModifier<R: RootRegistry>: ViewModifier {
         
         case _2(placement: SwiftUI.SearchFieldPlacement = .automatic, prompt: AttributeReference<String>)
         
-        #if os(iOS) || os(macOS)
+        #if os(macOS) || os(iOS)
         case _3(placement: Any, prompt: Any?)
         #endif
         #if os(macOS) || os(iOS)
         case _4(placement: Any, prompt: Any)
         #endif
-        #if os(iOS) || os(macOS)
+        #if os(macOS) || os(iOS)
         case _5(placement: Any, prompt: Any)
         #endif
     }
@@ -9122,8 +9164,8 @@ struct _searchableModifier<R: RootRegistry>: ViewModifier {
         self.__2_text = text
     }
     
-    #if os(iOS) || os(macOS)
-    @available(iOS 17.0,macOS 14.0, *)
+    #if os(macOS) || os(iOS)
+    @available(macOS 14.0,iOS 17.0, *)
     init(text: ChangeTracked<Swift.String>,isPresented: ChangeTracked<Swift.Bool>,placement: SwiftUI.SearchFieldPlacement = .automatic, prompt: TextReference? = nil ) {
         self.value = ._3(placement: placement, prompt: prompt)
         self.__3_text = text
@@ -9138,8 +9180,8 @@ self.__3_isPresented = isPresented
 self.__4_isPresented = isPresented
     }
     #endif
-    #if os(iOS) || os(macOS)
-    @available(iOS 17.0,macOS 14.0, *)
+    #if os(macOS) || os(iOS)
+    @available(macOS 14.0,iOS 17.0, *)
     init(text: ChangeTracked<Swift.String>,isPresented: ChangeTracked<Swift.Bool>,placement: SwiftUI.SearchFieldPlacement = .automatic, prompt: AttributeReference<String>) {
         self.value = ._5(placement: placement, prompt: prompt)
         self.__5_text = text
@@ -9175,9 +9217,9 @@ self.__5_isPresented = isPresented
                 .searchable(text: __2_text.projectedValue, placement: placement, prompt: prompt.resolve(on: element, in: context))
             
         
-        #if os(iOS) || os(macOS)
+        #if os(macOS) || os(iOS)
         case let ._3(placement, prompt):
-            if #available(iOS 17.0,macOS 14.0, *) {
+            if #available(macOS 14.0,iOS 17.0, *) {
             let placement = placement as! SwiftUI.SearchFieldPlacement 
 let prompt = prompt as? TextReference
             __content
@@ -9193,9 +9235,9 @@ let prompt = prompt as! SwiftUI.LocalizedStringKey
                 .searchable(text: __4_text.projectedValue, isPresented: __4_isPresented.projectedValue, placement: placement, prompt: prompt)
             } else { __content }
         #endif
-        #if os(iOS) || os(macOS)
+        #if os(macOS) || os(iOS)
         case let ._5(placement, prompt):
-            if #available(iOS 17.0,macOS 14.0, *) {
+            if #available(macOS 14.0,iOS 17.0, *) {
             let placement = placement as! SwiftUI.SearchFieldPlacement 
 let prompt = prompt as! AttributeReference<String>
             __content
@@ -9211,7 +9253,7 @@ struct _selectionDisabledModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(watchOS) || os(macOS) || os(tvOS) || os(iOS)
+        #if os(iOS) || os(watchOS) || os(tvOS) || os(macOS)
         case _0(isDisabled: Any)
         #endif
     }
@@ -9224,8 +9266,8 @@ struct _selectionDisabledModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(watchOS) || os(macOS) || os(tvOS) || os(iOS)
-    @available(watchOS 10.0,macOS 14.0,tvOS 17.0,iOS 17.0, *)
+    #if os(iOS) || os(watchOS) || os(tvOS) || os(macOS)
+    @available(iOS 17.0,watchOS 10.0,tvOS 17.0,macOS 14.0, *)
     init(_ isDisabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(isDisabled: isDisabled)
         
@@ -9236,9 +9278,9 @@ struct _selectionDisabledModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(watchOS) || os(macOS) || os(tvOS) || os(iOS)
+        #if os(iOS) || os(watchOS) || os(tvOS) || os(macOS)
         case let ._0(isDisabled):
-            if #available(watchOS 10.0,macOS 14.0,tvOS 17.0,iOS 17.0, *) {
+            if #available(iOS 17.0,watchOS 10.0,tvOS 17.0,macOS 14.0, *) {
             let isDisabled = isDisabled as! AttributeReference<Swift.Bool>
             __content
                 .selectionDisabled(isDisabled.resolve(on: element, in: context))
@@ -9716,7 +9758,7 @@ struct _swipeActionsModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(macOS) || os(watchOS)
+        #if os(macOS) || os(watchOS) || os(iOS)
         case _0(edge: Any, allowsFullSwipe: Any, content: Any)
         #endif
     }
@@ -9729,8 +9771,8 @@ struct _swipeActionsModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(macOS) || os(watchOS)
-    @available(iOS 15.0,macOS 12.0,watchOS 8.0, *)
+    #if os(macOS) || os(watchOS) || os(iOS)
+    @available(macOS 12.0,watchOS 8.0,iOS 15.0, *)
     init(edge: SwiftUI.HorizontalEdge = .trailing, allowsFullSwipe: AttributeReference<Swift.Bool> = .init(storage: .constant(true)), content: ViewReference=ViewReference(value: [])) {
         self.value = ._0(edge: edge, allowsFullSwipe: allowsFullSwipe, content: content)
         
@@ -9741,9 +9783,9 @@ struct _swipeActionsModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(macOS) || os(watchOS)
+        #if os(macOS) || os(watchOS) || os(iOS)
         case let ._0(edge, allowsFullSwipe, content):
-            if #available(iOS 15.0,macOS 12.0,watchOS 8.0, *) {
+            if #available(macOS 12.0,watchOS 8.0,iOS 15.0, *) {
             let edge = edge as! SwiftUI.HorizontalEdge 
 let allowsFullSwipe = allowsFullSwipe as! AttributeReference<Swift.Bool>
 let content = content as! ViewReference
@@ -9760,7 +9802,7 @@ struct _symbolEffectsRemovedModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
         case _0(isEnabled: Any)
         #endif
     }
@@ -9773,8 +9815,8 @@ struct _symbolEffectsRemovedModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-    @available(iOS 17.0,macOS 14.0,tvOS 17.0,watchOS 10.0, *)
+    #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
+    @available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0, *)
     init(_ isEnabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(isEnabled: isEnabled)
         
@@ -9785,9 +9827,9 @@ struct _symbolEffectsRemovedModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
         case let ._0(isEnabled):
-            if #available(iOS 17.0,macOS 14.0,tvOS 17.0,watchOS 10.0, *) {
+            if #available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0, *) {
             let isEnabled = isEnabled as! AttributeReference<Swift.Bool>
             __content
                 .symbolEffectsRemoved(isEnabled.resolve(on: element, in: context))
@@ -9970,7 +10012,7 @@ struct _tableStyleModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(macOS)
+        #if os(macOS) || os(iOS)
         case _0(style: Any)
         #endif
     }
@@ -9983,8 +10025,8 @@ struct _tableStyleModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(macOS)
-    @available(iOS 16.0,macOS 12.0, *)
+    #if os(macOS) || os(iOS)
+    @available(macOS 12.0,iOS 16.0, *)
     init(_ style: AnyTableStyle) {
         self.value = ._0(style: style)
         
@@ -9995,9 +10037,9 @@ struct _tableStyleModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(macOS)
+        #if os(macOS) || os(iOS)
         case let ._0(style):
-            if #available(iOS 16.0,macOS 12.0, *) {
+            if #available(macOS 12.0,iOS 16.0, *) {
             let style = style as! AnyTableStyle
             __content
                 .tableStyle(style)
@@ -10096,7 +10138,7 @@ struct _textEditorStyleModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(macOS) || os(visionOS)
+        #if os(visionOS) || os(macOS) || os(iOS)
         case _0(style: Any)
         #endif
     }
@@ -10109,8 +10151,8 @@ struct _textEditorStyleModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(macOS) || os(visionOS)
-    @available(iOS 17.0,macOS 14.0,visionOS 1.0, *)
+    #if os(visionOS) || os(macOS) || os(iOS)
+    @available(visionOS 1.0,macOS 14.0,iOS 17.0, *)
     init(_ style: AnyTextEditorStyle) {
         self.value = ._0(style: style)
         
@@ -10121,9 +10163,9 @@ struct _textEditorStyleModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(macOS) || os(visionOS)
+        #if os(visionOS) || os(macOS) || os(iOS)
         case let ._0(style):
-            if #available(iOS 17.0,macOS 14.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,macOS 14.0,iOS 17.0, *) {
             let style = style as! AnyTextEditorStyle
             __content
                 .textEditorStyle(style)
@@ -10180,7 +10222,7 @@ struct _textInputAutocapitalizationModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(tvOS) || os(watchOS)
+        #if os(watchOS) || os(tvOS) || os(iOS)
         case _0(autocapitalization: Any?)
         #endif
     }
@@ -10193,8 +10235,8 @@ struct _textInputAutocapitalizationModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(tvOS) || os(watchOS)
-    @available(iOS 15.0,tvOS 15.0,watchOS 8.0, *)
+    #if os(watchOS) || os(tvOS) || os(iOS)
+    @available(watchOS 8.0,tvOS 15.0,iOS 15.0, *)
     init(_ autocapitalization: SwiftUI.TextInputAutocapitalization?) {
         self.value = ._0(autocapitalization: autocapitalization)
         
@@ -10205,9 +10247,9 @@ struct _textInputAutocapitalizationModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(tvOS) || os(watchOS)
+        #if os(watchOS) || os(tvOS) || os(iOS)
         case let ._0(autocapitalization):
-            if #available(iOS 15.0,tvOS 15.0,watchOS 8.0, *) {
+            if #available(watchOS 8.0,tvOS 15.0,iOS 15.0, *) {
             let autocapitalization = autocapitalization as? SwiftUI.TextInputAutocapitalization
             __content
                 .textInputAutocapitalization(autocapitalization)
@@ -10222,7 +10264,7 @@ struct _textScaleModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(watchOS) || os(tvOS) || os(macOS) || os(iOS)
+        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
         case _0(scale: Any,isEnabled: Any)
         #endif
     }
@@ -10235,8 +10277,8 @@ struct _textScaleModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(watchOS) || os(tvOS) || os(macOS) || os(iOS)
-    @available(watchOS 10.0,tvOS 17.0,macOS 14.0,iOS 17.0, *)
+    #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
+    @available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0, *)
     init(_ scale: SwiftUI.Text.Scale,isEnabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(scale: scale, isEnabled: isEnabled)
         
@@ -10247,9 +10289,9 @@ struct _textScaleModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(watchOS) || os(tvOS) || os(macOS) || os(iOS)
+        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
         case let ._0(scale, isEnabled):
-            if #available(watchOS 10.0,tvOS 17.0,macOS 14.0,iOS 17.0, *) {
+            if #available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0, *) {
             let scale = scale as! SwiftUI.Text.Scale
 let isEnabled = isEnabled as! AttributeReference<Swift.Bool>
             __content
@@ -10414,7 +10456,7 @@ struct _toolbarModifier<R: RootRegistry>: ViewModifier {
         
         case _0(visibility: AttributeReference<SwiftUI.Visibility>,bars: SwiftUI.ToolbarPlacement)
         
-        #if os(tvOS) || os(macOS) || os(watchOS) || os(iOS)
+        #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
         case _1(defaultItemKind: Any?)
         #endif
         
@@ -10446,8 +10488,8 @@ struct _toolbarModifier<R: RootRegistry>: ViewModifier {
         
     }
     
-    #if os(tvOS) || os(macOS) || os(watchOS) || os(iOS)
-    @available(tvOS 17.0,macOS 14.0,watchOS 10.0,iOS 17.0, *)
+    #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
+    @available(iOS 17.0,macOS 14.0,watchOS 10.0,tvOS 17.0, *)
     init(removing defaultItemKind: SwiftUI.ToolbarDefaultItemKind?) {
         self.value = ._1(defaultItemKind: defaultItemKind)
         
@@ -10480,9 +10522,9 @@ struct _toolbarModifier<R: RootRegistry>: ViewModifier {
                 .toolbar(visibility.resolve(on: element, in: context), for: bars)
             
         
-        #if os(tvOS) || os(macOS) || os(watchOS) || os(iOS)
+        #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
         case let ._1(defaultItemKind):
-            if #available(tvOS 17.0,macOS 14.0,watchOS 10.0,iOS 17.0, *) {
+            if #available(iOS 17.0,macOS 14.0,watchOS 10.0,tvOS 17.0, *) {
             let defaultItemKind = defaultItemKind as? SwiftUI.ToolbarDefaultItemKind
             __content
                 .toolbar(removing: defaultItemKind)
@@ -10659,7 +10701,7 @@ struct _toolbarTitleDisplayModeModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(watchOS) || os(macOS) || os(iOS) || os(tvOS)
+        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
         case _0(mode: Any)
         #endif
     }
@@ -10672,8 +10714,8 @@ struct _toolbarTitleDisplayModeModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(watchOS) || os(macOS) || os(iOS) || os(tvOS)
-    @available(watchOS 10.0,macOS 14.0,iOS 17.0,tvOS 17.0, *)
+    #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
+    @available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0, *)
     init(_ mode: SwiftUI.ToolbarTitleDisplayMode) {
         self.value = ._0(mode: mode)
         
@@ -10684,9 +10726,9 @@ struct _toolbarTitleDisplayModeModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(watchOS) || os(macOS) || os(iOS) || os(tvOS)
+        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
         case let ._0(mode):
-            if #available(watchOS 10.0,macOS 14.0,iOS 17.0,tvOS 17.0, *) {
+            if #available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0, *) {
             let mode = mode as! SwiftUI.ToolbarTitleDisplayMode
             __content
                 .toolbarTitleDisplayMode(mode)
@@ -11276,6 +11318,7 @@ case privacySensitive(_privacySensitiveModifier<R>)
 case progressViewStyle(_progressViewStyleModifier<R>)
 case projectionEffect(_projectionEffectModifier<R>)
 case redacted(_redactedModifier<R>)
+case refreshable(_refreshableModifier<R>)
 case renameAction(_renameActionModifier<R>)
 case replaceDisabled(_replaceDisabledModifier<R>)
 case rotationEffect(_rotationEffectModifier<R>)
@@ -11342,28 +11385,28 @@ case truncationMode(_truncationModeModifier<R>)
 case underline(_underlineModifier<R>)
 case unredacted(_unredactedModifier<R>)
 case zIndex(_zIndexModifier<R>)
-        case _SubtractingModifier(LiveViewNative._SubtractingModifier)
-case _IntersectionModifier(LiveViewNative._IntersectionModifier)
+        case _ResizableModifier(LiveViewNative._ResizableModifier)
+case _RotationModifier(LiveViewNative._RotationModifier)
 case _LineSubtractionModifier(LiveViewNative._LineSubtractionModifier)
+case _LineIntersectionModifier(LiveViewNative._LineIntersectionModifier)
+case _SearchCompletionModifier(LiveViewNative._SearchCompletionModifier<R>)
+case _UnionModifier(LiveViewNative._UnionModifier)
 case _FocusScopeModifier(LiveViewNative._FocusScopeModifier<R>)
-case _StrokeModifier(LiveViewNative._StrokeModifier<R>)
-case _PresentationDetentsModifier(LiveViewNative._PresentationDetentsModifier)
-case _ResizableModifier(LiveViewNative._ResizableModifier)
-case _TransformModifier(LiveViewNative._TransformModifier)
+case _SymmetricDifferenceModifier(LiveViewNative._SymmetricDifferenceModifier)
+case _MatchedGeometryEffectModifier(LiveViewNative._MatchedGeometryEffectModifier<R>)
+case _FillModifier(LiveViewNative._FillModifier)
 case _RenderingModeModifier(LiveViewNative._RenderingModeModifier)
 case _ScaleModifier(LiveViewNative._ScaleModifier<R>)
-case _LineIntersectionModifier(LiveViewNative._LineIntersectionModifier)
+case _TransformModifier(LiveViewNative._TransformModifier)
 case _OnSubmitModifier(LiveViewNative._OnSubmitModifier)
-case _FillModifier(LiveViewNative._FillModifier)
-case _UnionModifier(LiveViewNative._UnionModifier)
 case _SearchScopesModifier(LiveViewNative._SearchScopesModifier<R>)
 case _MaskModifier(LiveViewNative._MaskModifier<R>)
-case _MatchedGeometryEffectModifier(LiveViewNative._MatchedGeometryEffectModifier<R>)
 case _Rotation3DEffectModifier(LiveViewNative._Rotation3DEffectModifier<R>)
-case _RotationModifier(LiveViewNative._RotationModifier)
-case _SymmetricDifferenceModifier(LiveViewNative._SymmetricDifferenceModifier)
-case _SearchCompletionModifier(LiveViewNative._SearchCompletionModifier<R>)
+case _PresentationDetentsModifier(LiveViewNative._PresentationDetentsModifier)
 case _PrefersDefaultFocusModifier(LiveViewNative._PrefersDefaultFocusModifier<R>)
+case _IntersectionModifier(LiveViewNative._IntersectionModifier)
+case _SubtractingModifier(LiveViewNative._SubtractingModifier)
+case _StrokeModifier(LiveViewNative._StrokeModifier<R>)
         
         func body(content: Content) -> some View {
             switch self {
@@ -11683,6 +11726,8 @@ case let .projectionEffect(modifier):
     content.modifier(modifier)
 case let .redacted(modifier):
     content.modifier(modifier)
+case let .refreshable(modifier):
+    content.modifier(modifier)
 case let .renameAction(modifier):
     content.modifier(modifier)
 case let .replaceDisabled(modifier):
@@ -11815,49 +11860,49 @@ case let .unredacted(modifier):
     content.modifier(modifier)
 case let .zIndex(modifier):
     content.modifier(modifier)
-            case let ._SubtractingModifier(modifier):
+            case let ._ResizableModifier(modifier):
     content.modifier(modifier)
-case let ._IntersectionModifier(modifier):
+case let ._RotationModifier(modifier):
     content.modifier(modifier)
 case let ._LineSubtractionModifier(modifier):
     content.modifier(modifier)
+case let ._LineIntersectionModifier(modifier):
+    content.modifier(modifier)
+case let ._SearchCompletionModifier(modifier):
+    content.modifier(modifier)
+case let ._UnionModifier(modifier):
+    content.modifier(modifier)
 case let ._FocusScopeModifier(modifier):
     content.modifier(modifier)
-case let ._StrokeModifier(modifier):
+case let ._SymmetricDifferenceModifier(modifier):
     content.modifier(modifier)
-case let ._PresentationDetentsModifier(modifier):
+case let ._MatchedGeometryEffectModifier(modifier):
     content.modifier(modifier)
-case let ._ResizableModifier(modifier):
-    content.modifier(modifier)
-case let ._TransformModifier(modifier):
+case let ._FillModifier(modifier):
     content.modifier(modifier)
 case let ._RenderingModeModifier(modifier):
     content.modifier(modifier)
 case let ._ScaleModifier(modifier):
     content.modifier(modifier)
-case let ._LineIntersectionModifier(modifier):
+case let ._TransformModifier(modifier):
     content.modifier(modifier)
 case let ._OnSubmitModifier(modifier):
-    content.modifier(modifier)
-case let ._FillModifier(modifier):
-    content.modifier(modifier)
-case let ._UnionModifier(modifier):
     content.modifier(modifier)
 case let ._SearchScopesModifier(modifier):
     content.modifier(modifier)
 case let ._MaskModifier(modifier):
     content.modifier(modifier)
-case let ._MatchedGeometryEffectModifier(modifier):
-    content.modifier(modifier)
 case let ._Rotation3DEffectModifier(modifier):
     content.modifier(modifier)
-case let ._RotationModifier(modifier):
-    content.modifier(modifier)
-case let ._SymmetricDifferenceModifier(modifier):
-    content.modifier(modifier)
-case let ._SearchCompletionModifier(modifier):
+case let ._PresentationDetentsModifier(modifier):
     content.modifier(modifier)
 case let ._PrefersDefaultFocusModifier(modifier):
+    content.modifier(modifier)
+case let ._IntersectionModifier(modifier):
+    content.modifier(modifier)
+case let ._SubtractingModifier(modifier):
+    content.modifier(modifier)
+case let ._StrokeModifier(modifier):
     content.modifier(modifier)
             }
         }
@@ -12032,6 +12077,7 @@ _privacySensitiveModifier<R>.name: _privacySensitiveModifier<R>.parser(in: conte
 _progressViewStyleModifier<R>.name: _progressViewStyleModifier<R>.parser(in: context).map(Output.progressViewStyle).eraseToAnyParser(),
 _projectionEffectModifier<R>.name: _projectionEffectModifier<R>.parser(in: context).map(Output.projectionEffect).eraseToAnyParser(),
 _redactedModifier<R>.name: _redactedModifier<R>.parser(in: context).map(Output.redacted).eraseToAnyParser(),
+_refreshableModifier<R>.name: _refreshableModifier<R>.parser(in: context).map(Output.refreshable).eraseToAnyParser(),
 _renameActionModifier<R>.name: _renameActionModifier<R>.parser(in: context).map(Output.renameAction).eraseToAnyParser(),
 _replaceDisabledModifier<R>.name: _replaceDisabledModifier<R>.parser(in: context).map(Output.replaceDisabled).eraseToAnyParser(),
 _rotationEffectModifier<R>.name: _rotationEffectModifier<R>.parser(in: context).map(Output.rotationEffect).eraseToAnyParser(),
@@ -12098,28 +12144,28 @@ _truncationModeModifier<R>.name: _truncationModeModifier<R>.parser(in: context).
 _underlineModifier<R>.name: _underlineModifier<R>.parser(in: context).map(Output.underline).eraseToAnyParser(),
 _unredactedModifier<R>.name: _unredactedModifier<R>.parser(in: context).map(Output.unredacted).eraseToAnyParser(),
 _zIndexModifier<R>.name: _zIndexModifier<R>.parser(in: context).map(Output.zIndex).eraseToAnyParser(),
-                    LiveViewNative._SubtractingModifier.name: LiveViewNative._SubtractingModifier.parser(in: context).map(Output._SubtractingModifier).eraseToAnyParser(),
-LiveViewNative._IntersectionModifier.name: LiveViewNative._IntersectionModifier.parser(in: context).map(Output._IntersectionModifier).eraseToAnyParser(),
+                    LiveViewNative._ResizableModifier.name: LiveViewNative._ResizableModifier.parser(in: context).map(Output._ResizableModifier).eraseToAnyParser(),
+LiveViewNative._RotationModifier.name: LiveViewNative._RotationModifier.parser(in: context).map(Output._RotationModifier).eraseToAnyParser(),
 LiveViewNative._LineSubtractionModifier.name: LiveViewNative._LineSubtractionModifier.parser(in: context).map(Output._LineSubtractionModifier).eraseToAnyParser(),
+LiveViewNative._LineIntersectionModifier.name: LiveViewNative._LineIntersectionModifier.parser(in: context).map(Output._LineIntersectionModifier).eraseToAnyParser(),
+LiveViewNative._SearchCompletionModifier<R>.name: LiveViewNative._SearchCompletionModifier<R>.parser(in: context).map(Output._SearchCompletionModifier).eraseToAnyParser(),
+LiveViewNative._UnionModifier.name: LiveViewNative._UnionModifier.parser(in: context).map(Output._UnionModifier).eraseToAnyParser(),
 LiveViewNative._FocusScopeModifier<R>.name: LiveViewNative._FocusScopeModifier<R>.parser(in: context).map(Output._FocusScopeModifier).eraseToAnyParser(),
-LiveViewNative._StrokeModifier<R>.name: LiveViewNative._StrokeModifier<R>.parser(in: context).map(Output._StrokeModifier).eraseToAnyParser(),
-LiveViewNative._PresentationDetentsModifier.name: LiveViewNative._PresentationDetentsModifier.parser(in: context).map(Output._PresentationDetentsModifier).eraseToAnyParser(),
-LiveViewNative._ResizableModifier.name: LiveViewNative._ResizableModifier.parser(in: context).map(Output._ResizableModifier).eraseToAnyParser(),
-LiveViewNative._TransformModifier.name: LiveViewNative._TransformModifier.parser(in: context).map(Output._TransformModifier).eraseToAnyParser(),
+LiveViewNative._SymmetricDifferenceModifier.name: LiveViewNative._SymmetricDifferenceModifier.parser(in: context).map(Output._SymmetricDifferenceModifier).eraseToAnyParser(),
+LiveViewNative._MatchedGeometryEffectModifier<R>.name: LiveViewNative._MatchedGeometryEffectModifier<R>.parser(in: context).map(Output._MatchedGeometryEffectModifier).eraseToAnyParser(),
+LiveViewNative._FillModifier.name: LiveViewNative._FillModifier.parser(in: context).map(Output._FillModifier).eraseToAnyParser(),
 LiveViewNative._RenderingModeModifier.name: LiveViewNative._RenderingModeModifier.parser(in: context).map(Output._RenderingModeModifier).eraseToAnyParser(),
 LiveViewNative._ScaleModifier<R>.name: LiveViewNative._ScaleModifier<R>.parser(in: context).map(Output._ScaleModifier).eraseToAnyParser(),
-LiveViewNative._LineIntersectionModifier.name: LiveViewNative._LineIntersectionModifier.parser(in: context).map(Output._LineIntersectionModifier).eraseToAnyParser(),
+LiveViewNative._TransformModifier.name: LiveViewNative._TransformModifier.parser(in: context).map(Output._TransformModifier).eraseToAnyParser(),
 LiveViewNative._OnSubmitModifier.name: LiveViewNative._OnSubmitModifier.parser(in: context).map(Output._OnSubmitModifier).eraseToAnyParser(),
-LiveViewNative._FillModifier.name: LiveViewNative._FillModifier.parser(in: context).map(Output._FillModifier).eraseToAnyParser(),
-LiveViewNative._UnionModifier.name: LiveViewNative._UnionModifier.parser(in: context).map(Output._UnionModifier).eraseToAnyParser(),
 LiveViewNative._SearchScopesModifier<R>.name: LiveViewNative._SearchScopesModifier<R>.parser(in: context).map(Output._SearchScopesModifier).eraseToAnyParser(),
 LiveViewNative._MaskModifier<R>.name: LiveViewNative._MaskModifier<R>.parser(in: context).map(Output._MaskModifier).eraseToAnyParser(),
-LiveViewNative._MatchedGeometryEffectModifier<R>.name: LiveViewNative._MatchedGeometryEffectModifier<R>.parser(in: context).map(Output._MatchedGeometryEffectModifier).eraseToAnyParser(),
 LiveViewNative._Rotation3DEffectModifier<R>.name: LiveViewNative._Rotation3DEffectModifier<R>.parser(in: context).map(Output._Rotation3DEffectModifier).eraseToAnyParser(),
-LiveViewNative._RotationModifier.name: LiveViewNative._RotationModifier.parser(in: context).map(Output._RotationModifier).eraseToAnyParser(),
-LiveViewNative._SymmetricDifferenceModifier.name: LiveViewNative._SymmetricDifferenceModifier.parser(in: context).map(Output._SymmetricDifferenceModifier).eraseToAnyParser(),
-LiveViewNative._SearchCompletionModifier<R>.name: LiveViewNative._SearchCompletionModifier<R>.parser(in: context).map(Output._SearchCompletionModifier).eraseToAnyParser(),
+LiveViewNative._PresentationDetentsModifier.name: LiveViewNative._PresentationDetentsModifier.parser(in: context).map(Output._PresentationDetentsModifier).eraseToAnyParser(),
 LiveViewNative._PrefersDefaultFocusModifier<R>.name: LiveViewNative._PrefersDefaultFocusModifier<R>.parser(in: context).map(Output._PrefersDefaultFocusModifier).eraseToAnyParser(),
+LiveViewNative._IntersectionModifier.name: LiveViewNative._IntersectionModifier.parser(in: context).map(Output._IntersectionModifier).eraseToAnyParser(),
+LiveViewNative._SubtractingModifier.name: LiveViewNative._SubtractingModifier.parser(in: context).map(Output._SubtractingModifier).eraseToAnyParser(),
+LiveViewNative._StrokeModifier<R>.name: LiveViewNative._StrokeModifier<R>.parser(in: context).map(Output._StrokeModifier).eraseToAnyParser(),
                 ]
                 
                 var copy = input
@@ -12513,14 +12559,14 @@ ConstantAtomLiteral("plusLighter").map({ () -> Self in
     }
 }
 
-#if os(macOS) || os(tvOS) || os(watchOS) || os(iOS)
-@available(macOS 14.0,tvOS 17.0,watchOS 10.0,iOS 17.0, *)
+#if os(tvOS) || os(macOS) || os(iOS) || os(watchOS)
+@available(tvOS 17.0,macOS 14.0,iOS 17.0,watchOS 10.0, *)
 extension ButtonRepeatBehavior: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             ConstantAtomLiteral("automatic").map({ () -> Self in
-#if os(watchOS) || os(macOS) || os(iOS) || os(tvOS)
+#if os(tvOS) || os(macOS) || os(iOS) || os(watchOS)
 
     return Self.automatic
 
@@ -12529,7 +12575,7 @@ fatalError("'automatic' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("enabled").map({ () -> Self in
-#if os(tvOS) || os(macOS) || os(watchOS) || os(iOS)
+#if os(tvOS) || os(macOS) || os(iOS) || os(watchOS)
 
     return Self.enabled
 
@@ -12538,7 +12584,7 @@ fatalError("'enabled' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("disabled").map({ () -> Self in
-#if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
+#if os(tvOS) || os(macOS) || os(iOS) || os(watchOS)
 
     return Self.disabled
 
@@ -12618,8 +12664,8 @@ ConstantAtomLiteral("dark").map({ () -> Self in
     }
 }
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
-@available(macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0, *)
+#if os(tvOS) || os(macOS) || os(iOS) || os(watchOS)
+@available(tvOS 17.0,macOS 14.0,iOS 17.0,watchOS 10.0, *)
 extension ContainerBackgroundPlacement: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -12647,14 +12693,14 @@ fatalError("'navigation' is not available on this OS")
     }
 }
 #endif
-#if os(tvOS) || os(iOS) || os(macOS) || os(watchOS)
-@available(tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0, *)
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+@available(macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0, *)
 extension ContentMarginPlacement: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             ConstantAtomLiteral("automatic").map({ () -> Self in
-#if os(tvOS) || os(iOS) || os(macOS) || os(watchOS)
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
 
     return Self.automatic
 
@@ -12663,7 +12709,7 @@ fatalError("'automatic' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("scrollContent").map({ () -> Self in
-#if os(tvOS) || os(iOS) || os(macOS) || os(watchOS)
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
 
     return Self.scrollContent
 
@@ -12672,7 +12718,7 @@ fatalError("'scrollContent' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("scrollIndicators").map({ () -> Self in
-#if os(tvOS) || os(iOS) || os(macOS) || os(watchOS)
+#if os(macOS) || os(watchOS) || os(iOS) || os(tvOS)
 
     return Self.scrollIndicators
 
@@ -12702,7 +12748,7 @@ extension ContentShapeKinds: ParseableModifierValue {
 })
 ConstantAtomLiteral("dragPreview").map({ () -> Self in
 #if os(macOS) || os(iOS)
-if #available(watchOS 8.0,macOS 12.0,iOS 15.0,tvOS 15.0, *) {
+if #available(tvOS 15.0,macOS 12.0,iOS 15.0,watchOS 8.0, *) {
     return Self.dragPreview
 } else { fatalError("'dragPreview' is not available in this OS version") }
 #else
@@ -12710,8 +12756,8 @@ fatalError("'dragPreview' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("contextMenuPreview").map({ () -> Self in
-#if os(tvOS) || os(iOS)
-if #available(tvOS 17.0,macOS 12.0,iOS 15.0,watchOS 8.0, *) {
+#if os(iOS) || os(tvOS)
+if #available(macOS 12.0,iOS 15.0,tvOS 17.0,watchOS 8.0, *) {
     return Self.contextMenuPreview
 } else { fatalError("'contextMenuPreview' is not available in this OS version") }
 #else
@@ -12720,7 +12766,7 @@ fatalError("'contextMenuPreview' is not available on this OS")
 })
 ConstantAtomLiteral("hoverEffect").map({ () -> Self in
 #if os(iOS)
-if #available(tvOS 15.0,macOS 12.0,iOS 15.0,watchOS 8.0, *) {
+if #available(macOS 12.0,iOS 15.0,tvOS 15.0,watchOS 8.0, *) {
     return Self.hoverEffect
 } else { fatalError("'hoverEffect' is not available in this OS version") }
 #else
@@ -12729,7 +12775,7 @@ fatalError("'hoverEffect' is not available on this OS")
 })
 ConstantAtomLiteral("focusEffect").map({ () -> Self in
 #if os(macOS) || os(watchOS)
-if #available(tvOS 15.0,macOS 12.0,iOS 15.0,watchOS 8.0, *) {
+if #available(macOS 12.0,iOS 15.0,tvOS 15.0,watchOS 8.0, *) {
     return Self.focusEffect
 } else { fatalError("'focusEffect' is not available in this OS version") }
 #else
@@ -12737,8 +12783,8 @@ fatalError("'focusEffect' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("accessibility").map({ () -> Self in
-#if os(tvOS) || os(watchOS) || os(macOS) || os(iOS)
-if #available(tvOS 17.0,watchOS 10.0,macOS 14.0,iOS 17.0, *) {
+#if os(macOS) || os(watchOS) || os(iOS) || os(tvOS)
+if #available(macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0, *) {
     return Self.accessibility
 } else { fatalError("'accessibility' is not available in this OS version") }
 #else
@@ -12750,14 +12796,14 @@ fatalError("'accessibility' is not available on this OS")
     }
 }
 
-#if os(watchOS) || os(macOS) || os(iOS)
-@available(watchOS 9.0,macOS 10.15,iOS 15.0, *)
+#if os(macOS) || os(watchOS) || os(iOS)
+@available(macOS 10.15,watchOS 9.0,iOS 15.0, *)
 extension ControlSize: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             ConstantAtomLiteral("mini").map({ () -> Self in
-#if os(watchOS) || os(macOS) || os(iOS)
+#if os(macOS) || os(watchOS) || os(iOS)
 
     return Self.mini
 
@@ -12766,7 +12812,7 @@ fatalError("'mini' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("small").map({ () -> Self in
-#if os(watchOS) || os(macOS) || os(iOS)
+#if os(macOS) || os(watchOS) || os(iOS)
 
     return Self.small
 
@@ -12775,7 +12821,7 @@ fatalError("'small' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("regular").map({ () -> Self in
-#if os(watchOS) || os(macOS) || os(iOS)
+#if os(macOS) || os(watchOS) || os(iOS)
 
     return Self.regular
 
@@ -12784,8 +12830,8 @@ fatalError("'regular' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("large").map({ () -> Self in
-#if os(watchOS) || os(macOS) || os(iOS)
-if #available(watchOS 9.0,macOS 11.0,iOS 15.0, *) {
+#if os(macOS) || os(watchOS) || os(iOS)
+if #available(macOS 11.0,watchOS 9.0,iOS 15.0, *) {
     return Self.large
 } else { fatalError("'large' is not available in this OS version") }
 #else
@@ -12793,8 +12839,8 @@ fatalError("'large' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("extraLarge").map({ () -> Self in
-#if os(macOS) || os(visionOS) || os(iOS) || os(watchOS)
-if #available(macOS 14.0,visionOS 1.0,iOS 17.0,watchOS 10.0, *) {
+#if os(watchOS) || os(macOS) || os(visionOS) || os(iOS)
+if #available(watchOS 10.0,macOS 14.0,visionOS 1.0,iOS 17.0, *) {
     return Self.extraLarge
 } else { fatalError("'extraLarge' is not available in this OS version") }
 #else
@@ -12835,14 +12881,14 @@ ConstantAtomLiteral("userInitiated").map({ () -> Self in
     }
 }
 
-#if os(macOS) || os(watchOS) || os(iOS) || os(tvOS)
-@available(macOS 13.0,watchOS 10.0,iOS 17.0,tvOS 17.0, *)
+#if os(watchOS) || os(macOS) || os(tvOS) || os(iOS)
+@available(watchOS 10.0,macOS 13.0,tvOS 17.0,iOS 17.0, *)
 extension DialogSeverity: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             ConstantAtomLiteral("automatic").map({ () -> Self in
-#if os(macOS) || os(watchOS) || os(iOS) || os(tvOS)
+#if os(tvOS) || os(macOS) || os(iOS) || os(watchOS)
 
     return Self.automatic
 
@@ -12851,7 +12897,7 @@ fatalError("'automatic' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("critical").map({ () -> Self in
-#if os(macOS) || os(watchOS) || os(iOS) || os(tvOS)
+#if os(watchOS) || os(macOS) || os(tvOS) || os(iOS)
 
     return Self.critical
 
@@ -12860,8 +12906,8 @@ fatalError("'critical' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("standard").map({ () -> Self in
-#if os(macOS) || os(watchOS) || os(iOS) || os(tvOS)
-if #available(macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0, *) {
+#if os(tvOS) || os(watchOS) || os(macOS) || os(iOS)
+if #available(tvOS 17.0,watchOS 10.0,macOS 14.0,iOS 17.0, *) {
     return Self.standard
 } else { fatalError("'standard' is not available in this OS version") }
 #else
@@ -12994,8 +13040,8 @@ ConstantAtomLiteral("all").map({ () -> Self in
     }
 }
 
-#if os(iOS) || os(macOS)
-@available(iOS 17.0,macOS 14.0, *)
+#if os(macOS) || os(iOS)
+@available(macOS 14.0,iOS 17.0, *)
 extension FileDialogBrowserOptions: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -13019,7 +13065,7 @@ fatalError("'includeHiddenFiles' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("displayFileExtensions").map({ () -> Self in
-#if os(iOS) || os(macOS)
+#if os(macOS) || os(iOS)
 
     return Self.displayFileExtensions
 
@@ -13032,8 +13078,8 @@ fatalError("'displayFileExtensions' is not available on this OS")
     }
 }
 #endif
-#if os(tvOS) || os(iOS) || os(macOS) || os(watchOS)
-@available(tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0, *)
+#if os(tvOS) || os(watchOS) || os(macOS) || os(iOS)
+@available(tvOS 17.0,watchOS 10.0,macOS 14.0,iOS 17.0, *)
 extension FocusInteractions: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -13057,7 +13103,7 @@ fatalError("'edit' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("automatic").map({ () -> Self in
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+#if os(tvOS) || os(macOS) || os(iOS) || os(watchOS)
 
     return Self.automatic
 
@@ -13151,8 +13197,8 @@ ConstantAtomLiteral("trailing").map({ () -> Self in
 
 })
 ConstantAtomLiteral("listRowSeparatorLeading").map({ () -> Self in
-#if os(iOS) || os(macOS)
-if #available(iOS 16.0,macOS 13.0, *) {
+#if os(macOS) || os(iOS)
+if #available(macOS 13.0,iOS 16.0, *) {
     return Self.listRowSeparatorLeading
 } else { fatalError("'listRowSeparatorLeading' is not available in this OS version") }
 #else
@@ -13160,8 +13206,8 @@ fatalError("'listRowSeparatorLeading' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("listRowSeparatorTrailing").map({ () -> Self in
-#if os(iOS) || os(macOS)
-if #available(iOS 16.0,macOS 13.0, *) {
+#if os(macOS) || os(iOS)
+if #available(macOS 13.0,iOS 16.0, *) {
     return Self.listRowSeparatorTrailing
 } else { fatalError("'listRowSeparatorTrailing' is not available in this OS version") }
 #else
@@ -13202,14 +13248,14 @@ ConstantAtomLiteral("trailing").map({ () -> Self in
     }
 }
 
-#if os(iOS) || os(tvOS)
-@available(iOS 13.4,tvOS 16.0, *)
+#if os(tvOS) || os(iOS)
+@available(tvOS 16.0,iOS 13.4, *)
 extension HoverEffect: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             ConstantAtomLiteral("automatic").map({ () -> Self in
-#if os(iOS) || os(tvOS)
+#if os(tvOS) || os(iOS)
 
     return Self.automatic
 
@@ -13240,14 +13286,14 @@ fatalError("'lift' is not available on this OS")
     }
 }
 #endif
-#if os(iOS) || os(macOS)
-@available(iOS 14.0,macOS 11.0, *)
+#if os(macOS) || os(iOS)
+@available(macOS 11.0,iOS 14.0, *)
 extension KeyboardShortcut: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             ConstantAtomLiteral("defaultAction").map({ () -> Self in
-#if os(iOS) || os(macOS)
+#if os(macOS) || os(iOS)
 
     return Self.defaultAction
 
@@ -13324,7 +13370,7 @@ extension MenuOrder: ParseableModifierValue {
 })
 ConstantAtomLiteral("priority").map({ () -> Self in
 #if os(iOS)
-if #available(tvOS 16.0,iOS 16.0,macOS 13.0,watchOS 9.0, *) {
+if #available(watchOS 9.0,macOS 13.0,iOS 16.0,tvOS 16.0, *) {
     return Self.priority
 } else { fatalError("'priority' is not available in this OS version") }
 #else
@@ -13345,14 +13391,14 @@ ConstantAtomLiteral("fixed").map({ () -> Self in
     }
 }
 
-#if os(iOS) || os(watchOS) || os(tvOS) || os(macOS)
-@available(iOS 16.4,watchOS 9.4,tvOS 16.4,macOS 13.3, *)
+#if os(tvOS) || os(macOS) || os(iOS) || os(watchOS)
+@available(tvOS 16.4,macOS 13.3,iOS 16.4,watchOS 9.4, *)
 extension PresentationAdaptation: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             ConstantAtomLiteral("automatic").map({ () -> Self in
-#if os(iOS) || os(watchOS) || os(tvOS) || os(macOS)
+#if os(macOS) || os(watchOS) || os(iOS) || os(tvOS)
 
     return Self.automatic
 
@@ -13361,7 +13407,7 @@ fatalError("'automatic' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("none").map({ () -> Self in
-#if os(iOS) || os(watchOS) || os(tvOS) || os(macOS)
+#if os(macOS) || os(watchOS) || os(iOS) || os(tvOS)
 
     return Self.none
 
@@ -13370,7 +13416,7 @@ fatalError("'none' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("popover").map({ () -> Self in
-#if os(watchOS) || os(tvOS) || os(iOS) || os(macOS)
+#if os(macOS) || os(watchOS) || os(iOS) || os(tvOS)
 
     return Self.popover
 
@@ -13379,7 +13425,7 @@ fatalError("'popover' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("sheet").map({ () -> Self in
-#if os(macOS) || os(tvOS) || os(watchOS) || os(iOS)
+#if os(macOS) || os(watchOS) || os(iOS) || os(tvOS)
 
     return Self.sheet
 
@@ -13388,7 +13434,7 @@ fatalError("'sheet' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("fullScreenCover").map({ () -> Self in
-#if os(macOS) || os(tvOS) || os(watchOS) || os(iOS)
+#if os(watchOS) || os(macOS) || os(tvOS) || os(iOS)
 
     return Self.fullScreenCover
 
@@ -13401,14 +13447,14 @@ fatalError("'fullScreenCover' is not available on this OS")
     }
 }
 #endif
-#if os(macOS) || os(tvOS) || os(watchOS) || os(iOS)
-@available(macOS 13.3,tvOS 16.4,watchOS 9.4,iOS 16.4, *)
+#if os(tvOS) || os(macOS) || os(iOS) || os(watchOS)
+@available(tvOS 16.4,macOS 13.3,iOS 16.4,watchOS 9.4, *)
 extension PresentationContentInteraction: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             ConstantAtomLiteral("automatic").map({ () -> Self in
-#if os(iOS) || os(tvOS) || os(macOS) || os(watchOS)
+#if os(macOS) || os(watchOS) || os(iOS) || os(tvOS)
 
     return Self.automatic
 
@@ -13417,7 +13463,7 @@ fatalError("'automatic' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("resizes").map({ () -> Self in
-#if os(iOS) || os(tvOS) || os(macOS) || os(watchOS)
+#if os(tvOS) || os(macOS) || os(iOS) || os(watchOS)
 
     return Self.resizes
 
@@ -13426,7 +13472,7 @@ fatalError("'resizes' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("scrolls").map({ () -> Self in
-#if os(tvOS) || os(macOS) || os(iOS) || os(watchOS)
+#if os(tvOS) || os(watchOS) || os(macOS) || os(iOS)
 
     return Self.scrolls
 
@@ -13493,8 +13539,8 @@ ConstantAtomLiteral("privacy").map({ () -> Self in
 
 })
 ConstantAtomLiteral("invalidated").map({ () -> Self in
-#if os(macOS) || os(watchOS) || os(tvOS) || os(iOS)
-if #available(macOS 14.0,watchOS 10.0,tvOS 17.0,iOS 17.0, *) {
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+if #available(macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0, *) {
     return Self.invalidated
 } else { fatalError("'invalidated' is not available in this OS version") }
 #else
@@ -13590,7 +13636,7 @@ extension ScenePadding: ParseableModifierValue {
 })
 ConstantAtomLiteral("navigationBar").map({ () -> Self in
 #if os(watchOS)
-if #available(watchOS 9.0,iOS 16.0,tvOS 16.0,macOS 13.0, *) {
+if #available(tvOS 16.0,watchOS 9.0,macOS 13.0,iOS 16.0, *) {
     return Self.navigationBar
 } else { fatalError("'navigationBar' is not available in this OS version") }
 #else
@@ -13602,14 +13648,14 @@ fatalError("'navigationBar' is not available on this OS")
     }
 }
 
-#if os(watchOS) || os(tvOS) || os(iOS) || os(macOS)
-@available(watchOS 9.4,tvOS 16.4,iOS 16.4,macOS 13.3, *)
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+@available(macOS 13.3,iOS 16.4,tvOS 16.4,watchOS 9.4, *)
 extension ScrollBounceBehavior: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             ConstantAtomLiteral("automatic").map({ () -> Self in
-#if os(iOS) || os(watchOS) || os(tvOS) || os(macOS)
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
 
     return Self.automatic
 
@@ -13618,7 +13664,7 @@ fatalError("'automatic' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("always").map({ () -> Self in
-#if os(iOS) || os(watchOS) || os(tvOS) || os(macOS)
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
 
     return Self.always
 
@@ -13640,8 +13686,8 @@ fatalError("'basedOnSize' is not available on this OS")
     }
 }
 #endif
-#if os(macOS) || os(tvOS) || os(watchOS) || os(iOS)
-@available(macOS 13.0,tvOS 16.0,watchOS 9.0,iOS 16.0, *)
+#if os(macOS) || os(watchOS) || os(iOS) || os(tvOS)
+@available(macOS 13.0,watchOS 9.0,iOS 16.0,tvOS 16.0, *)
 extension ScrollDismissesKeyboardMode: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -13734,14 +13780,14 @@ ConstantAtomLiteral("never").map({ () -> Self in
     }
 }
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
-@available(macOS 13.3,iOS 16.4,tvOS 16.4,watchOS 9.4, *)
+#if os(watchOS) || os(macOS) || os(tvOS) || os(iOS)
+@available(watchOS 9.4,macOS 13.3,tvOS 16.4,iOS 16.4, *)
 extension SearchScopeActivation: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             ConstantAtomLiteral("automatic").map({ () -> Self in
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+#if os(watchOS) || os(macOS) || os(tvOS) || os(iOS)
 
     return Self.automatic
 
@@ -13750,7 +13796,7 @@ fatalError("'automatic' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("onTextEntry").map({ () -> Self in
-#if os(macOS) || os(iOS) || os(watchOS)
+#if os(watchOS) || os(macOS) || os(iOS)
 
     return Self.onTextEntry
 
@@ -13759,7 +13805,7 @@ fatalError("'onTextEntry' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("onSearchPresentation").map({ () -> Self in
-#if os(iOS) || os(watchOS) || os(macOS)
+#if os(watchOS) || os(macOS) || os(iOS)
 
     return Self.onSearchPresentation
 
@@ -13810,14 +13856,14 @@ ConstantAtomLiteral("content").map({ () -> Self in
     }
 }
 
-#if os(tvOS) || os(iOS) || os(macOS) || os(watchOS)
-@available(tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0, *)
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+@available(macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0, *)
 extension SpringLoadingBehavior: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             ConstantAtomLiteral("automatic").map({ () -> Self in
-#if os(tvOS) || os(iOS) || os(macOS) || os(watchOS)
+#if os(watchOS) || os(iOS) || os(tvOS) || os(macOS)
 
     return Self.automatic
 
@@ -13826,7 +13872,7 @@ fatalError("'automatic' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("enabled").map({ () -> Self in
-#if os(tvOS) || os(macOS) || os(iOS) || os(watchOS)
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
 
     return Self.enabled
 
@@ -13835,7 +13881,7 @@ fatalError("'enabled' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("disabled").map({ () -> Self in
-#if os(macOS) || os(watchOS) || os(iOS) || os(tvOS)
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
 
     return Self.disabled
 
@@ -13969,14 +14015,14 @@ ConstantAtomLiteral("search").map({ () -> Self in
     }
 }
 
-#if os(macOS) || os(watchOS) || os(iOS) || os(tvOS)
-@available(macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0, *)
+#if os(tvOS) || os(macOS) || os(iOS) || os(watchOS)
+@available(tvOS 17.0,macOS 14.0,iOS 17.0,watchOS 10.0, *)
 extension ToolbarDefaultItemKind: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             ConstantAtomLiteral("sidebarToggle").map({ () -> Self in
-#if os(watchOS) || os(iOS) || os(macOS) || os(tvOS)
+#if os(tvOS) || os(macOS) || os(iOS) || os(watchOS)
 
     return Self.sidebarToggle
 
@@ -14006,7 +14052,7 @@ extension ToolbarRole: ParseableModifierValue {
 })
 ConstantAtomLiteral("navigationStack").map({ () -> Self in
 #if os(tvOS) || os(iOS) || os(watchOS)
-if #available(tvOS 16.0,iOS 16.0,watchOS 9.0,macOS 13.0, *) {
+if #available(tvOS 16.0,macOS 13.0,iOS 16.0,watchOS 9.0, *) {
     return Self.navigationStack
 } else { fatalError("'navigationStack' is not available in this OS version") }
 #else
@@ -14015,7 +14061,7 @@ fatalError("'navigationStack' is not available on this OS")
 })
 ConstantAtomLiteral("browser").map({ () -> Self in
 #if os(iOS)
-if #available(tvOS 16.0,iOS 16.0,watchOS 9.0,macOS 13.0, *) {
+if #available(macOS 13.0,watchOS 9.0,iOS 16.0,tvOS 16.0, *) {
     return Self.browser
 } else { fatalError("'browser' is not available in this OS version") }
 #else
@@ -14024,7 +14070,7 @@ fatalError("'browser' is not available on this OS")
 })
 ConstantAtomLiteral("editor").map({ () -> Self in
 #if os(iOS) || os(macOS)
-if #available(tvOS 16.0,iOS 16.0,watchOS 9.0,macOS 13.0, *) {
+if #available(tvOS 16.0,iOS 16.0,macOS 13.0,watchOS 9.0, *) {
     return Self.editor
 } else { fatalError("'editor' is not available in this OS version") }
 #else
@@ -14036,14 +14082,14 @@ fatalError("'editor' is not available on this OS")
     }
 }
 
-#if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
-@available(iOS 17.0,macOS 14.0,watchOS 10.0,tvOS 17.0, *)
+#if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
+@available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0, *)
 extension ToolbarTitleDisplayMode: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             ConstantAtomLiteral("automatic").map({ () -> Self in
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+#if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
 
     return Self.automatic
 
@@ -14061,7 +14107,7 @@ fatalError("'large' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("inlineLarge").map({ () -> Self in
-#if os(macOS) || os(iOS)
+#if os(iOS) || os(macOS)
 
     return Self.inlineLarge
 
@@ -14070,7 +14116,7 @@ fatalError("'inlineLarge' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("inline").map({ () -> Self in
-#if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
+#if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
 
     return Self.inline
 

--- a/Sources/ModifierGenerator/ModifierGenerator.swift
+++ b/Sources/ModifierGenerator/ModifierGenerator.swift
@@ -125,6 +125,10 @@ struct ModifierGenerator: ParsableCommand {
         
         "tag",
         "id",
+        
+        "task",
+        
+        "fileDialogURLEnabled",
 
         // manually implemented due to argument order edge cases
         "searchScopes",

--- a/Sources/ModifierGenerator/ModifierVisitor.swift
+++ b/Sources/ModifierGenerator/ModifierVisitor.swift
@@ -8,10 +8,10 @@ final class ModifierVisitor: SyntaxVisitor {
 
     static let minimumAvailability = [
         "iOS": VersionTupleSyntax(major: .integerLiteral("16"), components: VersionComponentListSyntax([VersionComponentSyntax(number: .integerLiteral("0"))])),
-        "macOS":  VersionTupleSyntax(major: .integerLiteral("13"), components: VersionComponentListSyntax([VersionComponentSyntax(number: .integerLiteral("0"))])),
-        "watchOS":  VersionTupleSyntax(major: .integerLiteral("9"), components: VersionComponentListSyntax([VersionComponentSyntax(number: .integerLiteral("0"))])),
-        "tvOS":  VersionTupleSyntax(major: .integerLiteral("16"), components: VersionComponentListSyntax([VersionComponentSyntax(number: .integerLiteral("0"))])),
-        "visionOS":  VersionTupleSyntax(major: .integerLiteral("1"), components: VersionComponentListSyntax([VersionComponentSyntax(number: .integerLiteral("0"))])),
+        "macOS": VersionTupleSyntax(major: .integerLiteral("13"), components: VersionComponentListSyntax([VersionComponentSyntax(number: .integerLiteral("0"))])),
+        "watchOS": VersionTupleSyntax(major: .integerLiteral("9"), components: VersionComponentListSyntax([VersionComponentSyntax(number: .integerLiteral("0"))])),
+        "tvOS": VersionTupleSyntax(major: .integerLiteral("16"), components: VersionComponentListSyntax([VersionComponentSyntax(number: .integerLiteral("0"))])),
+        "visionOS": VersionTupleSyntax(major: .integerLiteral("1"), components: VersionComponentListSyntax([VersionComponentSyntax(number: .integerLiteral("0"))])),
     ]
 
     static func availability(_ base: AttributeListSyntax, _ decl: AttributeListSyntax) -> (AvailabilityArgumentListSyntax, Set<String>) {
@@ -79,7 +79,12 @@ final class ModifierVisitor: SyntaxVisitor {
             return .skipChildren
         }
 
-        for member in node.memberBlock.members {
+        let ifConfigMembers = node.memberBlock.members.reduce(into: [], { prev, next in
+            prev.append(contentsOf: next.decl.as(IfConfigDeclSyntax.self)?.clauses.reduce(into: [], { prev, next in
+                prev.append(contentsOf: next.elements?.as(MemberBlockItemListSyntax.self).flatMap(Array.init) ?? [])
+            }) ?? [])
+        })
+        for member in Array(node.memberBlock.members) + ifConfigMembers {
             // find extensions on `SwiftUI.View`
             guard let decl = member.decl.as(FunctionDeclSyntax.self),
                   decl.modifiers.contains(where: { $0.name.tokenKind == .keyword(.public) }),


### PR DESCRIPTION
Some modifiers were missing because the `ModifierVisitor` was not looking inside `#if` conditionals.

This caused modifiers that had `async` closures (such as `refreshable`) to be skipped.