### PR TITLE
Pass `_format` to channel

### DIFF
--- a/Sources/LiveViewNative/Coordinators/LiveSessionCoordinator.swift
+++ b/Sources/LiveViewNative/Coordinators/LiveSessionCoordinator.swift
@@ -216,7 +216,7 @@ public class LiveSessionCoordinator<R: RootRegistry>: ObservableObject {
         let resp: URLResponse
         do {
             (data, resp) = try await configuration.urlSession.data(from: url.appending(queryItems: [
-                .init(name: "_lvn[format]", value: "swiftui")
+                .init(name: "_format", value: "swiftui")
             ]))
         } catch {
             throw LiveConnectionError.initialFetchError(error)
@@ -281,7 +281,16 @@ public class LiveSessionCoordinator<R: RootRegistry>: ObservableObject {
             var wsEndpoint = URLComponents(url: self.url, resolvingAgainstBaseURL: true)!
             wsEndpoint.scheme = self.url.scheme == "https" ? "wss" : "ws"
             wsEndpoint.path = "/live/websocket"
-            let socket = Socket(endPoint: wsEndpoint.string!, transport: { URLSessionTransport(url: $0, configuration: configuration) }, paramsClosure: {["_csrf_token": domValues.phxCSRFToken]})
+            let socket = Socket(
+                endPoint: wsEndpoint.string!,
+                transport: { URLSessionTransport(url: $0, configuration: configuration) },
+                paramsClosure: {
+                    [
+                        "_csrf_token": domValues.phxCSRFToken,
+                        "_format": "swiftui"
+                    ]
+                }
+            )
             
             var refs = [String]()
             

--- a/Sources/LiveViewNative/Coordinators/LiveViewCoordinator.swift
+++ b/Sources/LiveViewNative/Coordinators/LiveViewCoordinator.swift
@@ -226,6 +226,7 @@ public class LiveViewCoordinator<R: RootRegistry>: ObservableObject {
         
         var connectParams = session.configuration.connectParams?(self.url) ?? [:]
         connectParams["_mounts"] = 0
+        connectParams["_format"] = "swiftui"
         connectParams["_csrf_token"] = domValues.phxCSRFToken
         connectParams["_lvn"] = session.platformParams
 


### PR DESCRIPTION
The `_format` parameter is needed for v0.3.0