### PR TITLE
Add argument type mismatch error message

### DIFF
--- a/Sources/LiveViewNative/ContentBuilder.swift
+++ b/Sources/LiveViewNative/ContentBuilder.swift
@@ -376,7 +376,7 @@ enum BuilderModifierContainer<Builder: ContentBuilder>: ViewModifier, ParseableM
     static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         OneOf {
             Builder.ModifierType.parser(in: context).map(Self.modifier)
-            StylesheetParser<EmptyModifier>.RecoverableModifier.AnyNode(context: context).map({ _ in Self.unsupported })
+            _AnyNodeParser(context: context).map({ _ in Self.unsupported })
         }
     }
     

--- a/Sources/LiveViewNativeStylesheet/ModifierParseError.swift
+++ b/Sources/LiveViewNativeStylesheet/ModifierParseError.swift
@@ -21,9 +21,29 @@ public struct ModifierParseError: Error, CustomDebugStringConvertible {
         case deprecatedModifier(String, message: String)
         case missingRequiredArgument(String)
         case noMatchingClause(String, [[String]])
-        case incorrectArgumentValue(String, value: Any, expectedType: Any.Type)
+        case incorrectArgumentValue(String, value: Any, expectedType: Any.Type, replacement: ArgumentReplacement?)
         case multipleClauseErrors(String, [([String], ErrorType)])
         case multiRegistryFailure([(Any.Type, ErrorType)])
+        
+        public enum ArgumentReplacement {
+            case viewReference
+            case changeTracked
+            case event
+            case custom(String)
+            
+            var message: String {
+                switch self {
+                case .viewReference:
+                    return "Pass an atom type to reference nested content."
+                case .changeTracked:
+                    return #"Use `attr("...")` to link this argument with an attribute."#
+                case .event:
+                    return #"Use `event("...")` to reference an event."#
+                case let .custom(custom):
+                    return custom
+                }
+            }
+        }
         
         var localizedDescription: String {
             switch self {
@@ -41,12 +61,16 @@ public struct ModifierParseError: Error, CustomDebugStringConvertible {
                 } else {
                     return "No matching clause found for modifier `\(name)`. Expected one of \(clauses.map({ "`\(name)(\($0.joined(separator: ":"))\($0.count > 0 ? ":" : ""))`" }).joined(separator: ", "))"
                 }
-            case .incorrectArgumentValue(let name, let value, let expectedType):
-                return "Incorrect value passed to argument `\(name)`. Expected `\(expectedType)` but got `\(value)`"
+            case .incorrectArgumentValue(let name, let value, let expectedType, let replacement):
+                return "Incorrect value passed to argument `\(name)`. Expected `\(expectedType)` but got `\(value)`. \(replacement?.message ?? "")"
             case .multipleClauseErrors(let name, let signatureErrors):
                 return signatureErrors
+                    .reduce(into: [String:[ErrorType]]()) { result, next in
+                        let clause = "\(name)(\(next.0.joined(separator: ":"))\(next.0.count > 0 ? ":" : ""))"
+                        result[clause, default: []].append(next.1)
+                    }
                     .map {
-                        return "Clause `\(name)(\($0.0.joined(separator: ":"))\($0.0.count > 0 ? ":" : ""))` failed with: \($0.1.localizedDescription)"
+                        return "Clause `\($0.key)` failed:\n  - \($0.value.map(\.localizedDescription).joined(separator: "\n  - "))"
                     }
                     .joined(separator: "\n")
             case .multiRegistryFailure(let attempts):

--- a/Sources/LiveViewNativeStylesheet/ModifierParseError.swift
+++ b/Sources/LiveViewNativeStylesheet/ModifierParseError.swift
@@ -21,6 +21,8 @@ public struct ModifierParseError: Error, CustomDebugStringConvertible {
         case deprecatedModifier(String, message: String)
         case missingRequiredArgument(String)
         case noMatchingClause(String, [[String]])
+        case incorrectArgumentValue(String, value: Any, expectedType: Any.Type)
+        case multipleClauseErrors(String, [([String], ErrorType)])
         case multiRegistryFailure([(Any.Type, ErrorType)])
         
         var localizedDescription: String {
@@ -39,6 +41,14 @@ public struct ModifierParseError: Error, CustomDebugStringConvertible {
                 } else {
                     return "No matching clause found for modifier `\(name)`. Expected one of \(clauses.map({ "`\(name)(\($0.joined(separator: ":"))\($0.count > 0 ? ":" : ""))`" }).joined(separator: ", "))"
                 }
+            case .incorrectArgumentValue(let name, let value, let expectedType):
+                return "Incorrect value passed to argument `\(name)`. Expected `\(expectedType)` but got `\(value)`"
+            case .multipleClauseErrors(let name, let signatureErrors):
+                return signatureErrors
+                    .map {
+                        return "Clause `\(name)(\($0.0.joined(separator: ":"))\($0.0.count > 0 ? ":" : ""))` failed with: \($0.1.localizedDescription)"
+                    }
+                    .joined(separator: "\n")
             case .multiRegistryFailure(let attempts):
                 let allUnknown = attempts.allSatisfy({
                     if case .unknownModifier = $0.1 {

--- a/Sources/LiveViewNativeStylesheet/Parsing/External/AnyNodeParser.swift
+++ b/Sources/LiveViewNativeStylesheet/Parsing/External/AnyNodeParser.swift
@@ -1,0 +1,68 @@
+//
+//  AnyNodeParser.swift
+//
+//
+//  Created by Carson Katri on 1/23/24.
+//
+
+import Parsing
+
+public struct _AnyNodeParser: Parser {
+    let context: ParseableModifierContext
+    
+    public init(context: ParseableModifierContext) {
+        self.context = context
+    }
+    
+    public var body: some Parser<Substring.UTF8View, (String, Metadata, String)> {
+        "{".utf8
+        Whitespace()
+        OneOf {
+            ConstantAtomLiteral(".").map({ _ in "." })
+            AtomLiteral()
+        }
+        Whitespace()
+        ",".utf8
+        Whitespace()
+        Metadata.parser()
+        Whitespace()
+        ",".utf8
+        Whitespace()
+        AnyArgument(context: context)
+        Whitespace()
+        "}".utf8
+    }
+    
+    public struct AnyArgument: Parser {
+        let context: ParseableModifierContext
+        
+        public init(context: ParseableModifierContext) {
+            self.context = context
+        }
+        
+        public var body: some Parser<Substring.UTF8View, String> {
+            OneOf {
+                _AnyNodeParser(context: context).map({ "\($0.0)(\($0.2))" })
+                NilLiteral().map({ _ in "nil" })
+                AtomLiteral().map({ ":\($0)" })
+                String.parser(in: context).map({ #""\#($0)""# })
+                Double.parser().map({ String($0) })
+                Int.parser().map({ String($0) })
+                Bool.parser().map({ String($0) })
+                ListLiteral {
+                    AnyArgument(context: context)
+                }
+                .map({ "[\($0.joined(separator: ", "))]" })
+                // keyword list
+                ListLiteral {
+                    Identifier()
+                    Whitespace()
+                    ":".utf8
+                    Whitespace()
+                    AnyArgument(context: context)
+                }
+                .map({ "[\($0.map({ "\($0.0):\($0.1)" }).joined(separator: ", "))]" })
+            }
+        }
+    }
+}


### PR DESCRIPTION
Previously, error messages would only mention which modifier failed and provide a list of possible clauses.

The new error messages have details on which arguments failed, with possible solutions for fixing more complex types (such as `ViewReference` and `ChangeTracked`):

```
Stylesheet parsing failed for modifier `sheet` in class `sheet`:

  |
6 | sheet(isPresented: "isPresented", onDismiss: event("onDismiss"), content: "content")
  | ^ Clause `sheet(isPresented:onDismiss:content:)` failed:
  |     - Incorrect value passed to argument `isPresented`. Expected `ChangeTracked<Bool>` but got `"isPresented"`. Use `attr("...")` to link this argument with an attribute.
  |     - Incorrect value passed to argument `content`. Expected `ViewReference` but got `"content"`. Pass an atom type to reference nested content.

in HomeStyles (home_styles.ex:6)
```

This PR also adds `Whitespace` parsers to missing areas to fix pretty-printed stylesheets.