### PR TITLE
Support ime's chained to modifiers

### DIFF
--- a/lib/live_view_native/swiftui/rules_parser.ex
+++ b/lib/live_view_native/swiftui/rules_parser.ex
@@ -35,7 +35,7 @@ defmodule LiveViewNative.SwiftUI.RulesParser do
       |> Keyword.put(:module, module)
       |> Keyword.put(:line, line)
 
-      result =
+    result =
       rules
       |> Modifiers.modifiers(opts)
       |> Parser.error_from_result()

--- a/lib/live_view_native/swiftui/rules_parser/modifiers.ex
+++ b/lib/live_view_native/swiftui/rules_parser/modifiers.ex
@@ -86,7 +86,7 @@ defmodule LiveViewNative.SwiftUI.RulesParser.Modifiers do
     |> post_traverse({PostProcessors, :to_scoped_ime_ast, []})
 
   defparsecp(
-    :ime,
+    :ime1,
     start()
     |> choice([
       # Scoped
@@ -108,6 +108,30 @@ defmodule LiveViewNative.SwiftUI.RulesParser.Modifiers do
       ])
     )
     |> post_traverse({PostProcessors, :chain_ast, []})
+  )
+
+  defparsecp(
+    :ime2,
+    # Color(.displayP3, red: 0.4627, green: 0.8392, blue: 1.0)
+    parsec(:nested_modifier)
+    |> times(
+      choice([
+        # <other_ime>.#{color}
+        ime_function.(false),
+        # <other_ime>.red
+        dotted_ime.(false)
+      ]),
+      min: 1
+    )
+    |> post_traverse({PostProcessors, :chain_ast, []})
+  )
+
+  defparsecp(
+    :ime,
+    choice([
+      parsec(:ime1),
+      parsec(:ime2)
+    ])
   )
 
   defcombinator(

--- a/lib/live_view_native/swiftui/rules_parser/post_processors.ex
+++ b/lib/live_view_native/swiftui/rules_parser/post_processors.ex
@@ -64,7 +64,6 @@ defmodule LiveViewNative.SwiftUI.RulesParser.PostProcessors do
 
   def to_scoped_ime_ast(rest, [[nil, variable], scope], context, {_line, _}, _byte_offset) do
     {rest, [variable, String.to_atom(scope)], context}
-    # |> IO.inspect()
   end
 
   def to_scoped_ime_ast(rest, [variable, scope], context, {_line, _}, _byte_offset) do

--- a/lib/live_view_native/swiftui/rules_parser/post_processors.ex
+++ b/lib/live_view_native/swiftui/rules_parser/post_processors.ex
@@ -29,45 +29,27 @@ defmodule LiveViewNative.SwiftUI.RulesParser.PostProcessors do
     {rest,
      [
        {Elixir, context_to_annotation(context.context, line),
-        {String.to_atom(variable_name), context_to_annotation(context.context, line), context.variable_context}}
+        {String.to_atom(variable_name), context_to_annotation(context.context, line),
+         context.variable_context}}
      ], context}
   end
 
-  def to_dotted_ime_ast(
-        rest,
-        [[], variable_name],
-        context,
-        {line, _},
-        _offset,
-        _is_initial = true
-      ) do
-    {rest,
-     [{:., context_to_annotation(context.context, line), [nil, String.to_atom(variable_name)]}],
-     context}
-  end
+  def to_dotted_ime_ast(rest, [args, variable_name], context, {line, _}, _offset, is_initial) do
+    ime =
+      if args == [] do
+        String.to_atom(variable_name)
+      else
+        {String.to_atom(variable_name), context_to_annotation(context.context, line), args}
+      end
 
-  def to_dotted_ime_ast(
-        rest,
-        [args, variable_name],
-        context,
-        {line, _},
-        _offset,
-        _is_initial = true
-      ) do
-    {rest,
-     [
-       {:., context_to_annotation(context.context, line),
-        [nil, {String.to_atom(variable_name), context_to_annotation(context.context, line), args}]}
-     ], context}
-  end
+    wrapped_ime =
+      if is_initial do
+        [{:., context_to_annotation(context.context, line), [nil, ime]}]
+      else
+        [ime]
+      end
 
-  def to_dotted_ime_ast(rest, [[], variable_name], context, {_line, _}, _offset, false) do
-    {rest, [String.to_atom(variable_name)], context}
-  end
-
-  def to_dotted_ime_ast(rest, [args, variable_name], context, {line, _}, _offset, false) do
-    {rest, [{String.to_atom(variable_name), context_to_annotation(context.context, line), args}],
-     context}
+    {rest, wrapped_ime, context}
   end
 
   def to_scoped_ime_ast(rest, [[] = _args, variable_name, scope], context, _, _byte_offset) do
@@ -82,6 +64,7 @@ defmodule LiveViewNative.SwiftUI.RulesParser.PostProcessors do
 
   def to_scoped_ime_ast(rest, [[nil, variable], scope], context, {_line, _}, _byte_offset) do
     {rest, [variable, String.to_atom(scope)], context}
+    # |> IO.inspect()
   end
 
   def to_scoped_ime_ast(rest, [variable, scope], context, {_line, _}, _byte_offset) do

--- a/test/live_view_native/swiftui/rules_parser_test.exs
+++ b/test/live_view_native/swiftui/rules_parser_test.exs
@@ -35,7 +35,7 @@ defmodule LiveViewNative.SwiftUI.RulesParserTest do
       bold(true)
       italic(true)
       """}
-      
+
       output = [
         {:font, [file: __ENV__.file, line: line, module: __ENV__.module, source: "font(.largeTitle)"], [{:., [file: __ENV__.file, line: line, module: __ENV__.module, source: "font(.largeTitle)"], [nil, :largeTitle]}]},
         {:bold, [file: __ENV__.file, line: line + 1, module: __ENV__.module, source: "bold(true)"], [true]},
@@ -118,6 +118,13 @@ defmodule LiveViewNative.SwiftUI.RulesParserTest do
       output =
         {:font, [],
          [[color: {:., [], [:Color, {:., [], [:red, {:shadow, [], [{:., [], [nil, :thick]}]}]}]}]]}
+
+      assert parse(input) == output
+
+      input = "foregroundStyle(Color(.displayP3, red: 0.4627, green: 0.8392, blue: 1.0).opacity(0.25))"
+
+      output =
+        {:foregroundStyle, [], [{:., [], [{:Color, [], [{:., [], [nil, :displayP3]}, [red: 0.4627, green: 0.8392, blue: 1.0]]}, {:opacity, [], [0.25]}]}]}
 
       assert parse(input) == output
     end


### PR DESCRIPTION
Support `Color(...).opacity(0.25)` in

```swift
foregroundStyle(Color(.displayP3, red: 0.4627, green: 0.8392, blue: 1.0).opacity(0.25))
```

Resolves https://github.com/liveview-native/live_view_native_stylesheet/issues/41