### PR TITLE
Customizable `LiveView` state views

### DIFF
--- a/Sources/LiveViewNative/Coordinators/LiveSessionState.swift
+++ b/Sources/LiveViewNative/Coordinators/LiveSessionState.swift
@@ -13,6 +13,8 @@ public enum LiveSessionState {
     case notConnected
     /// The coordinator is attempting to connect.
     case connecting
+    /// The coordinator is attempting to reconnect.
+    case reconnecting
     /// The coordinator has connected and the view tree can be rendered.
     case connected
     // todo: disconnected state?
@@ -23,7 +25,8 @@ public enum LiveSessionState {
     var isPending: Bool {
         switch self {
         case .notConnected,
-             .connecting:
+             .connecting,
+             .reconnecting:
             return true
         default:
             return false

--- a/Sources/LiveViewNative/Coordinators/LiveSessionState.swift
+++ b/Sources/LiveViewNative/Coordinators/LiveSessionState.swift
@@ -41,4 +41,13 @@ public enum LiveSessionState {
             return false
         }
     }
+    
+    /// Is the enum in the `reconnecting` state.
+    var isReconnecting: Bool {
+        if case .reconnecting = self {
+            return true
+        } else {
+            return false
+        }
+    }
 }

--- a/Sources/LiveViewNative/ErrorModifier.swift
+++ b/Sources/LiveViewNative/ErrorModifier.swift
@@ -14,7 +14,7 @@ struct ErrorModifier<R: RootRegistry>: ViewModifier {
     func body(content: Content) -> some View {
         content
             .overlay {
-                ErrorView<R>(error)
+                AnyErrorView<R>(error)
             }
     }
 }

--- a/Sources/LiveViewNative/ErrorView.swift
+++ b/Sources/LiveViewNative/ErrorView.swift
@@ -12,7 +12,7 @@ enum ErrorSource {
     case error(Error)
 }
 
-struct ErrorView<R: RootRegistry>: View {
+struct AnyErrorView<R: RootRegistry>: View {
     let source: ErrorSource
     
     init(html: String) {

--- a/Sources/LiveViewNative/LiveErrorView.swift
+++ b/Sources/LiveViewNative/LiveErrorView.swift
@@ -9,6 +9,8 @@ import SwiftUI
 
 /// A View that renders a ``LiveConnectionError``, or a fallback View.
 /// This can be used to display the stack trace HTML returned by Phoenix when debugging.
+///
+/// When the app is built in release configuration, the `fallback` will always be used.
 public struct LiveErrorView<Fallback: View>: View {
     let error: Error
     let fallback: Fallback
@@ -19,6 +21,7 @@ public struct LiveErrorView<Fallback: View>: View {
     }
     
     public var body: some View {
+        #if DEBUG
         if let error = error as? LiveConnectionError,
            case let .initialFetchUnexpectedResponse(_, trace?) = error
         {
@@ -26,5 +29,8 @@ public struct LiveErrorView<Fallback: View>: View {
         } else {
             fallback
         }
+        #else
+        fallback
+        #endif
     }
 }

--- a/Sources/LiveViewNative/LiveErrorView.swift
+++ b/Sources/LiveViewNative/LiveErrorView.swift
@@ -1,0 +1,30 @@
+//
+//  LiveErrorView.swift
+//
+//
+//  Created by Carson Katri on 1/31/24.
+//
+
+import SwiftUI
+
+/// A View that renders a ``LiveConnectionError``, or a fallback View.
+/// This can be used to display the stack trace HTML returned by Phoenix when debugging.
+public struct LiveErrorView<Fallback: View>: View {
+    let error: Error
+    let fallback: Fallback
+    
+    public init(error: Error, @ViewBuilder fallback: () -> Fallback) {
+        self.error = error
+        self.fallback = fallback()
+    }
+    
+    public var body: some View {
+        if let error = error as? LiveConnectionError,
+           case let .initialFetchUnexpectedResponse(_, trace?) = error
+        {
+            WebErrorView(html: trace)
+        } else {
+            fallback
+        }
+    }
+}

--- a/Sources/LiveViewNative/LiveView.swift
+++ b/Sources/LiveViewNative/LiveView.swift
@@ -260,33 +260,6 @@ public struct LiveView<
             case .connected, .reconnecting:
                 if ReconnectingView.self == Never.self {
                     connectedContent
-                        .safeAreaInset(edge: .top) {
-                            if session.state.isReconnecting {
-                                SwiftUI.VStack {
-                                    SwiftUI.Label("No Connection", systemImage: "wifi.slash")
-                                        .bold()
-                                    SwiftUI.Text("Reconnecting")
-                                        .foregroundStyle(.secondary)
-                                        .tint(.secondary)
-                                }
-                                    .font(.caption)
-                                    .padding(8)
-                                    .frame(maxWidth: .infinity)
-                                    #if os(watchOS)
-                                    .background({ () -> AnyShapeStyle in
-                                        if #available(watchOS 10.0, *) {
-                                            return AnyShapeStyle(Material.regular)
-                                        } else {
-                                            return AnyShapeStyle(.background)
-                                        }
-                                    }())
-                                    #else
-                                    .background(.regularMaterial)
-                                    #endif
-                                    .transition(.move(edge: .top).combined(with: .opacity))
-                            }
-                        }
-                        .animation(.default, value: session.state.isReconnecting)
                 } else {
                     reconnectingView(
                         AnyView(
@@ -295,59 +268,17 @@ public struct LiveView<
                         session.state.isReconnecting
                     )
                 }
-            default:
-                switch session.state {
-                case .connected, .reconnecting:
-                    fatalError()
-                case .notConnected:
-                    if DisconnectedView.self == Never.self {
-                        if #available(iOS 17, macOS 14, tvOS 17, watchOS 10, *) {
-                            SwiftUI.ContentUnavailableView {
-                                SwiftUI.Label("No Connection", systemImage: "network.slash")
-                            } description: {
-                                SwiftUI.Text("The app will reconnect when network connection is regained.")
-                            }
-                        } else {
-                            SwiftUI.Text("No Connection")
-                        }
-                    } else {
-                        disconnectedView()
-                    }
-                case .connecting:
-                    if ConnectingView.self == Never.self {
-                        SwiftUI.ProgressView("Connecting")
-                    } else {
-                        connectingView()
-                    }
-                case .connectionFailed(let error):
-                    if ErrorView.self == Never.self {
-                        if let error = error as? LiveConnectionError,
-                           case let .initialFetchUnexpectedResponse(_, trace?) = error
-                        {
-                            AnyErrorView<R>(html: trace)
-                        } else {
-                            if #available(iOS 17, macOS 14, tvOS 17, watchOS 10, *) {
-                                SwiftUI.ContentUnavailableView {
-                                    SwiftUI.Label("No Connection", systemImage: "network.slash")
-                                } description: {
-                                    #if DEBUG
-                                    SwiftUI.Text(error.localizedDescription)
-                                        .monospaced()
-                                    #else
-                                    SwiftUI.Text("The app will reconnect when network connection is regained.")
-                                    #endif
-                                }
-                            } else {
-                                SwiftUI.VStack {
-                                    SwiftUI.Text("No Connection")
-                                        .font(.subheadline)
-                                    SwiftUI.Text(error.localizedDescription)
-                                }
-                            }
-                        }
-                    } else {
-                        errorView(error)
-                    }
+            case .notConnected:
+                if DisconnectedView.self != Never.self {
+                    disconnectedView()
+                }
+            case .connecting:
+                if ConnectingView.self != Never.self {
+                    connectingView()
+                }
+            case .connectionFailed(let error):
+                if ErrorView.self != Never.self {
+                    errorView(error)
                 }
             }
         }

--- a/Sources/LiveViewNative/LiveView.swift
+++ b/Sources/LiveViewNative/LiveView.swift
@@ -55,7 +55,49 @@ public struct _StatelessReconnectingView<Content: View>: View {
 ///
 /// The `LiveView` attempts to connect immediately when it appears.
 ///
-/// While in states other than ``LiveSessionState/connected``, this view only provides a basic text description of the state.
+/// ## State Views
+/// When in states other than ``LiveSessionState/connected``, this View will use a default indicator.
+/// Provide the `connecting`, `disconnected`, `reconnected`, and `error` arguments to customize the presentation of the state.
+///
+/// ```swift
+/// LiveView(.localhost) {
+///     ProgressView("Loading")
+/// } disconnected: {
+///     Text("No connection")
+/// }
+/// ```
+///
+/// The `reconnecting` closure is provided the contents of the LiveView before it lost connection.
+/// Use the `content` parameter to add an overlay to the previously rendered LiveView content.
+///
+/// ```swift
+/// LiveView(.localhost) {
+///     ProgressView("Loading")
+/// } reconnecting: { content in
+///     content.overlay(alignment: .bottom) {
+///         Text("Reconnecting")
+///     }
+/// }
+/// ```
+///
+/// The `reconnecting` closure can also take a second argument: a `Bool` indicating whether the View is reconnecting or connected.
+/// If you provide a closure with both arguments, any modifiers will always be applied. It is up to you to conditionally render the reconnecting state.
+/// This form can be useful when animating the reconnection indicator.
+///
+/// ```swift
+/// LiveView(.localhost) {
+///     ProgressView("Loading")
+/// } reconnecting: { content, isReconnecting in
+///     content
+///         .overlay(alignment: .bottom) {
+///             if isReconnecting {
+///                 Text("Reconnecting")
+///                     .transition(.move(edge: .bottom))
+///             }
+///         }
+///         .animation(.default, value: isReconnecting)
+/// }
+/// ```
 ///
 /// ## Topics
 /// ### Creating a LiveView

--- a/Sources/LiveViewNative/LiveView.swift
+++ b/Sources/LiveViewNative/LiveView.swift
@@ -227,7 +227,17 @@ public struct LiveView<
                                     .font(.caption)
                                     .padding(8)
                                     .frame(maxWidth: .infinity)
+                                    #if os(watchOS)
+                                    .background({ () -> AnyShapeStyle in
+                                        if #available(watchOS 10.0, *) {
+                                            return AnyShapeStyle(Material.regular)
+                                        } else {
+                                            return AnyShapeStyle(.background)
+                                        }
+                                    }())
+                                    #else
                                     .background(.regularMaterial)
+                                    #endif
                                     .transition(.move(edge: .top).combined(with: .opacity))
                             }
                         }

--- a/Sources/LiveViewNative/LiveView.swift
+++ b/Sources/LiveViewNative/LiveView.swift
@@ -242,21 +242,24 @@ public struct LiveView<
         session.navigationPath.first!.coordinator
     }
     
+    @ViewBuilder
+    var connectedContent: some View {
+        if let rootLayout = session.rootLayout {
+            self.rootCoordinator.builder.fromNodes(rootLayout[rootLayout.root()].children(), coordinator: rootCoordinator, url: rootCoordinator.url)
+                .environment(\.coordinatorEnvironment, CoordinatorEnvironment(rootCoordinator, document: rootLayout))
+        } else {
+            PhxMain<R>()
+                .environment(\.coordinatorEnvironment, CoordinatorEnvironment(rootCoordinator, document: rootCoordinator.document!))
+                .environment(\.anyLiveContextStorage, LiveContextStorage(coordinator: rootCoordinator, url: rootCoordinator.url))
+        }
+    }
+    
     public var body: some View {
         SwiftUI.Group {
             switch session.state {
             case .connected, .reconnecting:
                 if ReconnectingView.self == Never.self {
-                    SwiftUI.Group {
-                        if let rootLayout = session.rootLayout {
-                            self.rootCoordinator.builder.fromNodes(rootLayout[rootLayout.root()].children(), coordinator: rootCoordinator, url: rootCoordinator.url)
-                                .environment(\.coordinatorEnvironment, CoordinatorEnvironment(rootCoordinator, document: rootLayout))
-                        } else {
-                            PhxMain<R>()
-                                .environment(\.coordinatorEnvironment, CoordinatorEnvironment(rootCoordinator, document: rootCoordinator.document!))
-                                .environment(\.anyLiveContextStorage, LiveContextStorage(coordinator: rootCoordinator, url: rootCoordinator.url))
-                        }
-                    }
+                    connectedContent
                         .safeAreaInset(edge: .top) {
                             if session.state.isReconnecting {
                                 SwiftUI.VStack {
@@ -287,16 +290,7 @@ public struct LiveView<
                 } else {
                     reconnectingView(
                         AnyView(
-                            SwiftUI.Group {
-                                if let rootLayout = session.rootLayout {
-                                    self.rootCoordinator.builder.fromNodes(rootLayout[rootLayout.root()].children(), coordinator: rootCoordinator, url: rootCoordinator.url)
-                                        .environment(\.coordinatorEnvironment, CoordinatorEnvironment(rootCoordinator, document: rootLayout))
-                                } else {
-                                    PhxMain<R>()
-                                        .environment(\.coordinatorEnvironment, CoordinatorEnvironment(rootCoordinator, document: rootCoordinator.document!))
-                                        .environment(\.anyLiveContextStorage, LiveContextStorage(coordinator: rootCoordinator, url: rootCoordinator.url))
-                                }
-                            }
+                            connectedContent
                         ),
                         session.state.isReconnecting
                     )

--- a/Sources/LiveViewNative/LiveView.swift
+++ b/Sources/LiveViewNative/LiveView.swift
@@ -24,7 +24,10 @@ import Combine
 public macro LiveView<Host: LiveViewHost>(
     _ host: Host,
     configuration: LiveSessionConfiguration = .init(),
-    addons: [any CustomRegistry<EmptyRegistry>.Type]
+    addons: [any CustomRegistry<EmptyRegistry>.Type] = [],
+    @ViewBuilder connecting: () -> any View = { EmptyView() },
+    @ViewBuilder disconnected: () -> any View = { EmptyView() },
+    @ViewBuilder error: @escaping (Error) -> any View = { _ in EmptyView() }
 ) -> AnyView = #externalMacro(module: "LiveViewNativeMacros", type: "LiveViewMacro")
 
 /// The SwiftUI root view for a Phoenix LiveView.

--- a/Sources/LiveViewNative/LiveView.swift
+++ b/Sources/LiveViewNative/LiveView.swift
@@ -258,30 +258,43 @@ public struct LiveView<
         SwiftUI.Group {
             switch session.state {
             case .connected, .reconnecting:
-                if ReconnectingView.self == Never.self {
-                    connectedContent
-                } else {
-                    reconnectingView(
-                        AnyView(
-                            connectedContent
-                        ),
-                        session.state.isReconnecting
-                    )
+                SwiftUI.Group {
+                    if ReconnectingView.self == Never.self {
+                        connectedContent
+                    } else {
+                        reconnectingView(
+                            AnyView(
+                                connectedContent
+                            ),
+                            session.state.isReconnecting
+                        )
+                    }
                 }
+                .transition(session.configuration.transition ?? .identity)
             case .notConnected:
-                if DisconnectedView.self != Never.self {
-                    disconnectedView()
+                SwiftUI.Group {
+                    if DisconnectedView.self != Never.self {
+                        disconnectedView()
+                    }
                 }
+                .transition(session.configuration.transition ?? .identity)
             case .connecting:
-                if ConnectingView.self != Never.self {
-                    connectingView()
+                SwiftUI.Group {
+                    if ConnectingView.self != Never.self {
+                        connectingView()
+                    }
                 }
+                .transition(session.configuration.transition ?? .identity)
             case .connectionFailed(let error):
-                if ErrorView.self != Never.self {
-                    errorView(error)
+                SwiftUI.Group {
+                    if ErrorView.self != Never.self {
+                        errorView(error)
+                    }
                 }
+                .transition(session.configuration.transition ?? .identity)
             }
         }
+        .animation(session.configuration.transition.map({ _ in .default }), value: session.state.isConnected)
         .environment(\.liveViewStateViews, LiveViewStateViews(
             connecting: connectingView,
             disconnected: disconnectedView,

--- a/Sources/LiveViewNative/LiveViewHost.swift
+++ b/Sources/LiveViewNative/LiveViewHost.swift
@@ -114,3 +114,9 @@ public extension LiveViewHost where Self == AutomaticLiveViewHost {
         .init(development: .localhost, production: .custom(url))
     }
 }
+
+extension URL: LiveViewHost {
+    public var url: URL {
+        self
+    }
+}

--- a/Sources/LiveViewNative/NavStackEntryView.swift
+++ b/Sources/LiveViewNative/NavStackEntryView.swift
@@ -43,23 +43,19 @@ struct NavStackEntryView<R: RootRegistry>: View {
                         .id(ObjectIdentifier(document))
                 } else {
                     SwiftUI.Group {
-                        if R.LoadingView.self == Never.self {
-                            switch coordinator.state {
-                            case .connected:
-                                fatalError()
-                            case .notConnected:
-                                SwiftUI.Text("Not Connected")
-                            case .connecting:
-                                SwiftUI.ProgressView("Connecting")
-                            case .connectionFailed(let error):
-                                SwiftUI.VStack {
-                                    SwiftUI.Text("Connection Failed")
-                                        .font(.subheadline)
-                                    SwiftUI.Text(error.localizedDescription)
-                                }
+                        switch coordinator.state {
+                        case .connected:
+                            fatalError()
+                        case .notConnected:
+                            SwiftUI.Text("Not Connected")
+                        case .connecting:
+                            SwiftUI.ProgressView("Connecting")
+                        case .connectionFailed(let error):
+                            SwiftUI.VStack {
+                                SwiftUI.Text("Connection Failed")
+                                    .font(.subheadline)
+                                SwiftUI.Text(error.localizedDescription)
                             }
-                        } else {
-                            R.loadingView(for: coordinator.url, state: coordinator.state)
                         }
                     }
                     .transition(coordinator.session.configuration.transition ?? .identity)

--- a/Sources/LiveViewNative/NavStackEntryView.swift
+++ b/Sources/LiveViewNative/NavStackEntryView.swift
@@ -12,6 +12,7 @@ struct NavStackEntryView<R: RootRegistry>: View {
     private let entry: LiveNavigationEntry<R>
     @ObservedObject private var coordinator: LiveViewCoordinator<R>
     @StateObject private var liveViewModel = LiveViewModel()
+    @Environment(\.liveViewStateViews) private var liveViewStateViews
     
     init(_ entry: LiveNavigationEntry<R>) {
         self.entry = entry
@@ -47,15 +48,11 @@ struct NavStackEntryView<R: RootRegistry>: View {
                         case .connected, .reconnecting:
                             fatalError()
                         case .notConnected:
-                            SwiftUI.Text("Not Connected")
+                            liveViewStateViews.disconnectedView()
                         case .connecting:
-                            SwiftUI.ProgressView("Connecting")
+                            liveViewStateViews.connectingView()
                         case .connectionFailed(let error):
-                            SwiftUI.VStack {
-                                SwiftUI.Text("Connection Failed")
-                                    .font(.subheadline)
-                                SwiftUI.Text(error.localizedDescription)
-                            }
+                            liveViewStateViews.errorView(error)
                         }
                     }
                     .transition(coordinator.session.configuration.transition ?? .identity)

--- a/Sources/LiveViewNative/NavStackEntryView.swift
+++ b/Sources/LiveViewNative/NavStackEntryView.swift
@@ -44,7 +44,7 @@ struct NavStackEntryView<R: RootRegistry>: View {
                 } else {
                     SwiftUI.Group {
                         switch coordinator.state {
-                        case .connected:
+                        case .connected, .reconnecting:
                             fatalError()
                         case .notConnected:
                             SwiftUI.Text("Not Connected")

--- a/Sources/LiveViewNative/Registries/AggregateRegistry.swift
+++ b/Sources/LiveViewNative/Registries/AggregateRegistry.swift
@@ -71,13 +71,6 @@ public macro Registries() = #externalMacro(module: "LiveViewNativeMacros", type:
 /// }
 /// ```
 ///
-/// ### Loading Views
-/// Whereas tags and modifiers can be composed from multiple registry types without conflict, only one loading view implementation can be used.
-/// The aggregate registry will use the loading view from the first concrete registry type that is provided.
-/// In the above example, `AppRegistries` would use `MyRegistry`'s loading view by default.
-///
-/// If you don't want this behavior, you can override ``CustomRegistry/loadingView(for:state:)-6jd3b`` on your aggregate registry and provide another view.
-///
 /// ## Topics
 /// ### Protocol Requirements
 /// - ``Registries``
@@ -95,10 +88,6 @@ public protocol AggregateRegistry: RootRegistry {
 extension AggregateRegistry {
     public static func lookup(_ name: Registries.TagName, element: ElementNode) -> some View {
         return Registries.lookup(name, element: element)
-    }
-
-    public static func loadingView(for url: URL, state: LiveSessionState) -> some View {
-        return Registries.loadingView(for: url, state: state)
     }
     
     public static func errorView(for error: Error) -> some View {
@@ -218,10 +207,6 @@ public struct _MultiRegistry<First: CustomRegistry, Second: CustomRegistry>: Cus
         case .second(let name):
             Second.lookup(name, element: element)
         }
-    }
-
-    public static func loadingView(for url: URL, state: LiveSessionState) -> some View {
-        return First.loadingView(for: url, state: state)
     }
     
     public static func errorView(for error: Error) -> some View {

--- a/Sources/LiveViewNative/Registries/AggregateRegistry.swift
+++ b/Sources/LiveViewNative/Registries/AggregateRegistry.swift
@@ -248,3 +248,5 @@ public typealias Registry3<T0: CustomRegistry, T1: CustomRegistry, T2: CustomReg
 public typealias Registry4<T0: CustomRegistry, T1: CustomRegistry, T2: CustomRegistry, T3: CustomRegistry>
     = _MultiRegistry<_MultiRegistry<T0, T1>, _MultiRegistry<T2, T3>>
     where T0.Root == T1.Root, T0.Root == T2.Root, T0.Root == T3.Root
+
+public struct _SpecializedEmptyRegistry<Root: RootRegistry>: CustomRegistry {}

--- a/Sources/LiveViewNative/Registries/CustomRegistry.swift
+++ b/Sources/LiveViewNative/Registries/CustomRegistry.swift
@@ -11,7 +11,7 @@ import LiveViewNativeStylesheet
 
 /// A custom registry allows clients to include custom view types in the LiveView DOM.
 ///
-/// To add a custom element or attribute, define an enum for the type alias for the tag/attribute name and implement the appropriate method. To customize the loading view, implement the ``loadingView(for:state:)-6jd3b`` method.
+/// To add a custom element or attribute, define an enum for the type alias for the tag/attribute name and implement the appropriate method.
 ///
 /// To use a single registry, implement the ``RootRegistry`` protocol and implement the inherited `CustomRegistry` requirements. If you want to combine multiple registries, see ``AggregateRegistry``.
 /// To use your registry, provide it as the generic parameter for the ``LiveSessionCoordinator`` you construct:
@@ -30,9 +30,6 @@ import LiveViewNativeStylesheet
 /// ### Custom View Modifiers
 /// - ``CustomModifier``
 /// - ``parseModifier(_:in:)-tj5n``
-/// ### Customizing the Loading View
-/// - ``loadingView(for:state:)-6jd3b``
-/// - ``LoadingView``
 /// ### Composing Registries
 /// - ``AggregateRegistry``
 /// - ``RootRegistry``
@@ -72,10 +69,6 @@ public protocol CustomRegistry<Root> {
     ///
     /// Use the ``LiveViewNativeStylesheet/ParseableExpression`` macro to generate a parser for a modifier from its `init` clauses.
     associatedtype CustomModifier: ViewModifier & ParseableModifierValue = EmptyModifier
-    /// The type of view this registry produces for loading views.
-    ///
-    /// Generally, implementors will use an opaque return type on their ``loadingView(for:state:)-6jd3b`` implementations and this will be inferred automatically.
-    associatedtype LoadingView: View = Never
     /// The type of view this registry produces for error views.
     ///
     /// Generally, implementors will use an opaque return type on their ``errorView(for:)`` implementations and this will be inferred automatically.
@@ -90,15 +83,6 @@ public protocol CustomRegistry<Root> {
     /// - Parameter context: The live context in which the view is being created.
     @ViewBuilder
     static func lookup(_ name: TagName, element: ElementNode) -> CustomView
-    
-    /// This method is called when it needs a view to display while connecting to the live view.
-    ///
-    /// If you do not implement this method, the framework provides a loading view which displays a simple text representation of the state.
-    ///
-    /// - Parameter url: The URL of the view being connected to.
-    /// - Parameter state: The current state of the coordinator. This method is never called with ``LiveSessionState/connected``.
-    @ViewBuilder
-    static func loadingView(for url: URL, state: LiveSessionState) -> LoadingView
     
     /// This method is called when it needs a view to display when an error occurs in the View hierarchy.
     ///
@@ -117,13 +101,6 @@ public protocol CustomRegistry<Root> {
         _ input: inout Substring.UTF8View,
         in context: ParseableModifierContext
     ) throws -> CustomModifier
-}
-
-extension CustomRegistry where LoadingView == Never {
-    /// A default  implementation that falls back to the default framework loading view.
-    public static func loadingView(for url: URL, state: LiveSessionState) -> Never {
-        fatalError()
-    }
 }
 
 extension CustomRegistry where ErrorView == Never {

--- a/Sources/LiveViewNative/Stylesheets/ParseableTypes/ShapeStyles/AnyShapeStyle+ParseableModifierValue.swift
+++ b/Sources/LiveViewNative/Stylesheets/ParseableTypes/ShapeStyles/AnyShapeStyle+ParseableModifierValue.swift
@@ -43,7 +43,7 @@ extension AnyShapeStyle: ParseableModifierValue {
             
             ConstantAtomLiteral("foreground").map({ ForegroundStyle() as any ShapeStyle })
             ConstantAtomLiteral("background").map({ BackgroundStyle() as any ShapeStyle })
-            #if !os(watchOS)
+            #if !os(watchOS) && !os(tvOS)
             ConstantAtomLiteral("selection").map({ SelectionShapeStyle() as any ShapeStyle })
             #endif
             ConstantAtomLiteral("tint").map({ TintShapeStyle() as any ShapeStyle })
@@ -347,7 +347,7 @@ extension Material: ParseableModifierValue {
                 ConstantAtomLiteral("thickMaterial").map({ Self.thickMaterial })
                 ConstantAtomLiteral("ultraThickMaterial").map({ Self.ultraThickMaterial })
             }
-            #if !os(watchOS)
+            #if !os(watchOS) && !os(tvOS)
             if #available(iOS 15, macOS 12, visionOS 1.0, *) {
                 ConstantAtomLiteral("bar").map({ Self.bar })
             }

--- a/Sources/LiveViewNative/Stylesheets/ViewReference.swift
+++ b/Sources/LiveViewNative/Stylesheets/ViewReference.swift
@@ -147,7 +147,7 @@ struct ToolbarTreeBuilder<R: RootRegistry> {
             }
         case let .e(error):
             SwiftUI.ToolbarItem {
-                ErrorView<R>(error)
+                AnyErrorView<R>(error)
             }
         }
     }
@@ -163,7 +163,7 @@ struct ToolbarTreeBuilder<R: RootRegistry> {
             ToolbarTitleMenu<R>(element: node)
         default:
             SwiftUI.ToolbarItem {
-                ErrorView<R>(ToolbarError.unknownTag(node.tag))
+                AnyErrorView<R>(ToolbarError.unknownTag(node.tag))
             }
         }
     }
@@ -217,7 +217,7 @@ struct CustomizableToolbarTreeBuilder<R: RootRegistry> {
             }
         case let .e(error):
             SwiftUI.ToolbarItem(id: error.localizedDescription) {
-                ErrorView<R>(error)
+                AnyErrorView<R>(error)
             }
         }
     }
@@ -231,7 +231,7 @@ struct CustomizableToolbarTreeBuilder<R: RootRegistry> {
             ToolbarTitleMenu<R>(element: node)
         default:
             SwiftUI.ToolbarItem(id: node.tag) {
-                ErrorView<R>(ToolbarError.unknownTag(node.tag))
+                AnyErrorView<R>(ToolbarError.unknownTag(node.tag))
             }
         }
     }

--- a/Sources/LiveViewNative/Views/Layout Containers/Collection Containers/Table.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Collection Containers/Table.swift
@@ -221,7 +221,7 @@ struct Table<R: RootRegistry>: View {
                 columns[9]
             }
         default:
-            ErrorView<R>(TableError.badColumnCount(columns.count))
+            AnyErrorView<R>(TableError.badColumnCount(columns.count))
         }
     }
     

--- a/priv/xcodegen/Sources/TemplateApp/ContentView.swift
+++ b/priv/xcodegen/Sources/TemplateApp/ContentView.swift
@@ -8,9 +8,77 @@ import LiveViewNative
 
 struct ContentView: View {
     var body: some View {
-        LiveView(.automatic(
-            development: .localhost(path: "%LVN_PREFERRED_ROUTE%"),
-            production: .custom(URL(string: "https://%LVN_PREFERRED_PROD_URL%%LVN_PREFERRED_ROUTE%")!)
-        ))
+        LiveView(
+            .automatic(
+                development: .localhost(path: "%LVN_PREFERRED_ROUTE%"),
+                production: URL(string: "https://%LVN_PREFERRED_PROD_URL%%LVN_PREFERRED_ROUTE%")!
+            )
+        ) {
+            ProgressView("Connecting")
+        } disconnected: {
+            if #available(iOS 17, macOS 14, tvOS 17, watchOS 10, *) {
+                ContentUnavailableView {
+                    Label("No Connection", systemImage: "network.slash")
+                } description: {
+                    Text("The app will reconnect when network connection is regained.")
+                }
+            } else {
+                Text("No Connection")
+            }
+        } reconnecting: { content, isReconnecting in
+            content
+                .safeAreaInset(edge: .top) {
+                    if isReconnecting {
+                        VStack {
+                            Label("No Connection", systemImage: "wifi.slash")
+                                .bold()
+                            Text("Reconnecting")
+                                .foregroundStyle(.secondary)
+                        }
+                            .font(.caption)
+                            .padding(8)
+                            .frame(maxWidth: .infinity)
+                            #if os(watchOS)
+                            .background(
+                                if #available(watchOS 10.0, *) {
+                                    AnyShapeStyle(.regularMaterial)
+                                } else {
+                                    AnyShapeStyle(.background)
+                                }
+                            )
+                            #else
+                            .background(.regularMaterial)
+                            #endif
+                            .transition(.move(edge: .top).combined(with: .opacity))
+                    }
+                }
+                .animation(.default, value: isReconnecting)
+        } error: { error in
+            LiveErrorView(error: error) {
+                if #available(iOS 17, macOS 14, tvOS 17, watchOS 10, *) {
+                    ContentUnavailableView {
+                        Label("Connection Failed", systemImage: "network.slash")
+                    } description: {
+                        #if DEBUG
+                        Text(error.localizedDescription)
+                            .monospaced()
+                        #else
+                        Text("The app will reconnect when network connection is regained.")
+                        #endif
+                    }
+                } else {
+                    VStack {
+                        Label("Connection Failed", systemImage: "network.slash")
+                            .font(.subheadline)
+                        #if DEBUG
+                        Text(error.localizedDescription)
+                            .monospaced()
+                        #else
+                        Text("The app will reconnect when network connection is regained.")
+                        #endif
+                    }
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Closes #1232 

State views can be provided as arguments to the `LiveView`. The `loadingView` method was from the `CustomRegistry` protocol, as it makes more sense to provide these options on the `LiveView` itself. Here's an example of using these arguments:

```swift
LiveView(.localhost) {
    ProgressView("Loading")
} disconnected: {
    Text("Not connected to the server")
} reconnecting: { content in
    content
        .safeAreaInset(edge: .bottom) {
            HStack {
                ProgressView()
                Text("Reconnecting")
            }
            .padding()
            .frame(maxWidth: .infinity, alignment: .leading)
            .background(Color.orange)
        }
} error: { error in
    Text(error.localizedDescription)
}
```

Note that `reconnecting` provides the `content` of the `LiveView`, allowing you to create an overlay instead of fully replacing the screen when the connection temporarily drops.

All of these arguments are optional. If any is omitted, a default View will be used. They can also be used with the `#LiveView` macro when passing `addons`.

A new `registry` argument was also added. Previously, registries were passed as generic arguments:
```swift
LiveView<MyRegistryType>(.localhost)
```
With the addition of these state views, there are more generic arguments that must be provided.
```swift
LiveView<MyRegistryType, _, _, _, _>(.localhost)
```
Instead of passing a generic argument, it is now recommended to pass the `registry` argument:
```swift
LiveView(registry: MyRegistryType.self, .localhost)
```
However, it is generally easier to use the `#LiveView` macro to pass custom registries, so this argument is almost never required unless some further customization is required:
```swift
#LiveView(.localhost, addons: [MapKitRegistry<_>.self, ChartsRegistry<_>.self])
```