### PR TITLE
Support multi-item selection

### DIFF
--- a/Sources/LiveViewNative/Utils/Selection.swift
+++ b/Sources/LiveViewNative/Utils/Selection.swift
@@ -5,6 +5,7 @@
 //  Created by Carson Katri on 2/21/23.
 //
 
+import Foundation
 import LiveViewNativeCore
 
 /// Selection of either a single value or set of values.
@@ -59,10 +60,14 @@ enum Selection: Codable, AttributeDecodable, Equatable {
     init(from attribute: LiveViewNativeCore.Attribute?) throws {
         guard let value = attribute?.value
         else { throw AttributeDecodingError.missingAttribute(Self.self) }
-        if value.isEmpty {
-            self = .single(nil)
-        } else {
-            self = .single(value)
+        do {
+            self = try JSONDecoder().decode(Self.self, from: Data(value.utf8))
+        } catch {
+            if value.isEmpty {
+                self = .none
+            } else {
+                self = .single(value)
+            }
         }
     }
 }

--- a/Sources/LiveViewNative/Utils/Selection.swift
+++ b/Sources/LiveViewNative/Utils/Selection.swift
@@ -64,7 +64,7 @@ enum Selection: Codable, AttributeDecodable, Equatable {
             self = try JSONDecoder().decode(Self.self, from: Data(value.utf8))
         } catch {
             if value.isEmpty {
-                self = .none
+                self = .single(nil)
             } else {
                 self = .single(value)
             }


### PR DESCRIPTION
Closes #1213 

Pass a JSON encoded array to allow for multi-select. This also works with the `EditButton` element.

```ex
def mount(_params, _session, socket) do
  {:ok, assign(socket, selection: [])}
end

def render(%{format: :swiftui} = assigns) do
  ~SWIFTUI"""
  <EditButton />
  <List selection={Jason.encode!(@selection)} phx-change="selection-changed">
    <Text id={"#{i}"} :for={i <- 1..10}><%= i %></Text>
  </List>
  """
end

def handle_event("selection-changed", %{ "selection" => selection }, socket) do
  {:noreply, assign(socket, selection: selection)}
end
```

https://github.com/liveview-native/liveview-client-swiftui/assets/13581484/c9ac86fc-a8d9-43c3-bb2f-af951620482e
