### PR TITLE
Refactor AttributeDecodable API

### DIFF
--- a/Sources/LiveViewNative/FormValue.swift
+++ b/Sources/LiveViewNative/FormValue.swift
@@ -27,9 +27,9 @@ extension FormValue {
         return self == other
     }
     
-    static func fromAttribute(_ attribute: LiveViewNativeCore.Attribute) -> Self? {
+    static func fromAttribute(_ attribute: LiveViewNativeCore.Attribute, on element: ElementNode) -> Self? {
         if let self = Self.self as? AttributeDecodable.Type {
-            return try? (self.init(from: attribute) as! Self)
+            return try? (self.init(from: attribute, on: element) as! Self)
         } else {
             return nil
         }

--- a/Sources/LiveViewNative/Property Wrappers/Attribute.swift
+++ b/Sources/LiveViewNative/Property Wrappers/Attribute.swift
@@ -145,7 +145,18 @@ public struct Attribute<T>: DynamicProperty {
 /// ### Supporting Types
 /// - ``AttributeDecodingError``
 public protocol AttributeDecodable {
+    init(from attribute: LiveViewNativeCore.Attribute?) throws
     init(from attribute: LiveViewNativeCore.Attribute?, on element: ElementNode) throws
+}
+
+public extension AttributeDecodable {
+    init(from attribute: LiveViewNativeCore.Attribute?) throws {
+        fatalError("\(Self.self) cannot be decoded without an `element`")
+    }
+    
+    init(from attribute: LiveViewNativeCore.Attribute?, on element: ElementNode) throws {
+        try self.init(from: attribute)
+    }
 }
 
 /// An error encountered when converting a value from an attribute.

--- a/Sources/LiveViewNative/Property Wrappers/ChangeTracked.swift
+++ b/Sources/LiveViewNative/Property Wrappers/ChangeTracked.swift
@@ -134,7 +134,7 @@ extension ChangeTracked where Value: FormValue {
             if Value.self == Bool.self {
                 return element.attributeBoolean(for: self.attribute) as? Value
             } else if let attribute = element.attribute(named: self.attribute) {
-                return Value.fromAttribute(attribute)
+                return Value.fromAttribute(attribute, on: element)
             } else {
                 return nil
             }

--- a/Sources/LiveViewNative/Property Wrappers/FormState.swift
+++ b/Sources/LiveViewNative/Property Wrappers/FormState.swift
@@ -170,7 +170,7 @@ public struct FormState<Value: FormValue> {
     
     // the initial value converts the element's `value` attribute if possible, otherwise uses the default value
     private var initialValue: Value {
-        return element.attribute(named: valueAttribute).flatMap(Value.fromAttribute(_:)) ?? defaultValue
+        return element.attribute(named: valueAttribute).flatMap({ Value.fromAttribute($0, on: element) }) ?? defaultValue
     }
     
     private func resolveMode() {

--- a/Sources/LiveViewNative/Stylesheets/Stylesheet.swift
+++ b/Sources/LiveViewNative/Stylesheets/Stylesheet.swift
@@ -38,7 +38,7 @@ extension Stylesheet: StylesheetProtocol {
 }
 
 extension Stylesheet: AttributeDecodable {
-    init(from attribute: LiveViewNativeCore.Attribute?) throws {
+    init(from attribute: LiveViewNativeCore.Attribute?, on element: ElementNode) throws {
         guard let value = attribute?.value
         else { throw AttributeDecodingError.missingAttribute(Self.self) }
         do {

--- a/Sources/LiveViewNative/Utils/Alignment.swift
+++ b/Sources/LiveViewNative/Utils/Alignment.swift
@@ -62,7 +62,7 @@ extension Alignment: Decodable, AttributeDecodable {
         }
     }
     
-    public init(from attribute: LiveViewNativeCore.Attribute?) throws {
+    public init(from attribute: LiveViewNativeCore.Attribute?, on element: ElementNode) throws {
         guard let value = attribute?.value else { throw AttributeDecodingError.missingAttribute(Self.self) }
         guard let result = Self(string: value) else { throw AttributeDecodingError.badValue(Self.self) }
         self = result
@@ -99,7 +99,7 @@ extension HorizontalAlignment: Decodable, AttributeDecodable {
         }
     }
     
-    public init(from attribute: LiveViewNativeCore.Attribute?) throws {
+    public init(from attribute: LiveViewNativeCore.Attribute?, on element: ElementNode) throws {
         guard let value = attribute?.value else { throw AttributeDecodingError.missingAttribute(Self.self) }
         guard let result = Self(string: value) else { throw AttributeDecodingError.badValue(Self.self) }
         self = result
@@ -136,7 +136,7 @@ extension VerticalAlignment: Decodable, AttributeDecodable {
         }
     }
     
-    public init(from attribute: LiveViewNativeCore.Attribute?) throws {
+    public init(from attribute: LiveViewNativeCore.Attribute?, on element: ElementNode) throws {
         guard let value = attribute?.value else { throw AttributeDecodingError.missingAttribute(Self.self) }
         guard let result = Self(string: value) else { throw AttributeDecodingError.badValue(Self.self) }
         self = result

--- a/Sources/LiveViewNative/Utils/Angle.swift
+++ b/Sources/LiveViewNative/Utils/Angle.swift
@@ -9,7 +9,7 @@ import SwiftUI
 import LiveViewNativeCore
 
 extension Angle: AttributeDecodable {
-    public init(from attribute: LiveViewNativeCore.Attribute?) throws {
-        self.init(degrees: try Double.init(from: attribute))
+    public init(from attribute: LiveViewNativeCore.Attribute?, on element: ElementNode) throws {
+        self.init(degrees: try Double.init(from: attribute, on: element))
     }
 }

--- a/Sources/LiveViewNative/Utils/Axis.swift
+++ b/Sources/LiveViewNative/Utils/Axis.swift
@@ -28,7 +28,7 @@ extension Axis.Set: AttributeDecodable {
         }
     }
     
-    public init(from attribute: LiveViewNativeCore.Attribute?) throws {
+    public init(from attribute: LiveViewNativeCore.Attribute?, on element: ElementNode) throws {
         guard let value = attribute?.value else { throw AttributeDecodingError.missingAttribute(Self.self) }
         guard let result = Self(string: value) else { throw AttributeDecodingError.badValue(Self.self) }
         self = result

--- a/Sources/LiveViewNative/Utils/ColorScheme.swift
+++ b/Sources/LiveViewNative/Utils/ColorScheme.swift
@@ -14,7 +14,7 @@ import LiveViewNativeCore
 /// * `light`
 /// * `dark`
 extension ColorScheme: AttributeDecodable {
-    public init(from attribute: LiveViewNativeCore.Attribute?) throws {
+    public init(from attribute: LiveViewNativeCore.Attribute?, on element: ElementNode) throws {
         guard let attributeValue = attribute?.value else { throw AttributeDecodingError.missingAttribute(Self.self) }
         guard let value = Self(from: attributeValue) else { throw AttributeDecodingError.badValue(Self.self) }
         self = value

--- a/Sources/LiveViewNative/Utils/DOM.swift
+++ b/Sources/LiveViewNative/Utils/DOM.swift
@@ -69,7 +69,7 @@ public struct ElementNode {
     ///
     /// The attribute is decoded to the type ``T``, which must conform to the ``AttributeDecodable`` protocol.
     public func attributeValue<T: AttributeDecodable>(_: T.Type, for name: AttributeName) throws -> T {
-        try T.init(from: attribute(named: name))
+        try T.init(from: attribute(named: name), on: self)
     }
     
     /// Checks for a [boolean attribute](https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#boolean-attributes).

--- a/Sources/LiveViewNative/Utils/Font.swift
+++ b/Sources/LiveViewNative/Utils/Font.swift
@@ -24,7 +24,7 @@ import LiveViewNativeCore
 /// * `caption2`
 @_documentation(visibility: public)
 extension Font.TextStyle: AttributeDecodable {
-    public init(from attribute: LiveViewNativeCore.Attribute?) throws {
+    public init(from attribute: LiveViewNativeCore.Attribute?, on element: ElementNode) throws {
         guard let value = attribute?.value
         else { throw AttributeDecodingError.missingAttribute(Self.self) }
         try self.init(from: value)

--- a/Sources/LiveViewNative/Utils/PinnedScrollableViews.swift
+++ b/Sources/LiveViewNative/Utils/PinnedScrollableViews.swift
@@ -56,7 +56,7 @@ extension PinnedScrollableViews: AttributeDecodable {
         }
     }
     
-    public init(from attribute: LiveViewNativeCore.Attribute?) throws {
+    public init(from attribute: LiveViewNativeCore.Attribute?, on element: ElementNode) throws {
         guard let value = attribute?.value else { throw AttributeDecodingError.missingAttribute(Self.self) }
         self.init(string: value)
     }

--- a/Sources/LiveViewNative/Utils/Selection.swift
+++ b/Sources/LiveViewNative/Utils/Selection.swift
@@ -56,7 +56,7 @@ enum Selection: Codable, AttributeDecodable, Equatable {
         }
     }
     
-    init(from attribute: LiveViewNativeCore.Attribute?) throws {
+    init(from attribute: LiveViewNativeCore.Attribute?, on element: ElementNode) throws {
         guard let value = attribute?.value
         else { throw AttributeDecodingError.missingAttribute(Self.self) }
         if value.isEmpty {

--- a/Sources/LiveViewNative/Utils/UnitPoint.swift
+++ b/Sources/LiveViewNative/Utils/UnitPoint.swift
@@ -80,7 +80,7 @@ extension UnitPoint: AttributeDecodable {
         }
     }
     
-    public init(from attribute: LiveViewNativeCore.Attribute?) throws {
+    public init(from attribute: LiveViewNativeCore.Attribute?, on element: ElementNode) throws {
         guard let value = attribute?.value else { throw AttributeDecodingError.missingAttribute(Self.self) }
         try self.init(from: value)
     }

--- a/Sources/LiveViewNative/Utils/Visibility.swift
+++ b/Sources/LiveViewNative/Utils/Visibility.swift
@@ -15,7 +15,7 @@ import LiveViewNativeCore
 /// * `visible`
 /// * `hidden`
 extension Visibility: AttributeDecodable {
-    public init(from attribute: LiveViewNativeCore.Attribute?) throws {
+    public init(from attribute: LiveViewNativeCore.Attribute?, on element: ElementNode) throws {
         guard let attributeValue = attribute?.value else { throw AttributeDecodingError.missingAttribute(Self.self) }
         guard let value = Self(from: attributeValue) else { throw AttributeDecodingError.badValue(Self.self) }
         self = value

--- a/Sources/LiveViewNative/Views/Controls and Indicators/Pickers/ColorPicker.swift
+++ b/Sources/LiveViewNative/Views/Controls and Indicators/Pickers/ColorPicker.swift
@@ -42,7 +42,7 @@ struct ColorPicker<R: RootRegistry>: View {
     @Attribute("supports-opacity") private var supportsOpacity: Bool
     
     struct CodableColor: AttributeDecodable, Codable, Equatable {
-        init(from attribute: LiveViewNativeCore.Attribute?) throws {
+        init(from attribute: LiveViewNativeCore.Attribute?, on element: ElementNode) throws {
             guard let value = attribute?.value
             else { throw AttributeDecodingError.missingAttribute(Self.self) }
             self = try JSONDecoder().decode(Self.self, from: Data(value.utf8))

--- a/Sources/LiveViewNative/Views/Controls and Indicators/Pickers/DatePicker.swift
+++ b/Sources/LiveViewNative/Views/Controls and Indicators/Pickers/DatePicker.swift
@@ -101,7 +101,7 @@ private struct CodableDate: FormValue, AttributeDecodable {
         self.date = Date()
     }
     
-    init(from attribute: LiveViewNativeCore.Attribute?) throws {
+    init(from attribute: LiveViewNativeCore.Attribute?, on element: ElementNode) throws {
         guard let value = attribute?.value else {
             throw AttributeDecodingError.missingAttribute(CodableDate.self)
         }

--- a/Sources/LiveViewNative/Views/Drawing and Graphics/ColorView.swift
+++ b/Sources/LiveViewNative/Views/Drawing and Graphics/ColorView.swift
@@ -105,7 +105,7 @@ extension SwiftUI.Color.RGBColorSpace: AttributeDecodable, Decodable {
         }
     }
 
-    public init(from attribute: LiveViewNativeCore.Attribute?) throws {
+    public init(from attribute: LiveViewNativeCore.Attribute?, on element: ElementNode) throws {
         if let string = attribute?.value, let rgbColorSpace = Self(string: string) {
             self = rgbColorSpace
         } else {

--- a/Sources/LiveViewNative/Views/Layout Containers/Collection Containers/Table.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Collection Containers/Table.swift
@@ -299,7 +299,7 @@ fileprivate struct TableColumnSortContainer: Codable, Equatable, AttributeDecoda
         self.value = value
     }
     
-    init(from attribute: LiveViewNativeCore.Attribute?) throws {
+    init(from attribute: LiveViewNativeCore.Attribute?, on element: ElementNode) throws {
         guard let value = attribute?.value
         else { throw AttributeDecodingError.missingAttribute(Self.self) }
         self.value = try JSONDecoder().decode([TableColumnSort].self, from: Data(value.utf8))

--- a/Sources/LiveViewNative/Views/Shapes/Shape.swift
+++ b/Sources/LiveViewNative/Views/Shapes/Shape.swift
@@ -80,7 +80,7 @@ extension RoundedRectangle {
                 width: element.attributeValue(for: "corner-width").flatMap(Double.init) ?? radius,
                 height: element.attributeValue(for: "corner-height").flatMap(Double.init) ?? radius
             ),
-            style: (try? RoundedCornerStyle(from: element.attribute(named: "style"))) ?? .circular
+            style: (try? RoundedCornerStyle(from: element.attribute(named: "style"), on: element)) ?? .circular
         )
     }
 }
@@ -95,7 +95,7 @@ extension RoundedRectangle {
 extension Capsule {
     init(from element: ElementNode) {
         self.init(
-            style: (try? RoundedCornerStyle(from: element.attribute(named: "style"))) ?? .circular
+            style: (try? RoundedCornerStyle(from: element.attribute(named: "style"), on: element)) ?? .circular
         )
     }
 }
@@ -118,7 +118,7 @@ extension RoundedCornerStyle: Decodable, AttributeDecodable {
         }
     }
     
-    public init(from attribute: LiveViewNativeCore.Attribute?) throws {
+    public init(from attribute: LiveViewNativeCore.Attribute?, on element: ElementNode) throws {
         guard let string = attribute?.value
         else { throw AttributeDecodingError.missingAttribute(Self.self) }
         guard let value = Self(string: string)

--- a/Sources/LiveViewNative/Views/Text Input and Output/Text.swift
+++ b/Sources/LiveViewNative/Views/Text Input and Output/Text.swift
@@ -337,7 +337,7 @@ struct Text<R: RootRegistry>: View {
 /// * `timer`
 @_documentation(visibility: public)
 extension SwiftUI.Text.DateStyle: AttributeDecodable {
-    public init(from attribute: LiveViewNativeCore.Attribute?) throws {
+    public init(from attribute: LiveViewNativeCore.Attribute?, on element: ElementNode) throws {
         guard let value = attribute?.value else {
             throw AttributeDecodingError.missingAttribute(Self.self)
         }
@@ -367,7 +367,7 @@ extension SwiftUI.Text.DateStyle: AttributeDecodable {
 /// * `abbreviated`
 @_documentation(visibility: public)
 extension PersonNameComponents.FormatStyle.Style: AttributeDecodable {
-    public init(from attribute: LiveViewNativeCore.Attribute?) throws {
+    public init(from attribute: LiveViewNativeCore.Attribute?, on element: ElementNode) throws {
         guard let value = attribute?.value else {
             throw AttributeDecodingError.missingAttribute(Self.self)
         }

--- a/Sources/LiveViewNative/Views/Toolbars/ToolbarItem.swift
+++ b/Sources/LiveViewNative/Views/Toolbars/ToolbarItem.swift
@@ -72,7 +72,7 @@ struct ToolbarItem<R: RootRegistry>: ToolbarContent {
     init(element: ElementNode) {
         self._element = .init(element: element)
         self._placement = .init("placement", transform: {
-            (try? ToolbarItemPlacement(from: $0))?.placement ?? .automatic
+            (try? ToolbarItemPlacement(from: $0, on: $1))?.placement ?? .automatic
         }, element: element)
     }
     
@@ -90,7 +90,7 @@ struct CustomizableToolbarItem<R: RootRegistry>: CustomizableToolbarContent {
     @LiveContext<R> private var context
     
     private var placement: SwiftUI.ToolbarItemPlacement {
-        (try? ToolbarItemPlacement(from: element.attribute(named: "placement")))?.placement ?? .automatic
+        (try? ToolbarItemPlacement(from: element.attribute(named: "placement"), on: element))?.placement ?? .automatic
     }
     
     /// The unique ID for this customizable item.

--- a/Sources/LiveViewNative/Views/Toolbars/ToolbarItemGroup.swift
+++ b/Sources/LiveViewNative/Views/Toolbars/ToolbarItemGroup.swift
@@ -39,7 +39,7 @@ struct ToolbarItemGroup<R: RootRegistry>: ToolbarContent {
     init(element: ElementNode) {
         self._element = .init(element: element)
         self._placement = .init("placement", transform: {
-            (try? ToolbarItemPlacement(from: $0))?.placement ?? .automatic
+            (try? ToolbarItemPlacement(from: $0, on: $1))?.placement ?? .automatic
         }, element: element)
     }
     


### PR DESCRIPTION
This adds the `ElementNode` as an argument to the `AttributeDecodable` initializer. This allows attributes to look up the value of other attributes.