### PR TITLE
Chunk modifiers to reduce stack size

### DIFF
--- a/Sources/LiveViewNative/_GeneratedModifiers.swift
+++ b/Sources/LiveViewNative/_GeneratedModifiers.swift
@@ -877,16 +877,16 @@ struct _badgeModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS)
         case _0(count: Any)
         #endif
-        #if os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS)
         case _1(label: Any?)
         #endif
-        #if os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS)
         case _2(key: Any?)
         #endif
-        #if os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS)
         case _3(label: Any)
         #endif
     }
@@ -905,29 +905,29 @@ struct _badgeModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(macOS) || os(iOS)
-    @available(macOS 12.0,iOS 15.0, *)
+    #if os(iOS) || os(macOS)
+    @available(iOS 15.0,macOS 12.0, *)
     init(_ count: AttributeReference<Swift.Int>) {
         self.value = ._0(count: count)
         
     }
     #endif
-    #if os(macOS) || os(iOS)
-    @available(macOS 12.0,iOS 15.0, *)
+    #if os(iOS) || os(macOS)
+    @available(iOS 15.0,macOS 12.0, *)
     init(_ label: TextReference?) {
         self.value = ._1(label: label)
         
     }
     #endif
-    #if os(macOS) || os(iOS)
-    @available(macOS 12.0,iOS 15.0, *)
+    #if os(iOS) || os(macOS)
+    @available(iOS 15.0,macOS 12.0, *)
     init(_ key: SwiftUI.LocalizedStringKey?) {
         self.value = ._2(key: key)
         
     }
     #endif
-    #if os(macOS) || os(iOS)
-    @available(macOS 12.0,iOS 15.0, *)
+    #if os(iOS) || os(macOS)
+    @available(iOS 15.0,macOS 12.0, *)
     init(_ label: AttributeReference<String>) {
         self.value = ._3(label: label)
         
@@ -938,33 +938,33 @@ struct _badgeModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS)
         case let ._0(count):
-            if #available(macOS 12.0,iOS 15.0, *) {
+            if #available(iOS 15.0,macOS 12.0, *) {
             let count = count as! AttributeReference<Swift.Int>
             __content
                 .badge(count.resolve(on: element, in: context))
             } else { __content }
         #endif
-        #if os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS)
         case let ._1(label):
-            if #available(macOS 12.0,iOS 15.0, *) {
+            if #available(iOS 15.0,macOS 12.0, *) {
             let label = label as? TextReference
             __content
                 .badge(label?.resolve(on: element, in: context))
             } else { __content }
         #endif
-        #if os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS)
         case let ._2(key):
-            if #available(macOS 12.0,iOS 15.0, *) {
+            if #available(iOS 15.0,macOS 12.0, *) {
             let key = key as? SwiftUI.LocalizedStringKey
             __content
                 .badge(key)
             } else { __content }
         #endif
-        #if os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS)
         case let ._3(label):
-            if #available(macOS 12.0,iOS 15.0, *) {
+            if #available(iOS 15.0,macOS 12.0, *) {
             let label = label as! AttributeReference<String>
             __content
                 .badge(label.resolve(on: element, in: context))
@@ -1687,10 +1687,10 @@ struct _containerRelativeFrameModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
         case _0(axes: Any,alignment: Any)
         #endif
-        #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
         case _1(axes: Any,count: Any,span: Any, spacing: Any,alignment: Any)
         #endif
     }
@@ -1705,14 +1705,14 @@ struct _containerRelativeFrameModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
     @available(macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0, *)
     init(_ axes: SwiftUI.Axis.Set,alignment: AttributeReference<SwiftUI.Alignment> = .init(storage: .constant(.center)) ) {
         self.value = ._0(axes: axes, alignment: alignment)
         
     }
     #endif
-    #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
     @available(macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0, *)
     init(_ axes: SwiftUI.Axis.Set,count: AttributeReference<Swift.Int>,span: AttributeReference<Swift.Int> = .init(storage: .constant(1)), spacing: AttributeReference<CoreFoundation.CGFloat>,alignment: AttributeReference<SwiftUI.Alignment> = .init(storage: .constant(.center)) ) {
         self.value = ._1(axes: axes, count: count, span: span, spacing: spacing, alignment: alignment)
@@ -1724,7 +1724,7 @@ struct _containerRelativeFrameModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
         case let ._0(axes, alignment):
             if #available(macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0, *) {
             let axes = axes as! SwiftUI.Axis.Set
@@ -1733,7 +1733,7 @@ let alignment = alignment as! AttributeReference<SwiftUI.Alignment>
                 .containerRelativeFrame(axes, alignment: alignment.resolve(on: element, in: context))
             } else { __content }
         #endif
-        #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
         case let ._1(axes, count, span, spacing, alignment):
             if #available(macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0, *) {
             let axes = axes as! SwiftUI.Axis.Set
@@ -1900,10 +1900,10 @@ struct _contextMenuModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(tvOS) || os(iOS) || os(macOS)
+        #if os(iOS) || os(macOS) || os(tvOS)
         case _0(menuItems: Any)
         #endif
-        #if os(tvOS) || os(iOS) || os(macOS)
+        #if os(iOS) || os(macOS) || os(tvOS)
         case _1(menuItems: Any,preview: Any)
         #endif
     }
@@ -1918,15 +1918,15 @@ struct _contextMenuModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(tvOS) || os(iOS) || os(macOS)
+    #if os(iOS) || os(macOS) || os(tvOS)
     @available(tvOS 14.0,iOS 13.0,macOS 10.15, *)
     init(menuItems: ViewReference=ViewReference(value: [])) {
         self.value = ._0(menuItems: menuItems)
         
     }
     #endif
-    #if os(tvOS) || os(iOS) || os(macOS)
-    @available(tvOS 16.0,iOS 16.0,macOS 13.0, *)
+    #if os(iOS) || os(macOS) || os(tvOS)
+    @available(macOS 13.0,tvOS 16.0,iOS 16.0, *)
     init(menuItems: ViewReference=ViewReference(value: []),preview: ViewReference=ViewReference(value: [])) {
         self.value = ._1(menuItems: menuItems, preview: preview)
         
@@ -1937,7 +1937,7 @@ struct _contextMenuModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(tvOS) || os(iOS) || os(macOS)
+        #if os(iOS) || os(macOS) || os(tvOS)
         case let ._0(menuItems):
             if #available(tvOS 14.0,iOS 13.0,macOS 10.15, *) {
             let menuItems = menuItems as! ViewReference
@@ -1945,9 +1945,9 @@ struct _contextMenuModifier<R: RootRegistry>: ViewModifier {
                 .contextMenu(menuItems: { menuItems.resolve(on: element, in: context) })
             } else { __content }
         #endif
-        #if os(tvOS) || os(iOS) || os(macOS)
+        #if os(iOS) || os(macOS) || os(tvOS)
         case let ._1(menuItems, preview):
-            if #available(tvOS 16.0,iOS 16.0,macOS 13.0, *) {
+            if #available(macOS 13.0,tvOS 16.0,iOS 16.0, *) {
             let menuItems = menuItems as! ViewReference
 let preview = preview as! ViewReference
             __content
@@ -2005,7 +2005,7 @@ struct _controlGroupStyleModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(macOS) || os(iOS) || os(tvOS)
+        #if os(iOS) || os(macOS) || os(tvOS)
         case _0(style: Any)
         #endif
     }
@@ -2018,8 +2018,8 @@ struct _controlGroupStyleModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(macOS) || os(iOS) || os(tvOS)
-    @available(macOS 12.0,iOS 15.0,tvOS 17.0, *)
+    #if os(iOS) || os(macOS) || os(tvOS)
+    @available(tvOS 17.0,macOS 12.0,iOS 15.0, *)
     init(_ style: AnyControlGroupStyle) {
         self.value = ._0(style: style)
         
@@ -2030,9 +2030,9 @@ struct _controlGroupStyleModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(macOS) || os(iOS) || os(tvOS)
+        #if os(iOS) || os(macOS) || os(tvOS)
         case let ._0(style):
-            if #available(macOS 12.0,iOS 15.0,tvOS 17.0, *) {
+            if #available(tvOS 17.0,macOS 12.0,iOS 15.0, *) {
             let style = style as! AnyControlGroupStyle
             __content
                 .controlGroupStyle(style)
@@ -2047,7 +2047,7 @@ struct _controlSizeModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(macOS) || os(iOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(watchOS)
         case _0(controlSize: Any)
         #endif
     }
@@ -2060,8 +2060,8 @@ struct _controlSizeModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(macOS) || os(iOS) || os(watchOS)
-    @available(macOS 10.15,iOS 15.0,watchOS 9.0, *)
+    #if os(iOS) || os(macOS) || os(watchOS)
+    @available(watchOS 9.0,macOS 10.15,iOS 15.0, *)
     init(_ controlSize: SwiftUI.ControlSize) {
         self.value = ._0(controlSize: controlSize)
         
@@ -2072,9 +2072,9 @@ struct _controlSizeModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(macOS) || os(iOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(watchOS)
         case let ._0(controlSize):
-            if #available(macOS 10.15,iOS 15.0,watchOS 9.0, *) {
+            if #available(watchOS 9.0,macOS 10.15,iOS 15.0, *) {
             let controlSize = controlSize as! SwiftUI.ControlSize
             __content
                 .controlSize(controlSize)
@@ -2089,7 +2089,7 @@ struct _coordinateSpaceModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
         case _0(name: Any)
         #endif
     }
@@ -2102,8 +2102,8 @@ struct _coordinateSpaceModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
-    @available(macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0, *)
+    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+    @available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0, *)
     init(_ name: SwiftUI.NamedCoordinateSpace) {
         self.value = ._0(name: name)
         
@@ -2114,9 +2114,9 @@ struct _coordinateSpaceModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
         case let ._0(name):
-            if #available(macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0, *) {
+            if #available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0, *) {
             let name = name as! SwiftUI.NamedCoordinateSpace
             __content
                 .coordinateSpace(name)
@@ -2173,7 +2173,7 @@ struct _defaultScrollAnchorModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
         case _0(anchor: Any?)
         #endif
     }
@@ -2186,8 +2186,8 @@ struct _defaultScrollAnchorModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
-    @available(macOS 14.0,iOS 17.0,watchOS 10.0,tvOS 17.0, *)
+    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+    @available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0, *)
     init(_ anchor: AttributeReference<SwiftUI.UnitPoint?>?) {
         self.value = ._0(anchor: anchor)
         
@@ -2198,9 +2198,9 @@ struct _defaultScrollAnchorModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
         case let ._0(anchor):
-            if #available(macOS 14.0,iOS 17.0,watchOS 10.0,tvOS 17.0, *) {
+            if #available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0, *) {
             let anchor = anchor as? AttributeReference<SwiftUI.UnitPoint?>
             __content
                 .defaultScrollAnchor(anchor?.resolve(on: element, in: context))
@@ -2341,16 +2341,16 @@ struct _dialogSuppressionToggleModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(macOS) || os(watchOS) || os(iOS) || os(tvOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
         case _0(titleKey: Any)
         #endif
-        #if os(macOS) || os(watchOS) || os(iOS) || os(tvOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
         case _1(title: Any)
         #endif
-        #if os(macOS) || os(watchOS) || os(iOS) || os(tvOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
         case _2(label: Any)
         #endif
-        #if os(macOS) || os(watchOS) || os(iOS) || os(tvOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
         case _3
         #endif
     }
@@ -2369,29 +2369,29 @@ struct _dialogSuppressionToggleModifier<R: RootRegistry>: ViewModifier {
 @ChangeTracked private var _3_isSuppressed: Swift.Bool
 
 
-    #if os(macOS) || os(watchOS) || os(iOS) || os(tvOS)
-    @available(macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0, *)
+    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+    @available(watchOS 10.0,iOS 17.0,macOS 14.0,tvOS 17.0, *)
     init(_ titleKey: SwiftUI.LocalizedStringKey,isSuppressed: ChangeTracked<Swift.Bool>) {
         self.value = ._0(titleKey: titleKey)
         self.__0_isSuppressed = isSuppressed
     }
     #endif
-    #if os(macOS) || os(watchOS) || os(iOS) || os(tvOS)
-    @available(macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0, *)
+    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+    @available(watchOS 10.0,iOS 17.0,macOS 14.0,tvOS 17.0, *)
     init(_ title: AttributeReference<String>,isSuppressed: ChangeTracked<Swift.Bool>) {
         self.value = ._1(title: title)
         self.__1_isSuppressed = isSuppressed
     }
     #endif
-    #if os(macOS) || os(watchOS) || os(iOS) || os(tvOS)
-    @available(macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0, *)
+    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+    @available(macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0, *)
     init(_ label: TextReference,isSuppressed: ChangeTracked<Swift.Bool>) {
         self.value = ._2(label: label)
         self.__2_isSuppressed = isSuppressed
     }
     #endif
-    #if os(macOS) || os(watchOS) || os(iOS) || os(tvOS)
-    @available(macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0, *)
+    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+    @available(macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0, *)
     init(isSuppressed: ChangeTracked<Swift.Bool>) {
         self.value = ._3
         self.__3_isSuppressed = isSuppressed
@@ -2402,33 +2402,33 @@ struct _dialogSuppressionToggleModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(macOS) || os(watchOS) || os(iOS) || os(tvOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
         case let ._0(titleKey):
-            if #available(macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0, *) {
+            if #available(watchOS 10.0,iOS 17.0,macOS 14.0,tvOS 17.0, *) {
             let titleKey = titleKey as! SwiftUI.LocalizedStringKey
             __content
                 .dialogSuppressionToggle(titleKey, isSuppressed: __0_isSuppressed.projectedValue)
             } else { __content }
         #endif
-        #if os(macOS) || os(watchOS) || os(iOS) || os(tvOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
         case let ._1(title):
-            if #available(macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0, *) {
+            if #available(watchOS 10.0,iOS 17.0,macOS 14.0,tvOS 17.0, *) {
             let title = title as! AttributeReference<String>
             __content
                 .dialogSuppressionToggle(title.resolve(on: element, in: context), isSuppressed: __1_isSuppressed.projectedValue)
             } else { __content }
         #endif
-        #if os(macOS) || os(watchOS) || os(iOS) || os(tvOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
         case let ._2(label):
-            if #available(macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0, *) {
+            if #available(macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0, *) {
             let label = label as! TextReference
             __content
                 .dialogSuppressionToggle(label.resolve(on: element, in: context), isSuppressed: __2_isSuppressed.projectedValue)
             } else { __content }
         #endif
-        #if os(macOS) || os(watchOS) || os(iOS) || os(tvOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
         case ._3:
-            if #available(macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0, *) {
+            if #available(macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0, *) {
             
             __content
                 .dialogSuppressionToggle(isSuppressed: __3_isSuppressed.projectedValue)
@@ -2665,7 +2665,7 @@ struct _fileDialogCustomizationIDModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS)
-    @available(iOS 17.0,macOS 14.0, *)
+    @available(macOS 14.0,iOS 17.0, *)
     init(_ id: AttributeReference<Swift.String>) {
         self.value = ._0(id: id)
         
@@ -2678,7 +2678,7 @@ struct _fileDialogCustomizationIDModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS)
         case let ._0(id):
-            if #available(iOS 17.0,macOS 14.0, *) {
+            if #available(macOS 14.0,iOS 17.0, *) {
             let id = id as! AttributeReference<Swift.String>
             __content
                 .fileDialogCustomizationID(id.resolve(on: element, in: context))
@@ -2923,7 +2923,7 @@ struct _focusEffectDisabledModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
         case _0(disabled: Any)
         #endif
     }
@@ -2936,8 +2936,8 @@ struct _focusEffectDisabledModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
-    @available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0, *)
+    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+    @available(macOS 14.0,watchOS 10.0,tvOS 17.0,iOS 17.0, *)
     init(_ disabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(disabled: disabled)
         
@@ -2948,9 +2948,9 @@ struct _focusEffectDisabledModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
         case let ._0(disabled):
-            if #available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0, *) {
+            if #available(macOS 14.0,watchOS 10.0,tvOS 17.0,iOS 17.0, *) {
             let disabled = disabled as! AttributeReference<Swift.Bool>
             __content
                 .focusEffectDisabled(disabled.resolve(on: element, in: context))
@@ -2965,7 +2965,7 @@ struct _focusSectionModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(tvOS) || os(macOS)
+        #if os(macOS) || os(tvOS)
         case _0
         #endif
     }
@@ -2978,7 +2978,7 @@ struct _focusSectionModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(tvOS) || os(macOS)
+    #if os(macOS) || os(tvOS)
     @available(tvOS 15.0,macOS 13.0, *)
     init() {
         self.value = ._0
@@ -2990,7 +2990,7 @@ struct _focusSectionModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(tvOS) || os(macOS)
+        #if os(macOS) || os(tvOS)
         case ._0:
             if #available(tvOS 15.0,macOS 13.0, *) {
             
@@ -3007,10 +3007,10 @@ struct _focusableModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
         case _0(isFocusable: Any)
         #endif
-        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
         case _1(isFocusable: Any, interactions: Any)
         #endif
     }
@@ -3025,15 +3025,15 @@ struct _focusableModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
-    @available(iOS 17.0,watchOS 8.0,macOS 12.0,tvOS 15.0, *)
+    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+    @available(macOS 12.0,watchOS 8.0,tvOS 15.0,iOS 17.0, *)
     init(_ isFocusable: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(isFocusable: isFocusable)
         
     }
     #endif
-    #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
-    @available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0, *)
+    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+    @available(macOS 14.0,watchOS 10.0,tvOS 17.0,iOS 17.0, *)
     init(_ isFocusable: AttributeReference<Swift.Bool> = .init(storage: .constant(true)), interactions: SwiftUI.FocusInteractions) {
         self.value = ._1(isFocusable: isFocusable, interactions: interactions)
         
@@ -3044,17 +3044,17 @@ struct _focusableModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
         case let ._0(isFocusable):
-            if #available(iOS 17.0,watchOS 8.0,macOS 12.0,tvOS 15.0, *) {
+            if #available(macOS 12.0,watchOS 8.0,tvOS 15.0,iOS 17.0, *) {
             let isFocusable = isFocusable as! AttributeReference<Swift.Bool>
             __content
                 .focusable(isFocusable.resolve(on: element, in: context))
             } else { __content }
         #endif
-        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
         case let ._1(isFocusable, interactions):
-            if #available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0, *) {
+            if #available(macOS 14.0,watchOS 10.0,tvOS 17.0,iOS 17.0, *) {
             let isFocusable = isFocusable as! AttributeReference<Swift.Bool>
 let interactions = interactions as! SwiftUI.FocusInteractions
             __content
@@ -3112,7 +3112,7 @@ struct _fontDesignModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(tvOS) || os(macOS) || os(watchOS) || os(iOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
         case _0(design: Any?)
         #endif
     }
@@ -3125,8 +3125,8 @@ struct _fontDesignModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(tvOS) || os(macOS) || os(watchOS) || os(iOS)
-    @available(tvOS 16.1,macOS 13.0,watchOS 9.1,iOS 16.1, *)
+    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+    @available(macOS 13.0,iOS 16.1,tvOS 16.1,watchOS 9.1, *)
     init(_ design: SwiftUI.Font.Design?) {
         self.value = ._0(design: design)
         
@@ -3137,9 +3137,9 @@ struct _fontDesignModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(tvOS) || os(macOS) || os(watchOS) || os(iOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
         case let ._0(design):
-            if #available(tvOS 16.1,macOS 13.0,watchOS 9.1,iOS 16.1, *) {
+            if #available(macOS 13.0,iOS 16.1,tvOS 16.1,watchOS 9.1, *) {
             let design = design as? SwiftUI.Font.Design
             __content
                 .fontDesign(design)
@@ -3444,7 +3444,7 @@ struct _fullScreenCoverModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(watchOS) || os(tvOS)
+        #if os(iOS) || os(tvOS) || os(watchOS)
         case _0(content: Any)
         #endif
     }
@@ -3457,8 +3457,8 @@ struct _fullScreenCoverModifier<R: RootRegistry>: ViewModifier {
 @ChangeTracked private var _0_isPresented: Swift.Bool
 @Event private var _0_onDismiss__0: Event.EventHandler
 
-    #if os(iOS) || os(watchOS) || os(tvOS)
-    @available(iOS 14.0,watchOS 7.0,tvOS 14.0, *)
+    #if os(iOS) || os(tvOS) || os(watchOS)
+    @available(tvOS 14.0,watchOS 7.0,iOS 14.0, *)
     init(isPresented: ChangeTracked<Swift.Bool>,onDismiss onDismiss__0: Event=Event(), content: ViewReference=ViewReference(value: [])) {
         self.value = ._0(content: content)
         self.__0_isPresented = isPresented
@@ -3470,9 +3470,9 @@ self.__0_onDismiss__0 = onDismiss__0
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(watchOS) || os(tvOS)
+        #if os(iOS) || os(tvOS) || os(watchOS)
         case let ._0(content):
-            if #available(iOS 14.0,watchOS 7.0,tvOS 14.0, *) {
+            if #available(tvOS 14.0,watchOS 7.0,iOS 14.0, *) {
             let content = content as! ViewReference
             __content
                 .fullScreenCover(isPresented: __0_isPresented.projectedValue, onDismiss: { __0_onDismiss__0.wrappedValue() }, content: { content.resolve(on: element, in: context) })
@@ -3487,7 +3487,7 @@ struct _gaugeStyleModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(macOS) || os(iOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(watchOS)
         case _0(style: Any)
         #endif
     }
@@ -3500,8 +3500,8 @@ struct _gaugeStyleModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(macOS) || os(iOS) || os(watchOS)
-    @available(macOS 13.0,iOS 16.0,watchOS 7.0, *)
+    #if os(iOS) || os(macOS) || os(watchOS)
+    @available(watchOS 7.0,macOS 13.0,iOS 16.0, *)
     init(_ style: AnyGaugeStyle) {
         self.value = ._0(style: style)
         
@@ -3512,9 +3512,9 @@ struct _gaugeStyleModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(macOS) || os(iOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(watchOS)
         case let ._0(style):
-            if #available(macOS 13.0,iOS 16.0,watchOS 7.0, *) {
+            if #available(watchOS 7.0,macOS 13.0,iOS 16.0, *) {
             let style = style as! AnyGaugeStyle
             __content
                 .gaugeStyle(style)
@@ -3529,7 +3529,7 @@ struct _geometryGroupModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(watchOS) || os(iOS) || os(macOS) || os(tvOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
         case _0
         #endif
     }
@@ -3542,8 +3542,8 @@ struct _geometryGroupModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(watchOS) || os(iOS) || os(macOS) || os(tvOS)
-    @available(watchOS 10.0,iOS 17.0,macOS 14.0,tvOS 17.0, *)
+    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+    @available(tvOS 17.0,macOS 14.0,watchOS 10.0,iOS 17.0, *)
     init() {
         self.value = ._0
         
@@ -3554,9 +3554,9 @@ struct _geometryGroupModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(watchOS) || os(iOS) || os(macOS) || os(tvOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
         case ._0:
-            if #available(watchOS 10.0,iOS 17.0,macOS 14.0,tvOS 17.0, *) {
+            if #available(tvOS 17.0,macOS 14.0,watchOS 10.0,iOS 17.0, *) {
             
             __content
                 .geometryGroup()
@@ -3823,7 +3823,7 @@ struct _groupBoxStyleModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS)
         case _0(style: Any)
         #endif
     }
@@ -3836,7 +3836,7 @@ struct _groupBoxStyleModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(macOS) || os(iOS)
+    #if os(iOS) || os(macOS)
     @available(macOS 11.0,iOS 14.0, *)
     init(_ style: AnyGroupBoxStyle) {
         self.value = ._0(style: style)
@@ -3848,7 +3848,7 @@ struct _groupBoxStyleModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS)
         case let ._0(style):
             if #available(macOS 11.0,iOS 14.0, *) {
             let style = style as! AnyGroupBoxStyle
@@ -4134,14 +4134,14 @@ struct _hoverEffectModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(tvOS) || os(visionOS)
-    @available(iOS 13.4,tvOS 16.0,visionOS 1.0, *)
+    @available(tvOS 16.0,visionOS 1.0,iOS 13.4, *)
     init(_ effect: SwiftUI.HoverEffect = .automatic ) {
         self.value = ._0(effect: effect)
         
     }
     #endif
     #if os(iOS) || os(tvOS) || os(visionOS)
-    @available(iOS 17.0,tvOS 17.0,visionOS 1.0, *)
+    @available(tvOS 17.0,iOS 17.0,visionOS 1.0, *)
     init(_ effect: SwiftUI.HoverEffect = .automatic, isEnabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._1(effect: effect, isEnabled: isEnabled)
         
@@ -4154,7 +4154,7 @@ struct _hoverEffectModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(tvOS) || os(visionOS)
         case let ._0(effect):
-            if #available(iOS 13.4,tvOS 16.0,visionOS 1.0, *) {
+            if #available(tvOS 16.0,visionOS 1.0,iOS 13.4, *) {
             let effect = effect as! SwiftUI.HoverEffect 
             __content
                 .hoverEffect(effect)
@@ -4162,7 +4162,7 @@ struct _hoverEffectModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(tvOS) || os(visionOS)
         case let ._1(effect, isEnabled):
-            if #available(iOS 17.0,tvOS 17.0,visionOS 1.0, *) {
+            if #available(tvOS 17.0,iOS 17.0,visionOS 1.0, *) {
             let effect = effect as! SwiftUI.HoverEffect 
 let isEnabled = isEnabled as! AttributeReference<Swift.Bool>
             __content
@@ -4192,7 +4192,7 @@ struct _hoverEffectDisabledModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(tvOS) || os(visionOS)
-    @available(iOS 17.0,tvOS 17.0,visionOS 1.0, *)
+    @available(tvOS 17.0,iOS 17.0,visionOS 1.0, *)
     init(_ disabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(disabled: disabled)
         
@@ -4205,7 +4205,7 @@ struct _hoverEffectDisabledModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(tvOS) || os(visionOS)
         case let ._0(disabled):
-            if #available(iOS 17.0,tvOS 17.0,visionOS 1.0, *) {
+            if #available(tvOS 17.0,iOS 17.0,visionOS 1.0, *) {
             let disabled = disabled as! AttributeReference<Swift.Bool>
             __content
                 .hoverEffectDisabled(disabled.resolve(on: element, in: context))
@@ -4346,7 +4346,7 @@ struct _indexViewStyleModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(tvOS) || os(iOS) || os(watchOS)
+        #if os(iOS) || os(tvOS) || os(watchOS)
         case _0(style: Any)
         #endif
     }
@@ -4359,8 +4359,8 @@ struct _indexViewStyleModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(tvOS) || os(iOS) || os(watchOS)
-    @available(tvOS 14.0,iOS 14.0,watchOS 8.0, *)
+    #if os(iOS) || os(tvOS) || os(watchOS)
+    @available(iOS 14.0,tvOS 14.0,watchOS 8.0, *)
     init(_ style: AnyIndexViewStyle) {
         self.value = ._0(style: style)
         
@@ -4371,9 +4371,9 @@ struct _indexViewStyleModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(tvOS) || os(iOS) || os(watchOS)
+        #if os(iOS) || os(tvOS) || os(watchOS)
         case let ._0(style):
-            if #available(tvOS 14.0,iOS 14.0,watchOS 8.0, *) {
+            if #available(iOS 14.0,tvOS 14.0,watchOS 8.0, *) {
             let style = style as! AnyIndexViewStyle
             __content
                 .indexViewStyle(style)
@@ -4578,7 +4578,7 @@ struct _invalidatableContentModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
         case _0(invalidatable: Any)
         #endif
     }
@@ -4591,8 +4591,8 @@ struct _invalidatableContentModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
-    @available(iOS 17.0,macOS 14.0,watchOS 10.0,tvOS 17.0, *)
+    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+    @available(tvOS 17.0,macOS 14.0,watchOS 10.0,iOS 17.0, *)
     init(_ invalidatable: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(invalidatable: invalidatable)
         
@@ -4603,9 +4603,9 @@ struct _invalidatableContentModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
         case let ._0(invalidatable):
-            if #available(iOS 17.0,macOS 14.0,watchOS 10.0,tvOS 17.0, *) {
+            if #available(tvOS 17.0,macOS 14.0,watchOS 10.0,iOS 17.0, *) {
             let invalidatable = invalidatable as! AttributeReference<Swift.Bool>
             __content
                 .invalidatableContent(invalidatable.resolve(on: element, in: context))
@@ -4704,16 +4704,16 @@ struct _keyboardShortcutModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS)
         case _0(key: Any,modifiers: Any)
         #endif
-        #if os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS)
         case _1(shortcut: Any)
         #endif
-        #if os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS)
         case _2(shortcut: Any?)
         #endif
-        #if os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS)
         case _3(key: Any,modifiers: Any, localization: Any)
         #endif
     }
@@ -4732,29 +4732,29 @@ struct _keyboardShortcutModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(macOS) || os(iOS)
+    #if os(iOS) || os(macOS)
     @available(macOS 11.0,iOS 14.0, *)
     init(_ key: SwiftUI.KeyEquivalent,modifiers: SwiftUI.EventModifiers = .command ) {
         self.value = ._0(key: key, modifiers: modifiers)
         
     }
     #endif
-    #if os(macOS) || os(iOS)
-    @available(macOS 11.0,iOS 14.0, *)
+    #if os(iOS) || os(macOS)
+    @available(iOS 14.0,macOS 11.0, *)
     init(_ shortcut: SwiftUI.KeyboardShortcut) {
         self.value = ._1(shortcut: shortcut)
         
     }
     #endif
-    #if os(macOS) || os(iOS)
-    @available(macOS 12.3,iOS 15.4, *)
+    #if os(iOS) || os(macOS)
+    @available(iOS 15.4,macOS 12.3, *)
     init(_ shortcut: SwiftUI.KeyboardShortcut?) {
         self.value = ._2(shortcut: shortcut)
         
     }
     #endif
-    #if os(macOS) || os(iOS)
-    @available(macOS 12.0,iOS 15.0, *)
+    #if os(iOS) || os(macOS)
+    @available(iOS 15.0,macOS 12.0, *)
     init(_ key: SwiftUI.KeyEquivalent,modifiers: SwiftUI.EventModifiers = .command, localization: SwiftUI.KeyboardShortcut.Localization) {
         self.value = ._3(key: key, modifiers: modifiers, localization: localization)
         
@@ -4765,7 +4765,7 @@ struct _keyboardShortcutModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS)
         case let ._0(key, modifiers):
             if #available(macOS 11.0,iOS 14.0, *) {
             let key = key as! SwiftUI.KeyEquivalent
@@ -4774,25 +4774,25 @@ let modifiers = modifiers as! SwiftUI.EventModifiers
                 .keyboardShortcut(key, modifiers: modifiers)
             } else { __content }
         #endif
-        #if os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS)
         case let ._1(shortcut):
-            if #available(macOS 11.0,iOS 14.0, *) {
+            if #available(iOS 14.0,macOS 11.0, *) {
             let shortcut = shortcut as! SwiftUI.KeyboardShortcut
             __content
                 .keyboardShortcut(shortcut)
             } else { __content }
         #endif
-        #if os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS)
         case let ._2(shortcut):
-            if #available(macOS 12.3,iOS 15.4, *) {
+            if #available(iOS 15.4,macOS 12.3, *) {
             let shortcut = shortcut as? SwiftUI.KeyboardShortcut
             __content
                 .keyboardShortcut(shortcut)
             } else { __content }
         #endif
-        #if os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS)
         case let ._3(key, modifiers, localization):
-            if #available(macOS 12.0,iOS 15.0, *) {
+            if #available(iOS 15.0,macOS 12.0, *) {
             let key = key as! SwiftUI.KeyEquivalent
 let modifiers = modifiers as! SwiftUI.EventModifiers 
 let localization = localization as! SwiftUI.KeyboardShortcut.Localization
@@ -5413,7 +5413,7 @@ struct _listRowSeparatorModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS)
         case _0(visibility: Any,edges: Any)
         #endif
     }
@@ -5426,8 +5426,8 @@ struct _listRowSeparatorModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(macOS) || os(iOS)
-    @available(macOS 13.0,iOS 15.0, *)
+    #if os(iOS) || os(macOS)
+    @available(iOS 15.0,macOS 13.0, *)
     init(_ visibility: AttributeReference<SwiftUI.Visibility>,edges: SwiftUI.VerticalEdge.Set = .all ) {
         self.value = ._0(visibility: visibility, edges: edges)
         
@@ -5438,9 +5438,9 @@ struct _listRowSeparatorModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS)
         case let ._0(visibility, edges):
-            if #available(macOS 13.0,iOS 15.0, *) {
+            if #available(iOS 15.0,macOS 13.0, *) {
             let visibility = visibility as! AttributeReference<SwiftUI.Visibility>
 let edges = edges as! SwiftUI.VerticalEdge.Set 
             __content
@@ -5456,7 +5456,7 @@ struct _listRowSeparatorTintModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS)
         case _0(color: Any?,edges: Any)
         #endif
     }
@@ -5469,7 +5469,7 @@ struct _listRowSeparatorTintModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(macOS) || os(iOS)
+    #if os(iOS) || os(macOS)
     @available(macOS 13.0,iOS 15.0, *)
     init(_ color: AttributeReference<SwiftUI.Color?>?,edges: SwiftUI.VerticalEdge.Set = .all ) {
         self.value = ._0(color: color, edges: edges)
@@ -5481,7 +5481,7 @@ struct _listRowSeparatorTintModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS)
         case let ._0(color, edges):
             if #available(macOS 13.0,iOS 15.0, *) {
             let color = color as? AttributeReference<SwiftUI.Color?>
@@ -5541,7 +5541,7 @@ struct _listSectionSeparatorModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS)
         case _0(visibility: Any,edges: Any)
         #endif
     }
@@ -5554,7 +5554,7 @@ struct _listSectionSeparatorModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(macOS) || os(iOS)
+    #if os(iOS) || os(macOS)
     @available(macOS 13.0,iOS 15.0, *)
     init(_ visibility: AttributeReference<SwiftUI.Visibility>,edges: SwiftUI.VerticalEdge.Set = .all ) {
         self.value = ._0(visibility: visibility, edges: edges)
@@ -5566,7 +5566,7 @@ struct _listSectionSeparatorModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS)
         case let ._0(visibility, edges):
             if #available(macOS 13.0,iOS 15.0, *) {
             let visibility = visibility as! AttributeReference<SwiftUI.Visibility>
@@ -5584,7 +5584,7 @@ struct _listSectionSeparatorTintModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS)
         case _0(color: Any?,edges: Any)
         #endif
     }
@@ -5597,7 +5597,7 @@ struct _listSectionSeparatorTintModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(macOS) || os(iOS)
+    #if os(iOS) || os(macOS)
     @available(macOS 13.0,iOS 15.0, *)
     init(_ color: AttributeReference<SwiftUI.Color?>?,edges: SwiftUI.VerticalEdge.Set = .all ) {
         self.value = ._0(color: color, edges: edges)
@@ -5609,7 +5609,7 @@ struct _listSectionSeparatorTintModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS)
         case let ._0(color, edges):
             if #available(macOS 13.0,iOS 15.0, *) {
             let color = color as? AttributeReference<SwiftUI.Color?>
@@ -5773,7 +5773,7 @@ struct _menuIndicatorModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(macOS) || os(iOS) || os(tvOS)
+        #if os(iOS) || os(macOS) || os(tvOS)
         case _0(visibility: Any)
         #endif
     }
@@ -5786,8 +5786,8 @@ struct _menuIndicatorModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(macOS) || os(iOS) || os(tvOS)
-    @available(macOS 12.0,iOS 15.0,tvOS 17.0, *)
+    #if os(iOS) || os(macOS) || os(tvOS)
+    @available(tvOS 17.0,macOS 12.0,iOS 15.0, *)
     init(_ visibility: AttributeReference<SwiftUI.Visibility>) {
         self.value = ._0(visibility: visibility)
         
@@ -5798,9 +5798,9 @@ struct _menuIndicatorModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(macOS) || os(iOS) || os(tvOS)
+        #if os(iOS) || os(macOS) || os(tvOS)
         case let ._0(visibility):
-            if #available(macOS 12.0,iOS 15.0,tvOS 17.0, *) {
+            if #available(tvOS 17.0,macOS 12.0,iOS 15.0, *) {
             let visibility = visibility as! AttributeReference<SwiftUI.Visibility>
             __content
                 .menuIndicator(visibility.resolve(on: element, in: context))
@@ -5857,7 +5857,7 @@ struct _menuStyleModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(tvOS) || os(iOS) || os(macOS)
+        #if os(iOS) || os(macOS) || os(tvOS)
         case _0(style: Any)
         #endif
     }
@@ -5870,8 +5870,8 @@ struct _menuStyleModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(tvOS) || os(iOS) || os(macOS)
-    @available(tvOS 17.0,iOS 14.0,macOS 11.0, *)
+    #if os(iOS) || os(macOS) || os(tvOS)
+    @available(tvOS 17.0,macOS 11.0,iOS 14.0, *)
     init(_ style: AnyMenuStyle) {
         self.value = ._0(style: style)
         
@@ -5882,9 +5882,9 @@ struct _menuStyleModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(tvOS) || os(iOS) || os(macOS)
+        #if os(iOS) || os(macOS) || os(tvOS)
         case let ._0(style):
-            if #available(tvOS 17.0,iOS 14.0,macOS 11.0, *) {
+            if #available(tvOS 17.0,macOS 11.0,iOS 14.0, *) {
             let style = style as! AnyMenuStyle
             __content
                 .menuStyle(style)
@@ -6165,7 +6165,7 @@ struct _navigationBarTitleDisplayModeModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(watchOS)
-    @available(iOS 14.0,watchOS 8.0, *)
+    @available(watchOS 8.0,iOS 14.0, *)
     init(_ displayMode: SwiftUI.NavigationBarItem.TitleDisplayMode) {
         self.value = ._0(displayMode: displayMode)
         
@@ -6178,7 +6178,7 @@ struct _navigationBarTitleDisplayModeModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(watchOS)
         case let ._0(displayMode):
-            if #available(iOS 14.0,watchOS 8.0, *) {
+            if #available(watchOS 8.0,iOS 14.0, *) {
             let displayMode = displayMode as! SwiftUI.NavigationBarItem.TitleDisplayMode
             __content
                 .navigationBarTitleDisplayMode(displayMode)
@@ -6339,13 +6339,13 @@ struct _navigationSubtitleModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if targetEnvironment(macCatalyst) || os(macOS)
+        #if os(macOS) || targetEnvironment(macCatalyst)
         case _0(subtitle: Any)
         #endif
-        #if targetEnvironment(macCatalyst) || os(macOS)
+        #if os(macOS) || targetEnvironment(macCatalyst)
         case _1(subtitleKey: Any)
         #endif
-        #if targetEnvironment(macCatalyst) || os(macOS)
+        #if os(macOS) || targetEnvironment(macCatalyst)
         case _2(subtitle: Any)
         #endif
     }
@@ -6362,21 +6362,21 @@ struct _navigationSubtitleModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if targetEnvironment(macCatalyst) || os(macOS)
+    #if os(macOS) || targetEnvironment(macCatalyst)
     @available(macCatalyst 14.0,macOS 11.0, *)
     init(_ subtitle: TextReference) {
         self.value = ._0(subtitle: subtitle)
         
     }
     #endif
-    #if targetEnvironment(macCatalyst) || os(macOS)
+    #if os(macOS) || targetEnvironment(macCatalyst)
     @available(macCatalyst 14.0,macOS 11.0, *)
     init(_ subtitleKey: SwiftUI.LocalizedStringKey) {
         self.value = ._1(subtitleKey: subtitleKey)
         
     }
     #endif
-    #if targetEnvironment(macCatalyst) || os(macOS)
+    #if os(macOS) || targetEnvironment(macCatalyst)
     @available(macCatalyst 14.0,macOS 11.0, *)
     init(_ subtitle: AttributeReference<String>) {
         self.value = ._2(subtitle: subtitle)
@@ -6388,7 +6388,7 @@ struct _navigationSubtitleModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if targetEnvironment(macCatalyst) || os(macOS)
+        #if os(macOS) || targetEnvironment(macCatalyst)
         case let ._0(subtitle):
             if #available(macCatalyst 14.0,macOS 11.0, *) {
             let subtitle = subtitle as! TextReference
@@ -6396,7 +6396,7 @@ struct _navigationSubtitleModifier<R: RootRegistry>: ViewModifier {
                 .navigationSubtitle(subtitle.resolve(on: element, in: context))
             } else { __content }
         #endif
-        #if targetEnvironment(macCatalyst) || os(macOS)
+        #if os(macOS) || targetEnvironment(macCatalyst)
         case let ._1(subtitleKey):
             if #available(macCatalyst 14.0,macOS 11.0, *) {
             let subtitleKey = subtitleKey as! SwiftUI.LocalizedStringKey
@@ -6404,7 +6404,7 @@ struct _navigationSubtitleModifier<R: RootRegistry>: ViewModifier {
                 .navigationSubtitle(subtitleKey)
             } else { __content }
         #endif
-        #if targetEnvironment(macCatalyst) || os(macOS)
+        #if os(macOS) || targetEnvironment(macCatalyst)
         case let ._2(subtitle):
             if #available(macCatalyst 14.0,macOS 11.0, *) {
             let subtitle = subtitle as! AttributeReference<String>
@@ -6476,7 +6476,7 @@ struct _navigationTitleModifier<R: RootRegistry>: ViewModifier {
     }
     
     #if os(watchOS)
-    @available(iOS 14.0,watchOS 7.0,tvOS 14.0,macOS 11.0, *)
+    @available(macOS 11.0,iOS 14.0,tvOS 14.0,watchOS 7.0, *)
     init(_ title: ViewReference=ViewReference(value: [])) {
         self.value = ._3(title: title)
         
@@ -6520,7 +6520,7 @@ struct _navigationTitleModifier<R: RootRegistry>: ViewModifier {
         
         #if os(watchOS)
         case let ._3(title):
-            if #available(iOS 14.0,watchOS 7.0,tvOS 14.0,macOS 11.0, *) {
+            if #available(macOS 11.0,iOS 14.0,tvOS 14.0,watchOS 7.0, *) {
             let title = title as! ViewReference
             __content
                 .navigationTitle({ title.resolve(on: element, in: context) })
@@ -6661,7 +6661,7 @@ struct _onDeleteCommandModifier<R: RootRegistry>: ViewModifier {
 @Event private var _0_action__0: Event.EventHandler
 
     #if os(macOS)
-    @available(tvOS 13.0,macOS 10.15, *)
+    @available(macOS 10.15,tvOS 13.0, *)
     init(perform action__0: Event=Event()) {
         self.value = ._0
         self.__0_action__0 = action__0
@@ -6674,7 +6674,7 @@ struct _onDeleteCommandModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(macOS)
         case ._0:
-            if #available(tvOS 13.0,macOS 10.15, *) {
+            if #available(macOS 10.15,tvOS 13.0, *) {
             
             __content
                 .onDeleteCommand(perform: { __0_action__0.wrappedValue() })
@@ -6731,7 +6731,7 @@ struct _onExitCommandModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(tvOS) || os(macOS)
+        #if os(macOS) || os(tvOS)
         case _0
         #endif
     }
@@ -6744,8 +6744,8 @@ struct _onExitCommandModifier<R: RootRegistry>: ViewModifier {
 
 @Event private var _0_action__0: Event.EventHandler
 
-    #if os(tvOS) || os(macOS)
-    @available(tvOS 13.0,macOS 10.15, *)
+    #if os(macOS) || os(tvOS)
+    @available(macOS 10.15,tvOS 13.0, *)
     init(perform action__0: Event=Event()) {
         self.value = ._0
         self.__0_action__0 = action__0
@@ -6756,9 +6756,9 @@ struct _onExitCommandModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(tvOS) || os(macOS)
+        #if os(macOS) || os(tvOS)
         case ._0:
-            if #available(tvOS 13.0,macOS 10.15, *) {
+            if #available(macOS 10.15,tvOS 13.0, *) {
             
             __content
                 .onExitCommand(perform: { __0_action__0.wrappedValue() })
@@ -6773,7 +6773,7 @@ struct _onHoverModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS)
         case _0
         #endif
     }
@@ -6786,7 +6786,7 @@ struct _onHoverModifier<R: RootRegistry>: ViewModifier {
 
 @Event private var _0_action__1: Event.EventHandler
 
-    #if os(macOS) || os(iOS)
+    #if os(iOS) || os(macOS)
     @available(macOS 10.15,iOS 13.4, *)
     init(perform action__1: Event) {
         self.value = ._0
@@ -6798,7 +6798,7 @@ struct _onHoverModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS)
         case ._0:
             if #available(macOS 10.15,iOS 13.4, *) {
             
@@ -6815,7 +6815,7 @@ struct _onLongPressGestureModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(macOS) || os(iOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(watchOS)
         case _0(minimumDuration: Any, maximumDistance: Any)
         #endif
         #if os(tvOS)
@@ -6835,8 +6835,8 @@ struct _onLongPressGestureModifier<R: RootRegistry>: ViewModifier {
 @Event private var _1_action__0: Event.EventHandler
 @Event private var _1_onPressingChanged__1: Event.EventHandler
 
-    #if os(macOS) || os(iOS) || os(watchOS)
-    @available(macOS 10.15,iOS 13.0,watchOS 6.0,tvOS 14.0, *)
+    #if os(iOS) || os(macOS) || os(watchOS)
+    @available(tvOS 14.0,macOS 10.15,watchOS 6.0,iOS 13.0, *)
     init(minimumDuration: AttributeReference<Swift.Double> = .init(storage: .constant(0.5)), maximumDistance: AttributeReference<CoreFoundation.CGFloat> = .init(storage: .constant(10)), perform action__0: Event,onPressingChanged onPressingChanged__1: Event=Event() ) {
         self.value = ._0(minimumDuration: minimumDuration, maximumDistance: maximumDistance)
         self.__0_action__0 = action__0
@@ -6844,7 +6844,7 @@ self.__0_onPressingChanged__1 = onPressingChanged__1
     }
     #endif
     #if os(tvOS)
-    @available(macOS 10.15,iOS 13.0,watchOS 6.0,tvOS 14.0, *)
+    @available(tvOS 14.0,macOS 10.15,watchOS 6.0,iOS 13.0, *)
     init(minimumDuration: AttributeReference<Swift.Double> = .init(storage: .constant(0.5)), perform action__0: Event,onPressingChanged onPressingChanged__1: Event=Event() ) {
         self.value = ._1(minimumDuration: minimumDuration)
         self.__1_action__0 = action__0
@@ -6856,9 +6856,9 @@ self.__1_onPressingChanged__1 = onPressingChanged__1
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(macOS) || os(iOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(watchOS)
         case let ._0(minimumDuration, maximumDistance):
-            if #available(macOS 10.15,iOS 13.0,watchOS 6.0,tvOS 14.0, *) {
+            if #available(tvOS 14.0,macOS 10.15,watchOS 6.0,iOS 13.0, *) {
             let minimumDuration = minimumDuration as! AttributeReference<Swift.Double>
 let maximumDistance = maximumDistance as! AttributeReference<CoreFoundation.CGFloat>
             __content
@@ -6867,7 +6867,7 @@ let maximumDistance = maximumDistance as! AttributeReference<CoreFoundation.CGFl
         #endif
         #if os(tvOS)
         case let ._1(minimumDuration):
-            if #available(macOS 10.15,iOS 13.0,watchOS 6.0,tvOS 14.0, *) {
+            if #available(tvOS 14.0,macOS 10.15,watchOS 6.0,iOS 13.0, *) {
             let minimumDuration = minimumDuration as! AttributeReference<Swift.Double>
             __content
                 .onLongPressGesture(minimumDuration: minimumDuration.resolve(on: element, in: context), perform: { __1_action__0.wrappedValue() }, onPressingChanged: { __1_onPressingChanged__1.wrappedValue(value: $0) })
@@ -6926,7 +6926,7 @@ struct _onMoveCommandModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(tvOS) || os(macOS)
+        #if os(macOS) || os(tvOS)
         case _0
         #endif
     }
@@ -6939,8 +6939,8 @@ struct _onMoveCommandModifier<R: RootRegistry>: ViewModifier {
 
 @Event private var _0_action__1: Event.EventHandler
 
-    #if os(tvOS) || os(macOS)
-    @available(tvOS 13.0,macOS 10.15, *)
+    #if os(macOS) || os(tvOS)
+    @available(macOS 10.15,tvOS 13.0, *)
     init(perform action__1: Event=Event()) {
         self.value = ._0
         self.__0_action__1 = action__1
@@ -6951,9 +6951,9 @@ struct _onMoveCommandModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(tvOS) || os(macOS)
+        #if os(macOS) || os(tvOS)
         case ._0:
-            if #available(tvOS 13.0,macOS 10.15, *) {
+            if #available(macOS 10.15,tvOS 13.0, *) {
             
             __content
                 .onMoveCommand(perform: { __0_action__1.wrappedValue(value: $0) })
@@ -6982,7 +6982,7 @@ struct _onPlayPauseCommandModifier<R: RootRegistry>: ViewModifier {
 @Event private var _0_action__0: Event.EventHandler
 
     #if os(tvOS)
-    @available(tvOS 13.0,macOS 10.15, *)
+    @available(macOS 10.15,tvOS 13.0, *)
     init(perform action__0: Event=Event()) {
         self.value = ._0
         self.__0_action__0 = action__0
@@ -6995,7 +6995,7 @@ struct _onPlayPauseCommandModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(tvOS)
         case ._0:
-            if #available(tvOS 13.0,macOS 10.15, *) {
+            if #available(macOS 10.15,tvOS 13.0, *) {
             
             __content
                 .onPlayPauseCommand(perform: { __0_action__0.wrappedValue() })
@@ -7013,7 +7013,7 @@ struct _onTapGestureModifier<R: RootRegistry>: ViewModifier {
         
         case _0(count: AttributeReference<Swift.Int> = .init(storage: .constant(1)))
         
-        #if os(macOS) || os(iOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(watchOS)
         case _1(count: Any, coordinateSpace: Any)
         #endif
     }
@@ -7035,8 +7035,8 @@ struct _onTapGestureModifier<R: RootRegistry>: ViewModifier {
         self.__0_action__0 = action__0
     }
     
-    #if os(macOS) || os(iOS) || os(watchOS)
-    @available(macOS 14.0,iOS 17.0,watchOS 10.0, *)
+    #if os(iOS) || os(macOS) || os(watchOS)
+    @available(watchOS 10.0,iOS 17.0,macOS 14.0, *)
     init(count: AttributeReference<Swift.Int> = .init(storage: .constant(1)), coordinateSpace: AnyCoordinateSpaceProtocol = .local, perform action__1: Event) {
         self.value = ._1(count: count, coordinateSpace: coordinateSpace)
         self.__1_action__1 = action__1
@@ -7055,9 +7055,9 @@ struct _onTapGestureModifier<R: RootRegistry>: ViewModifier {
                 .onTapGesture(count: count.resolve(on: element, in: context), perform: { __0_action__0.wrappedValue() })
             
         
-        #if os(macOS) || os(iOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(watchOS)
         case let ._1(count, coordinateSpace):
-            if #available(macOS 14.0,iOS 17.0,watchOS 10.0, *) {
+            if #available(watchOS 10.0,iOS 17.0,macOS 14.0, *) {
             let count = count as! AttributeReference<Swift.Int>
 let coordinateSpace = coordinateSpace as! AnyCoordinateSpaceProtocol 
             __content
@@ -7363,7 +7363,7 @@ struct _popoverModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS)
         case _0(attachmentAnchor: Any, arrowEdge: Any, content: Any)
         #endif
     }
@@ -7376,7 +7376,7 @@ struct _popoverModifier<R: RootRegistry>: ViewModifier {
 @ChangeTracked private var _0_isPresented: Swift.Bool
 
 
-    #if os(macOS) || os(iOS)
+    #if os(iOS) || os(macOS)
     @available(macOS 10.15,iOS 13.0, *)
     init(isPresented: ChangeTracked<Swift.Bool>,attachmentAnchor: SwiftUI.PopoverAttachmentAnchor = .rect(.bounds), arrowEdge: SwiftUI.Edge = .top, content: ViewReference=ViewReference(value: [])) {
         self.value = ._0(attachmentAnchor: attachmentAnchor, arrowEdge: arrowEdge, content: content)
@@ -7388,7 +7388,7 @@ struct _popoverModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS)
         case let ._0(attachmentAnchor, arrowEdge, content):
             if #available(macOS 10.15,iOS 13.0, *) {
             let attachmentAnchor = attachmentAnchor as! SwiftUI.PopoverAttachmentAnchor 
@@ -7511,10 +7511,10 @@ struct _presentationBackgroundModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
         case _0(style: Any)
         #endif
-        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
         case _1(alignment: Any, content: Any)
         #endif
     }
@@ -7529,15 +7529,15 @@ struct _presentationBackgroundModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
-    @available(iOS 16.4,watchOS 9.4,macOS 13.3,tvOS 16.4, *)
+    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+    @available(tvOS 16.4,watchOS 9.4,iOS 16.4,macOS 13.3, *)
     init(_ style: AnyShapeStyle) {
         self.value = ._0(style: style)
         
     }
     #endif
-    #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
-    @available(iOS 16.4,watchOS 9.4,macOS 13.3,tvOS 16.4, *)
+    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+    @available(tvOS 16.4,watchOS 9.4,iOS 16.4,macOS 13.3, *)
     init(alignment: AttributeReference<SwiftUI.Alignment> = .init(storage: .constant(.center)), content: ViewReference=ViewReference(value: [])) {
         self.value = ._1(alignment: alignment, content: content)
         
@@ -7548,17 +7548,17 @@ struct _presentationBackgroundModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
         case let ._0(style):
-            if #available(iOS 16.4,watchOS 9.4,macOS 13.3,tvOS 16.4, *) {
+            if #available(tvOS 16.4,watchOS 9.4,iOS 16.4,macOS 13.3, *) {
             let style = style as! AnyShapeStyle
             __content
                 .presentationBackground(style)
             } else { __content }
         #endif
-        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
         case let ._1(alignment, content):
-            if #available(iOS 16.4,watchOS 9.4,macOS 13.3,tvOS 16.4, *) {
+            if #available(tvOS 16.4,watchOS 9.4,iOS 16.4,macOS 13.3, *) {
             let alignment = alignment as! AttributeReference<SwiftUI.Alignment>
 let content = content as! ViewReference
             __content
@@ -7574,7 +7574,7 @@ struct _presentationBackgroundInteractionModifier<R: RootRegistry>: ViewModifier
 
     enum Value {
         case _never
-        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
         case _0(interaction: Any)
         #endif
     }
@@ -7587,7 +7587,7 @@ struct _presentationBackgroundInteractionModifier<R: RootRegistry>: ViewModifier
 
 
 
-    #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
+    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
     @available(iOS 16.4,watchOS 9.4,macOS 13.3,tvOS 16.4, *)
     init(_ interaction: SwiftUI.PresentationBackgroundInteraction) {
         self.value = ._0(interaction: interaction)
@@ -7599,7 +7599,7 @@ struct _presentationBackgroundInteractionModifier<R: RootRegistry>: ViewModifier
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
         case let ._0(interaction):
             if #available(iOS 16.4,watchOS 9.4,macOS 13.3,tvOS 16.4, *) {
             let interaction = interaction as! SwiftUI.PresentationBackgroundInteraction
@@ -7616,10 +7616,10 @@ struct _presentationCompactAdaptationModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
         case _0(adaptation: Any)
         #endif
-        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
         case _1(horizontalAdaptation: Any,verticalAdaptation: Any)
         #endif
     }
@@ -7634,15 +7634,15 @@ struct _presentationCompactAdaptationModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
-    @available(iOS 16.4,watchOS 9.4,macOS 13.3,tvOS 16.4, *)
+    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+    @available(tvOS 16.4,macOS 13.3,watchOS 9.4,iOS 16.4, *)
     init(_ adaptation: SwiftUI.PresentationAdaptation) {
         self.value = ._0(adaptation: adaptation)
         
     }
     #endif
-    #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
-    @available(iOS 16.4,watchOS 9.4,macOS 13.3,tvOS 16.4, *)
+    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+    @available(tvOS 16.4,macOS 13.3,watchOS 9.4,iOS 16.4, *)
     init(horizontal horizontalAdaptation: SwiftUI.PresentationAdaptation,vertical verticalAdaptation: SwiftUI.PresentationAdaptation) {
         self.value = ._1(horizontalAdaptation: horizontalAdaptation, verticalAdaptation: verticalAdaptation)
         
@@ -7653,17 +7653,17 @@ struct _presentationCompactAdaptationModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
         case let ._0(adaptation):
-            if #available(iOS 16.4,watchOS 9.4,macOS 13.3,tvOS 16.4, *) {
+            if #available(tvOS 16.4,macOS 13.3,watchOS 9.4,iOS 16.4, *) {
             let adaptation = adaptation as! SwiftUI.PresentationAdaptation
             __content
                 .presentationCompactAdaptation(adaptation)
             } else { __content }
         #endif
-        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
         case let ._1(horizontalAdaptation, verticalAdaptation):
-            if #available(iOS 16.4,watchOS 9.4,macOS 13.3,tvOS 16.4, *) {
+            if #available(tvOS 16.4,macOS 13.3,watchOS 9.4,iOS 16.4, *) {
             let horizontalAdaptation = horizontalAdaptation as! SwiftUI.PresentationAdaptation
 let verticalAdaptation = verticalAdaptation as! SwiftUI.PresentationAdaptation
             __content
@@ -7679,7 +7679,7 @@ struct _presentationContentInteractionModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
         case _0(behavior: Any)
         #endif
     }
@@ -7692,8 +7692,8 @@ struct _presentationContentInteractionModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
-    @available(iOS 16.4,watchOS 9.4,macOS 13.3,tvOS 16.4, *)
+    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+    @available(macOS 13.3,iOS 16.4,tvOS 16.4,watchOS 9.4, *)
     init(_ behavior: SwiftUI.PresentationContentInteraction) {
         self.value = ._0(behavior: behavior)
         
@@ -7704,9 +7704,9 @@ struct _presentationContentInteractionModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
         case let ._0(behavior):
-            if #available(iOS 16.4,watchOS 9.4,macOS 13.3,tvOS 16.4, *) {
+            if #available(macOS 13.3,iOS 16.4,tvOS 16.4,watchOS 9.4, *) {
             let behavior = behavior as! SwiftUI.PresentationContentInteraction
             __content
                 .presentationContentInteraction(behavior)
@@ -7721,7 +7721,7 @@ struct _presentationCornerRadiusModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
         case _0(cornerRadius: Any?)
         #endif
     }
@@ -7734,8 +7734,8 @@ struct _presentationCornerRadiusModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
-    @available(iOS 16.4,watchOS 9.4,macOS 13.3,tvOS 16.4, *)
+    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+    @available(macOS 13.3,iOS 16.4,tvOS 16.4,watchOS 9.4, *)
     init(_ cornerRadius: AttributeReference<CoreFoundation.CGFloat?>?) {
         self.value = ._0(cornerRadius: cornerRadius)
         
@@ -7746,9 +7746,9 @@ struct _presentationCornerRadiusModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
         case let ._0(cornerRadius):
-            if #available(iOS 16.4,watchOS 9.4,macOS 13.3,tvOS 16.4, *) {
+            if #available(macOS 13.3,iOS 16.4,tvOS 16.4,watchOS 9.4, *) {
             let cornerRadius = cornerRadius as? AttributeReference<CoreFoundation.CGFloat?>
             __content
                 .presentationCornerRadius(cornerRadius?.resolve(on: element, in: context))
@@ -8515,7 +8515,7 @@ struct _scrollBounceBehaviorModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
         case _0(behavior: Any,axes: Any)
         #endif
     }
@@ -8528,8 +8528,8 @@ struct _scrollBounceBehaviorModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
-    @available(macOS 13.3,iOS 16.4,watchOS 9.4,tvOS 16.4, *)
+    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+    @available(macOS 13.3,iOS 16.4,tvOS 16.4,watchOS 9.4, *)
     init(_ behavior: SwiftUI.ScrollBounceBehavior,axes: SwiftUI.Axis.Set = [.vertical] ) {
         self.value = ._0(behavior: behavior, axes: axes)
         
@@ -8540,9 +8540,9 @@ struct _scrollBounceBehaviorModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
         case let ._0(behavior, axes):
-            if #available(macOS 13.3,iOS 16.4,watchOS 9.4,tvOS 16.4, *) {
+            if #available(macOS 13.3,iOS 16.4,tvOS 16.4,watchOS 9.4, *) {
             let behavior = behavior as! SwiftUI.ScrollBounceBehavior
 let axes = axes as! SwiftUI.Axis.Set 
             __content
@@ -8558,7 +8558,7 @@ struct _scrollClipDisabledModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
         case _0(disabled: Any)
         #endif
     }
@@ -8571,8 +8571,8 @@ struct _scrollClipDisabledModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
-    @available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0, *)
+    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+    @available(macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0, *)
     init(_ disabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(disabled: disabled)
         
@@ -8583,9 +8583,9 @@ struct _scrollClipDisabledModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
         case let ._0(disabled):
-            if #available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0, *) {
+            if #available(macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0, *) {
             let disabled = disabled as! AttributeReference<Swift.Bool>
             __content
                 .scrollClipDisabled(disabled.resolve(on: element, in: context))
@@ -8600,7 +8600,7 @@ struct _scrollContentBackgroundModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(watchOS) || os(iOS) || os(macOS)
+        #if os(iOS) || os(macOS) || os(watchOS)
         case _0(visibility: Any)
         #endif
     }
@@ -8613,7 +8613,7 @@ struct _scrollContentBackgroundModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(watchOS) || os(iOS) || os(macOS)
+    #if os(iOS) || os(macOS) || os(watchOS)
     @available(watchOS 9.0,iOS 16.0,macOS 13.0, *)
     init(_ visibility: AttributeReference<SwiftUI.Visibility>) {
         self.value = ._0(visibility: visibility)
@@ -8625,7 +8625,7 @@ struct _scrollContentBackgroundModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(watchOS) || os(iOS) || os(macOS)
+        #if os(iOS) || os(macOS) || os(watchOS)
         case let ._0(visibility):
             if #available(watchOS 9.0,iOS 16.0,macOS 13.0, *) {
             let visibility = visibility as! AttributeReference<SwiftUI.Visibility>
@@ -8684,7 +8684,7 @@ struct _scrollDismissesKeyboardModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
         case _0(mode: Any)
         #endif
     }
@@ -8697,8 +8697,8 @@ struct _scrollDismissesKeyboardModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
-    @available(macOS 13.0,iOS 16.0,watchOS 9.0,tvOS 16.0, *)
+    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+    @available(macOS 13.0,iOS 16.0,tvOS 16.0,watchOS 9.0, *)
     init(_ mode: SwiftUI.ScrollDismissesKeyboardMode) {
         self.value = ._0(mode: mode)
         
@@ -8709,9 +8709,9 @@ struct _scrollDismissesKeyboardModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
         case let ._0(mode):
-            if #available(macOS 13.0,iOS 16.0,watchOS 9.0,tvOS 16.0, *) {
+            if #available(macOS 13.0,iOS 16.0,tvOS 16.0,watchOS 9.0, *) {
             let mode = mode as! SwiftUI.ScrollDismissesKeyboardMode
             __content
                 .scrollDismissesKeyboard(mode)
@@ -8768,10 +8768,10 @@ struct _scrollIndicatorsFlashModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
         case _0(value: Any)
         #endif
-        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
         case _1(onAppear: Any)
         #endif
     }
@@ -8786,14 +8786,14 @@ struct _scrollIndicatorsFlashModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
-    @available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0, *)
+    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+    @available(macOS 14.0,watchOS 10.0,tvOS 17.0,iOS 17.0, *)
     init(trigger value: AttributeReference<String>) {
         self.value = ._0(value: value)
         
     }
     #endif
-    #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
+    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
     @available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0, *)
     init(onAppear: AttributeReference<Swift.Bool>) {
         self.value = ._1(onAppear: onAppear)
@@ -8805,15 +8805,15 @@ struct _scrollIndicatorsFlashModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
         case let ._0(value):
-            if #available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0, *) {
+            if #available(macOS 14.0,watchOS 10.0,tvOS 17.0,iOS 17.0, *) {
             let value = value as! AttributeReference<String>
             __content
                 .scrollIndicatorsFlash(trigger: value.resolve(on: element, in: context))
             } else { __content }
         #endif
-        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
         case let ._1(onAppear):
             if #available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0, *) {
             let onAppear = onAppear as! AttributeReference<Swift.Bool>
@@ -8830,7 +8830,7 @@ struct _scrollPositionModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
         case _0(anchor: Any?)
         #endif
     }
@@ -8843,8 +8843,8 @@ struct _scrollPositionModifier<R: RootRegistry>: ViewModifier {
 @ChangeTracked private var _0_id: String?
 
 
-    #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
-    @available(macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0, *)
+    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+    @available(tvOS 17.0,macOS 14.0,watchOS 10.0,iOS 17.0, *)
     init(id: ChangeTracked<String?>,anchor: AttributeReference<SwiftUI.UnitPoint?>? = .init(storage: .constant(nil)) ) {
         self.value = ._0(anchor: anchor)
         self.__0_id = id
@@ -8855,9 +8855,9 @@ struct _scrollPositionModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
         case let ._0(anchor):
-            if #available(macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0, *) {
+            if #available(tvOS 17.0,macOS 14.0,watchOS 10.0,iOS 17.0, *) {
             let anchor = anchor as? AttributeReference<SwiftUI.UnitPoint?>
             __content
                 .scrollPosition(id: __0_id.projectedValue, anchor: anchor?.resolve(on: element, in: context))
@@ -8872,7 +8872,7 @@ struct _scrollTargetBehaviorModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
         case _0(behavior: Any)
         #endif
     }
@@ -8885,7 +8885,7 @@ struct _scrollTargetBehaviorModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
     @available(macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0, *)
     init(_ behavior: AnyScrollTargetBehavior) {
         self.value = ._0(behavior: behavior)
@@ -8897,7 +8897,7 @@ struct _scrollTargetBehaviorModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
         case let ._0(behavior):
             if #available(macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0, *) {
             let behavior = behavior as! AnyScrollTargetBehavior
@@ -8914,7 +8914,7 @@ struct _scrollTargetLayoutModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
         case _0(isEnabled: Any)
         #endif
     }
@@ -8927,7 +8927,7 @@ struct _scrollTargetLayoutModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
     @available(macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0, *)
     init(isEnabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(isEnabled: isEnabled)
@@ -8939,7 +8939,7 @@ struct _scrollTargetLayoutModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
         case let ._0(isEnabled):
             if #available(macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0, *) {
             let isEnabled = isEnabled as! AttributeReference<Swift.Bool>
@@ -8970,7 +8970,7 @@ struct _searchDictationBehaviorModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(visionOS)
-    @available(iOS 17.0,visionOS 1.0, *)
+    @available(visionOS 1.0,iOS 17.0, *)
     init(_ dictationBehavior: SwiftUI.TextInputDictationBehavior) {
         self.value = ._0(dictationBehavior: dictationBehavior)
         
@@ -8983,7 +8983,7 @@ struct _searchDictationBehaviorModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(visionOS)
         case let ._0(dictationBehavior):
-            if #available(iOS 17.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,iOS 17.0, *) {
             let dictationBehavior = dictationBehavior as! SwiftUI.TextInputDictationBehavior
             __content
                 .searchDictationBehavior(dictationBehavior)
@@ -8998,7 +8998,7 @@ struct _searchPresentationToolbarBehaviorModifier<R: RootRegistry>: ViewModifier
 
     enum Value {
         case _never
-        #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
         case _0(behavior: Any)
         #endif
     }
@@ -9011,7 +9011,7 @@ struct _searchPresentationToolbarBehaviorModifier<R: RootRegistry>: ViewModifier
 
 
 
-    #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
     @available(macOS 14.1,iOS 17.1,tvOS 17.1,watchOS 10.1, *)
     init(_ behavior: SwiftUI.SearchPresentationToolbarBehavior) {
         self.value = ._0(behavior: behavior)
@@ -9023,7 +9023,7 @@ struct _searchPresentationToolbarBehaviorModifier<R: RootRegistry>: ViewModifier
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
         case let ._0(behavior):
             if #available(macOS 14.1,iOS 17.1,tvOS 17.1,watchOS 10.1, *) {
             let behavior = behavior as! SwiftUI.SearchPresentationToolbarBehavior
@@ -9173,7 +9173,7 @@ self.__3_isPresented = isPresented
     }
     #endif
     #if os(iOS) || os(macOS)
-    @available(iOS 17.0,macOS 14.0, *)
+    @available(macOS 14.0,iOS 17.0, *)
     init(text: ChangeTracked<Swift.String>,isPresented: ChangeTracked<Swift.Bool>,placement: SwiftUI.SearchFieldPlacement = .automatic, prompt: SwiftUI.LocalizedStringKey) {
         self.value = ._4(placement: placement, prompt: prompt)
         self.__4_text = text
@@ -9228,7 +9228,7 @@ let prompt = prompt as? TextReference
         #endif
         #if os(iOS) || os(macOS)
         case let ._4(placement, prompt):
-            if #available(iOS 17.0,macOS 14.0, *) {
+            if #available(macOS 14.0,iOS 17.0, *) {
             let placement = placement as! SwiftUI.SearchFieldPlacement 
 let prompt = prompt as! SwiftUI.LocalizedStringKey
             __content
@@ -9253,7 +9253,7 @@ struct _selectionDisabledModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
         case _0(isDisabled: Any)
         #endif
     }
@@ -9266,8 +9266,8 @@ struct _selectionDisabledModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
-    @available(iOS 17.0,macOS 14.0,watchOS 10.0,tvOS 17.0, *)
+    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+    @available(tvOS 17.0,macOS 14.0,watchOS 10.0,iOS 17.0, *)
     init(_ isDisabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(isDisabled: isDisabled)
         
@@ -9278,9 +9278,9 @@ struct _selectionDisabledModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
         case let ._0(isDisabled):
-            if #available(iOS 17.0,macOS 14.0,watchOS 10.0,tvOS 17.0, *) {
+            if #available(tvOS 17.0,macOS 14.0,watchOS 10.0,iOS 17.0, *) {
             let isDisabled = isDisabled as! AttributeReference<Swift.Bool>
             __content
                 .selectionDisabled(isDisabled.resolve(on: element, in: context))
@@ -9758,7 +9758,7 @@ struct _swipeActionsModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(watchOS) || os(macOS)
+        #if os(iOS) || os(macOS) || os(watchOS)
         case _0(edge: Any, allowsFullSwipe: Any, content: Any)
         #endif
     }
@@ -9771,8 +9771,8 @@ struct _swipeActionsModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(watchOS) || os(macOS)
-    @available(iOS 15.0,watchOS 8.0,macOS 12.0, *)
+    #if os(iOS) || os(macOS) || os(watchOS)
+    @available(iOS 15.0,macOS 12.0,watchOS 8.0, *)
     init(edge: SwiftUI.HorizontalEdge = .trailing, allowsFullSwipe: AttributeReference<Swift.Bool> = .init(storage: .constant(true)), content: ViewReference=ViewReference(value: [])) {
         self.value = ._0(edge: edge, allowsFullSwipe: allowsFullSwipe, content: content)
         
@@ -9783,9 +9783,9 @@ struct _swipeActionsModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(watchOS) || os(macOS)
+        #if os(iOS) || os(macOS) || os(watchOS)
         case let ._0(edge, allowsFullSwipe, content):
-            if #available(iOS 15.0,watchOS 8.0,macOS 12.0, *) {
+            if #available(iOS 15.0,macOS 12.0,watchOS 8.0, *) {
             let edge = edge as! SwiftUI.HorizontalEdge 
 let allowsFullSwipe = allowsFullSwipe as! AttributeReference<Swift.Bool>
 let content = content as! ViewReference
@@ -9802,7 +9802,7 @@ struct _symbolEffectsRemovedModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
         case _0(isEnabled: Any)
         #endif
     }
@@ -9815,8 +9815,8 @@ struct _symbolEffectsRemovedModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
-    @available(iOS 17.0,macOS 14.0,watchOS 10.0,tvOS 17.0, *)
+    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+    @available(tvOS 17.0,macOS 14.0,watchOS 10.0,iOS 17.0, *)
     init(_ isEnabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(isEnabled: isEnabled)
         
@@ -9827,9 +9827,9 @@ struct _symbolEffectsRemovedModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
         case let ._0(isEnabled):
-            if #available(iOS 17.0,macOS 14.0,watchOS 10.0,tvOS 17.0, *) {
+            if #available(tvOS 17.0,macOS 14.0,watchOS 10.0,iOS 17.0, *) {
             let isEnabled = isEnabled as! AttributeReference<Swift.Bool>
             __content
                 .symbolEffectsRemoved(isEnabled.resolve(on: element, in: context))
@@ -10012,7 +10012,7 @@ struct _tableStyleModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS)
         case _0(style: Any)
         #endif
     }
@@ -10025,8 +10025,8 @@ struct _tableStyleModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(macOS) || os(iOS)
-    @available(macOS 12.0,iOS 16.0, *)
+    #if os(iOS) || os(macOS)
+    @available(iOS 16.0,macOS 12.0, *)
     init(_ style: AnyTableStyle) {
         self.value = ._0(style: style)
         
@@ -10037,9 +10037,9 @@ struct _tableStyleModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS)
         case let ._0(style):
-            if #available(macOS 12.0,iOS 16.0, *) {
+            if #available(iOS 16.0,macOS 12.0, *) {
             let style = style as! AnyTableStyle
             __content
                 .tableStyle(style)
@@ -10096,7 +10096,7 @@ struct _textContentTypeModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(tvOS) || os(iOS)
+        #if os(iOS) || os(tvOS)
         case _0(textContentType: Any?)
         #endif
     }
@@ -10109,7 +10109,7 @@ struct _textContentTypeModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(tvOS) || os(iOS)
+    #if os(iOS) || os(tvOS)
     @available(tvOS 13.0,iOS 13.0, *)
     init(_ textContentType: UIKit.UITextContentType?) {
         self.value = ._0(textContentType: textContentType)
@@ -10121,7 +10121,7 @@ struct _textContentTypeModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(tvOS) || os(iOS)
+        #if os(iOS) || os(tvOS)
         case let ._0(textContentType):
             if #available(tvOS 13.0,iOS 13.0, *) {
             let textContentType = textContentType as? UIKit.UITextContentType
@@ -10236,7 +10236,7 @@ struct _textInputAutocapitalizationModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(tvOS) || os(watchOS)
-    @available(iOS 15.0,tvOS 15.0,watchOS 8.0, *)
+    @available(watchOS 8.0,iOS 15.0,tvOS 15.0, *)
     init(_ autocapitalization: SwiftUI.TextInputAutocapitalization?) {
         self.value = ._0(autocapitalization: autocapitalization)
         
@@ -10249,7 +10249,7 @@ struct _textInputAutocapitalizationModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(tvOS) || os(watchOS)
         case let ._0(autocapitalization):
-            if #available(iOS 15.0,tvOS 15.0,watchOS 8.0, *) {
+            if #available(watchOS 8.0,iOS 15.0,tvOS 15.0, *) {
             let autocapitalization = autocapitalization as? SwiftUI.TextInputAutocapitalization
             __content
                 .textInputAutocapitalization(autocapitalization)
@@ -10264,7 +10264,7 @@ struct _textScaleModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
         case _0(scale: Any,isEnabled: Any)
         #endif
     }
@@ -10277,8 +10277,8 @@ struct _textScaleModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
-    @available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0, *)
+    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+    @available(macOS 14.0,watchOS 10.0,tvOS 17.0,iOS 17.0, *)
     init(_ scale: SwiftUI.Text.Scale,isEnabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(scale: scale, isEnabled: isEnabled)
         
@@ -10289,9 +10289,9 @@ struct _textScaleModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
         case let ._0(scale, isEnabled):
-            if #available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0, *) {
+            if #available(macOS 14.0,watchOS 10.0,tvOS 17.0,iOS 17.0, *) {
             let scale = scale as! SwiftUI.Text.Scale
 let isEnabled = isEnabled as! AttributeReference<Swift.Bool>
             __content
@@ -10307,7 +10307,7 @@ struct _textSelectionModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS)
         case _0(selectability: Any)
         #endif
     }
@@ -10320,8 +10320,8 @@ struct _textSelectionModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(macOS) || os(iOS)
-    @available(macOS 12.0,iOS 15.0, *)
+    #if os(iOS) || os(macOS)
+    @available(iOS 15.0,macOS 12.0, *)
     init(_ selectability: AnyTextSelectability) {
         self.value = ._0(selectability: selectability)
         
@@ -10332,9 +10332,9 @@ struct _textSelectionModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS)
         case let ._0(selectability):
-            if #available(macOS 12.0,iOS 15.0, *) {
+            if #available(iOS 15.0,macOS 12.0, *) {
             let selectability = selectability as! AnyTextSelectability
             __content
                 .textSelection(selectability)
@@ -10456,7 +10456,7 @@ struct _toolbarModifier<R: RootRegistry>: ViewModifier {
         
         case _0(visibility: AttributeReference<SwiftUI.Visibility>,bars: SwiftUI.ToolbarPlacement)
         
-        #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
         case _1(defaultItemKind: Any?)
         #endif
         
@@ -10488,8 +10488,8 @@ struct _toolbarModifier<R: RootRegistry>: ViewModifier {
         
     }
     
-    #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
-    @available(macOS 14.0,iOS 17.0,watchOS 10.0,tvOS 17.0, *)
+    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+    @available(tvOS 17.0,macOS 14.0,watchOS 10.0,iOS 17.0, *)
     init(removing defaultItemKind: SwiftUI.ToolbarDefaultItemKind?) {
         self.value = ._1(defaultItemKind: defaultItemKind)
         
@@ -10522,9 +10522,9 @@ struct _toolbarModifier<R: RootRegistry>: ViewModifier {
                 .toolbar(visibility.resolve(on: element, in: context), for: bars)
             
         
-        #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
         case let ._1(defaultItemKind):
-            if #available(macOS 14.0,iOS 17.0,watchOS 10.0,tvOS 17.0, *) {
+            if #available(tvOS 17.0,macOS 14.0,watchOS 10.0,iOS 17.0, *) {
             let defaultItemKind = defaultItemKind as? SwiftUI.ToolbarDefaultItemKind
             __content
                 .toolbar(removing: defaultItemKind)
@@ -10701,7 +10701,7 @@ struct _toolbarTitleDisplayModeModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
         case _0(mode: Any)
         #endif
     }
@@ -10714,8 +10714,8 @@ struct _toolbarTitleDisplayModeModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
-    @available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0, *)
+    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+    @available(macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0, *)
     init(_ mode: SwiftUI.ToolbarTitleDisplayMode) {
         self.value = ._0(mode: mode)
         
@@ -10726,9 +10726,9 @@ struct _toolbarTitleDisplayModeModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
         case let ._0(mode):
-            if #available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0, *) {
+            if #available(macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0, *) {
             let mode = mode as! SwiftUI.ToolbarTitleDisplayMode
             __content
                 .toolbarTitleDisplayMode(mode)
@@ -12065,28 +12065,28 @@ case chunk19(_BuiltinModifierChunk19)
 case chunk20(_BuiltinModifierChunk20)
 case chunk21(_BuiltinModifierChunk21)
 case chunk22(_BuiltinModifierChunk22)
-        case _TransformModifier(LiveViewNative._TransformModifier)
-case _IntersectionModifier(LiveViewNative._IntersectionModifier)
+        case _FillModifier(LiveViewNative._FillModifier)
+case _TransformModifier(LiveViewNative._TransformModifier)
 case _SubtractingModifier(LiveViewNative._SubtractingModifier)
-case _Rotation3DEffectModifier(LiveViewNative._Rotation3DEffectModifier<R>)
-case _PresentationDetentsModifier(LiveViewNative._PresentationDetentsModifier)
-case _SymmetricDifferenceModifier(LiveViewNative._SymmetricDifferenceModifier)
 case _OnSubmitModifier(LiveViewNative._OnSubmitModifier)
-case _LineSubtractionModifier(LiveViewNative._LineSubtractionModifier)
-case _PrefersDefaultFocusModifier(LiveViewNative._PrefersDefaultFocusModifier<R>)
-case _SearchScopesModifier(LiveViewNative._SearchScopesModifier<R>)
-case _MatchedGeometryEffectModifier(LiveViewNative._MatchedGeometryEffectModifier<R>)
-case _FillModifier(LiveViewNative._FillModifier)
-case _SearchCompletionModifier(LiveViewNative._SearchCompletionModifier<R>)
-case _LineIntersectionModifier(LiveViewNative._LineIntersectionModifier)
-case _StrokeModifier(LiveViewNative._StrokeModifier<R>)
-case _ScaleModifier(LiveViewNative._ScaleModifier<R>)
-case _RotationModifier(LiveViewNative._RotationModifier)
-case _ResizableModifier(LiveViewNative._ResizableModifier)
 case _UnionModifier(LiveViewNative._UnionModifier)
-case _FocusScopeModifier(LiveViewNative._FocusScopeModifier<R>)
+case _PresentationDetentsModifier(LiveViewNative._PresentationDetentsModifier)
+case _Rotation3DEffectModifier(LiveViewNative._Rotation3DEffectModifier<R>)
+case _SearchCompletionModifier(LiveViewNative._SearchCompletionModifier<R>)
+case _LineSubtractionModifier(LiveViewNative._LineSubtractionModifier)
 case _MaskModifier(LiveViewNative._MaskModifier<R>)
+case _PrefersDefaultFocusModifier(LiveViewNative._PrefersDefaultFocusModifier<R>)
+case _StrokeModifier(LiveViewNative._StrokeModifier<R>)
+case _SymmetricDifferenceModifier(LiveViewNative._SymmetricDifferenceModifier)
+case _LineIntersectionModifier(LiveViewNative._LineIntersectionModifier)
+case _SearchScopesModifier(LiveViewNative._SearchScopesModifier<R>)
+case _IntersectionModifier(LiveViewNative._IntersectionModifier)
 case _RenderingModeModifier(LiveViewNative._RenderingModeModifier)
+case _FocusScopeModifier(LiveViewNative._FocusScopeModifier<R>)
+case _ResizableModifier(LiveViewNative._ResizableModifier)
+case _RotationModifier(LiveViewNative._RotationModifier)
+case _ScaleModifier(LiveViewNative._ScaleModifier<R>)
+case _MatchedGeometryEffectModifier(LiveViewNative._MatchedGeometryEffectModifier<R>)
         case _customRegistryModifier(R.CustomModifier)
         
         func body(content: Content) -> some View {
@@ -12137,49 +12137,49 @@ case let .chunk21(chunk):
     content.modifier(chunk)
 case let .chunk22(chunk):
     content.modifier(chunk)
-            case let ._TransformModifier(modifier):
+            case let ._FillModifier(modifier):
     content.modifier(modifier)
-case let ._IntersectionModifier(modifier):
+case let ._TransformModifier(modifier):
     content.modifier(modifier)
 case let ._SubtractingModifier(modifier):
     content.modifier(modifier)
-case let ._Rotation3DEffectModifier(modifier):
-    content.modifier(modifier)
-case let ._PresentationDetentsModifier(modifier):
-    content.modifier(modifier)
-case let ._SymmetricDifferenceModifier(modifier):
-    content.modifier(modifier)
 case let ._OnSubmitModifier(modifier):
-    content.modifier(modifier)
-case let ._LineSubtractionModifier(modifier):
-    content.modifier(modifier)
-case let ._PrefersDefaultFocusModifier(modifier):
-    content.modifier(modifier)
-case let ._SearchScopesModifier(modifier):
-    content.modifier(modifier)
-case let ._MatchedGeometryEffectModifier(modifier):
-    content.modifier(modifier)
-case let ._FillModifier(modifier):
-    content.modifier(modifier)
-case let ._SearchCompletionModifier(modifier):
-    content.modifier(modifier)
-case let ._LineIntersectionModifier(modifier):
-    content.modifier(modifier)
-case let ._StrokeModifier(modifier):
-    content.modifier(modifier)
-case let ._ScaleModifier(modifier):
-    content.modifier(modifier)
-case let ._RotationModifier(modifier):
-    content.modifier(modifier)
-case let ._ResizableModifier(modifier):
     content.modifier(modifier)
 case let ._UnionModifier(modifier):
     content.modifier(modifier)
-case let ._FocusScopeModifier(modifier):
+case let ._PresentationDetentsModifier(modifier):
+    content.modifier(modifier)
+case let ._Rotation3DEffectModifier(modifier):
+    content.modifier(modifier)
+case let ._SearchCompletionModifier(modifier):
+    content.modifier(modifier)
+case let ._LineSubtractionModifier(modifier):
     content.modifier(modifier)
 case let ._MaskModifier(modifier):
     content.modifier(modifier)
+case let ._PrefersDefaultFocusModifier(modifier):
+    content.modifier(modifier)
+case let ._StrokeModifier(modifier):
+    content.modifier(modifier)
+case let ._SymmetricDifferenceModifier(modifier):
+    content.modifier(modifier)
+case let ._LineIntersectionModifier(modifier):
+    content.modifier(modifier)
+case let ._SearchScopesModifier(modifier):
+    content.modifier(modifier)
+case let ._IntersectionModifier(modifier):
+    content.modifier(modifier)
 case let ._RenderingModeModifier(modifier):
+    content.modifier(modifier)
+case let ._FocusScopeModifier(modifier):
+    content.modifier(modifier)
+case let ._ResizableModifier(modifier):
+    content.modifier(modifier)
+case let ._RotationModifier(modifier):
+    content.modifier(modifier)
+case let ._ScaleModifier(modifier):
+    content.modifier(modifier)
+case let ._MatchedGeometryEffectModifier(modifier):
     content.modifier(modifier)
             case let ._customRegistryModifier(modifier):
                 content.modifier(modifier)
@@ -12423,28 +12423,28 @@ _truncationModeModifier<R>.name: _truncationModeModifier<R>.parser(in: context).
 _underlineModifier<R>.name: _underlineModifier<R>.parser(in: context).map({ Output.chunk22(.underline($0)) }).eraseToAnyParser(),
 _unredactedModifier<R>.name: _unredactedModifier<R>.parser(in: context).map({ Output.chunk22(.unredacted($0)) }).eraseToAnyParser(),
 _zIndexModifier<R>.name: _zIndexModifier<R>.parser(in: context).map({ Output.chunk22(.zIndex($0)) }).eraseToAnyParser(),
-                    LiveViewNative._TransformModifier.name: LiveViewNative._TransformModifier.parser(in: context).map(Output._TransformModifier).eraseToAnyParser(),
-LiveViewNative._IntersectionModifier.name: LiveViewNative._IntersectionModifier.parser(in: context).map(Output._IntersectionModifier).eraseToAnyParser(),
+                    LiveViewNative._FillModifier.name: LiveViewNative._FillModifier.parser(in: context).map(Output._FillModifier).eraseToAnyParser(),
+LiveViewNative._TransformModifier.name: LiveViewNative._TransformModifier.parser(in: context).map(Output._TransformModifier).eraseToAnyParser(),
 LiveViewNative._SubtractingModifier.name: LiveViewNative._SubtractingModifier.parser(in: context).map(Output._SubtractingModifier).eraseToAnyParser(),
-LiveViewNative._Rotation3DEffectModifier<R>.name: LiveViewNative._Rotation3DEffectModifier<R>.parser(in: context).map(Output._Rotation3DEffectModifier).eraseToAnyParser(),
-LiveViewNative._PresentationDetentsModifier.name: LiveViewNative._PresentationDetentsModifier.parser(in: context).map(Output._PresentationDetentsModifier).eraseToAnyParser(),
-LiveViewNative._SymmetricDifferenceModifier.name: LiveViewNative._SymmetricDifferenceModifier.parser(in: context).map(Output._SymmetricDifferenceModifier).eraseToAnyParser(),
 LiveViewNative._OnSubmitModifier.name: LiveViewNative._OnSubmitModifier.parser(in: context).map(Output._OnSubmitModifier).eraseToAnyParser(),
-LiveViewNative._LineSubtractionModifier.name: LiveViewNative._LineSubtractionModifier.parser(in: context).map(Output._LineSubtractionModifier).eraseToAnyParser(),
-LiveViewNative._PrefersDefaultFocusModifier<R>.name: LiveViewNative._PrefersDefaultFocusModifier<R>.parser(in: context).map(Output._PrefersDefaultFocusModifier).eraseToAnyParser(),
-LiveViewNative._SearchScopesModifier<R>.name: LiveViewNative._SearchScopesModifier<R>.parser(in: context).map(Output._SearchScopesModifier).eraseToAnyParser(),
-LiveViewNative._MatchedGeometryEffectModifier<R>.name: LiveViewNative._MatchedGeometryEffectModifier<R>.parser(in: context).map(Output._MatchedGeometryEffectModifier).eraseToAnyParser(),
-LiveViewNative._FillModifier.name: LiveViewNative._FillModifier.parser(in: context).map(Output._FillModifier).eraseToAnyParser(),
-LiveViewNative._SearchCompletionModifier<R>.name: LiveViewNative._SearchCompletionModifier<R>.parser(in: context).map(Output._SearchCompletionModifier).eraseToAnyParser(),
-LiveViewNative._LineIntersectionModifier.name: LiveViewNative._LineIntersectionModifier.parser(in: context).map(Output._LineIntersectionModifier).eraseToAnyParser(),
-LiveViewNative._StrokeModifier<R>.name: LiveViewNative._StrokeModifier<R>.parser(in: context).map(Output._StrokeModifier).eraseToAnyParser(),
-LiveViewNative._ScaleModifier<R>.name: LiveViewNative._ScaleModifier<R>.parser(in: context).map(Output._ScaleModifier).eraseToAnyParser(),
-LiveViewNative._RotationModifier.name: LiveViewNative._RotationModifier.parser(in: context).map(Output._RotationModifier).eraseToAnyParser(),
-LiveViewNative._ResizableModifier.name: LiveViewNative._ResizableModifier.parser(in: context).map(Output._ResizableModifier).eraseToAnyParser(),
 LiveViewNative._UnionModifier.name: LiveViewNative._UnionModifier.parser(in: context).map(Output._UnionModifier).eraseToAnyParser(),
-LiveViewNative._FocusScopeModifier<R>.name: LiveViewNative._FocusScopeModifier<R>.parser(in: context).map(Output._FocusScopeModifier).eraseToAnyParser(),
+LiveViewNative._PresentationDetentsModifier.name: LiveViewNative._PresentationDetentsModifier.parser(in: context).map(Output._PresentationDetentsModifier).eraseToAnyParser(),
+LiveViewNative._Rotation3DEffectModifier<R>.name: LiveViewNative._Rotation3DEffectModifier<R>.parser(in: context).map(Output._Rotation3DEffectModifier).eraseToAnyParser(),
+LiveViewNative._SearchCompletionModifier<R>.name: LiveViewNative._SearchCompletionModifier<R>.parser(in: context).map(Output._SearchCompletionModifier).eraseToAnyParser(),
+LiveViewNative._LineSubtractionModifier.name: LiveViewNative._LineSubtractionModifier.parser(in: context).map(Output._LineSubtractionModifier).eraseToAnyParser(),
 LiveViewNative._MaskModifier<R>.name: LiveViewNative._MaskModifier<R>.parser(in: context).map(Output._MaskModifier).eraseToAnyParser(),
+LiveViewNative._PrefersDefaultFocusModifier<R>.name: LiveViewNative._PrefersDefaultFocusModifier<R>.parser(in: context).map(Output._PrefersDefaultFocusModifier).eraseToAnyParser(),
+LiveViewNative._StrokeModifier<R>.name: LiveViewNative._StrokeModifier<R>.parser(in: context).map(Output._StrokeModifier).eraseToAnyParser(),
+LiveViewNative._SymmetricDifferenceModifier.name: LiveViewNative._SymmetricDifferenceModifier.parser(in: context).map(Output._SymmetricDifferenceModifier).eraseToAnyParser(),
+LiveViewNative._LineIntersectionModifier.name: LiveViewNative._LineIntersectionModifier.parser(in: context).map(Output._LineIntersectionModifier).eraseToAnyParser(),
+LiveViewNative._SearchScopesModifier<R>.name: LiveViewNative._SearchScopesModifier<R>.parser(in: context).map(Output._SearchScopesModifier).eraseToAnyParser(),
+LiveViewNative._IntersectionModifier.name: LiveViewNative._IntersectionModifier.parser(in: context).map(Output._IntersectionModifier).eraseToAnyParser(),
 LiveViewNative._RenderingModeModifier.name: LiveViewNative._RenderingModeModifier.parser(in: context).map(Output._RenderingModeModifier).eraseToAnyParser(),
+LiveViewNative._FocusScopeModifier<R>.name: LiveViewNative._FocusScopeModifier<R>.parser(in: context).map(Output._FocusScopeModifier).eraseToAnyParser(),
+LiveViewNative._ResizableModifier.name: LiveViewNative._ResizableModifier.parser(in: context).map(Output._ResizableModifier).eraseToAnyParser(),
+LiveViewNative._RotationModifier.name: LiveViewNative._RotationModifier.parser(in: context).map(Output._RotationModifier).eraseToAnyParser(),
+LiveViewNative._ScaleModifier<R>.name: LiveViewNative._ScaleModifier<R>.parser(in: context).map(Output._ScaleModifier).eraseToAnyParser(),
+LiveViewNative._MatchedGeometryEffectModifier<R>.name: LiveViewNative._MatchedGeometryEffectModifier<R>.parser(in: context).map(Output._MatchedGeometryEffectModifier).eraseToAnyParser(),
                 ]
 
                 let deprecations = [
@@ -12905,14 +12905,14 @@ ConstantAtomLiteral("plusLighter").map({ () -> Self in
     }
 }
 
-#if os(tvOS) || os(iOS) || os(macOS) || os(watchOS)
-@available(tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0, *)
+#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+@available(macOS 14.0,tvOS 17.0,iOS 17.0,watchOS 10.0, *)
 extension ButtonRepeatBehavior: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             ConstantAtomLiteral("automatic").map({ () -> Self in
-#if os(tvOS) || os(iOS) || os(macOS) || os(watchOS)
+#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
 
     return Self.automatic
 
@@ -12921,7 +12921,7 @@ fatalError("'automatic' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("enabled").map({ () -> Self in
-#if os(tvOS) || os(iOS) || os(macOS) || os(watchOS)
+#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
 
     return Self.enabled
 
@@ -12930,7 +12930,7 @@ fatalError("'enabled' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("disabled").map({ () -> Self in
-#if os(tvOS) || os(iOS) || os(macOS) || os(watchOS)
+#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
 
     return Self.disabled
 
@@ -13010,8 +13010,8 @@ ConstantAtomLiteral("dark").map({ () -> Self in
     }
 }
 
-#if os(macOS) || os(tvOS) || os(watchOS) || os(iOS)
-@available(macOS 14.0,tvOS 17.0,watchOS 10.0,iOS 17.0, *)
+#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+@available(iOS 17.0,tvOS 17.0,macOS 14.0,watchOS 10.0, *)
 extension ContainerBackgroundPlacement: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -13039,14 +13039,14 @@ fatalError("'navigation' is not available on this OS")
     }
 }
 #endif
-#if os(macOS) || os(watchOS) || os(tvOS) || os(iOS)
-@available(macOS 14.0,watchOS 10.0,tvOS 17.0,iOS 17.0, *)
+#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+@available(watchOS 10.0,tvOS 17.0,iOS 17.0,macOS 14.0, *)
 extension ContentMarginPlacement: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             ConstantAtomLiteral("automatic").map({ () -> Self in
-#if os(macOS) || os(watchOS) || os(tvOS) || os(iOS)
+#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
 
     return Self.automatic
 
@@ -13055,7 +13055,7 @@ fatalError("'automatic' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("scrollContent").map({ () -> Self in
-#if os(macOS) || os(watchOS) || os(tvOS) || os(iOS)
+#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
 
     return Self.scrollContent
 
@@ -13064,7 +13064,7 @@ fatalError("'scrollContent' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("scrollIndicators").map({ () -> Self in
-#if os(macOS) || os(watchOS) || os(tvOS) || os(iOS)
+#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
 
     return Self.scrollIndicators
 
@@ -13093,8 +13093,8 @@ extension ContentShapeKinds: ParseableModifierValue {
 
 })
 ConstantAtomLiteral("dragPreview").map({ () -> Self in
-#if os(macOS) || os(iOS)
-if #available(tvOS 15.0,macOS 12.0,watchOS 8.0,iOS 15.0, *) {
+#if os(iOS) || os(macOS)
+if #available(iOS 15.0,tvOS 15.0,macOS 12.0,watchOS 8.0, *) {
     return Self.dragPreview
 } else { fatalError("'dragPreview' is not available in this OS version") }
 #else
@@ -13102,8 +13102,8 @@ fatalError("'dragPreview' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("contextMenuPreview").map({ () -> Self in
-#if os(tvOS) || os(iOS)
-if #available(tvOS 17.0,macOS 12.0,watchOS 8.0,iOS 15.0, *) {
+#if os(iOS) || os(tvOS)
+if #available(iOS 15.0,tvOS 17.0,macOS 12.0,watchOS 8.0, *) {
     return Self.contextMenuPreview
 } else { fatalError("'contextMenuPreview' is not available in this OS version") }
 #else
@@ -13112,7 +13112,7 @@ fatalError("'contextMenuPreview' is not available on this OS")
 })
 ConstantAtomLiteral("hoverEffect").map({ () -> Self in
 #if os(iOS)
-if #available(tvOS 15.0,macOS 12.0,watchOS 8.0,iOS 15.0, *) {
+if #available(iOS 15.0,tvOS 15.0,macOS 12.0,watchOS 8.0, *) {
     return Self.hoverEffect
 } else { fatalError("'hoverEffect' is not available in this OS version") }
 #else
@@ -13121,7 +13121,7 @@ fatalError("'hoverEffect' is not available on this OS")
 })
 ConstantAtomLiteral("focusEffect").map({ () -> Self in
 #if os(macOS) || os(watchOS)
-if #available(tvOS 15.0,macOS 12.0,watchOS 8.0,iOS 15.0, *) {
+if #available(iOS 15.0,tvOS 15.0,macOS 12.0,watchOS 8.0, *) {
     return Self.focusEffect
 } else { fatalError("'focusEffect' is not available in this OS version") }
 #else
@@ -13129,8 +13129,8 @@ fatalError("'focusEffect' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("accessibility").map({ () -> Self in
-#if os(watchOS) || os(tvOS) || os(macOS) || os(iOS)
-if #available(watchOS 10.0,tvOS 17.0,macOS 14.0,iOS 17.0, *) {
+#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+if #available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0, *) {
     return Self.accessibility
 } else { fatalError("'accessibility' is not available in this OS version") }
 #else
@@ -13142,14 +13142,14 @@ fatalError("'accessibility' is not available on this OS")
     }
 }
 
-#if os(watchOS) || os(iOS) || os(macOS)
-@available(watchOS 9.0,iOS 15.0,macOS 10.15, *)
+#if os(iOS) || os(macOS) || os(watchOS)
+@available(iOS 15.0,macOS 10.15,watchOS 9.0, *)
 extension ControlSize: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             ConstantAtomLiteral("mini").map({ () -> Self in
-#if os(watchOS) || os(iOS) || os(macOS)
+#if os(iOS) || os(macOS) || os(watchOS)
 
     return Self.mini
 
@@ -13158,7 +13158,7 @@ fatalError("'mini' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("small").map({ () -> Self in
-#if os(watchOS) || os(iOS) || os(macOS)
+#if os(iOS) || os(macOS) || os(watchOS)
 
     return Self.small
 
@@ -13167,7 +13167,7 @@ fatalError("'small' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("regular").map({ () -> Self in
-#if os(watchOS) || os(iOS) || os(macOS)
+#if os(iOS) || os(macOS) || os(watchOS)
 
     return Self.regular
 
@@ -13176,8 +13176,8 @@ fatalError("'regular' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("large").map({ () -> Self in
-#if os(watchOS) || os(iOS) || os(macOS)
-if #available(watchOS 9.0,iOS 15.0,macOS 11.0, *) {
+#if os(iOS) || os(macOS) || os(watchOS)
+if #available(iOS 15.0,macOS 11.0,watchOS 9.0, *) {
     return Self.large
 } else { fatalError("'large' is not available in this OS version") }
 #else
@@ -13185,8 +13185,8 @@ fatalError("'large' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("extraLarge").map({ () -> Self in
-#if os(watchOS) || os(macOS) || os(visionOS) || os(iOS)
-if #available(watchOS 10.0,macOS 14.0,visionOS 1.0,iOS 17.0, *) {
+#if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
+if #available(iOS 17.0,macOS 14.0,visionOS 1.0,watchOS 10.0, *) {
     return Self.extraLarge
 } else { fatalError("'extraLarge' is not available in this OS version") }
 #else
@@ -13227,14 +13227,14 @@ ConstantAtomLiteral("userInitiated").map({ () -> Self in
     }
 }
 
-#if os(watchOS) || os(tvOS) || os(macOS) || os(iOS)
-@available(watchOS 10.0,tvOS 17.0,macOS 13.0,iOS 17.0, *)
+#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+@available(iOS 17.0,watchOS 10.0,macOS 13.0,tvOS 17.0, *)
 extension DialogSeverity: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             ConstantAtomLiteral("automatic").map({ () -> Self in
-#if os(watchOS) || os(tvOS) || os(macOS) || os(iOS)
+#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
 
     return Self.automatic
 
@@ -13243,7 +13243,7 @@ fatalError("'automatic' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("critical").map({ () -> Self in
-#if os(watchOS) || os(tvOS) || os(macOS) || os(iOS)
+#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
 
     return Self.critical
 
@@ -13252,8 +13252,8 @@ fatalError("'critical' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("standard").map({ () -> Self in
-#if os(watchOS) || os(tvOS) || os(macOS) || os(iOS)
-if #available(watchOS 10.0,tvOS 17.0,macOS 14.0,iOS 17.0, *) {
+#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+if #available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0, *) {
     return Self.standard
 } else { fatalError("'standard' is not available in this OS version") }
 #else
@@ -13424,14 +13424,14 @@ fatalError("'displayFileExtensions' is not available on this OS")
     }
 }
 #endif
-#if os(tvOS) || os(iOS) || os(macOS) || os(watchOS)
-@available(tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0, *)
+#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+@available(macOS 14.0,tvOS 17.0,iOS 17.0,watchOS 10.0, *)
 extension FocusInteractions: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             ConstantAtomLiteral("activate").map({ () -> Self in
-#if os(tvOS) || os(iOS) || os(macOS) || os(watchOS)
+#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
 
     return Self.activate
 
@@ -13440,7 +13440,7 @@ fatalError("'activate' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("edit").map({ () -> Self in
-#if os(tvOS) || os(iOS) || os(macOS) || os(watchOS)
+#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
 
     return Self.edit
 
@@ -13449,7 +13449,7 @@ fatalError("'edit' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("automatic").map({ () -> Self in
-#if os(tvOS) || os(iOS) || os(macOS) || os(watchOS)
+#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
 
     return Self.automatic
 
@@ -13716,7 +13716,7 @@ extension MenuOrder: ParseableModifierValue {
 })
 ConstantAtomLiteral("priority").map({ () -> Self in
 #if os(iOS)
-if #available(tvOS 16.0,watchOS 9.0,macOS 13.0,iOS 16.0, *) {
+if #available(tvOS 16.0,macOS 13.0,watchOS 9.0,iOS 16.0, *) {
     return Self.priority
 } else { fatalError("'priority' is not available in this OS version") }
 #else
@@ -13737,14 +13737,14 @@ ConstantAtomLiteral("fixed").map({ () -> Self in
     }
 }
 
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
-@available(macOS 13.3,iOS 16.4,watchOS 9.4,tvOS 16.4, *)
+#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+@available(macOS 13.3,tvOS 16.4,iOS 16.4,watchOS 9.4, *)
 extension PresentationAdaptation: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             ConstantAtomLiteral("automatic").map({ () -> Self in
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
 
     return Self.automatic
 
@@ -13753,7 +13753,7 @@ fatalError("'automatic' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("none").map({ () -> Self in
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
 
     return Self.none
 
@@ -13762,7 +13762,7 @@ fatalError("'none' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("popover").map({ () -> Self in
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
 
     return Self.popover
 
@@ -13771,7 +13771,7 @@ fatalError("'popover' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("sheet").map({ () -> Self in
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
 
     return Self.sheet
 
@@ -13780,7 +13780,7 @@ fatalError("'sheet' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("fullScreenCover").map({ () -> Self in
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
 
     return Self.fullScreenCover
 
@@ -13793,14 +13793,14 @@ fatalError("'fullScreenCover' is not available on this OS")
     }
 }
 #endif
-#if os(tvOS) || os(iOS) || os(macOS) || os(watchOS)
-@available(tvOS 16.4,iOS 16.4,macOS 13.3,watchOS 9.4, *)
+#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+@available(macOS 13.3,tvOS 16.4,iOS 16.4,watchOS 9.4, *)
 extension PresentationContentInteraction: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             ConstantAtomLiteral("automatic").map({ () -> Self in
-#if os(tvOS) || os(iOS) || os(macOS) || os(watchOS)
+#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
 
     return Self.automatic
 
@@ -13809,7 +13809,7 @@ fatalError("'automatic' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("resizes").map({ () -> Self in
-#if os(tvOS) || os(iOS) || os(macOS) || os(watchOS)
+#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
 
     return Self.resizes
 
@@ -13818,7 +13818,7 @@ fatalError("'resizes' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("scrolls").map({ () -> Self in
-#if os(tvOS) || os(iOS) || os(macOS) || os(watchOS)
+#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
 
     return Self.scrolls
 
@@ -13885,8 +13885,8 @@ ConstantAtomLiteral("privacy").map({ () -> Self in
 
 })
 ConstantAtomLiteral("invalidated").map({ () -> Self in
-#if os(iOS) || os(tvOS) || os(macOS) || os(watchOS)
-if #available(iOS 17.0,tvOS 17.0,macOS 14.0,watchOS 10.0, *) {
+#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+if #available(tvOS 17.0,iOS 17.0,watchOS 10.0,macOS 14.0, *) {
     return Self.invalidated
 } else { fatalError("'invalidated' is not available in this OS version") }
 #else
@@ -13982,7 +13982,7 @@ extension ScenePadding: ParseableModifierValue {
 })
 ConstantAtomLiteral("navigationBar").map({ () -> Self in
 #if os(watchOS)
-if #available(macOS 13.0,watchOS 9.0,tvOS 16.0,iOS 16.0, *) {
+if #available(watchOS 9.0,tvOS 16.0,iOS 16.0,macOS 13.0, *) {
     return Self.navigationBar
 } else { fatalError("'navigationBar' is not available in this OS version") }
 #else
@@ -13994,14 +13994,14 @@ fatalError("'navigationBar' is not available on this OS")
     }
 }
 
-#if os(tvOS) || os(macOS) || os(watchOS) || os(iOS)
-@available(tvOS 16.4,macOS 13.3,watchOS 9.4,iOS 16.4, *)
+#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+@available(iOS 16.4,tvOS 16.4,macOS 13.3,watchOS 9.4, *)
 extension ScrollBounceBehavior: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             ConstantAtomLiteral("automatic").map({ () -> Self in
-#if os(tvOS) || os(macOS) || os(watchOS) || os(iOS)
+#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
 
     return Self.automatic
 
@@ -14010,7 +14010,7 @@ fatalError("'automatic' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("always").map({ () -> Self in
-#if os(tvOS) || os(macOS) || os(watchOS) || os(iOS)
+#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
 
     return Self.always
 
@@ -14019,7 +14019,7 @@ fatalError("'always' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("basedOnSize").map({ () -> Self in
-#if os(tvOS) || os(macOS) || os(watchOS) || os(iOS)
+#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
 
     return Self.basedOnSize
 
@@ -14032,8 +14032,8 @@ fatalError("'basedOnSize' is not available on this OS")
     }
 }
 #endif
-#if os(tvOS) || os(macOS) || os(watchOS) || os(iOS)
-@available(tvOS 16.0,macOS 13.0,watchOS 9.0,iOS 16.0, *)
+#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+@available(iOS 16.0,tvOS 16.0,macOS 13.0,watchOS 9.0, *)
 extension ScrollDismissesKeyboardMode: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -14127,7 +14127,7 @@ ConstantAtomLiteral("never").map({ () -> Self in
 }
 
 #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-@available(iOS 16.4,macOS 13.3,tvOS 16.4,watchOS 9.4, *)
+@available(tvOS 16.4,iOS 16.4,watchOS 9.4,macOS 13.3, *)
 extension SearchScopeActivation: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -14202,14 +14202,14 @@ ConstantAtomLiteral("content").map({ () -> Self in
     }
 }
 
-#if os(tvOS) || os(macOS) || os(watchOS) || os(iOS)
+#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
 @available(tvOS 17.0,macOS 14.0,watchOS 10.0,iOS 17.0, *)
 extension SpringLoadingBehavior: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             ConstantAtomLiteral("automatic").map({ () -> Self in
-#if os(tvOS) || os(macOS) || os(watchOS) || os(iOS)
+#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
 
     return Self.automatic
 
@@ -14218,7 +14218,7 @@ fatalError("'automatic' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("enabled").map({ () -> Self in
-#if os(tvOS) || os(macOS) || os(watchOS) || os(iOS)
+#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
 
     return Self.enabled
 
@@ -14227,7 +14227,7 @@ fatalError("'enabled' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("disabled").map({ () -> Self in
-#if os(tvOS) || os(macOS) || os(watchOS) || os(iOS)
+#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
 
     return Self.disabled
 
@@ -14361,14 +14361,14 @@ ConstantAtomLiteral("search").map({ () -> Self in
     }
 }
 
-#if os(watchOS) || os(tvOS) || os(macOS) || os(iOS)
-@available(watchOS 10.0,tvOS 17.0,macOS 14.0,iOS 17.0, *)
+#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+@available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0, *)
 extension ToolbarDefaultItemKind: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             ConstantAtomLiteral("sidebarToggle").map({ () -> Self in
-#if os(watchOS) || os(tvOS) || os(macOS) || os(iOS)
+#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
 
     return Self.sidebarToggle
 
@@ -14397,8 +14397,8 @@ extension ToolbarRole: ParseableModifierValue {
 
 })
 ConstantAtomLiteral("navigationStack").map({ () -> Self in
-#if os(tvOS) || os(iOS) || os(watchOS)
-if #available(tvOS 16.0,iOS 16.0,macOS 13.0,watchOS 9.0, *) {
+#if os(iOS) || os(tvOS) || os(watchOS)
+if #available(macOS 13.0,tvOS 16.0,iOS 16.0,watchOS 9.0, *) {
     return Self.navigationStack
 } else { fatalError("'navigationStack' is not available in this OS version") }
 #else
@@ -14407,7 +14407,7 @@ fatalError("'navigationStack' is not available on this OS")
 })
 ConstantAtomLiteral("browser").map({ () -> Self in
 #if os(iOS)
-if #available(tvOS 16.0,iOS 16.0,macOS 13.0,watchOS 9.0, *) {
+if #available(macOS 13.0,tvOS 16.0,iOS 16.0,watchOS 9.0, *) {
     return Self.browser
 } else { fatalError("'browser' is not available in this OS version") }
 #else
@@ -14416,7 +14416,7 @@ fatalError("'browser' is not available on this OS")
 })
 ConstantAtomLiteral("editor").map({ () -> Self in
 #if os(iOS) || os(macOS)
-if #available(tvOS 16.0,iOS 16.0,macOS 13.0,watchOS 9.0, *) {
+if #available(macOS 13.0,tvOS 16.0,iOS 16.0,watchOS 9.0, *) {
     return Self.editor
 } else { fatalError("'editor' is not available in this OS version") }
 #else
@@ -14428,14 +14428,14 @@ fatalError("'editor' is not available on this OS")
     }
 }
 
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
-@available(macOS 14.0,iOS 17.0,watchOS 10.0,tvOS 17.0, *)
+#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+@available(macOS 14.0,tvOS 17.0,iOS 17.0,watchOS 10.0, *)
 extension ToolbarTitleDisplayMode: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             ConstantAtomLiteral("automatic").map({ () -> Self in
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
 
     return Self.automatic
 
@@ -14453,7 +14453,7 @@ fatalError("'large' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("inlineLarge").map({ () -> Self in
-#if os(macOS) || os(iOS)
+#if os(iOS) || os(macOS)
 
     return Self.inlineLarge
 
@@ -14462,7 +14462,7 @@ fatalError("'inlineLarge' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("inline").map({ () -> Self in
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
 
     return Self.inline
 

--- a/Sources/LiveViewNative/_GeneratedModifiers.swift
+++ b/Sources/LiveViewNative/_GeneratedModifiers.swift
@@ -886,7 +886,7 @@ struct _badgeModifier<R: RootRegistry>: ViewModifier {
         #if os(macOS) || os(iOS)
         case _2(key: Any?)
         #endif
-        #if os(iOS) || os(macOS)
+        #if os(macOS) || os(iOS)
         case _3(label: Any)
         #endif
     }
@@ -926,8 +926,8 @@ struct _badgeModifier<R: RootRegistry>: ViewModifier {
         
     }
     #endif
-    #if os(iOS) || os(macOS)
-    @available(iOS 15.0,macOS 12.0, *)
+    #if os(macOS) || os(iOS)
+    @available(macOS 12.0,iOS 15.0, *)
     init(_ label: AttributeReference<String>) {
         self.value = ._3(label: label)
         
@@ -962,9 +962,9 @@ struct _badgeModifier<R: RootRegistry>: ViewModifier {
                 .badge(key)
             } else { __content }
         #endif
-        #if os(iOS) || os(macOS)
+        #if os(macOS) || os(iOS)
         case let ._3(label):
-            if #available(iOS 15.0,macOS 12.0, *) {
+            if #available(macOS 12.0,iOS 15.0, *) {
             let label = label as! AttributeReference<String>
             __content
                 .badge(label.resolve(on: element, in: context))
@@ -1687,10 +1687,10 @@ struct _containerRelativeFrameModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(tvOS) || os(watchOS) || os(iOS) || os(macOS)
+        #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
         case _0(axes: Any,alignment: Any)
         #endif
-        #if os(tvOS) || os(watchOS) || os(macOS) || os(iOS)
+        #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
         case _1(axes: Any,count: Any,span: Any, spacing: Any,alignment: Any)
         #endif
     }
@@ -1705,15 +1705,15 @@ struct _containerRelativeFrameModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(tvOS) || os(watchOS) || os(iOS) || os(macOS)
-    @available(tvOS 17.0,watchOS 10.0,iOS 17.0,macOS 14.0, *)
+    #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+    @available(macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0, *)
     init(_ axes: SwiftUI.Axis.Set,alignment: AttributeReference<SwiftUI.Alignment> = .init(storage: .constant(.center)) ) {
         self.value = ._0(axes: axes, alignment: alignment)
         
     }
     #endif
-    #if os(tvOS) || os(watchOS) || os(macOS) || os(iOS)
-    @available(tvOS 17.0,watchOS 10.0,macOS 14.0,iOS 17.0, *)
+    #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+    @available(macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0, *)
     init(_ axes: SwiftUI.Axis.Set,count: AttributeReference<Swift.Int>,span: AttributeReference<Swift.Int> = .init(storage: .constant(1)), spacing: AttributeReference<CoreFoundation.CGFloat>,alignment: AttributeReference<SwiftUI.Alignment> = .init(storage: .constant(.center)) ) {
         self.value = ._1(axes: axes, count: count, span: span, spacing: spacing, alignment: alignment)
         
@@ -1724,18 +1724,18 @@ struct _containerRelativeFrameModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(tvOS) || os(watchOS) || os(iOS) || os(macOS)
+        #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
         case let ._0(axes, alignment):
-            if #available(tvOS 17.0,watchOS 10.0,iOS 17.0,macOS 14.0, *) {
+            if #available(macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0, *) {
             let axes = axes as! SwiftUI.Axis.Set
 let alignment = alignment as! AttributeReference<SwiftUI.Alignment>
             __content
                 .containerRelativeFrame(axes, alignment: alignment.resolve(on: element, in: context))
             } else { __content }
         #endif
-        #if os(tvOS) || os(watchOS) || os(macOS) || os(iOS)
+        #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
         case let ._1(axes, count, span, spacing, alignment):
-            if #available(tvOS 17.0,watchOS 10.0,macOS 14.0,iOS 17.0, *) {
+            if #available(macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0, *) {
             let axes = axes as! SwiftUI.Axis.Set
 let count = count as! AttributeReference<Swift.Int>
 let span = span as! AttributeReference<Swift.Int>
@@ -1900,10 +1900,10 @@ struct _contextMenuModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(macOS) || os(tvOS)
+        #if os(tvOS) || os(iOS) || os(macOS)
         case _0(menuItems: Any)
         #endif
-        #if os(iOS) || os(macOS) || os(tvOS)
+        #if os(tvOS) || os(iOS) || os(macOS)
         case _1(menuItems: Any,preview: Any)
         #endif
     }
@@ -1918,15 +1918,15 @@ struct _contextMenuModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(macOS) || os(tvOS)
-    @available(iOS 13.0,macOS 10.15,tvOS 14.0, *)
+    #if os(tvOS) || os(iOS) || os(macOS)
+    @available(tvOS 14.0,iOS 13.0,macOS 10.15, *)
     init(menuItems: ViewReference=ViewReference(value: [])) {
         self.value = ._0(menuItems: menuItems)
         
     }
     #endif
-    #if os(iOS) || os(macOS) || os(tvOS)
-    @available(iOS 16.0,macOS 13.0,tvOS 16.0, *)
+    #if os(tvOS) || os(iOS) || os(macOS)
+    @available(tvOS 16.0,iOS 16.0,macOS 13.0, *)
     init(menuItems: ViewReference=ViewReference(value: []),preview: ViewReference=ViewReference(value: [])) {
         self.value = ._1(menuItems: menuItems, preview: preview)
         
@@ -1937,17 +1937,17 @@ struct _contextMenuModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(macOS) || os(tvOS)
+        #if os(tvOS) || os(iOS) || os(macOS)
         case let ._0(menuItems):
-            if #available(iOS 13.0,macOS 10.15,tvOS 14.0, *) {
+            if #available(tvOS 14.0,iOS 13.0,macOS 10.15, *) {
             let menuItems = menuItems as! ViewReference
             __content
                 .contextMenu(menuItems: { menuItems.resolve(on: element, in: context) })
             } else { __content }
         #endif
-        #if os(iOS) || os(macOS) || os(tvOS)
+        #if os(tvOS) || os(iOS) || os(macOS)
         case let ._1(menuItems, preview):
-            if #available(iOS 16.0,macOS 13.0,tvOS 16.0, *) {
+            if #available(tvOS 16.0,iOS 16.0,macOS 13.0, *) {
             let menuItems = menuItems as! ViewReference
 let preview = preview as! ViewReference
             __content
@@ -2089,7 +2089,7 @@ struct _coordinateSpaceModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
+        #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
         case _0(name: Any)
         #endif
     }
@@ -2102,8 +2102,8 @@ struct _coordinateSpaceModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
-    @available(tvOS 17.0,iOS 17.0,watchOS 10.0,macOS 14.0, *)
+    #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+    @available(macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0, *)
     init(_ name: SwiftUI.NamedCoordinateSpace) {
         self.value = ._0(name: name)
         
@@ -2114,9 +2114,9 @@ struct _coordinateSpaceModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
+        #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
         case let ._0(name):
-            if #available(tvOS 17.0,iOS 17.0,watchOS 10.0,macOS 14.0, *) {
+            if #available(macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0, *) {
             let name = name as! SwiftUI.NamedCoordinateSpace
             __content
                 .coordinateSpace(name)
@@ -2131,7 +2131,7 @@ struct _datePickerStyleModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(macOS) || os(iOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(watchOS)
         case _0(style: Any)
         #endif
     }
@@ -2144,8 +2144,8 @@ struct _datePickerStyleModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(macOS) || os(iOS) || os(watchOS)
-    @available(macOS 10.15,iOS 13.0,watchOS 10.0, *)
+    #if os(iOS) || os(macOS) || os(watchOS)
+    @available(iOS 13.0,macOS 10.15,watchOS 10.0, *)
     init(_ style: AnyDatePickerStyle) {
         self.value = ._0(style: style)
         
@@ -2156,9 +2156,9 @@ struct _datePickerStyleModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(macOS) || os(iOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(watchOS)
         case let ._0(style):
-            if #available(macOS 10.15,iOS 13.0,watchOS 10.0, *) {
+            if #available(iOS 13.0,macOS 10.15,watchOS 10.0, *) {
             let style = style as! AnyDatePickerStyle
             __content
                 .datePickerStyle(style)
@@ -2173,7 +2173,7 @@ struct _defaultScrollAnchorModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(tvOS) || os(watchOS) || os(macOS) || os(iOS)
+        #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
         case _0(anchor: Any?)
         #endif
     }
@@ -2186,8 +2186,8 @@ struct _defaultScrollAnchorModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(tvOS) || os(watchOS) || os(macOS) || os(iOS)
-    @available(tvOS 17.0,watchOS 10.0,macOS 14.0,iOS 17.0, *)
+    #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+    @available(macOS 14.0,iOS 17.0,watchOS 10.0,tvOS 17.0, *)
     init(_ anchor: AttributeReference<SwiftUI.UnitPoint?>?) {
         self.value = ._0(anchor: anchor)
         
@@ -2198,9 +2198,9 @@ struct _defaultScrollAnchorModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(tvOS) || os(watchOS) || os(macOS) || os(iOS)
+        #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
         case let ._0(anchor):
-            if #available(tvOS 17.0,watchOS 10.0,macOS 14.0,iOS 17.0, *) {
+            if #available(macOS 14.0,iOS 17.0,watchOS 10.0,tvOS 17.0, *) {
             let anchor = anchor as? AttributeReference<SwiftUI.UnitPoint?>
             __content
                 .defaultScrollAnchor(anchor?.resolve(on: element, in: context))
@@ -2341,16 +2341,16 @@ struct _dialogSuppressionToggleModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(tvOS) || os(watchOS) || os(macOS) || os(iOS)
+        #if os(macOS) || os(watchOS) || os(iOS) || os(tvOS)
         case _0(titleKey: Any)
         #endif
-        #if os(tvOS) || os(macOS) || os(watchOS) || os(iOS)
+        #if os(macOS) || os(watchOS) || os(iOS) || os(tvOS)
         case _1(title: Any)
         #endif
-        #if os(tvOS) || os(macOS) || os(watchOS) || os(iOS)
+        #if os(macOS) || os(watchOS) || os(iOS) || os(tvOS)
         case _2(label: Any)
         #endif
-        #if os(tvOS) || os(macOS) || os(watchOS) || os(iOS)
+        #if os(macOS) || os(watchOS) || os(iOS) || os(tvOS)
         case _3
         #endif
     }
@@ -2369,29 +2369,29 @@ struct _dialogSuppressionToggleModifier<R: RootRegistry>: ViewModifier {
 @ChangeTracked private var _3_isSuppressed: Swift.Bool
 
 
-    #if os(tvOS) || os(watchOS) || os(macOS) || os(iOS)
-    @available(tvOS 17.0,watchOS 10.0,macOS 14.0,iOS 17.0, *)
+    #if os(macOS) || os(watchOS) || os(iOS) || os(tvOS)
+    @available(macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0, *)
     init(_ titleKey: SwiftUI.LocalizedStringKey,isSuppressed: ChangeTracked<Swift.Bool>) {
         self.value = ._0(titleKey: titleKey)
         self.__0_isSuppressed = isSuppressed
     }
     #endif
-    #if os(tvOS) || os(macOS) || os(watchOS) || os(iOS)
-    @available(tvOS 17.0,macOS 14.0,watchOS 10.0,iOS 17.0, *)
+    #if os(macOS) || os(watchOS) || os(iOS) || os(tvOS)
+    @available(macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0, *)
     init(_ title: AttributeReference<String>,isSuppressed: ChangeTracked<Swift.Bool>) {
         self.value = ._1(title: title)
         self.__1_isSuppressed = isSuppressed
     }
     #endif
-    #if os(tvOS) || os(macOS) || os(watchOS) || os(iOS)
-    @available(tvOS 17.0,macOS 14.0,watchOS 10.0,iOS 17.0, *)
+    #if os(macOS) || os(watchOS) || os(iOS) || os(tvOS)
+    @available(macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0, *)
     init(_ label: TextReference,isSuppressed: ChangeTracked<Swift.Bool>) {
         self.value = ._2(label: label)
         self.__2_isSuppressed = isSuppressed
     }
     #endif
-    #if os(tvOS) || os(macOS) || os(watchOS) || os(iOS)
-    @available(tvOS 17.0,macOS 14.0,watchOS 10.0,iOS 17.0, *)
+    #if os(macOS) || os(watchOS) || os(iOS) || os(tvOS)
+    @available(macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0, *)
     init(isSuppressed: ChangeTracked<Swift.Bool>) {
         self.value = ._3
         self.__3_isSuppressed = isSuppressed
@@ -2402,33 +2402,33 @@ struct _dialogSuppressionToggleModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(tvOS) || os(watchOS) || os(macOS) || os(iOS)
+        #if os(macOS) || os(watchOS) || os(iOS) || os(tvOS)
         case let ._0(titleKey):
-            if #available(tvOS 17.0,watchOS 10.0,macOS 14.0,iOS 17.0, *) {
+            if #available(macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0, *) {
             let titleKey = titleKey as! SwiftUI.LocalizedStringKey
             __content
                 .dialogSuppressionToggle(titleKey, isSuppressed: __0_isSuppressed.projectedValue)
             } else { __content }
         #endif
-        #if os(tvOS) || os(macOS) || os(watchOS) || os(iOS)
+        #if os(macOS) || os(watchOS) || os(iOS) || os(tvOS)
         case let ._1(title):
-            if #available(tvOS 17.0,macOS 14.0,watchOS 10.0,iOS 17.0, *) {
+            if #available(macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0, *) {
             let title = title as! AttributeReference<String>
             __content
                 .dialogSuppressionToggle(title.resolve(on: element, in: context), isSuppressed: __1_isSuppressed.projectedValue)
             } else { __content }
         #endif
-        #if os(tvOS) || os(macOS) || os(watchOS) || os(iOS)
+        #if os(macOS) || os(watchOS) || os(iOS) || os(tvOS)
         case let ._2(label):
-            if #available(tvOS 17.0,macOS 14.0,watchOS 10.0,iOS 17.0, *) {
+            if #available(macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0, *) {
             let label = label as! TextReference
             __content
                 .dialogSuppressionToggle(label.resolve(on: element, in: context), isSuppressed: __2_isSuppressed.projectedValue)
             } else { __content }
         #endif
-        #if os(tvOS) || os(macOS) || os(watchOS) || os(iOS)
+        #if os(macOS) || os(watchOS) || os(iOS) || os(tvOS)
         case ._3:
-            if #available(tvOS 17.0,macOS 14.0,watchOS 10.0,iOS 17.0, *) {
+            if #available(macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0, *) {
             
             __content
                 .dialogSuppressionToggle(isSuppressed: __3_isSuppressed.projectedValue)
@@ -2923,7 +2923,7 @@ struct _focusEffectDisabledModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(tvOS) || os(macOS) || os(watchOS)
+        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
         case _0(disabled: Any)
         #endif
     }
@@ -2936,8 +2936,8 @@ struct _focusEffectDisabledModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(tvOS) || os(macOS) || os(watchOS)
-    @available(iOS 17.0,tvOS 17.0,macOS 14.0,watchOS 10.0, *)
+    #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
+    @available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0, *)
     init(_ disabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(disabled: disabled)
         
@@ -2948,9 +2948,9 @@ struct _focusEffectDisabledModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(tvOS) || os(macOS) || os(watchOS)
+        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
         case let ._0(disabled):
-            if #available(iOS 17.0,tvOS 17.0,macOS 14.0,watchOS 10.0, *) {
+            if #available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0, *) {
             let disabled = disabled as! AttributeReference<Swift.Bool>
             __content
                 .focusEffectDisabled(disabled.resolve(on: element, in: context))
@@ -2965,7 +2965,7 @@ struct _focusSectionModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(macOS) || os(tvOS)
+        #if os(tvOS) || os(macOS)
         case _0
         #endif
     }
@@ -2978,8 +2978,8 @@ struct _focusSectionModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(macOS) || os(tvOS)
-    @available(macOS 13.0,tvOS 15.0, *)
+    #if os(tvOS) || os(macOS)
+    @available(tvOS 15.0,macOS 13.0, *)
     init() {
         self.value = ._0
         
@@ -2990,9 +2990,9 @@ struct _focusSectionModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(macOS) || os(tvOS)
+        #if os(tvOS) || os(macOS)
         case ._0:
-            if #available(macOS 13.0,tvOS 15.0, *) {
+            if #available(tvOS 15.0,macOS 13.0, *) {
             
             __content
                 .focusSection()
@@ -3007,7 +3007,7 @@ struct _focusableModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(watchOS) || os(tvOS) || os(macOS)
+        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
         case _0(isFocusable: Any)
         #endif
         #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
@@ -3025,8 +3025,8 @@ struct _focusableModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(watchOS) || os(tvOS) || os(macOS)
-    @available(iOS 17.0,watchOS 8.0,tvOS 15.0,macOS 12.0, *)
+    #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
+    @available(iOS 17.0,watchOS 8.0,macOS 12.0,tvOS 15.0, *)
     init(_ isFocusable: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(isFocusable: isFocusable)
         
@@ -3044,9 +3044,9 @@ struct _focusableModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(watchOS) || os(tvOS) || os(macOS)
+        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
         case let ._0(isFocusable):
-            if #available(iOS 17.0,watchOS 8.0,tvOS 15.0,macOS 12.0, *) {
+            if #available(iOS 17.0,watchOS 8.0,macOS 12.0,tvOS 15.0, *) {
             let isFocusable = isFocusable as! AttributeReference<Swift.Bool>
             __content
                 .focusable(isFocusable.resolve(on: element, in: context))
@@ -3444,7 +3444,7 @@ struct _fullScreenCoverModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(watchOS) || os(iOS) || os(tvOS)
+        #if os(iOS) || os(watchOS) || os(tvOS)
         case _0(content: Any)
         #endif
     }
@@ -3457,8 +3457,8 @@ struct _fullScreenCoverModifier<R: RootRegistry>: ViewModifier {
 @ChangeTracked private var _0_isPresented: Swift.Bool
 @Event private var _0_onDismiss__0: Event.EventHandler
 
-    #if os(watchOS) || os(iOS) || os(tvOS)
-    @available(watchOS 7.0,iOS 14.0,tvOS 14.0, *)
+    #if os(iOS) || os(watchOS) || os(tvOS)
+    @available(iOS 14.0,watchOS 7.0,tvOS 14.0, *)
     init(isPresented: ChangeTracked<Swift.Bool>,onDismiss onDismiss__0: Event=Event(), content: ViewReference=ViewReference(value: [])) {
         self.value = ._0(content: content)
         self.__0_isPresented = isPresented
@@ -3470,9 +3470,9 @@ self.__0_onDismiss__0 = onDismiss__0
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(watchOS) || os(iOS) || os(tvOS)
+        #if os(iOS) || os(watchOS) || os(tvOS)
         case let ._0(content):
-            if #available(watchOS 7.0,iOS 14.0,tvOS 14.0, *) {
+            if #available(iOS 14.0,watchOS 7.0,tvOS 14.0, *) {
             let content = content as! ViewReference
             __content
                 .fullScreenCover(isPresented: __0_isPresented.projectedValue, onDismiss: { __0_onDismiss__0.wrappedValue() }, content: { content.resolve(on: element, in: context) })
@@ -3487,7 +3487,7 @@ struct _gaugeStyleModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(watchOS) || os(iOS) || os(macOS)
+        #if os(macOS) || os(iOS) || os(watchOS)
         case _0(style: Any)
         #endif
     }
@@ -3500,8 +3500,8 @@ struct _gaugeStyleModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(watchOS) || os(iOS) || os(macOS)
-    @available(watchOS 7.0,iOS 16.0,macOS 13.0, *)
+    #if os(macOS) || os(iOS) || os(watchOS)
+    @available(macOS 13.0,iOS 16.0,watchOS 7.0, *)
     init(_ style: AnyGaugeStyle) {
         self.value = ._0(style: style)
         
@@ -3512,9 +3512,9 @@ struct _gaugeStyleModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(watchOS) || os(iOS) || os(macOS)
+        #if os(macOS) || os(iOS) || os(watchOS)
         case let ._0(style):
-            if #available(watchOS 7.0,iOS 16.0,macOS 13.0, *) {
+            if #available(macOS 13.0,iOS 16.0,watchOS 7.0, *) {
             let style = style as! AnyGaugeStyle
             __content
                 .gaugeStyle(style)
@@ -3529,7 +3529,7 @@ struct _geometryGroupModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(tvOS) || os(iOS) || os(macOS) || os(watchOS)
+        #if os(watchOS) || os(iOS) || os(macOS) || os(tvOS)
         case _0
         #endif
     }
@@ -3542,8 +3542,8 @@ struct _geometryGroupModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(tvOS) || os(iOS) || os(macOS) || os(watchOS)
-    @available(tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0, *)
+    #if os(watchOS) || os(iOS) || os(macOS) || os(tvOS)
+    @available(watchOS 10.0,iOS 17.0,macOS 14.0,tvOS 17.0, *)
     init() {
         self.value = ._0
         
@@ -3554,9 +3554,9 @@ struct _geometryGroupModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(tvOS) || os(iOS) || os(macOS) || os(watchOS)
+        #if os(watchOS) || os(iOS) || os(macOS) || os(tvOS)
         case ._0:
-            if #available(tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0, *) {
+            if #available(watchOS 10.0,iOS 17.0,macOS 14.0,tvOS 17.0, *) {
             
             __content
                 .geometryGroup()
@@ -4115,10 +4115,10 @@ struct _hoverEffectModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(tvOS) || os(visionOS) || os(iOS)
+        #if os(iOS) || os(tvOS) || os(visionOS)
         case _0(effect: Any)
         #endif
-        #if os(tvOS) || os(visionOS) || os(iOS)
+        #if os(iOS) || os(tvOS) || os(visionOS)
         case _1(effect: Any, isEnabled: Any)
         #endif
     }
@@ -4133,15 +4133,15 @@ struct _hoverEffectModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(tvOS) || os(visionOS) || os(iOS)
-    @available(tvOS 16.0,visionOS 1.0,iOS 13.4, *)
+    #if os(iOS) || os(tvOS) || os(visionOS)
+    @available(iOS 13.4,tvOS 16.0,visionOS 1.0, *)
     init(_ effect: SwiftUI.HoverEffect = .automatic ) {
         self.value = ._0(effect: effect)
         
     }
     #endif
-    #if os(tvOS) || os(visionOS) || os(iOS)
-    @available(tvOS 17.0,visionOS 1.0,iOS 17.0, *)
+    #if os(iOS) || os(tvOS) || os(visionOS)
+    @available(iOS 17.0,tvOS 17.0,visionOS 1.0, *)
     init(_ effect: SwiftUI.HoverEffect = .automatic, isEnabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._1(effect: effect, isEnabled: isEnabled)
         
@@ -4152,17 +4152,17 @@ struct _hoverEffectModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(tvOS) || os(visionOS) || os(iOS)
+        #if os(iOS) || os(tvOS) || os(visionOS)
         case let ._0(effect):
-            if #available(tvOS 16.0,visionOS 1.0,iOS 13.4, *) {
+            if #available(iOS 13.4,tvOS 16.0,visionOS 1.0, *) {
             let effect = effect as! SwiftUI.HoverEffect 
             __content
                 .hoverEffect(effect)
             } else { __content }
         #endif
-        #if os(tvOS) || os(visionOS) || os(iOS)
+        #if os(iOS) || os(tvOS) || os(visionOS)
         case let ._1(effect, isEnabled):
-            if #available(tvOS 17.0,visionOS 1.0,iOS 17.0, *) {
+            if #available(iOS 17.0,tvOS 17.0,visionOS 1.0, *) {
             let effect = effect as! SwiftUI.HoverEffect 
 let isEnabled = isEnabled as! AttributeReference<Swift.Bool>
             __content
@@ -4346,7 +4346,7 @@ struct _indexViewStyleModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(tvOS) || os(watchOS)
+        #if os(tvOS) || os(iOS) || os(watchOS)
         case _0(style: Any)
         #endif
     }
@@ -4359,8 +4359,8 @@ struct _indexViewStyleModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(tvOS) || os(watchOS)
-    @available(iOS 14.0,tvOS 14.0,watchOS 8.0, *)
+    #if os(tvOS) || os(iOS) || os(watchOS)
+    @available(tvOS 14.0,iOS 14.0,watchOS 8.0, *)
     init(_ style: AnyIndexViewStyle) {
         self.value = ._0(style: style)
         
@@ -4371,9 +4371,9 @@ struct _indexViewStyleModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(tvOS) || os(watchOS)
+        #if os(tvOS) || os(iOS) || os(watchOS)
         case let ._0(style):
-            if #available(iOS 14.0,tvOS 14.0,watchOS 8.0, *) {
+            if #available(tvOS 14.0,iOS 14.0,watchOS 8.0, *) {
             let style = style as! AnyIndexViewStyle
             __content
                 .indexViewStyle(style)
@@ -4433,7 +4433,7 @@ struct _inspectorColumnWidthModifier<R: RootRegistry>: ViewModifier {
         #if os(iOS) || os(macOS)
         case _0(min: Any?, ideal: Any,max: Any?)
         #endif
-        #if os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS)
         case _1(width: Any)
         #endif
     }
@@ -4455,8 +4455,8 @@ struct _inspectorColumnWidthModifier<R: RootRegistry>: ViewModifier {
         
     }
     #endif
-    #if os(macOS) || os(iOS)
-    @available(macOS 14.0,iOS 17.0, *)
+    #if os(iOS) || os(macOS)
+    @available(iOS 17.0,macOS 14.0, *)
     init(_ width: AttributeReference<CoreFoundation.CGFloat>) {
         self.value = ._1(width: width)
         
@@ -4477,9 +4477,9 @@ let max = max as? AttributeReference<CoreFoundation.CGFloat?>
                 .inspectorColumnWidth(min: min?.resolve(on: element, in: context), ideal: ideal.resolve(on: element, in: context), max: max?.resolve(on: element, in: context))
             } else { __content }
         #endif
-        #if os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS)
         case let ._1(width):
-            if #available(macOS 14.0,iOS 17.0, *) {
+            if #available(iOS 17.0,macOS 14.0, *) {
             let width = width as! AttributeReference<CoreFoundation.CGFloat>
             __content
                 .inspectorColumnWidth(width.resolve(on: element, in: context))
@@ -4578,7 +4578,7 @@ struct _invalidatableContentModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(tvOS) || os(macOS) || os(watchOS) || os(iOS)
+        #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
         case _0(invalidatable: Any)
         #endif
     }
@@ -4591,8 +4591,8 @@ struct _invalidatableContentModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(tvOS) || os(macOS) || os(watchOS) || os(iOS)
-    @available(tvOS 17.0,macOS 14.0,watchOS 10.0,iOS 17.0, *)
+    #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
+    @available(iOS 17.0,macOS 14.0,watchOS 10.0,tvOS 17.0, *)
     init(_ invalidatable: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(invalidatable: invalidatable)
         
@@ -4603,9 +4603,9 @@ struct _invalidatableContentModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(tvOS) || os(macOS) || os(watchOS) || os(iOS)
+        #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
         case let ._0(invalidatable):
-            if #available(tvOS 17.0,macOS 14.0,watchOS 10.0,iOS 17.0, *) {
+            if #available(iOS 17.0,macOS 14.0,watchOS 10.0,tvOS 17.0, *) {
             let invalidatable = invalidatable as! AttributeReference<Swift.Bool>
             __content
                 .invalidatableContent(invalidatable.resolve(on: element, in: context))
@@ -4710,10 +4710,10 @@ struct _keyboardShortcutModifier<R: RootRegistry>: ViewModifier {
         #if os(macOS) || os(iOS)
         case _1(shortcut: Any)
         #endif
-        #if os(iOS) || os(macOS)
+        #if os(macOS) || os(iOS)
         case _2(shortcut: Any?)
         #endif
-        #if os(iOS) || os(macOS)
+        #if os(macOS) || os(iOS)
         case _3(key: Any,modifiers: Any, localization: Any)
         #endif
     }
@@ -4746,15 +4746,15 @@ struct _keyboardShortcutModifier<R: RootRegistry>: ViewModifier {
         
     }
     #endif
-    #if os(iOS) || os(macOS)
-    @available(iOS 15.4,macOS 12.3, *)
+    #if os(macOS) || os(iOS)
+    @available(macOS 12.3,iOS 15.4, *)
     init(_ shortcut: SwiftUI.KeyboardShortcut?) {
         self.value = ._2(shortcut: shortcut)
         
     }
     #endif
-    #if os(iOS) || os(macOS)
-    @available(iOS 15.0,macOS 12.0, *)
+    #if os(macOS) || os(iOS)
+    @available(macOS 12.0,iOS 15.0, *)
     init(_ key: SwiftUI.KeyEquivalent,modifiers: SwiftUI.EventModifiers = .command, localization: SwiftUI.KeyboardShortcut.Localization) {
         self.value = ._3(key: key, modifiers: modifiers, localization: localization)
         
@@ -4782,17 +4782,17 @@ let modifiers = modifiers as! SwiftUI.EventModifiers
                 .keyboardShortcut(shortcut)
             } else { __content }
         #endif
-        #if os(iOS) || os(macOS)
+        #if os(macOS) || os(iOS)
         case let ._2(shortcut):
-            if #available(iOS 15.4,macOS 12.3, *) {
+            if #available(macOS 12.3,iOS 15.4, *) {
             let shortcut = shortcut as? SwiftUI.KeyboardShortcut
             __content
                 .keyboardShortcut(shortcut)
             } else { __content }
         #endif
-        #if os(iOS) || os(macOS)
+        #if os(macOS) || os(iOS)
         case let ._3(key, modifiers, localization):
-            if #available(iOS 15.0,macOS 12.0, *) {
+            if #available(macOS 12.0,iOS 15.0, *) {
             let key = key as! SwiftUI.KeyEquivalent
 let modifiers = modifiers as! SwiftUI.EventModifiers 
 let localization = localization as! SwiftUI.KeyboardShortcut.Localization
@@ -5773,7 +5773,7 @@ struct _menuIndicatorModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(macOS) || os(tvOS)
+        #if os(macOS) || os(iOS) || os(tvOS)
         case _0(visibility: Any)
         #endif
     }
@@ -5786,8 +5786,8 @@ struct _menuIndicatorModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(macOS) || os(tvOS)
-    @available(iOS 15.0,macOS 12.0,tvOS 17.0, *)
+    #if os(macOS) || os(iOS) || os(tvOS)
+    @available(macOS 12.0,iOS 15.0,tvOS 17.0, *)
     init(_ visibility: AttributeReference<SwiftUI.Visibility>) {
         self.value = ._0(visibility: visibility)
         
@@ -5798,9 +5798,9 @@ struct _menuIndicatorModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(macOS) || os(tvOS)
+        #if os(macOS) || os(iOS) || os(tvOS)
         case let ._0(visibility):
-            if #available(iOS 15.0,macOS 12.0,tvOS 17.0, *) {
+            if #available(macOS 12.0,iOS 15.0,tvOS 17.0, *) {
             let visibility = visibility as! AttributeReference<SwiftUI.Visibility>
             __content
                 .menuIndicator(visibility.resolve(on: element, in: context))
@@ -5857,7 +5857,7 @@ struct _menuStyleModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(tvOS) || os(macOS) || os(iOS)
+        #if os(tvOS) || os(iOS) || os(macOS)
         case _0(style: Any)
         #endif
     }
@@ -5870,8 +5870,8 @@ struct _menuStyleModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(tvOS) || os(macOS) || os(iOS)
-    @available(tvOS 17.0,macOS 11.0,iOS 14.0, *)
+    #if os(tvOS) || os(iOS) || os(macOS)
+    @available(tvOS 17.0,iOS 14.0,macOS 11.0, *)
     init(_ style: AnyMenuStyle) {
         self.value = ._0(style: style)
         
@@ -5882,9 +5882,9 @@ struct _menuStyleModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(tvOS) || os(macOS) || os(iOS)
+        #if os(tvOS) || os(iOS) || os(macOS)
         case let ._0(style):
-            if #available(tvOS 17.0,macOS 11.0,iOS 14.0, *) {
+            if #available(tvOS 17.0,iOS 14.0,macOS 11.0, *) {
             let style = style as! AnyMenuStyle
             __content
                 .menuStyle(style)
@@ -6151,7 +6151,7 @@ struct _navigationBarTitleDisplayModeModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(watchOS) || os(iOS)
+        #if os(iOS) || os(watchOS)
         case _0(displayMode: Any)
         #endif
     }
@@ -6164,8 +6164,8 @@ struct _navigationBarTitleDisplayModeModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(watchOS) || os(iOS)
-    @available(watchOS 8.0,iOS 14.0, *)
+    #if os(iOS) || os(watchOS)
+    @available(iOS 14.0,watchOS 8.0, *)
     init(_ displayMode: SwiftUI.NavigationBarItem.TitleDisplayMode) {
         self.value = ._0(displayMode: displayMode)
         
@@ -6176,9 +6176,9 @@ struct _navigationBarTitleDisplayModeModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(watchOS) || os(iOS)
+        #if os(iOS) || os(watchOS)
         case let ._0(displayMode):
-            if #available(watchOS 8.0,iOS 14.0, *) {
+            if #available(iOS 14.0,watchOS 8.0, *) {
             let displayMode = displayMode as! SwiftUI.NavigationBarItem.TitleDisplayMode
             __content
                 .navigationBarTitleDisplayMode(displayMode)
@@ -6339,7 +6339,7 @@ struct _navigationSubtitleModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(macOS) || targetEnvironment(macCatalyst)
+        #if targetEnvironment(macCatalyst) || os(macOS)
         case _0(subtitle: Any)
         #endif
         #if targetEnvironment(macCatalyst) || os(macOS)
@@ -6362,8 +6362,8 @@ struct _navigationSubtitleModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(macOS) || targetEnvironment(macCatalyst)
-    @available(macOS 11.0,macCatalyst 14.0, *)
+    #if targetEnvironment(macCatalyst) || os(macOS)
+    @available(macCatalyst 14.0,macOS 11.0, *)
     init(_ subtitle: TextReference) {
         self.value = ._0(subtitle: subtitle)
         
@@ -6388,9 +6388,9 @@ struct _navigationSubtitleModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(macOS) || targetEnvironment(macCatalyst)
+        #if targetEnvironment(macCatalyst) || os(macOS)
         case let ._0(subtitle):
-            if #available(macOS 11.0,macCatalyst 14.0, *) {
+            if #available(macCatalyst 14.0,macOS 11.0, *) {
             let subtitle = subtitle as! TextReference
             __content
                 .navigationSubtitle(subtitle.resolve(on: element, in: context))
@@ -6476,7 +6476,7 @@ struct _navigationTitleModifier<R: RootRegistry>: ViewModifier {
     }
     
     #if os(watchOS)
-    @available(tvOS 14.0,watchOS 7.0,macOS 11.0,iOS 14.0, *)
+    @available(iOS 14.0,watchOS 7.0,tvOS 14.0,macOS 11.0, *)
     init(_ title: ViewReference=ViewReference(value: [])) {
         self.value = ._3(title: title)
         
@@ -6520,7 +6520,7 @@ struct _navigationTitleModifier<R: RootRegistry>: ViewModifier {
         
         #if os(watchOS)
         case let ._3(title):
-            if #available(tvOS 14.0,watchOS 7.0,macOS 11.0,iOS 14.0, *) {
+            if #available(iOS 14.0,watchOS 7.0,tvOS 14.0,macOS 11.0, *) {
             let title = title as! ViewReference
             __content
                 .navigationTitle({ title.resolve(on: element, in: context) })
@@ -6661,7 +6661,7 @@ struct _onDeleteCommandModifier<R: RootRegistry>: ViewModifier {
 @Event private var _0_action__0: Event.EventHandler
 
     #if os(macOS)
-    @available(macOS 10.15,tvOS 13.0, *)
+    @available(tvOS 13.0,macOS 10.15, *)
     init(perform action__0: Event=Event()) {
         self.value = ._0
         self.__0_action__0 = action__0
@@ -6674,7 +6674,7 @@ struct _onDeleteCommandModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(macOS)
         case ._0:
-            if #available(macOS 10.15,tvOS 13.0, *) {
+            if #available(tvOS 13.0,macOS 10.15, *) {
             
             __content
                 .onDeleteCommand(perform: { __0_action__0.wrappedValue() })
@@ -6731,7 +6731,7 @@ struct _onExitCommandModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(macOS) || os(tvOS)
+        #if os(tvOS) || os(macOS)
         case _0
         #endif
     }
@@ -6744,8 +6744,8 @@ struct _onExitCommandModifier<R: RootRegistry>: ViewModifier {
 
 @Event private var _0_action__0: Event.EventHandler
 
-    #if os(macOS) || os(tvOS)
-    @available(macOS 10.15,tvOS 13.0, *)
+    #if os(tvOS) || os(macOS)
+    @available(tvOS 13.0,macOS 10.15, *)
     init(perform action__0: Event=Event()) {
         self.value = ._0
         self.__0_action__0 = action__0
@@ -6756,9 +6756,9 @@ struct _onExitCommandModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(macOS) || os(tvOS)
+        #if os(tvOS) || os(macOS)
         case ._0:
-            if #available(macOS 10.15,tvOS 13.0, *) {
+            if #available(tvOS 13.0,macOS 10.15, *) {
             
             __content
                 .onExitCommand(perform: { __0_action__0.wrappedValue() })
@@ -6773,7 +6773,7 @@ struct _onHoverModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(macOS)
+        #if os(macOS) || os(iOS)
         case _0
         #endif
     }
@@ -6786,8 +6786,8 @@ struct _onHoverModifier<R: RootRegistry>: ViewModifier {
 
 @Event private var _0_action__1: Event.EventHandler
 
-    #if os(iOS) || os(macOS)
-    @available(iOS 13.4,macOS 10.15, *)
+    #if os(macOS) || os(iOS)
+    @available(macOS 10.15,iOS 13.4, *)
     init(perform action__1: Event) {
         self.value = ._0
         self.__0_action__1 = action__1
@@ -6798,9 +6798,9 @@ struct _onHoverModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(macOS)
+        #if os(macOS) || os(iOS)
         case ._0:
-            if #available(iOS 13.4,macOS 10.15, *) {
+            if #available(macOS 10.15,iOS 13.4, *) {
             
             __content
                 .onHover(perform: { __0_action__1.wrappedValue(value: $0) })
@@ -6815,7 +6815,7 @@ struct _onLongPressGestureModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(macOS) || os(watchOS) || os(iOS)
+        #if os(macOS) || os(iOS) || os(watchOS)
         case _0(minimumDuration: Any, maximumDistance: Any)
         #endif
         #if os(tvOS)
@@ -6835,8 +6835,8 @@ struct _onLongPressGestureModifier<R: RootRegistry>: ViewModifier {
 @Event private var _1_action__0: Event.EventHandler
 @Event private var _1_onPressingChanged__1: Event.EventHandler
 
-    #if os(macOS) || os(watchOS) || os(iOS)
-    @available(tvOS 14.0,macOS 10.15,watchOS 6.0,iOS 13.0, *)
+    #if os(macOS) || os(iOS) || os(watchOS)
+    @available(macOS 10.15,iOS 13.0,watchOS 6.0,tvOS 14.0, *)
     init(minimumDuration: AttributeReference<Swift.Double> = .init(storage: .constant(0.5)), maximumDistance: AttributeReference<CoreFoundation.CGFloat> = .init(storage: .constant(10)), perform action__0: Event,onPressingChanged onPressingChanged__1: Event=Event() ) {
         self.value = ._0(minimumDuration: minimumDuration, maximumDistance: maximumDistance)
         self.__0_action__0 = action__0
@@ -6844,7 +6844,7 @@ self.__0_onPressingChanged__1 = onPressingChanged__1
     }
     #endif
     #if os(tvOS)
-    @available(tvOS 14.0,watchOS 6.0,macOS 10.15,iOS 13.0, *)
+    @available(macOS 10.15,iOS 13.0,watchOS 6.0,tvOS 14.0, *)
     init(minimumDuration: AttributeReference<Swift.Double> = .init(storage: .constant(0.5)), perform action__0: Event,onPressingChanged onPressingChanged__1: Event=Event() ) {
         self.value = ._1(minimumDuration: minimumDuration)
         self.__1_action__0 = action__0
@@ -6856,9 +6856,9 @@ self.__1_onPressingChanged__1 = onPressingChanged__1
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(macOS) || os(watchOS) || os(iOS)
+        #if os(macOS) || os(iOS) || os(watchOS)
         case let ._0(minimumDuration, maximumDistance):
-            if #available(tvOS 14.0,macOS 10.15,watchOS 6.0,iOS 13.0, *) {
+            if #available(macOS 10.15,iOS 13.0,watchOS 6.0,tvOS 14.0, *) {
             let minimumDuration = minimumDuration as! AttributeReference<Swift.Double>
 let maximumDistance = maximumDistance as! AttributeReference<CoreFoundation.CGFloat>
             __content
@@ -6867,7 +6867,7 @@ let maximumDistance = maximumDistance as! AttributeReference<CoreFoundation.CGFl
         #endif
         #if os(tvOS)
         case let ._1(minimumDuration):
-            if #available(tvOS 14.0,watchOS 6.0,macOS 10.15,iOS 13.0, *) {
+            if #available(macOS 10.15,iOS 13.0,watchOS 6.0,tvOS 14.0, *) {
             let minimumDuration = minimumDuration as! AttributeReference<Swift.Double>
             __content
                 .onLongPressGesture(minimumDuration: minimumDuration.resolve(on: element, in: context), perform: { __1_action__0.wrappedValue() }, onPressingChanged: { __1_onPressingChanged__1.wrappedValue(value: $0) })
@@ -6926,7 +6926,7 @@ struct _onMoveCommandModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(macOS) || os(tvOS)
+        #if os(tvOS) || os(macOS)
         case _0
         #endif
     }
@@ -6939,8 +6939,8 @@ struct _onMoveCommandModifier<R: RootRegistry>: ViewModifier {
 
 @Event private var _0_action__1: Event.EventHandler
 
-    #if os(macOS) || os(tvOS)
-    @available(macOS 10.15,tvOS 13.0, *)
+    #if os(tvOS) || os(macOS)
+    @available(tvOS 13.0,macOS 10.15, *)
     init(perform action__1: Event=Event()) {
         self.value = ._0
         self.__0_action__1 = action__1
@@ -6951,9 +6951,9 @@ struct _onMoveCommandModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(macOS) || os(tvOS)
+        #if os(tvOS) || os(macOS)
         case ._0:
-            if #available(macOS 10.15,tvOS 13.0, *) {
+            if #available(tvOS 13.0,macOS 10.15, *) {
             
             __content
                 .onMoveCommand(perform: { __0_action__1.wrappedValue(value: $0) })
@@ -6982,7 +6982,7 @@ struct _onPlayPauseCommandModifier<R: RootRegistry>: ViewModifier {
 @Event private var _0_action__0: Event.EventHandler
 
     #if os(tvOS)
-    @available(macOS 10.15,tvOS 13.0, *)
+    @available(tvOS 13.0,macOS 10.15, *)
     init(perform action__0: Event=Event()) {
         self.value = ._0
         self.__0_action__0 = action__0
@@ -6995,7 +6995,7 @@ struct _onPlayPauseCommandModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(tvOS)
         case ._0:
-            if #available(macOS 10.15,tvOS 13.0, *) {
+            if #available(tvOS 13.0,macOS 10.15, *) {
             
             __content
                 .onPlayPauseCommand(perform: { __0_action__0.wrappedValue() })
@@ -7511,10 +7511,10 @@ struct _presentationBackgroundModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
         case _0(style: Any)
         #endif
-        #if os(iOS) || os(watchOS) || os(tvOS) || os(macOS)
+        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
         case _1(alignment: Any, content: Any)
         #endif
     }
@@ -7529,15 +7529,15 @@ struct _presentationBackgroundModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
-    @available(macOS 13.3,iOS 16.4,tvOS 16.4,watchOS 9.4, *)
+    #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
+    @available(iOS 16.4,watchOS 9.4,macOS 13.3,tvOS 16.4, *)
     init(_ style: AnyShapeStyle) {
         self.value = ._0(style: style)
         
     }
     #endif
-    #if os(iOS) || os(watchOS) || os(tvOS) || os(macOS)
-    @available(iOS 16.4,watchOS 9.4,tvOS 16.4,macOS 13.3, *)
+    #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
+    @available(iOS 16.4,watchOS 9.4,macOS 13.3,tvOS 16.4, *)
     init(alignment: AttributeReference<SwiftUI.Alignment> = .init(storage: .constant(.center)), content: ViewReference=ViewReference(value: [])) {
         self.value = ._1(alignment: alignment, content: content)
         
@@ -7548,17 +7548,17 @@ struct _presentationBackgroundModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
         case let ._0(style):
-            if #available(macOS 13.3,iOS 16.4,tvOS 16.4,watchOS 9.4, *) {
+            if #available(iOS 16.4,watchOS 9.4,macOS 13.3,tvOS 16.4, *) {
             let style = style as! AnyShapeStyle
             __content
                 .presentationBackground(style)
             } else { __content }
         #endif
-        #if os(iOS) || os(watchOS) || os(tvOS) || os(macOS)
+        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
         case let ._1(alignment, content):
-            if #available(iOS 16.4,watchOS 9.4,tvOS 16.4,macOS 13.3, *) {
+            if #available(iOS 16.4,watchOS 9.4,macOS 13.3,tvOS 16.4, *) {
             let alignment = alignment as! AttributeReference<SwiftUI.Alignment>
 let content = content as! ViewReference
             __content
@@ -7574,7 +7574,7 @@ struct _presentationBackgroundInteractionModifier<R: RootRegistry>: ViewModifier
 
     enum Value {
         case _never
-        #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
         case _0(interaction: Any)
         #endif
     }
@@ -7587,8 +7587,8 @@ struct _presentationBackgroundInteractionModifier<R: RootRegistry>: ViewModifier
 
 
 
-    #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
-    @available(macOS 13.3,iOS 16.4,tvOS 16.4,watchOS 9.4, *)
+    #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
+    @available(iOS 16.4,watchOS 9.4,macOS 13.3,tvOS 16.4, *)
     init(_ interaction: SwiftUI.PresentationBackgroundInteraction) {
         self.value = ._0(interaction: interaction)
         
@@ -7599,9 +7599,9 @@ struct _presentationBackgroundInteractionModifier<R: RootRegistry>: ViewModifier
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
         case let ._0(interaction):
-            if #available(macOS 13.3,iOS 16.4,tvOS 16.4,watchOS 9.4, *) {
+            if #available(iOS 16.4,watchOS 9.4,macOS 13.3,tvOS 16.4, *) {
             let interaction = interaction as! SwiftUI.PresentationBackgroundInteraction
             __content
                 .presentationBackgroundInteraction(interaction)
@@ -7616,10 +7616,10 @@ struct _presentationCompactAdaptationModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
         case _0(adaptation: Any)
         #endif
-        #if os(iOS) || os(watchOS) || os(tvOS) || os(macOS)
+        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
         case _1(horizontalAdaptation: Any,verticalAdaptation: Any)
         #endif
     }
@@ -7634,15 +7634,15 @@ struct _presentationCompactAdaptationModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
-    @available(macOS 13.3,iOS 16.4,tvOS 16.4,watchOS 9.4, *)
+    #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
+    @available(iOS 16.4,watchOS 9.4,macOS 13.3,tvOS 16.4, *)
     init(_ adaptation: SwiftUI.PresentationAdaptation) {
         self.value = ._0(adaptation: adaptation)
         
     }
     #endif
-    #if os(iOS) || os(watchOS) || os(tvOS) || os(macOS)
-    @available(iOS 16.4,watchOS 9.4,tvOS 16.4,macOS 13.3, *)
+    #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
+    @available(iOS 16.4,watchOS 9.4,macOS 13.3,tvOS 16.4, *)
     init(horizontal horizontalAdaptation: SwiftUI.PresentationAdaptation,vertical verticalAdaptation: SwiftUI.PresentationAdaptation) {
         self.value = ._1(horizontalAdaptation: horizontalAdaptation, verticalAdaptation: verticalAdaptation)
         
@@ -7653,17 +7653,17 @@ struct _presentationCompactAdaptationModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
         case let ._0(adaptation):
-            if #available(macOS 13.3,iOS 16.4,tvOS 16.4,watchOS 9.4, *) {
+            if #available(iOS 16.4,watchOS 9.4,macOS 13.3,tvOS 16.4, *) {
             let adaptation = adaptation as! SwiftUI.PresentationAdaptation
             __content
                 .presentationCompactAdaptation(adaptation)
             } else { __content }
         #endif
-        #if os(iOS) || os(watchOS) || os(tvOS) || os(macOS)
+        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
         case let ._1(horizontalAdaptation, verticalAdaptation):
-            if #available(iOS 16.4,watchOS 9.4,tvOS 16.4,macOS 13.3, *) {
+            if #available(iOS 16.4,watchOS 9.4,macOS 13.3,tvOS 16.4, *) {
             let horizontalAdaptation = horizontalAdaptation as! SwiftUI.PresentationAdaptation
 let verticalAdaptation = verticalAdaptation as! SwiftUI.PresentationAdaptation
             __content
@@ -7679,7 +7679,7 @@ struct _presentationContentInteractionModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(tvOS) || os(watchOS) || os(macOS) || os(iOS)
+        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
         case _0(behavior: Any)
         #endif
     }
@@ -7692,8 +7692,8 @@ struct _presentationContentInteractionModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(tvOS) || os(watchOS) || os(macOS) || os(iOS)
-    @available(tvOS 16.4,watchOS 9.4,macOS 13.3,iOS 16.4, *)
+    #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
+    @available(iOS 16.4,watchOS 9.4,macOS 13.3,tvOS 16.4, *)
     init(_ behavior: SwiftUI.PresentationContentInteraction) {
         self.value = ._0(behavior: behavior)
         
@@ -7704,9 +7704,9 @@ struct _presentationContentInteractionModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(tvOS) || os(watchOS) || os(macOS) || os(iOS)
+        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
         case let ._0(behavior):
-            if #available(tvOS 16.4,watchOS 9.4,macOS 13.3,iOS 16.4, *) {
+            if #available(iOS 16.4,watchOS 9.4,macOS 13.3,tvOS 16.4, *) {
             let behavior = behavior as! SwiftUI.PresentationContentInteraction
             __content
                 .presentationContentInteraction(behavior)
@@ -7721,7 +7721,7 @@ struct _presentationCornerRadiusModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(watchOS) || os(tvOS) || os(macOS)
+        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
         case _0(cornerRadius: Any?)
         #endif
     }
@@ -7734,8 +7734,8 @@ struct _presentationCornerRadiusModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(watchOS) || os(tvOS) || os(macOS)
-    @available(iOS 16.4,watchOS 9.4,tvOS 16.4,macOS 13.3, *)
+    #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
+    @available(iOS 16.4,watchOS 9.4,macOS 13.3,tvOS 16.4, *)
     init(_ cornerRadius: AttributeReference<CoreFoundation.CGFloat?>?) {
         self.value = ._0(cornerRadius: cornerRadius)
         
@@ -7746,9 +7746,9 @@ struct _presentationCornerRadiusModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(watchOS) || os(tvOS) || os(macOS)
+        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
         case let ._0(cornerRadius):
-            if #available(iOS 16.4,watchOS 9.4,tvOS 16.4,macOS 13.3, *) {
+            if #available(iOS 16.4,watchOS 9.4,macOS 13.3,tvOS 16.4, *) {
             let cornerRadius = cornerRadius as? AttributeReference<CoreFoundation.CGFloat?>
             __content
                 .presentationCornerRadius(cornerRadius?.resolve(on: element, in: context))
@@ -8515,7 +8515,7 @@ struct _scrollBounceBehaviorModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
+        #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
         case _0(behavior: Any,axes: Any)
         #endif
     }
@@ -8528,8 +8528,8 @@ struct _scrollBounceBehaviorModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
-    @available(iOS 16.4,macOS 13.3,watchOS 9.4,tvOS 16.4, *)
+    #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+    @available(macOS 13.3,iOS 16.4,watchOS 9.4,tvOS 16.4, *)
     init(_ behavior: SwiftUI.ScrollBounceBehavior,axes: SwiftUI.Axis.Set = [.vertical] ) {
         self.value = ._0(behavior: behavior, axes: axes)
         
@@ -8540,9 +8540,9 @@ struct _scrollBounceBehaviorModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
+        #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
         case let ._0(behavior, axes):
-            if #available(iOS 16.4,macOS 13.3,watchOS 9.4,tvOS 16.4, *) {
+            if #available(macOS 13.3,iOS 16.4,watchOS 9.4,tvOS 16.4, *) {
             let behavior = behavior as! SwiftUI.ScrollBounceBehavior
 let axes = axes as! SwiftUI.Axis.Set 
             __content
@@ -8558,7 +8558,7 @@ struct _scrollClipDisabledModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(watchOS) || os(tvOS) || os(macOS)
+        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
         case _0(disabled: Any)
         #endif
     }
@@ -8571,8 +8571,8 @@ struct _scrollClipDisabledModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(watchOS) || os(tvOS) || os(macOS)
-    @available(iOS 17.0,watchOS 10.0,tvOS 17.0,macOS 14.0, *)
+    #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
+    @available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0, *)
     init(_ disabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(disabled: disabled)
         
@@ -8583,9 +8583,9 @@ struct _scrollClipDisabledModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(watchOS) || os(tvOS) || os(macOS)
+        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
         case let ._0(disabled):
-            if #available(iOS 17.0,watchOS 10.0,tvOS 17.0,macOS 14.0, *) {
+            if #available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0, *) {
             let disabled = disabled as! AttributeReference<Swift.Bool>
             __content
                 .scrollClipDisabled(disabled.resolve(on: element, in: context))
@@ -8600,7 +8600,7 @@ struct _scrollContentBackgroundModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(macOS) || os(iOS) || os(watchOS)
+        #if os(watchOS) || os(iOS) || os(macOS)
         case _0(visibility: Any)
         #endif
     }
@@ -8613,8 +8613,8 @@ struct _scrollContentBackgroundModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(macOS) || os(iOS) || os(watchOS)
-    @available(macOS 13.0,iOS 16.0,watchOS 9.0, *)
+    #if os(watchOS) || os(iOS) || os(macOS)
+    @available(watchOS 9.0,iOS 16.0,macOS 13.0, *)
     init(_ visibility: AttributeReference<SwiftUI.Visibility>) {
         self.value = ._0(visibility: visibility)
         
@@ -8625,9 +8625,9 @@ struct _scrollContentBackgroundModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(macOS) || os(iOS) || os(watchOS)
+        #if os(watchOS) || os(iOS) || os(macOS)
         case let ._0(visibility):
-            if #available(macOS 13.0,iOS 16.0,watchOS 9.0, *) {
+            if #available(watchOS 9.0,iOS 16.0,macOS 13.0, *) {
             let visibility = visibility as! AttributeReference<SwiftUI.Visibility>
             __content
                 .scrollContentBackground(visibility.resolve(on: element, in: context))
@@ -8684,7 +8684,7 @@ struct _scrollDismissesKeyboardModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(watchOS) || os(tvOS) || os(macOS)
+        #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
         case _0(mode: Any)
         #endif
     }
@@ -8697,8 +8697,8 @@ struct _scrollDismissesKeyboardModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(watchOS) || os(tvOS) || os(macOS)
-    @available(iOS 16.0,watchOS 9.0,tvOS 16.0,macOS 13.0, *)
+    #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+    @available(macOS 13.0,iOS 16.0,watchOS 9.0,tvOS 16.0, *)
     init(_ mode: SwiftUI.ScrollDismissesKeyboardMode) {
         self.value = ._0(mode: mode)
         
@@ -8709,9 +8709,9 @@ struct _scrollDismissesKeyboardModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(watchOS) || os(tvOS) || os(macOS)
+        #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
         case let ._0(mode):
-            if #available(iOS 16.0,watchOS 9.0,tvOS 16.0,macOS 13.0, *) {
+            if #available(macOS 13.0,iOS 16.0,watchOS 9.0,tvOS 16.0, *) {
             let mode = mode as! SwiftUI.ScrollDismissesKeyboardMode
             __content
                 .scrollDismissesKeyboard(mode)
@@ -8768,10 +8768,10 @@ struct _scrollIndicatorsFlashModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
+        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
         case _0(value: Any)
         #endif
-        #if os(tvOS) || os(watchOS) || os(macOS) || os(iOS)
+        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
         case _1(onAppear: Any)
         #endif
     }
@@ -8786,15 +8786,15 @@ struct _scrollIndicatorsFlashModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
-    @available(tvOS 17.0,iOS 17.0,watchOS 10.0,macOS 14.0, *)
+    #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
+    @available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0, *)
     init(trigger value: AttributeReference<String>) {
         self.value = ._0(value: value)
         
     }
     #endif
-    #if os(tvOS) || os(watchOS) || os(macOS) || os(iOS)
-    @available(tvOS 17.0,watchOS 10.0,macOS 14.0,iOS 17.0, *)
+    #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
+    @available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0, *)
     init(onAppear: AttributeReference<Swift.Bool>) {
         self.value = ._1(onAppear: onAppear)
         
@@ -8805,17 +8805,17 @@ struct _scrollIndicatorsFlashModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
+        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
         case let ._0(value):
-            if #available(tvOS 17.0,iOS 17.0,watchOS 10.0,macOS 14.0, *) {
+            if #available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0, *) {
             let value = value as! AttributeReference<String>
             __content
                 .scrollIndicatorsFlash(trigger: value.resolve(on: element, in: context))
             } else { __content }
         #endif
-        #if os(tvOS) || os(watchOS) || os(macOS) || os(iOS)
+        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
         case let ._1(onAppear):
-            if #available(tvOS 17.0,watchOS 10.0,macOS 14.0,iOS 17.0, *) {
+            if #available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0, *) {
             let onAppear = onAppear as! AttributeReference<Swift.Bool>
             __content
                 .scrollIndicatorsFlash(onAppear: onAppear.resolve(on: element, in: context))
@@ -8830,7 +8830,7 @@ struct _scrollPositionModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(tvOS) || os(watchOS) || os(macOS) || os(iOS)
+        #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
         case _0(anchor: Any?)
         #endif
     }
@@ -8843,8 +8843,8 @@ struct _scrollPositionModifier<R: RootRegistry>: ViewModifier {
 @ChangeTracked private var _0_id: String?
 
 
-    #if os(tvOS) || os(watchOS) || os(macOS) || os(iOS)
-    @available(tvOS 17.0,watchOS 10.0,macOS 14.0,iOS 17.0, *)
+    #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+    @available(macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0, *)
     init(id: ChangeTracked<String?>,anchor: AttributeReference<SwiftUI.UnitPoint?>? = .init(storage: .constant(nil)) ) {
         self.value = ._0(anchor: anchor)
         self.__0_id = id
@@ -8855,9 +8855,9 @@ struct _scrollPositionModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(tvOS) || os(watchOS) || os(macOS) || os(iOS)
+        #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
         case let ._0(anchor):
-            if #available(tvOS 17.0,watchOS 10.0,macOS 14.0,iOS 17.0, *) {
+            if #available(macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0, *) {
             let anchor = anchor as? AttributeReference<SwiftUI.UnitPoint?>
             __content
                 .scrollPosition(id: __0_id.projectedValue, anchor: anchor?.resolve(on: element, in: context))
@@ -8872,7 +8872,7 @@ struct _scrollTargetBehaviorModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
+        #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
         case _0(behavior: Any)
         #endif
     }
@@ -8885,8 +8885,8 @@ struct _scrollTargetBehaviorModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
-    @available(tvOS 17.0,iOS 17.0,watchOS 10.0,macOS 14.0, *)
+    #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+    @available(macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0, *)
     init(_ behavior: AnyScrollTargetBehavior) {
         self.value = ._0(behavior: behavior)
         
@@ -8897,9 +8897,9 @@ struct _scrollTargetBehaviorModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
+        #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
         case let ._0(behavior):
-            if #available(tvOS 17.0,iOS 17.0,watchOS 10.0,macOS 14.0, *) {
+            if #available(macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0, *) {
             let behavior = behavior as! AnyScrollTargetBehavior
             __content
                 .scrollTargetBehavior(behavior)
@@ -8914,7 +8914,7 @@ struct _scrollTargetLayoutModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
+        #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
         case _0(isEnabled: Any)
         #endif
     }
@@ -8927,8 +8927,8 @@ struct _scrollTargetLayoutModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
-    @available(tvOS 17.0,iOS 17.0,watchOS 10.0,macOS 14.0, *)
+    #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+    @available(macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0, *)
     init(isEnabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(isEnabled: isEnabled)
         
@@ -8939,9 +8939,9 @@ struct _scrollTargetLayoutModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(tvOS) || os(iOS) || os(watchOS) || os(macOS)
+        #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
         case let ._0(isEnabled):
-            if #available(tvOS 17.0,iOS 17.0,watchOS 10.0,macOS 14.0, *) {
+            if #available(macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0, *) {
             let isEnabled = isEnabled as! AttributeReference<Swift.Bool>
             __content
                 .scrollTargetLayout(isEnabled: isEnabled.resolve(on: element, in: context))
@@ -8956,7 +8956,7 @@ struct _searchDictationBehaviorModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(visionOS) || os(iOS)
+        #if os(iOS) || os(visionOS)
         case _0(dictationBehavior: Any)
         #endif
     }
@@ -8969,8 +8969,8 @@ struct _searchDictationBehaviorModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(visionOS) || os(iOS)
-    @available(visionOS 1.0,iOS 17.0, *)
+    #if os(iOS) || os(visionOS)
+    @available(iOS 17.0,visionOS 1.0, *)
     init(_ dictationBehavior: SwiftUI.TextInputDictationBehavior) {
         self.value = ._0(dictationBehavior: dictationBehavior)
         
@@ -8981,9 +8981,9 @@ struct _searchDictationBehaviorModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(visionOS) || os(iOS)
+        #if os(iOS) || os(visionOS)
         case let ._0(dictationBehavior):
-            if #available(visionOS 1.0,iOS 17.0, *) {
+            if #available(iOS 17.0,visionOS 1.0, *) {
             let dictationBehavior = dictationBehavior as! SwiftUI.TextInputDictationBehavior
             __content
                 .searchDictationBehavior(dictationBehavior)
@@ -8998,7 +8998,7 @@ struct _searchPresentationToolbarBehaviorModifier<R: RootRegistry>: ViewModifier
 
     enum Value {
         case _never
-        #if os(tvOS) || os(watchOS) || os(macOS) || os(iOS)
+        #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
         case _0(behavior: Any)
         #endif
     }
@@ -9011,8 +9011,8 @@ struct _searchPresentationToolbarBehaviorModifier<R: RootRegistry>: ViewModifier
 
 
 
-    #if os(tvOS) || os(watchOS) || os(macOS) || os(iOS)
-    @available(tvOS 17.1,watchOS 10.1,macOS 14.1,iOS 17.1, *)
+    #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+    @available(macOS 14.1,iOS 17.1,tvOS 17.1,watchOS 10.1, *)
     init(_ behavior: SwiftUI.SearchPresentationToolbarBehavior) {
         self.value = ._0(behavior: behavior)
         
@@ -9023,9 +9023,9 @@ struct _searchPresentationToolbarBehaviorModifier<R: RootRegistry>: ViewModifier
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(tvOS) || os(watchOS) || os(macOS) || os(iOS)
+        #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
         case let ._0(behavior):
-            if #available(tvOS 17.1,watchOS 10.1,macOS 14.1,iOS 17.1, *) {
+            if #available(macOS 14.1,iOS 17.1,tvOS 17.1,watchOS 10.1, *) {
             let behavior = behavior as! SwiftUI.SearchPresentationToolbarBehavior
             __content
                 .searchPresentationToolbarBehavior(behavior)
@@ -9111,13 +9111,13 @@ struct _searchableModifier<R: RootRegistry>: ViewModifier {
         
         case _2(placement: SwiftUI.SearchFieldPlacement = .automatic, prompt: AttributeReference<String>)
         
-        #if os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS)
         case _3(placement: Any, prompt: Any?)
         #endif
-        #if os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS)
         case _4(placement: Any, prompt: Any)
         #endif
-        #if os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS)
         case _5(placement: Any, prompt: Any)
         #endif
     }
@@ -9164,24 +9164,24 @@ struct _searchableModifier<R: RootRegistry>: ViewModifier {
         self.__2_text = text
     }
     
-    #if os(macOS) || os(iOS)
-    @available(macOS 14.0,iOS 17.0, *)
+    #if os(iOS) || os(macOS)
+    @available(iOS 17.0,macOS 14.0, *)
     init(text: ChangeTracked<Swift.String>,isPresented: ChangeTracked<Swift.Bool>,placement: SwiftUI.SearchFieldPlacement = .automatic, prompt: TextReference? = nil ) {
         self.value = ._3(placement: placement, prompt: prompt)
         self.__3_text = text
 self.__3_isPresented = isPresented
     }
     #endif
-    #if os(macOS) || os(iOS)
-    @available(macOS 14.0,iOS 17.0, *)
+    #if os(iOS) || os(macOS)
+    @available(iOS 17.0,macOS 14.0, *)
     init(text: ChangeTracked<Swift.String>,isPresented: ChangeTracked<Swift.Bool>,placement: SwiftUI.SearchFieldPlacement = .automatic, prompt: SwiftUI.LocalizedStringKey) {
         self.value = ._4(placement: placement, prompt: prompt)
         self.__4_text = text
 self.__4_isPresented = isPresented
     }
     #endif
-    #if os(macOS) || os(iOS)
-    @available(macOS 14.0,iOS 17.0, *)
+    #if os(iOS) || os(macOS)
+    @available(iOS 17.0,macOS 14.0, *)
     init(text: ChangeTracked<Swift.String>,isPresented: ChangeTracked<Swift.Bool>,placement: SwiftUI.SearchFieldPlacement = .automatic, prompt: AttributeReference<String>) {
         self.value = ._5(placement: placement, prompt: prompt)
         self.__5_text = text
@@ -9217,27 +9217,27 @@ self.__5_isPresented = isPresented
                 .searchable(text: __2_text.projectedValue, placement: placement, prompt: prompt.resolve(on: element, in: context))
             
         
-        #if os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS)
         case let ._3(placement, prompt):
-            if #available(macOS 14.0,iOS 17.0, *) {
+            if #available(iOS 17.0,macOS 14.0, *) {
             let placement = placement as! SwiftUI.SearchFieldPlacement 
 let prompt = prompt as? TextReference
             __content
                 .searchable(text: __3_text.projectedValue, isPresented: __3_isPresented.projectedValue, placement: placement, prompt: prompt?.resolve(on: element, in: context))
             } else { __content }
         #endif
-        #if os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS)
         case let ._4(placement, prompt):
-            if #available(macOS 14.0,iOS 17.0, *) {
+            if #available(iOS 17.0,macOS 14.0, *) {
             let placement = placement as! SwiftUI.SearchFieldPlacement 
 let prompt = prompt as! SwiftUI.LocalizedStringKey
             __content
                 .searchable(text: __4_text.projectedValue, isPresented: __4_isPresented.projectedValue, placement: placement, prompt: prompt)
             } else { __content }
         #endif
-        #if os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS)
         case let ._5(placement, prompt):
-            if #available(macOS 14.0,iOS 17.0, *) {
+            if #available(iOS 17.0,macOS 14.0, *) {
             let placement = placement as! SwiftUI.SearchFieldPlacement 
 let prompt = prompt as! AttributeReference<String>
             __content
@@ -9253,7 +9253,7 @@ struct _selectionDisabledModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(tvOS) || os(macOS) || os(watchOS) || os(iOS)
+        #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
         case _0(isDisabled: Any)
         #endif
     }
@@ -9266,8 +9266,8 @@ struct _selectionDisabledModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(tvOS) || os(macOS) || os(watchOS) || os(iOS)
-    @available(tvOS 17.0,macOS 14.0,watchOS 10.0,iOS 17.0, *)
+    #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
+    @available(iOS 17.0,macOS 14.0,watchOS 10.0,tvOS 17.0, *)
     init(_ isDisabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(isDisabled: isDisabled)
         
@@ -9278,9 +9278,9 @@ struct _selectionDisabledModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(tvOS) || os(macOS) || os(watchOS) || os(iOS)
+        #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
         case let ._0(isDisabled):
-            if #available(tvOS 17.0,macOS 14.0,watchOS 10.0,iOS 17.0, *) {
+            if #available(iOS 17.0,macOS 14.0,watchOS 10.0,tvOS 17.0, *) {
             let isDisabled = isDisabled as! AttributeReference<Swift.Bool>
             __content
                 .selectionDisabled(isDisabled.resolve(on: element, in: context))
@@ -9758,7 +9758,7 @@ struct _swipeActionsModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(watchOS) || os(macOS) || os(iOS)
+        #if os(iOS) || os(watchOS) || os(macOS)
         case _0(edge: Any, allowsFullSwipe: Any, content: Any)
         #endif
     }
@@ -9771,8 +9771,8 @@ struct _swipeActionsModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(watchOS) || os(macOS) || os(iOS)
-    @available(watchOS 8.0,macOS 12.0,iOS 15.0, *)
+    #if os(iOS) || os(watchOS) || os(macOS)
+    @available(iOS 15.0,watchOS 8.0,macOS 12.0, *)
     init(edge: SwiftUI.HorizontalEdge = .trailing, allowsFullSwipe: AttributeReference<Swift.Bool> = .init(storage: .constant(true)), content: ViewReference=ViewReference(value: [])) {
         self.value = ._0(edge: edge, allowsFullSwipe: allowsFullSwipe, content: content)
         
@@ -9783,9 +9783,9 @@ struct _swipeActionsModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(watchOS) || os(macOS) || os(iOS)
+        #if os(iOS) || os(watchOS) || os(macOS)
         case let ._0(edge, allowsFullSwipe, content):
-            if #available(watchOS 8.0,macOS 12.0,iOS 15.0, *) {
+            if #available(iOS 15.0,watchOS 8.0,macOS 12.0, *) {
             let edge = edge as! SwiftUI.HorizontalEdge 
 let allowsFullSwipe = allowsFullSwipe as! AttributeReference<Swift.Bool>
 let content = content as! ViewReference
@@ -9802,7 +9802,7 @@ struct _symbolEffectsRemovedModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(tvOS) || os(watchOS) || os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
         case _0(isEnabled: Any)
         #endif
     }
@@ -9815,8 +9815,8 @@ struct _symbolEffectsRemovedModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(tvOS) || os(watchOS) || os(macOS) || os(iOS)
-    @available(tvOS 17.0,watchOS 10.0,macOS 14.0,iOS 17.0, *)
+    #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
+    @available(iOS 17.0,macOS 14.0,watchOS 10.0,tvOS 17.0, *)
     init(_ isEnabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(isEnabled: isEnabled)
         
@@ -9827,9 +9827,9 @@ struct _symbolEffectsRemovedModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(tvOS) || os(watchOS) || os(macOS) || os(iOS)
+        #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
         case let ._0(isEnabled):
-            if #available(tvOS 17.0,watchOS 10.0,macOS 14.0,iOS 17.0, *) {
+            if #available(iOS 17.0,macOS 14.0,watchOS 10.0,tvOS 17.0, *) {
             let isEnabled = isEnabled as! AttributeReference<Swift.Bool>
             __content
                 .symbolEffectsRemoved(isEnabled.resolve(on: element, in: context))
@@ -10096,7 +10096,7 @@ struct _textContentTypeModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(tvOS)
+        #if os(tvOS) || os(iOS)
         case _0(textContentType: Any?)
         #endif
     }
@@ -10109,8 +10109,8 @@ struct _textContentTypeModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(tvOS)
-    @available(iOS 13.0,tvOS 13.0, *)
+    #if os(tvOS) || os(iOS)
+    @available(tvOS 13.0,iOS 13.0, *)
     init(_ textContentType: UIKit.UITextContentType?) {
         self.value = ._0(textContentType: textContentType)
         
@@ -10121,9 +10121,9 @@ struct _textContentTypeModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(tvOS)
+        #if os(tvOS) || os(iOS)
         case let ._0(textContentType):
-            if #available(iOS 13.0,tvOS 13.0, *) {
+            if #available(tvOS 13.0,iOS 13.0, *) {
             let textContentType = textContentType as? UIKit.UITextContentType
             __content
                 .textContentType(textContentType)
@@ -10138,7 +10138,7 @@ struct _textEditorStyleModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(macOS) || os(visionOS) || os(iOS)
+        #if os(iOS) || os(macOS) || os(visionOS)
         case _0(style: Any)
         #endif
     }
@@ -10151,8 +10151,8 @@ struct _textEditorStyleModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(macOS) || os(visionOS) || os(iOS)
-    @available(macOS 14.0,visionOS 1.0,iOS 17.0, *)
+    #if os(iOS) || os(macOS) || os(visionOS)
+    @available(iOS 17.0,macOS 14.0,visionOS 1.0, *)
     init(_ style: AnyTextEditorStyle) {
         self.value = ._0(style: style)
         
@@ -10163,9 +10163,9 @@ struct _textEditorStyleModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(macOS) || os(visionOS) || os(iOS)
+        #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(style):
-            if #available(macOS 14.0,visionOS 1.0,iOS 17.0, *) {
+            if #available(iOS 17.0,macOS 14.0,visionOS 1.0, *) {
             let style = style as! AnyTextEditorStyle
             __content
                 .textEditorStyle(style)
@@ -10222,7 +10222,7 @@ struct _textInputAutocapitalizationModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(tvOS) || os(watchOS) || os(iOS)
+        #if os(iOS) || os(tvOS) || os(watchOS)
         case _0(autocapitalization: Any?)
         #endif
     }
@@ -10235,8 +10235,8 @@ struct _textInputAutocapitalizationModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(tvOS) || os(watchOS) || os(iOS)
-    @available(tvOS 15.0,watchOS 8.0,iOS 15.0, *)
+    #if os(iOS) || os(tvOS) || os(watchOS)
+    @available(iOS 15.0,tvOS 15.0,watchOS 8.0, *)
     init(_ autocapitalization: SwiftUI.TextInputAutocapitalization?) {
         self.value = ._0(autocapitalization: autocapitalization)
         
@@ -10247,9 +10247,9 @@ struct _textInputAutocapitalizationModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(tvOS) || os(watchOS) || os(iOS)
+        #if os(iOS) || os(tvOS) || os(watchOS)
         case let ._0(autocapitalization):
-            if #available(tvOS 15.0,watchOS 8.0,iOS 15.0, *) {
+            if #available(iOS 15.0,tvOS 15.0,watchOS 8.0, *) {
             let autocapitalization = autocapitalization as? SwiftUI.TextInputAutocapitalization
             __content
                 .textInputAutocapitalization(autocapitalization)
@@ -10264,7 +10264,7 @@ struct _textScaleModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(tvOS) || os(watchOS) || os(macOS) || os(iOS)
+        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
         case _0(scale: Any,isEnabled: Any)
         #endif
     }
@@ -10277,8 +10277,8 @@ struct _textScaleModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(tvOS) || os(watchOS) || os(macOS) || os(iOS)
-    @available(tvOS 17.0,watchOS 10.0,macOS 14.0,iOS 17.0, *)
+    #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
+    @available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0, *)
     init(_ scale: SwiftUI.Text.Scale,isEnabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(scale: scale, isEnabled: isEnabled)
         
@@ -10289,9 +10289,9 @@ struct _textScaleModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(tvOS) || os(watchOS) || os(macOS) || os(iOS)
+        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
         case let ._0(scale, isEnabled):
-            if #available(tvOS 17.0,watchOS 10.0,macOS 14.0,iOS 17.0, *) {
+            if #available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0, *) {
             let scale = scale as! SwiftUI.Text.Scale
 let isEnabled = isEnabled as! AttributeReference<Swift.Bool>
             __content
@@ -10456,7 +10456,7 @@ struct _toolbarModifier<R: RootRegistry>: ViewModifier {
         
         case _0(visibility: AttributeReference<SwiftUI.Visibility>,bars: SwiftUI.ToolbarPlacement)
         
-        #if os(tvOS) || os(macOS) || os(watchOS) || os(iOS)
+        #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
         case _1(defaultItemKind: Any?)
         #endif
         
@@ -10488,8 +10488,8 @@ struct _toolbarModifier<R: RootRegistry>: ViewModifier {
         
     }
     
-    #if os(tvOS) || os(macOS) || os(watchOS) || os(iOS)
-    @available(tvOS 17.0,macOS 14.0,watchOS 10.0,iOS 17.0, *)
+    #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+    @available(macOS 14.0,iOS 17.0,watchOS 10.0,tvOS 17.0, *)
     init(removing defaultItemKind: SwiftUI.ToolbarDefaultItemKind?) {
         self.value = ._1(defaultItemKind: defaultItemKind)
         
@@ -10522,9 +10522,9 @@ struct _toolbarModifier<R: RootRegistry>: ViewModifier {
                 .toolbar(visibility.resolve(on: element, in: context), for: bars)
             
         
-        #if os(tvOS) || os(macOS) || os(watchOS) || os(iOS)
+        #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
         case let ._1(defaultItemKind):
-            if #available(tvOS 17.0,macOS 14.0,watchOS 10.0,iOS 17.0, *) {
+            if #available(macOS 14.0,iOS 17.0,watchOS 10.0,tvOS 17.0, *) {
             let defaultItemKind = defaultItemKind as? SwiftUI.ToolbarDefaultItemKind
             __content
                 .toolbar(removing: defaultItemKind)
@@ -10701,7 +10701,7 @@ struct _toolbarTitleDisplayModeModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(tvOS) || os(macOS) || os(watchOS)
+        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
         case _0(mode: Any)
         #endif
     }
@@ -10714,8 +10714,8 @@ struct _toolbarTitleDisplayModeModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(tvOS) || os(macOS) || os(watchOS)
-    @available(iOS 17.0,tvOS 17.0,macOS 14.0,watchOS 10.0, *)
+    #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
+    @available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0, *)
     init(_ mode: SwiftUI.ToolbarTitleDisplayMode) {
         self.value = ._0(mode: mode)
         
@@ -10726,9 +10726,9 @@ struct _toolbarTitleDisplayModeModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(tvOS) || os(macOS) || os(watchOS)
+        #if os(iOS) || os(watchOS) || os(macOS) || os(tvOS)
         case let ._0(mode):
-            if #available(iOS 17.0,tvOS 17.0,macOS 14.0,watchOS 10.0, *) {
+            if #available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0, *) {
             let mode = mode as! SwiftUI.ToolbarTitleDisplayMode
             __content
                 .toolbarTitleDisplayMode(mode)
@@ -11159,7 +11159,7 @@ struct _zIndexModifier<R: RootRegistry>: ViewModifier {
 }
 
 extension BuiltinRegistry {
-    enum BuiltinModifier: ViewModifier, ParseableModifierValue {
+    enum _BuiltinModifierChunk0: ViewModifier {
         case accessibilityAction(_accessibilityActionModifier<R>)
 case accessibilityActions(_accessibilityActionsModifier<R>)
 case accessibilityChildren(_accessibilityChildrenModifier<R>)
@@ -11170,244 +11170,6 @@ case alert(_alertModifier<R>)
 case allowsHitTesting(_allowsHitTestingModifier<R>)
 case allowsTightening(_allowsTighteningModifier<R>)
 case animation(_animationModifier<R>)
-case aspectRatio(_aspectRatioModifier<R>)
-case autocorrectionDisabled(_autocorrectionDisabledModifier<R>)
-case background(_backgroundModifier<R>)
-case backgroundStyle(_backgroundStyleModifier<R>)
-case badge(_badgeModifier<R>)
-case baselineOffset(_baselineOffsetModifier<R>)
-case blendMode(_blendModeModifier<R>)
-case blur(_blurModifier<R>)
-case bold(_boldModifier<R>)
-case border(_borderModifier<R>)
-case brightness(_brightnessModifier<R>)
-case buttonBorderShape(_buttonBorderShapeModifier<R>)
-case buttonStyle(_buttonStyleModifier<R>)
-case clipShape(_clipShapeModifier<R>)
-case clipped(_clippedModifier<R>)
-case colorInvert(_colorInvertModifier<R>)
-case colorMultiply(_colorMultiplyModifier<R>)
-case compositingGroup(_compositingGroupModifier<R>)
-case confirmationDialog(_confirmationDialogModifier<R>)
-case containerRelativeFrame(_containerRelativeFrameModifier<R>)
-case containerShape(_containerShapeModifier<R>)
-case contentShape(_contentShapeModifier<R>)
-case contentTransition(_contentTransitionModifier<R>)
-case contextMenu(_contextMenuModifier<R>)
-case contrast(_contrastModifier<R>)
-case controlGroupStyle(_controlGroupStyleModifier<R>)
-case controlSize(_controlSizeModifier<R>)
-case coordinateSpace(_coordinateSpaceModifier<R>)
-case datePickerStyle(_datePickerStyleModifier<R>)
-case defaultScrollAnchor(_defaultScrollAnchorModifier<R>)
-case defaultWheelPickerItemHeight(_defaultWheelPickerItemHeightModifier<R>)
-case defersSystemGestures(_defersSystemGesturesModifier<R>)
-case deleteDisabled(_deleteDisabledModifier<R>)
-case dialogSuppressionToggle(_dialogSuppressionToggleModifier<R>)
-case digitalCrownAccessory(_digitalCrownAccessoryModifier<R>)
-case disabled(_disabledModifier<R>)
-case drawingGroup(_drawingGroupModifier<R>)
-case dynamicTypeSize(_dynamicTypeSizeModifier<R>)
-case fileDialogCustomizationID(_fileDialogCustomizationIDModifier<R>)
-case fileDialogImportsUnresolvedAliases(_fileDialogImportsUnresolvedAliasesModifier<R>)
-case findDisabled(_findDisabledModifier<R>)
-case findNavigator(_findNavigatorModifier<R>)
-case fixedSize(_fixedSizeModifier<R>)
-case flipsForRightToLeftLayoutDirection(_flipsForRightToLeftLayoutDirectionModifier<R>)
-case focusEffectDisabled(_focusEffectDisabledModifier<R>)
-case focusSection(_focusSectionModifier<R>)
-case focusable(_focusableModifier<R>)
-case font(_fontModifier<R>)
-case fontDesign(_fontDesignModifier<R>)
-case fontWeight(_fontWeightModifier<R>)
-case fontWidth(_fontWidthModifier<R>)
-case foregroundStyle(_foregroundStyleModifier<R>)
-case formStyle(_formStyleModifier<R>)
-case frame(_frameModifier<R>)
-case fullScreenCover(_fullScreenCoverModifier<R>)
-case gaugeStyle(_gaugeStyleModifier<R>)
-case geometryGroup(_geometryGroupModifier<R>)
-case gesture(_gestureModifier<R>)
-case grayscale(_grayscaleModifier<R>)
-case gridCellAnchor(_gridCellAnchorModifier<R>)
-case gridCellColumns(_gridCellColumnsModifier<R>)
-case gridCellUnsizedAxes(_gridCellUnsizedAxesModifier<R>)
-case gridColumnAlignment(_gridColumnAlignmentModifier<R>)
-case groupBoxStyle(_groupBoxStyleModifier<R>)
-case headerProminence(_headerProminenceModifier<R>)
-case help(_helpModifier<R>)
-case hidden(_hiddenModifier<R>)
-case highPriorityGesture(_highPriorityGestureModifier<R>)
-case horizontalRadioGroupLayout(_horizontalRadioGroupLayoutModifier<R>)
-case hoverEffect(_hoverEffectModifier<R>)
-case hoverEffectDisabled(_hoverEffectDisabledModifier<R>)
-case hueRotation(_hueRotationModifier<R>)
-case ignoresSafeArea(_ignoresSafeAreaModifier<R>)
-case imageScale(_imageScaleModifier<R>)
-case indexViewStyle(_indexViewStyleModifier<R>)
-case inspector(_inspectorModifier<R>)
-case inspectorColumnWidth(_inspectorColumnWidthModifier<R>)
-case interactionActivityTrackingTag(_interactionActivityTrackingTagModifier<R>)
-case interactiveDismissDisabled(_interactiveDismissDisabledModifier<R>)
-case invalidatableContent(_invalidatableContentModifier<R>)
-case italic(_italicModifier<R>)
-case kerning(_kerningModifier<R>)
-case keyboardShortcut(_keyboardShortcutModifier<R>)
-case keyboardType(_keyboardTypeModifier<R>)
-case labelStyle(_labelStyleModifier<R>)
-case labeledContentStyle(_labeledContentStyleModifier<R>)
-case labelsHidden(_labelsHiddenModifier<R>)
-case layoutPriority(_layoutPriorityModifier<R>)
-case lineLimit(_lineLimitModifier<R>)
-case lineSpacing(_lineSpacingModifier<R>)
-case listItemTint(_listItemTintModifier<R>)
-case listRowBackground(_listRowBackgroundModifier<R>)
-case listRowHoverEffect(_listRowHoverEffectModifier<R>)
-case listRowHoverEffectDisabled(_listRowHoverEffectDisabledModifier<R>)
-case listRowInsets(_listRowInsetsModifier<R>)
-case listRowSeparator(_listRowSeparatorModifier<R>)
-case listRowSeparatorTint(_listRowSeparatorTintModifier<R>)
-case listRowSpacing(_listRowSpacingModifier<R>)
-case listSectionSeparator(_listSectionSeparatorModifier<R>)
-case listSectionSeparatorTint(_listSectionSeparatorTintModifier<R>)
-case listSectionSpacing(_listSectionSpacingModifier<R>)
-case listStyle(_listStyleModifier<R>)
-case luminanceToAlpha(_luminanceToAlphaModifier<R>)
-case menuIndicator(_menuIndicatorModifier<R>)
-case menuOrder(_menuOrderModifier<R>)
-case menuStyle(_menuStyleModifier<R>)
-case minimumScaleFactor(_minimumScaleFactorModifier<R>)
-case monospaced(_monospacedModifier<R>)
-case monospacedDigit(_monospacedDigitModifier<R>)
-case moveDisabled(_moveDisabledModifier<R>)
-case multilineTextAlignment(_multilineTextAlignmentModifier<R>)
-case navigationBarBackButtonHidden(_navigationBarBackButtonHiddenModifier<R>)
-case navigationBarTitleDisplayMode(_navigationBarTitleDisplayModeModifier<R>)
-case navigationDestination(_navigationDestinationModifier<R>)
-case navigationSplitViewColumnWidth(_navigationSplitViewColumnWidthModifier<R>)
-case navigationSplitViewStyle(_navigationSplitViewStyleModifier<R>)
-case navigationSubtitle(_navigationSubtitleModifier<R>)
-case navigationTitle(_navigationTitleModifier<R>)
-case offset(_offsetModifier<R>)
-case onAppear(_onAppearModifier<R>)
-case onDeleteCommand(_onDeleteCommandModifier<R>)
-case onDisappear(_onDisappearModifier<R>)
-case onExitCommand(_onExitCommandModifier<R>)
-case onHover(_onHoverModifier<R>)
-case onLongPressGesture(_onLongPressGestureModifier<R>)
-case onLongTouchGesture(_onLongTouchGestureModifier<R>)
-case onMoveCommand(_onMoveCommandModifier<R>)
-case onPlayPauseCommand(_onPlayPauseCommandModifier<R>)
-case onTapGesture(_onTapGestureModifier<R>)
-case opacity(_opacityModifier<R>)
-case overlay(_overlayModifier<R>)
-case padding(_paddingModifier<R>)
-case persistentSystemOverlays(_persistentSystemOverlaysModifier<R>)
-case pickerStyle(_pickerStyleModifier<R>)
-case popover(_popoverModifier<R>)
-case position(_positionModifier<R>)
-case preferredColorScheme(_preferredColorSchemeModifier<R>)
-case presentationBackground(_presentationBackgroundModifier<R>)
-case presentationBackgroundInteraction(_presentationBackgroundInteractionModifier<R>)
-case presentationCompactAdaptation(_presentationCompactAdaptationModifier<R>)
-case presentationContentInteraction(_presentationContentInteractionModifier<R>)
-case presentationCornerRadius(_presentationCornerRadiusModifier<R>)
-case presentationDragIndicator(_presentationDragIndicatorModifier<R>)
-case previewDisplayName(_previewDisplayNameModifier<R>)
-case privacySensitive(_privacySensitiveModifier<R>)
-case progressViewStyle(_progressViewStyleModifier<R>)
-case projectionEffect(_projectionEffectModifier<R>)
-case redacted(_redactedModifier<R>)
-case refreshable(_refreshableModifier<R>)
-case renameAction(_renameActionModifier<R>)
-case replaceDisabled(_replaceDisabledModifier<R>)
-case rotationEffect(_rotationEffectModifier<R>)
-case safeAreaInset(_safeAreaInsetModifier<R>)
-case saturation(_saturationModifier<R>)
-case scaleEffect(_scaleEffectModifier<R>)
-case scaledToFill(_scaledToFillModifier<R>)
-case scaledToFit(_scaledToFitModifier<R>)
-case scenePadding(_scenePaddingModifier<R>)
-case scrollBounceBehavior(_scrollBounceBehaviorModifier<R>)
-case scrollClipDisabled(_scrollClipDisabledModifier<R>)
-case scrollContentBackground(_scrollContentBackgroundModifier<R>)
-case scrollDisabled(_scrollDisabledModifier<R>)
-case scrollDismissesKeyboard(_scrollDismissesKeyboardModifier<R>)
-case scrollIndicators(_scrollIndicatorsModifier<R>)
-case scrollIndicatorsFlash(_scrollIndicatorsFlashModifier<R>)
-case scrollPosition(_scrollPositionModifier<R>)
-case scrollTargetBehavior(_scrollTargetBehaviorModifier<R>)
-case scrollTargetLayout(_scrollTargetLayoutModifier<R>)
-case searchDictationBehavior(_searchDictationBehaviorModifier<R>)
-case searchPresentationToolbarBehavior(_searchPresentationToolbarBehaviorModifier<R>)
-case searchSuggestions(_searchSuggestionsModifier<R>)
-case searchable(_searchableModifier<R>)
-case selectionDisabled(_selectionDisabledModifier<R>)
-case shadow(_shadowModifier<R>)
-case sheet(_sheetModifier<R>)
-case simultaneousGesture(_simultaneousGestureModifier<R>)
-case speechAdjustedPitch(_speechAdjustedPitchModifier<R>)
-case speechAlwaysIncludesPunctuation(_speechAlwaysIncludesPunctuationModifier<R>)
-case speechAnnouncementsQueued(_speechAnnouncementsQueuedModifier<R>)
-case speechSpellsOutCharacters(_speechSpellsOutCharactersModifier<R>)
-case statusBarHidden(_statusBarHiddenModifier<R>)
-case strikethrough(_strikethroughModifier<R>)
-case submitLabel(_submitLabelModifier<R>)
-case submitScope(_submitScopeModifier<R>)
-case swipeActions(_swipeActionsModifier<R>)
-case symbolEffectsRemoved(_symbolEffectsRemovedModifier<R>)
-case symbolRenderingMode(_symbolRenderingModeModifier<R>)
-case symbolVariant(_symbolVariantModifier<R>)
-case tabItem(_tabItemModifier<R>)
-case tabViewStyle(_tabViewStyleModifier<R>)
-case tableStyle(_tableStyleModifier<R>)
-case textCase(_textCaseModifier<R>)
-case textContentType(_textContentTypeModifier<R>)
-case textEditorStyle(_textEditorStyleModifier<R>)
-case textFieldStyle(_textFieldStyleModifier<R>)
-case textInputAutocapitalization(_textInputAutocapitalizationModifier<R>)
-case textScale(_textScaleModifier<R>)
-case textSelection(_textSelectionModifier<R>)
-case tint(_tintModifier<R>)
-case toggleStyle(_toggleStyleModifier<R>)
-case toolbar(_toolbarModifier<R>)
-case toolbarBackground(_toolbarBackgroundModifier<R>)
-case toolbarColorScheme(_toolbarColorSchemeModifier<R>)
-case toolbarRole(_toolbarRoleModifier<R>)
-case toolbarTitleDisplayMode(_toolbarTitleDisplayModeModifier<R>)
-case toolbarTitleMenu(_toolbarTitleMenuModifier<R>)
-case touchBarCustomizationLabel(_touchBarCustomizationLabelModifier<R>)
-case touchBarItemPrincipal(_touchBarItemPrincipalModifier<R>)
-case tracking(_trackingModifier<R>)
-case transformEffect(_transformEffectModifier<R>)
-case transition(_transitionModifier<R>)
-case truncationMode(_truncationModeModifier<R>)
-case underline(_underlineModifier<R>)
-case unredacted(_unredactedModifier<R>)
-case zIndex(_zIndexModifier<R>)
-        case _LineIntersectionModifier(LiveViewNative._LineIntersectionModifier)
-case _Rotation3DEffectModifier(LiveViewNative._Rotation3DEffectModifier<R>)
-case _IntersectionModifier(LiveViewNative._IntersectionModifier)
-case _MaskModifier(LiveViewNative._MaskModifier<R>)
-case _StrokeModifier(LiveViewNative._StrokeModifier<R>)
-case _PresentationDetentsModifier(LiveViewNative._PresentationDetentsModifier)
-case _PrefersDefaultFocusModifier(LiveViewNative._PrefersDefaultFocusModifier<R>)
-case _UnionModifier(LiveViewNative._UnionModifier)
-case _SubtractingModifier(LiveViewNative._SubtractingModifier)
-case _SearchCompletionModifier(LiveViewNative._SearchCompletionModifier<R>)
-case _TransformModifier(LiveViewNative._TransformModifier)
-case _OnSubmitModifier(LiveViewNative._OnSubmitModifier)
-case _LineSubtractionModifier(LiveViewNative._LineSubtractionModifier)
-case _MatchedGeometryEffectModifier(LiveViewNative._MatchedGeometryEffectModifier<R>)
-case _RenderingModeModifier(LiveViewNative._RenderingModeModifier)
-case _RotationModifier(LiveViewNative._RotationModifier)
-case _SearchScopesModifier(LiveViewNative._SearchScopesModifier<R>)
-case _FocusScopeModifier(LiveViewNative._FocusScopeModifier<R>)
-case _ResizableModifier(LiveViewNative._ResizableModifier)
-case _ScaleModifier(LiveViewNative._ScaleModifier<R>)
-case _FillModifier(LiveViewNative._FillModifier)
-case _SymmetricDifferenceModifier(LiveViewNative._SymmetricDifferenceModifier)
-        case _customRegistryModifier(R.CustomModifier)
         
         func body(content: Content) -> some View {
             switch self {
@@ -11431,7 +11193,26 @@ case let .allowsTightening(modifier):
     content.modifier(modifier)
 case let .animation(modifier):
     content.modifier(modifier)
-case let .aspectRatio(modifier):
+            }
+        }
+    }
+}
+extension BuiltinRegistry {
+    enum _BuiltinModifierChunk1: ViewModifier {
+        case aspectRatio(_aspectRatioModifier<R>)
+case autocorrectionDisabled(_autocorrectionDisabledModifier<R>)
+case background(_backgroundModifier<R>)
+case backgroundStyle(_backgroundStyleModifier<R>)
+case badge(_badgeModifier<R>)
+case baselineOffset(_baselineOffsetModifier<R>)
+case blendMode(_blendModeModifier<R>)
+case blur(_blurModifier<R>)
+case bold(_boldModifier<R>)
+case border(_borderModifier<R>)
+        
+        func body(content: Content) -> some View {
+            switch self {
+            case let .aspectRatio(modifier):
     content.modifier(modifier)
 case let .autocorrectionDisabled(modifier):
     content.modifier(modifier)
@@ -11451,7 +11232,26 @@ case let .bold(modifier):
     content.modifier(modifier)
 case let .border(modifier):
     content.modifier(modifier)
-case let .brightness(modifier):
+            }
+        }
+    }
+}
+extension BuiltinRegistry {
+    enum _BuiltinModifierChunk2: ViewModifier {
+        case brightness(_brightnessModifier<R>)
+case buttonBorderShape(_buttonBorderShapeModifier<R>)
+case buttonStyle(_buttonStyleModifier<R>)
+case clipShape(_clipShapeModifier<R>)
+case clipped(_clippedModifier<R>)
+case colorInvert(_colorInvertModifier<R>)
+case colorMultiply(_colorMultiplyModifier<R>)
+case compositingGroup(_compositingGroupModifier<R>)
+case confirmationDialog(_confirmationDialogModifier<R>)
+case containerRelativeFrame(_containerRelativeFrameModifier<R>)
+        
+        func body(content: Content) -> some View {
+            switch self {
+            case let .brightness(modifier):
     content.modifier(modifier)
 case let .buttonBorderShape(modifier):
     content.modifier(modifier)
@@ -11471,7 +11271,26 @@ case let .confirmationDialog(modifier):
     content.modifier(modifier)
 case let .containerRelativeFrame(modifier):
     content.modifier(modifier)
-case let .containerShape(modifier):
+            }
+        }
+    }
+}
+extension BuiltinRegistry {
+    enum _BuiltinModifierChunk3: ViewModifier {
+        case containerShape(_containerShapeModifier<R>)
+case contentShape(_contentShapeModifier<R>)
+case contentTransition(_contentTransitionModifier<R>)
+case contextMenu(_contextMenuModifier<R>)
+case contrast(_contrastModifier<R>)
+case controlGroupStyle(_controlGroupStyleModifier<R>)
+case controlSize(_controlSizeModifier<R>)
+case coordinateSpace(_coordinateSpaceModifier<R>)
+case datePickerStyle(_datePickerStyleModifier<R>)
+case defaultScrollAnchor(_defaultScrollAnchorModifier<R>)
+        
+        func body(content: Content) -> some View {
+            switch self {
+            case let .containerShape(modifier):
     content.modifier(modifier)
 case let .contentShape(modifier):
     content.modifier(modifier)
@@ -11491,7 +11310,26 @@ case let .datePickerStyle(modifier):
     content.modifier(modifier)
 case let .defaultScrollAnchor(modifier):
     content.modifier(modifier)
-case let .defaultWheelPickerItemHeight(modifier):
+            }
+        }
+    }
+}
+extension BuiltinRegistry {
+    enum _BuiltinModifierChunk4: ViewModifier {
+        case defaultWheelPickerItemHeight(_defaultWheelPickerItemHeightModifier<R>)
+case defersSystemGestures(_defersSystemGesturesModifier<R>)
+case deleteDisabled(_deleteDisabledModifier<R>)
+case dialogSuppressionToggle(_dialogSuppressionToggleModifier<R>)
+case digitalCrownAccessory(_digitalCrownAccessoryModifier<R>)
+case disabled(_disabledModifier<R>)
+case drawingGroup(_drawingGroupModifier<R>)
+case dynamicTypeSize(_dynamicTypeSizeModifier<R>)
+case fileDialogCustomizationID(_fileDialogCustomizationIDModifier<R>)
+case fileDialogImportsUnresolvedAliases(_fileDialogImportsUnresolvedAliasesModifier<R>)
+        
+        func body(content: Content) -> some View {
+            switch self {
+            case let .defaultWheelPickerItemHeight(modifier):
     content.modifier(modifier)
 case let .defersSystemGestures(modifier):
     content.modifier(modifier)
@@ -11511,7 +11349,26 @@ case let .fileDialogCustomizationID(modifier):
     content.modifier(modifier)
 case let .fileDialogImportsUnresolvedAliases(modifier):
     content.modifier(modifier)
-case let .findDisabled(modifier):
+            }
+        }
+    }
+}
+extension BuiltinRegistry {
+    enum _BuiltinModifierChunk5: ViewModifier {
+        case findDisabled(_findDisabledModifier<R>)
+case findNavigator(_findNavigatorModifier<R>)
+case fixedSize(_fixedSizeModifier<R>)
+case flipsForRightToLeftLayoutDirection(_flipsForRightToLeftLayoutDirectionModifier<R>)
+case focusEffectDisabled(_focusEffectDisabledModifier<R>)
+case focusSection(_focusSectionModifier<R>)
+case focusable(_focusableModifier<R>)
+case font(_fontModifier<R>)
+case fontDesign(_fontDesignModifier<R>)
+case fontWeight(_fontWeightModifier<R>)
+        
+        func body(content: Content) -> some View {
+            switch self {
+            case let .findDisabled(modifier):
     content.modifier(modifier)
 case let .findNavigator(modifier):
     content.modifier(modifier)
@@ -11531,7 +11388,26 @@ case let .fontDesign(modifier):
     content.modifier(modifier)
 case let .fontWeight(modifier):
     content.modifier(modifier)
-case let .fontWidth(modifier):
+            }
+        }
+    }
+}
+extension BuiltinRegistry {
+    enum _BuiltinModifierChunk6: ViewModifier {
+        case fontWidth(_fontWidthModifier<R>)
+case foregroundStyle(_foregroundStyleModifier<R>)
+case formStyle(_formStyleModifier<R>)
+case frame(_frameModifier<R>)
+case fullScreenCover(_fullScreenCoverModifier<R>)
+case gaugeStyle(_gaugeStyleModifier<R>)
+case geometryGroup(_geometryGroupModifier<R>)
+case gesture(_gestureModifier<R>)
+case grayscale(_grayscaleModifier<R>)
+case gridCellAnchor(_gridCellAnchorModifier<R>)
+        
+        func body(content: Content) -> some View {
+            switch self {
+            case let .fontWidth(modifier):
     content.modifier(modifier)
 case let .foregroundStyle(modifier):
     content.modifier(modifier)
@@ -11551,7 +11427,26 @@ case let .grayscale(modifier):
     content.modifier(modifier)
 case let .gridCellAnchor(modifier):
     content.modifier(modifier)
-case let .gridCellColumns(modifier):
+            }
+        }
+    }
+}
+extension BuiltinRegistry {
+    enum _BuiltinModifierChunk7: ViewModifier {
+        case gridCellColumns(_gridCellColumnsModifier<R>)
+case gridCellUnsizedAxes(_gridCellUnsizedAxesModifier<R>)
+case gridColumnAlignment(_gridColumnAlignmentModifier<R>)
+case groupBoxStyle(_groupBoxStyleModifier<R>)
+case headerProminence(_headerProminenceModifier<R>)
+case help(_helpModifier<R>)
+case hidden(_hiddenModifier<R>)
+case highPriorityGesture(_highPriorityGestureModifier<R>)
+case horizontalRadioGroupLayout(_horizontalRadioGroupLayoutModifier<R>)
+case hoverEffect(_hoverEffectModifier<R>)
+        
+        func body(content: Content) -> some View {
+            switch self {
+            case let .gridCellColumns(modifier):
     content.modifier(modifier)
 case let .gridCellUnsizedAxes(modifier):
     content.modifier(modifier)
@@ -11571,7 +11466,26 @@ case let .horizontalRadioGroupLayout(modifier):
     content.modifier(modifier)
 case let .hoverEffect(modifier):
     content.modifier(modifier)
-case let .hoverEffectDisabled(modifier):
+            }
+        }
+    }
+}
+extension BuiltinRegistry {
+    enum _BuiltinModifierChunk8: ViewModifier {
+        case hoverEffectDisabled(_hoverEffectDisabledModifier<R>)
+case hueRotation(_hueRotationModifier<R>)
+case ignoresSafeArea(_ignoresSafeAreaModifier<R>)
+case imageScale(_imageScaleModifier<R>)
+case indexViewStyle(_indexViewStyleModifier<R>)
+case inspector(_inspectorModifier<R>)
+case inspectorColumnWidth(_inspectorColumnWidthModifier<R>)
+case interactionActivityTrackingTag(_interactionActivityTrackingTagModifier<R>)
+case interactiveDismissDisabled(_interactiveDismissDisabledModifier<R>)
+case invalidatableContent(_invalidatableContentModifier<R>)
+        
+        func body(content: Content) -> some View {
+            switch self {
+            case let .hoverEffectDisabled(modifier):
     content.modifier(modifier)
 case let .hueRotation(modifier):
     content.modifier(modifier)
@@ -11591,7 +11505,26 @@ case let .interactiveDismissDisabled(modifier):
     content.modifier(modifier)
 case let .invalidatableContent(modifier):
     content.modifier(modifier)
-case let .italic(modifier):
+            }
+        }
+    }
+}
+extension BuiltinRegistry {
+    enum _BuiltinModifierChunk9: ViewModifier {
+        case italic(_italicModifier<R>)
+case kerning(_kerningModifier<R>)
+case keyboardShortcut(_keyboardShortcutModifier<R>)
+case keyboardType(_keyboardTypeModifier<R>)
+case labelStyle(_labelStyleModifier<R>)
+case labeledContentStyle(_labeledContentStyleModifier<R>)
+case labelsHidden(_labelsHiddenModifier<R>)
+case layoutPriority(_layoutPriorityModifier<R>)
+case lineLimit(_lineLimitModifier<R>)
+case lineSpacing(_lineSpacingModifier<R>)
+        
+        func body(content: Content) -> some View {
+            switch self {
+            case let .italic(modifier):
     content.modifier(modifier)
 case let .kerning(modifier):
     content.modifier(modifier)
@@ -11611,7 +11544,26 @@ case let .lineLimit(modifier):
     content.modifier(modifier)
 case let .lineSpacing(modifier):
     content.modifier(modifier)
-case let .listItemTint(modifier):
+            }
+        }
+    }
+}
+extension BuiltinRegistry {
+    enum _BuiltinModifierChunk10: ViewModifier {
+        case listItemTint(_listItemTintModifier<R>)
+case listRowBackground(_listRowBackgroundModifier<R>)
+case listRowHoverEffect(_listRowHoverEffectModifier<R>)
+case listRowHoverEffectDisabled(_listRowHoverEffectDisabledModifier<R>)
+case listRowInsets(_listRowInsetsModifier<R>)
+case listRowSeparator(_listRowSeparatorModifier<R>)
+case listRowSeparatorTint(_listRowSeparatorTintModifier<R>)
+case listRowSpacing(_listRowSpacingModifier<R>)
+case listSectionSeparator(_listSectionSeparatorModifier<R>)
+case listSectionSeparatorTint(_listSectionSeparatorTintModifier<R>)
+        
+        func body(content: Content) -> some View {
+            switch self {
+            case let .listItemTint(modifier):
     content.modifier(modifier)
 case let .listRowBackground(modifier):
     content.modifier(modifier)
@@ -11631,7 +11583,26 @@ case let .listSectionSeparator(modifier):
     content.modifier(modifier)
 case let .listSectionSeparatorTint(modifier):
     content.modifier(modifier)
-case let .listSectionSpacing(modifier):
+            }
+        }
+    }
+}
+extension BuiltinRegistry {
+    enum _BuiltinModifierChunk11: ViewModifier {
+        case listSectionSpacing(_listSectionSpacingModifier<R>)
+case listStyle(_listStyleModifier<R>)
+case luminanceToAlpha(_luminanceToAlphaModifier<R>)
+case menuIndicator(_menuIndicatorModifier<R>)
+case menuOrder(_menuOrderModifier<R>)
+case menuStyle(_menuStyleModifier<R>)
+case minimumScaleFactor(_minimumScaleFactorModifier<R>)
+case monospaced(_monospacedModifier<R>)
+case monospacedDigit(_monospacedDigitModifier<R>)
+case moveDisabled(_moveDisabledModifier<R>)
+        
+        func body(content: Content) -> some View {
+            switch self {
+            case let .listSectionSpacing(modifier):
     content.modifier(modifier)
 case let .listStyle(modifier):
     content.modifier(modifier)
@@ -11651,7 +11622,26 @@ case let .monospacedDigit(modifier):
     content.modifier(modifier)
 case let .moveDisabled(modifier):
     content.modifier(modifier)
-case let .multilineTextAlignment(modifier):
+            }
+        }
+    }
+}
+extension BuiltinRegistry {
+    enum _BuiltinModifierChunk12: ViewModifier {
+        case multilineTextAlignment(_multilineTextAlignmentModifier<R>)
+case navigationBarBackButtonHidden(_navigationBarBackButtonHiddenModifier<R>)
+case navigationBarTitleDisplayMode(_navigationBarTitleDisplayModeModifier<R>)
+case navigationDestination(_navigationDestinationModifier<R>)
+case navigationSplitViewColumnWidth(_navigationSplitViewColumnWidthModifier<R>)
+case navigationSplitViewStyle(_navigationSplitViewStyleModifier<R>)
+case navigationSubtitle(_navigationSubtitleModifier<R>)
+case navigationTitle(_navigationTitleModifier<R>)
+case offset(_offsetModifier<R>)
+case onAppear(_onAppearModifier<R>)
+        
+        func body(content: Content) -> some View {
+            switch self {
+            case let .multilineTextAlignment(modifier):
     content.modifier(modifier)
 case let .navigationBarBackButtonHidden(modifier):
     content.modifier(modifier)
@@ -11671,7 +11661,26 @@ case let .offset(modifier):
     content.modifier(modifier)
 case let .onAppear(modifier):
     content.modifier(modifier)
-case let .onDeleteCommand(modifier):
+            }
+        }
+    }
+}
+extension BuiltinRegistry {
+    enum _BuiltinModifierChunk13: ViewModifier {
+        case onDeleteCommand(_onDeleteCommandModifier<R>)
+case onDisappear(_onDisappearModifier<R>)
+case onExitCommand(_onExitCommandModifier<R>)
+case onHover(_onHoverModifier<R>)
+case onLongPressGesture(_onLongPressGestureModifier<R>)
+case onLongTouchGesture(_onLongTouchGestureModifier<R>)
+case onMoveCommand(_onMoveCommandModifier<R>)
+case onPlayPauseCommand(_onPlayPauseCommandModifier<R>)
+case onTapGesture(_onTapGestureModifier<R>)
+case opacity(_opacityModifier<R>)
+        
+        func body(content: Content) -> some View {
+            switch self {
+            case let .onDeleteCommand(modifier):
     content.modifier(modifier)
 case let .onDisappear(modifier):
     content.modifier(modifier)
@@ -11691,7 +11700,26 @@ case let .onTapGesture(modifier):
     content.modifier(modifier)
 case let .opacity(modifier):
     content.modifier(modifier)
-case let .overlay(modifier):
+            }
+        }
+    }
+}
+extension BuiltinRegistry {
+    enum _BuiltinModifierChunk14: ViewModifier {
+        case overlay(_overlayModifier<R>)
+case padding(_paddingModifier<R>)
+case persistentSystemOverlays(_persistentSystemOverlaysModifier<R>)
+case pickerStyle(_pickerStyleModifier<R>)
+case popover(_popoverModifier<R>)
+case position(_positionModifier<R>)
+case preferredColorScheme(_preferredColorSchemeModifier<R>)
+case presentationBackground(_presentationBackgroundModifier<R>)
+case presentationBackgroundInteraction(_presentationBackgroundInteractionModifier<R>)
+case presentationCompactAdaptation(_presentationCompactAdaptationModifier<R>)
+        
+        func body(content: Content) -> some View {
+            switch self {
+            case let .overlay(modifier):
     content.modifier(modifier)
 case let .padding(modifier):
     content.modifier(modifier)
@@ -11711,7 +11739,26 @@ case let .presentationBackgroundInteraction(modifier):
     content.modifier(modifier)
 case let .presentationCompactAdaptation(modifier):
     content.modifier(modifier)
-case let .presentationContentInteraction(modifier):
+            }
+        }
+    }
+}
+extension BuiltinRegistry {
+    enum _BuiltinModifierChunk15: ViewModifier {
+        case presentationContentInteraction(_presentationContentInteractionModifier<R>)
+case presentationCornerRadius(_presentationCornerRadiusModifier<R>)
+case presentationDragIndicator(_presentationDragIndicatorModifier<R>)
+case previewDisplayName(_previewDisplayNameModifier<R>)
+case privacySensitive(_privacySensitiveModifier<R>)
+case progressViewStyle(_progressViewStyleModifier<R>)
+case projectionEffect(_projectionEffectModifier<R>)
+case redacted(_redactedModifier<R>)
+case refreshable(_refreshableModifier<R>)
+case renameAction(_renameActionModifier<R>)
+        
+        func body(content: Content) -> some View {
+            switch self {
+            case let .presentationContentInteraction(modifier):
     content.modifier(modifier)
 case let .presentationCornerRadius(modifier):
     content.modifier(modifier)
@@ -11731,7 +11778,26 @@ case let .refreshable(modifier):
     content.modifier(modifier)
 case let .renameAction(modifier):
     content.modifier(modifier)
-case let .replaceDisabled(modifier):
+            }
+        }
+    }
+}
+extension BuiltinRegistry {
+    enum _BuiltinModifierChunk16: ViewModifier {
+        case replaceDisabled(_replaceDisabledModifier<R>)
+case rotationEffect(_rotationEffectModifier<R>)
+case safeAreaInset(_safeAreaInsetModifier<R>)
+case saturation(_saturationModifier<R>)
+case scaleEffect(_scaleEffectModifier<R>)
+case scaledToFill(_scaledToFillModifier<R>)
+case scaledToFit(_scaledToFitModifier<R>)
+case scenePadding(_scenePaddingModifier<R>)
+case scrollBounceBehavior(_scrollBounceBehaviorModifier<R>)
+case scrollClipDisabled(_scrollClipDisabledModifier<R>)
+        
+        func body(content: Content) -> some View {
+            switch self {
+            case let .replaceDisabled(modifier):
     content.modifier(modifier)
 case let .rotationEffect(modifier):
     content.modifier(modifier)
@@ -11751,7 +11817,26 @@ case let .scrollBounceBehavior(modifier):
     content.modifier(modifier)
 case let .scrollClipDisabled(modifier):
     content.modifier(modifier)
-case let .scrollContentBackground(modifier):
+            }
+        }
+    }
+}
+extension BuiltinRegistry {
+    enum _BuiltinModifierChunk17: ViewModifier {
+        case scrollContentBackground(_scrollContentBackgroundModifier<R>)
+case scrollDisabled(_scrollDisabledModifier<R>)
+case scrollDismissesKeyboard(_scrollDismissesKeyboardModifier<R>)
+case scrollIndicators(_scrollIndicatorsModifier<R>)
+case scrollIndicatorsFlash(_scrollIndicatorsFlashModifier<R>)
+case scrollPosition(_scrollPositionModifier<R>)
+case scrollTargetBehavior(_scrollTargetBehaviorModifier<R>)
+case scrollTargetLayout(_scrollTargetLayoutModifier<R>)
+case searchDictationBehavior(_searchDictationBehaviorModifier<R>)
+case searchPresentationToolbarBehavior(_searchPresentationToolbarBehaviorModifier<R>)
+        
+        func body(content: Content) -> some View {
+            switch self {
+            case let .scrollContentBackground(modifier):
     content.modifier(modifier)
 case let .scrollDisabled(modifier):
     content.modifier(modifier)
@@ -11771,7 +11856,26 @@ case let .searchDictationBehavior(modifier):
     content.modifier(modifier)
 case let .searchPresentationToolbarBehavior(modifier):
     content.modifier(modifier)
-case let .searchSuggestions(modifier):
+            }
+        }
+    }
+}
+extension BuiltinRegistry {
+    enum _BuiltinModifierChunk18: ViewModifier {
+        case searchSuggestions(_searchSuggestionsModifier<R>)
+case searchable(_searchableModifier<R>)
+case selectionDisabled(_selectionDisabledModifier<R>)
+case shadow(_shadowModifier<R>)
+case sheet(_sheetModifier<R>)
+case simultaneousGesture(_simultaneousGestureModifier<R>)
+case speechAdjustedPitch(_speechAdjustedPitchModifier<R>)
+case speechAlwaysIncludesPunctuation(_speechAlwaysIncludesPunctuationModifier<R>)
+case speechAnnouncementsQueued(_speechAnnouncementsQueuedModifier<R>)
+case speechSpellsOutCharacters(_speechSpellsOutCharactersModifier<R>)
+        
+        func body(content: Content) -> some View {
+            switch self {
+            case let .searchSuggestions(modifier):
     content.modifier(modifier)
 case let .searchable(modifier):
     content.modifier(modifier)
@@ -11791,7 +11895,26 @@ case let .speechAnnouncementsQueued(modifier):
     content.modifier(modifier)
 case let .speechSpellsOutCharacters(modifier):
     content.modifier(modifier)
-case let .statusBarHidden(modifier):
+            }
+        }
+    }
+}
+extension BuiltinRegistry {
+    enum _BuiltinModifierChunk19: ViewModifier {
+        case statusBarHidden(_statusBarHiddenModifier<R>)
+case strikethrough(_strikethroughModifier<R>)
+case submitLabel(_submitLabelModifier<R>)
+case submitScope(_submitScopeModifier<R>)
+case swipeActions(_swipeActionsModifier<R>)
+case symbolEffectsRemoved(_symbolEffectsRemovedModifier<R>)
+case symbolRenderingMode(_symbolRenderingModeModifier<R>)
+case symbolVariant(_symbolVariantModifier<R>)
+case tabItem(_tabItemModifier<R>)
+case tabViewStyle(_tabViewStyleModifier<R>)
+        
+        func body(content: Content) -> some View {
+            switch self {
+            case let .statusBarHidden(modifier):
     content.modifier(modifier)
 case let .strikethrough(modifier):
     content.modifier(modifier)
@@ -11811,7 +11934,26 @@ case let .tabItem(modifier):
     content.modifier(modifier)
 case let .tabViewStyle(modifier):
     content.modifier(modifier)
-case let .tableStyle(modifier):
+            }
+        }
+    }
+}
+extension BuiltinRegistry {
+    enum _BuiltinModifierChunk20: ViewModifier {
+        case tableStyle(_tableStyleModifier<R>)
+case textCase(_textCaseModifier<R>)
+case textContentType(_textContentTypeModifier<R>)
+case textEditorStyle(_textEditorStyleModifier<R>)
+case textFieldStyle(_textFieldStyleModifier<R>)
+case textInputAutocapitalization(_textInputAutocapitalizationModifier<R>)
+case textScale(_textScaleModifier<R>)
+case textSelection(_textSelectionModifier<R>)
+case tint(_tintModifier<R>)
+case toggleStyle(_toggleStyleModifier<R>)
+        
+        func body(content: Content) -> some View {
+            switch self {
+            case let .tableStyle(modifier):
     content.modifier(modifier)
 case let .textCase(modifier):
     content.modifier(modifier)
@@ -11831,7 +11973,26 @@ case let .tint(modifier):
     content.modifier(modifier)
 case let .toggleStyle(modifier):
     content.modifier(modifier)
-case let .toolbar(modifier):
+            }
+        }
+    }
+}
+extension BuiltinRegistry {
+    enum _BuiltinModifierChunk21: ViewModifier {
+        case toolbar(_toolbarModifier<R>)
+case toolbarBackground(_toolbarBackgroundModifier<R>)
+case toolbarColorScheme(_toolbarColorSchemeModifier<R>)
+case toolbarRole(_toolbarRoleModifier<R>)
+case toolbarTitleDisplayMode(_toolbarTitleDisplayModeModifier<R>)
+case toolbarTitleMenu(_toolbarTitleMenuModifier<R>)
+case touchBarCustomizationLabel(_touchBarCustomizationLabelModifier<R>)
+case touchBarItemPrincipal(_touchBarItemPrincipalModifier<R>)
+case tracking(_trackingModifier<R>)
+case transformEffect(_transformEffectModifier<R>)
+        
+        func body(content: Content) -> some View {
+            switch self {
+            case let .toolbar(modifier):
     content.modifier(modifier)
 case let .toolbarBackground(modifier):
     content.modifier(modifier)
@@ -11851,7 +12012,21 @@ case let .tracking(modifier):
     content.modifier(modifier)
 case let .transformEffect(modifier):
     content.modifier(modifier)
-case let .transition(modifier):
+            }
+        }
+    }
+}
+extension BuiltinRegistry {
+    enum _BuiltinModifierChunk22: ViewModifier {
+        case transition(_transitionModifier<R>)
+case truncationMode(_truncationModeModifier<R>)
+case underline(_underlineModifier<R>)
+case unredacted(_unredactedModifier<R>)
+case zIndex(_zIndexModifier<R>)
+        
+        func body(content: Content) -> some View {
+            switch self {
+            case let .transition(modifier):
     content.modifier(modifier)
 case let .truncationMode(modifier):
     content.modifier(modifier)
@@ -11861,49 +12036,150 @@ case let .unredacted(modifier):
     content.modifier(modifier)
 case let .zIndex(modifier):
     content.modifier(modifier)
-            case let ._LineIntersectionModifier(modifier):
-    content.modifier(modifier)
-case let ._Rotation3DEffectModifier(modifier):
+            }
+        }
+    }
+}
+extension BuiltinRegistry {
+    enum BuiltinModifier: ViewModifier, ParseableModifierValue {
+        case chunk0(_BuiltinModifierChunk0)
+case chunk1(_BuiltinModifierChunk1)
+case chunk2(_BuiltinModifierChunk2)
+case chunk3(_BuiltinModifierChunk3)
+case chunk4(_BuiltinModifierChunk4)
+case chunk5(_BuiltinModifierChunk5)
+case chunk6(_BuiltinModifierChunk6)
+case chunk7(_BuiltinModifierChunk7)
+case chunk8(_BuiltinModifierChunk8)
+case chunk9(_BuiltinModifierChunk9)
+case chunk10(_BuiltinModifierChunk10)
+case chunk11(_BuiltinModifierChunk11)
+case chunk12(_BuiltinModifierChunk12)
+case chunk13(_BuiltinModifierChunk13)
+case chunk14(_BuiltinModifierChunk14)
+case chunk15(_BuiltinModifierChunk15)
+case chunk16(_BuiltinModifierChunk16)
+case chunk17(_BuiltinModifierChunk17)
+case chunk18(_BuiltinModifierChunk18)
+case chunk19(_BuiltinModifierChunk19)
+case chunk20(_BuiltinModifierChunk20)
+case chunk21(_BuiltinModifierChunk21)
+case chunk22(_BuiltinModifierChunk22)
+        case _TransformModifier(LiveViewNative._TransformModifier)
+case _IntersectionModifier(LiveViewNative._IntersectionModifier)
+case _SubtractingModifier(LiveViewNative._SubtractingModifier)
+case _Rotation3DEffectModifier(LiveViewNative._Rotation3DEffectModifier<R>)
+case _PresentationDetentsModifier(LiveViewNative._PresentationDetentsModifier)
+case _SymmetricDifferenceModifier(LiveViewNative._SymmetricDifferenceModifier)
+case _OnSubmitModifier(LiveViewNative._OnSubmitModifier)
+case _LineSubtractionModifier(LiveViewNative._LineSubtractionModifier)
+case _PrefersDefaultFocusModifier(LiveViewNative._PrefersDefaultFocusModifier<R>)
+case _SearchScopesModifier(LiveViewNative._SearchScopesModifier<R>)
+case _MatchedGeometryEffectModifier(LiveViewNative._MatchedGeometryEffectModifier<R>)
+case _FillModifier(LiveViewNative._FillModifier)
+case _SearchCompletionModifier(LiveViewNative._SearchCompletionModifier<R>)
+case _LineIntersectionModifier(LiveViewNative._LineIntersectionModifier)
+case _StrokeModifier(LiveViewNative._StrokeModifier<R>)
+case _ScaleModifier(LiveViewNative._ScaleModifier<R>)
+case _RotationModifier(LiveViewNative._RotationModifier)
+case _ResizableModifier(LiveViewNative._ResizableModifier)
+case _UnionModifier(LiveViewNative._UnionModifier)
+case _FocusScopeModifier(LiveViewNative._FocusScopeModifier<R>)
+case _MaskModifier(LiveViewNative._MaskModifier<R>)
+case _RenderingModeModifier(LiveViewNative._RenderingModeModifier)
+        case _customRegistryModifier(R.CustomModifier)
+        
+        func body(content: Content) -> some View {
+            switch self {
+            case let .chunk0(chunk):
+    content.modifier(chunk)
+case let .chunk1(chunk):
+    content.modifier(chunk)
+case let .chunk2(chunk):
+    content.modifier(chunk)
+case let .chunk3(chunk):
+    content.modifier(chunk)
+case let .chunk4(chunk):
+    content.modifier(chunk)
+case let .chunk5(chunk):
+    content.modifier(chunk)
+case let .chunk6(chunk):
+    content.modifier(chunk)
+case let .chunk7(chunk):
+    content.modifier(chunk)
+case let .chunk8(chunk):
+    content.modifier(chunk)
+case let .chunk9(chunk):
+    content.modifier(chunk)
+case let .chunk10(chunk):
+    content.modifier(chunk)
+case let .chunk11(chunk):
+    content.modifier(chunk)
+case let .chunk12(chunk):
+    content.modifier(chunk)
+case let .chunk13(chunk):
+    content.modifier(chunk)
+case let .chunk14(chunk):
+    content.modifier(chunk)
+case let .chunk15(chunk):
+    content.modifier(chunk)
+case let .chunk16(chunk):
+    content.modifier(chunk)
+case let .chunk17(chunk):
+    content.modifier(chunk)
+case let .chunk18(chunk):
+    content.modifier(chunk)
+case let .chunk19(chunk):
+    content.modifier(chunk)
+case let .chunk20(chunk):
+    content.modifier(chunk)
+case let .chunk21(chunk):
+    content.modifier(chunk)
+case let .chunk22(chunk):
+    content.modifier(chunk)
+            case let ._TransformModifier(modifier):
     content.modifier(modifier)
 case let ._IntersectionModifier(modifier):
     content.modifier(modifier)
-case let ._MaskModifier(modifier):
+case let ._SubtractingModifier(modifier):
     content.modifier(modifier)
-case let ._StrokeModifier(modifier):
+case let ._Rotation3DEffectModifier(modifier):
     content.modifier(modifier)
 case let ._PresentationDetentsModifier(modifier):
     content.modifier(modifier)
-case let ._PrefersDefaultFocusModifier(modifier):
-    content.modifier(modifier)
-case let ._UnionModifier(modifier):
-    content.modifier(modifier)
-case let ._SubtractingModifier(modifier):
-    content.modifier(modifier)
-case let ._SearchCompletionModifier(modifier):
-    content.modifier(modifier)
-case let ._TransformModifier(modifier):
+case let ._SymmetricDifferenceModifier(modifier):
     content.modifier(modifier)
 case let ._OnSubmitModifier(modifier):
     content.modifier(modifier)
 case let ._LineSubtractionModifier(modifier):
     content.modifier(modifier)
-case let ._MatchedGeometryEffectModifier(modifier):
-    content.modifier(modifier)
-case let ._RenderingModeModifier(modifier):
-    content.modifier(modifier)
-case let ._RotationModifier(modifier):
+case let ._PrefersDefaultFocusModifier(modifier):
     content.modifier(modifier)
 case let ._SearchScopesModifier(modifier):
     content.modifier(modifier)
-case let ._FocusScopeModifier(modifier):
-    content.modifier(modifier)
-case let ._ResizableModifier(modifier):
-    content.modifier(modifier)
-case let ._ScaleModifier(modifier):
+case let ._MatchedGeometryEffectModifier(modifier):
     content.modifier(modifier)
 case let ._FillModifier(modifier):
     content.modifier(modifier)
-case let ._SymmetricDifferenceModifier(modifier):
+case let ._SearchCompletionModifier(modifier):
+    content.modifier(modifier)
+case let ._LineIntersectionModifier(modifier):
+    content.modifier(modifier)
+case let ._StrokeModifier(modifier):
+    content.modifier(modifier)
+case let ._ScaleModifier(modifier):
+    content.modifier(modifier)
+case let ._RotationModifier(modifier):
+    content.modifier(modifier)
+case let ._ResizableModifier(modifier):
+    content.modifier(modifier)
+case let ._UnionModifier(modifier):
+    content.modifier(modifier)
+case let ._FocusScopeModifier(modifier):
+    content.modifier(modifier)
+case let ._MaskModifier(modifier):
+    content.modifier(modifier)
+case let ._RenderingModeModifier(modifier):
     content.modifier(modifier)
             case let ._customRegistryModifier(modifier):
                 content.modifier(modifier)
@@ -11922,253 +12198,253 @@ case let ._SymmetricDifferenceModifier(modifier):
             
             func parse(_ input: inout Substring.UTF8View) throws -> Output {
                 let parsers = [
-                    _accessibilityActionModifier<R>.name: _accessibilityActionModifier<R>.parser(in: context).map(Output.accessibilityAction).eraseToAnyParser(),
-_accessibilityActionsModifier<R>.name: _accessibilityActionsModifier<R>.parser(in: context).map(Output.accessibilityActions).eraseToAnyParser(),
-_accessibilityChildrenModifier<R>.name: _accessibilityChildrenModifier<R>.parser(in: context).map(Output.accessibilityChildren).eraseToAnyParser(),
-_accessibilityIgnoresInvertColorsModifier<R>.name: _accessibilityIgnoresInvertColorsModifier<R>.parser(in: context).map(Output.accessibilityIgnoresInvertColors).eraseToAnyParser(),
-_accessibilityRepresentationModifier<R>.name: _accessibilityRepresentationModifier<R>.parser(in: context).map(Output.accessibilityRepresentation).eraseToAnyParser(),
-_accessibilityShowsLargeContentViewerModifier<R>.name: _accessibilityShowsLargeContentViewerModifier<R>.parser(in: context).map(Output.accessibilityShowsLargeContentViewer).eraseToAnyParser(),
-_alertModifier<R>.name: _alertModifier<R>.parser(in: context).map(Output.alert).eraseToAnyParser(),
-_allowsHitTestingModifier<R>.name: _allowsHitTestingModifier<R>.parser(in: context).map(Output.allowsHitTesting).eraseToAnyParser(),
-_allowsTighteningModifier<R>.name: _allowsTighteningModifier<R>.parser(in: context).map(Output.allowsTightening).eraseToAnyParser(),
-_animationModifier<R>.name: _animationModifier<R>.parser(in: context).map(Output.animation).eraseToAnyParser(),
-_aspectRatioModifier<R>.name: _aspectRatioModifier<R>.parser(in: context).map(Output.aspectRatio).eraseToAnyParser(),
-_autocorrectionDisabledModifier<R>.name: _autocorrectionDisabledModifier<R>.parser(in: context).map(Output.autocorrectionDisabled).eraseToAnyParser(),
-_backgroundModifier<R>.name: _backgroundModifier<R>.parser(in: context).map(Output.background).eraseToAnyParser(),
-_backgroundStyleModifier<R>.name: _backgroundStyleModifier<R>.parser(in: context).map(Output.backgroundStyle).eraseToAnyParser(),
-_badgeModifier<R>.name: _badgeModifier<R>.parser(in: context).map(Output.badge).eraseToAnyParser(),
-_baselineOffsetModifier<R>.name: _baselineOffsetModifier<R>.parser(in: context).map(Output.baselineOffset).eraseToAnyParser(),
-_blendModeModifier<R>.name: _blendModeModifier<R>.parser(in: context).map(Output.blendMode).eraseToAnyParser(),
-_blurModifier<R>.name: _blurModifier<R>.parser(in: context).map(Output.blur).eraseToAnyParser(),
-_boldModifier<R>.name: _boldModifier<R>.parser(in: context).map(Output.bold).eraseToAnyParser(),
-_borderModifier<R>.name: _borderModifier<R>.parser(in: context).map(Output.border).eraseToAnyParser(),
-_brightnessModifier<R>.name: _brightnessModifier<R>.parser(in: context).map(Output.brightness).eraseToAnyParser(),
-_buttonBorderShapeModifier<R>.name: _buttonBorderShapeModifier<R>.parser(in: context).map(Output.buttonBorderShape).eraseToAnyParser(),
-_buttonStyleModifier<R>.name: _buttonStyleModifier<R>.parser(in: context).map(Output.buttonStyle).eraseToAnyParser(),
-_clipShapeModifier<R>.name: _clipShapeModifier<R>.parser(in: context).map(Output.clipShape).eraseToAnyParser(),
-_clippedModifier<R>.name: _clippedModifier<R>.parser(in: context).map(Output.clipped).eraseToAnyParser(),
-_colorInvertModifier<R>.name: _colorInvertModifier<R>.parser(in: context).map(Output.colorInvert).eraseToAnyParser(),
-_colorMultiplyModifier<R>.name: _colorMultiplyModifier<R>.parser(in: context).map(Output.colorMultiply).eraseToAnyParser(),
-_compositingGroupModifier<R>.name: _compositingGroupModifier<R>.parser(in: context).map(Output.compositingGroup).eraseToAnyParser(),
-_confirmationDialogModifier<R>.name: _confirmationDialogModifier<R>.parser(in: context).map(Output.confirmationDialog).eraseToAnyParser(),
-_containerRelativeFrameModifier<R>.name: _containerRelativeFrameModifier<R>.parser(in: context).map(Output.containerRelativeFrame).eraseToAnyParser(),
-_containerShapeModifier<R>.name: _containerShapeModifier<R>.parser(in: context).map(Output.containerShape).eraseToAnyParser(),
-_contentShapeModifier<R>.name: _contentShapeModifier<R>.parser(in: context).map(Output.contentShape).eraseToAnyParser(),
-_contentTransitionModifier<R>.name: _contentTransitionModifier<R>.parser(in: context).map(Output.contentTransition).eraseToAnyParser(),
-_contextMenuModifier<R>.name: _contextMenuModifier<R>.parser(in: context).map(Output.contextMenu).eraseToAnyParser(),
-_contrastModifier<R>.name: _contrastModifier<R>.parser(in: context).map(Output.contrast).eraseToAnyParser(),
-_controlGroupStyleModifier<R>.name: _controlGroupStyleModifier<R>.parser(in: context).map(Output.controlGroupStyle).eraseToAnyParser(),
-_controlSizeModifier<R>.name: _controlSizeModifier<R>.parser(in: context).map(Output.controlSize).eraseToAnyParser(),
-_coordinateSpaceModifier<R>.name: _coordinateSpaceModifier<R>.parser(in: context).map(Output.coordinateSpace).eraseToAnyParser(),
-_datePickerStyleModifier<R>.name: _datePickerStyleModifier<R>.parser(in: context).map(Output.datePickerStyle).eraseToAnyParser(),
-_defaultScrollAnchorModifier<R>.name: _defaultScrollAnchorModifier<R>.parser(in: context).map(Output.defaultScrollAnchor).eraseToAnyParser(),
-_defaultWheelPickerItemHeightModifier<R>.name: _defaultWheelPickerItemHeightModifier<R>.parser(in: context).map(Output.defaultWheelPickerItemHeight).eraseToAnyParser(),
-_defersSystemGesturesModifier<R>.name: _defersSystemGesturesModifier<R>.parser(in: context).map(Output.defersSystemGestures).eraseToAnyParser(),
-_deleteDisabledModifier<R>.name: _deleteDisabledModifier<R>.parser(in: context).map(Output.deleteDisabled).eraseToAnyParser(),
-_dialogSuppressionToggleModifier<R>.name: _dialogSuppressionToggleModifier<R>.parser(in: context).map(Output.dialogSuppressionToggle).eraseToAnyParser(),
-_digitalCrownAccessoryModifier<R>.name: _digitalCrownAccessoryModifier<R>.parser(in: context).map(Output.digitalCrownAccessory).eraseToAnyParser(),
-_disabledModifier<R>.name: _disabledModifier<R>.parser(in: context).map(Output.disabled).eraseToAnyParser(),
-_drawingGroupModifier<R>.name: _drawingGroupModifier<R>.parser(in: context).map(Output.drawingGroup).eraseToAnyParser(),
-_dynamicTypeSizeModifier<R>.name: _dynamicTypeSizeModifier<R>.parser(in: context).map(Output.dynamicTypeSize).eraseToAnyParser(),
-_fileDialogCustomizationIDModifier<R>.name: _fileDialogCustomizationIDModifier<R>.parser(in: context).map(Output.fileDialogCustomizationID).eraseToAnyParser(),
-_fileDialogImportsUnresolvedAliasesModifier<R>.name: _fileDialogImportsUnresolvedAliasesModifier<R>.parser(in: context).map(Output.fileDialogImportsUnresolvedAliases).eraseToAnyParser(),
-_findDisabledModifier<R>.name: _findDisabledModifier<R>.parser(in: context).map(Output.findDisabled).eraseToAnyParser(),
-_findNavigatorModifier<R>.name: _findNavigatorModifier<R>.parser(in: context).map(Output.findNavigator).eraseToAnyParser(),
-_fixedSizeModifier<R>.name: _fixedSizeModifier<R>.parser(in: context).map(Output.fixedSize).eraseToAnyParser(),
-_flipsForRightToLeftLayoutDirectionModifier<R>.name: _flipsForRightToLeftLayoutDirectionModifier<R>.parser(in: context).map(Output.flipsForRightToLeftLayoutDirection).eraseToAnyParser(),
-_focusEffectDisabledModifier<R>.name: _focusEffectDisabledModifier<R>.parser(in: context).map(Output.focusEffectDisabled).eraseToAnyParser(),
-_focusSectionModifier<R>.name: _focusSectionModifier<R>.parser(in: context).map(Output.focusSection).eraseToAnyParser(),
-_focusableModifier<R>.name: _focusableModifier<R>.parser(in: context).map(Output.focusable).eraseToAnyParser(),
-_fontModifier<R>.name: _fontModifier<R>.parser(in: context).map(Output.font).eraseToAnyParser(),
-_fontDesignModifier<R>.name: _fontDesignModifier<R>.parser(in: context).map(Output.fontDesign).eraseToAnyParser(),
-_fontWeightModifier<R>.name: _fontWeightModifier<R>.parser(in: context).map(Output.fontWeight).eraseToAnyParser(),
-_fontWidthModifier<R>.name: _fontWidthModifier<R>.parser(in: context).map(Output.fontWidth).eraseToAnyParser(),
-_foregroundStyleModifier<R>.name: _foregroundStyleModifier<R>.parser(in: context).map(Output.foregroundStyle).eraseToAnyParser(),
-_formStyleModifier<R>.name: _formStyleModifier<R>.parser(in: context).map(Output.formStyle).eraseToAnyParser(),
-_frameModifier<R>.name: _frameModifier<R>.parser(in: context).map(Output.frame).eraseToAnyParser(),
-_fullScreenCoverModifier<R>.name: _fullScreenCoverModifier<R>.parser(in: context).map(Output.fullScreenCover).eraseToAnyParser(),
-_gaugeStyleModifier<R>.name: _gaugeStyleModifier<R>.parser(in: context).map(Output.gaugeStyle).eraseToAnyParser(),
-_geometryGroupModifier<R>.name: _geometryGroupModifier<R>.parser(in: context).map(Output.geometryGroup).eraseToAnyParser(),
-_gestureModifier<R>.name: _gestureModifier<R>.parser(in: context).map(Output.gesture).eraseToAnyParser(),
-_grayscaleModifier<R>.name: _grayscaleModifier<R>.parser(in: context).map(Output.grayscale).eraseToAnyParser(),
-_gridCellAnchorModifier<R>.name: _gridCellAnchorModifier<R>.parser(in: context).map(Output.gridCellAnchor).eraseToAnyParser(),
-_gridCellColumnsModifier<R>.name: _gridCellColumnsModifier<R>.parser(in: context).map(Output.gridCellColumns).eraseToAnyParser(),
-_gridCellUnsizedAxesModifier<R>.name: _gridCellUnsizedAxesModifier<R>.parser(in: context).map(Output.gridCellUnsizedAxes).eraseToAnyParser(),
-_gridColumnAlignmentModifier<R>.name: _gridColumnAlignmentModifier<R>.parser(in: context).map(Output.gridColumnAlignment).eraseToAnyParser(),
-_groupBoxStyleModifier<R>.name: _groupBoxStyleModifier<R>.parser(in: context).map(Output.groupBoxStyle).eraseToAnyParser(),
-_headerProminenceModifier<R>.name: _headerProminenceModifier<R>.parser(in: context).map(Output.headerProminence).eraseToAnyParser(),
-_helpModifier<R>.name: _helpModifier<R>.parser(in: context).map(Output.help).eraseToAnyParser(),
-_hiddenModifier<R>.name: _hiddenModifier<R>.parser(in: context).map(Output.hidden).eraseToAnyParser(),
-_highPriorityGestureModifier<R>.name: _highPriorityGestureModifier<R>.parser(in: context).map(Output.highPriorityGesture).eraseToAnyParser(),
-_horizontalRadioGroupLayoutModifier<R>.name: _horizontalRadioGroupLayoutModifier<R>.parser(in: context).map(Output.horizontalRadioGroupLayout).eraseToAnyParser(),
-_hoverEffectModifier<R>.name: _hoverEffectModifier<R>.parser(in: context).map(Output.hoverEffect).eraseToAnyParser(),
-_hoverEffectDisabledModifier<R>.name: _hoverEffectDisabledModifier<R>.parser(in: context).map(Output.hoverEffectDisabled).eraseToAnyParser(),
-_hueRotationModifier<R>.name: _hueRotationModifier<R>.parser(in: context).map(Output.hueRotation).eraseToAnyParser(),
-_ignoresSafeAreaModifier<R>.name: _ignoresSafeAreaModifier<R>.parser(in: context).map(Output.ignoresSafeArea).eraseToAnyParser(),
-_imageScaleModifier<R>.name: _imageScaleModifier<R>.parser(in: context).map(Output.imageScale).eraseToAnyParser(),
-_indexViewStyleModifier<R>.name: _indexViewStyleModifier<R>.parser(in: context).map(Output.indexViewStyle).eraseToAnyParser(),
-_inspectorModifier<R>.name: _inspectorModifier<R>.parser(in: context).map(Output.inspector).eraseToAnyParser(),
-_inspectorColumnWidthModifier<R>.name: _inspectorColumnWidthModifier<R>.parser(in: context).map(Output.inspectorColumnWidth).eraseToAnyParser(),
-_interactionActivityTrackingTagModifier<R>.name: _interactionActivityTrackingTagModifier<R>.parser(in: context).map(Output.interactionActivityTrackingTag).eraseToAnyParser(),
-_interactiveDismissDisabledModifier<R>.name: _interactiveDismissDisabledModifier<R>.parser(in: context).map(Output.interactiveDismissDisabled).eraseToAnyParser(),
-_invalidatableContentModifier<R>.name: _invalidatableContentModifier<R>.parser(in: context).map(Output.invalidatableContent).eraseToAnyParser(),
-_italicModifier<R>.name: _italicModifier<R>.parser(in: context).map(Output.italic).eraseToAnyParser(),
-_kerningModifier<R>.name: _kerningModifier<R>.parser(in: context).map(Output.kerning).eraseToAnyParser(),
-_keyboardShortcutModifier<R>.name: _keyboardShortcutModifier<R>.parser(in: context).map(Output.keyboardShortcut).eraseToAnyParser(),
-_keyboardTypeModifier<R>.name: _keyboardTypeModifier<R>.parser(in: context).map(Output.keyboardType).eraseToAnyParser(),
-_labelStyleModifier<R>.name: _labelStyleModifier<R>.parser(in: context).map(Output.labelStyle).eraseToAnyParser(),
-_labeledContentStyleModifier<R>.name: _labeledContentStyleModifier<R>.parser(in: context).map(Output.labeledContentStyle).eraseToAnyParser(),
-_labelsHiddenModifier<R>.name: _labelsHiddenModifier<R>.parser(in: context).map(Output.labelsHidden).eraseToAnyParser(),
-_layoutPriorityModifier<R>.name: _layoutPriorityModifier<R>.parser(in: context).map(Output.layoutPriority).eraseToAnyParser(),
-_lineLimitModifier<R>.name: _lineLimitModifier<R>.parser(in: context).map(Output.lineLimit).eraseToAnyParser(),
-_lineSpacingModifier<R>.name: _lineSpacingModifier<R>.parser(in: context).map(Output.lineSpacing).eraseToAnyParser(),
-_listItemTintModifier<R>.name: _listItemTintModifier<R>.parser(in: context).map(Output.listItemTint).eraseToAnyParser(),
-_listRowBackgroundModifier<R>.name: _listRowBackgroundModifier<R>.parser(in: context).map(Output.listRowBackground).eraseToAnyParser(),
-_listRowHoverEffectModifier<R>.name: _listRowHoverEffectModifier<R>.parser(in: context).map(Output.listRowHoverEffect).eraseToAnyParser(),
-_listRowHoverEffectDisabledModifier<R>.name: _listRowHoverEffectDisabledModifier<R>.parser(in: context).map(Output.listRowHoverEffectDisabled).eraseToAnyParser(),
-_listRowInsetsModifier<R>.name: _listRowInsetsModifier<R>.parser(in: context).map(Output.listRowInsets).eraseToAnyParser(),
-_listRowSeparatorModifier<R>.name: _listRowSeparatorModifier<R>.parser(in: context).map(Output.listRowSeparator).eraseToAnyParser(),
-_listRowSeparatorTintModifier<R>.name: _listRowSeparatorTintModifier<R>.parser(in: context).map(Output.listRowSeparatorTint).eraseToAnyParser(),
-_listRowSpacingModifier<R>.name: _listRowSpacingModifier<R>.parser(in: context).map(Output.listRowSpacing).eraseToAnyParser(),
-_listSectionSeparatorModifier<R>.name: _listSectionSeparatorModifier<R>.parser(in: context).map(Output.listSectionSeparator).eraseToAnyParser(),
-_listSectionSeparatorTintModifier<R>.name: _listSectionSeparatorTintModifier<R>.parser(in: context).map(Output.listSectionSeparatorTint).eraseToAnyParser(),
-_listSectionSpacingModifier<R>.name: _listSectionSpacingModifier<R>.parser(in: context).map(Output.listSectionSpacing).eraseToAnyParser(),
-_listStyleModifier<R>.name: _listStyleModifier<R>.parser(in: context).map(Output.listStyle).eraseToAnyParser(),
-_luminanceToAlphaModifier<R>.name: _luminanceToAlphaModifier<R>.parser(in: context).map(Output.luminanceToAlpha).eraseToAnyParser(),
-_menuIndicatorModifier<R>.name: _menuIndicatorModifier<R>.parser(in: context).map(Output.menuIndicator).eraseToAnyParser(),
-_menuOrderModifier<R>.name: _menuOrderModifier<R>.parser(in: context).map(Output.menuOrder).eraseToAnyParser(),
-_menuStyleModifier<R>.name: _menuStyleModifier<R>.parser(in: context).map(Output.menuStyle).eraseToAnyParser(),
-_minimumScaleFactorModifier<R>.name: _minimumScaleFactorModifier<R>.parser(in: context).map(Output.minimumScaleFactor).eraseToAnyParser(),
-_monospacedModifier<R>.name: _monospacedModifier<R>.parser(in: context).map(Output.monospaced).eraseToAnyParser(),
-_monospacedDigitModifier<R>.name: _monospacedDigitModifier<R>.parser(in: context).map(Output.monospacedDigit).eraseToAnyParser(),
-_moveDisabledModifier<R>.name: _moveDisabledModifier<R>.parser(in: context).map(Output.moveDisabled).eraseToAnyParser(),
-_multilineTextAlignmentModifier<R>.name: _multilineTextAlignmentModifier<R>.parser(in: context).map(Output.multilineTextAlignment).eraseToAnyParser(),
-_navigationBarBackButtonHiddenModifier<R>.name: _navigationBarBackButtonHiddenModifier<R>.parser(in: context).map(Output.navigationBarBackButtonHidden).eraseToAnyParser(),
-_navigationBarTitleDisplayModeModifier<R>.name: _navigationBarTitleDisplayModeModifier<R>.parser(in: context).map(Output.navigationBarTitleDisplayMode).eraseToAnyParser(),
-_navigationDestinationModifier<R>.name: _navigationDestinationModifier<R>.parser(in: context).map(Output.navigationDestination).eraseToAnyParser(),
-_navigationSplitViewColumnWidthModifier<R>.name: _navigationSplitViewColumnWidthModifier<R>.parser(in: context).map(Output.navigationSplitViewColumnWidth).eraseToAnyParser(),
-_navigationSplitViewStyleModifier<R>.name: _navigationSplitViewStyleModifier<R>.parser(in: context).map(Output.navigationSplitViewStyle).eraseToAnyParser(),
-_navigationSubtitleModifier<R>.name: _navigationSubtitleModifier<R>.parser(in: context).map(Output.navigationSubtitle).eraseToAnyParser(),
-_navigationTitleModifier<R>.name: _navigationTitleModifier<R>.parser(in: context).map(Output.navigationTitle).eraseToAnyParser(),
-_offsetModifier<R>.name: _offsetModifier<R>.parser(in: context).map(Output.offset).eraseToAnyParser(),
-_onAppearModifier<R>.name: _onAppearModifier<R>.parser(in: context).map(Output.onAppear).eraseToAnyParser(),
-_onDeleteCommandModifier<R>.name: _onDeleteCommandModifier<R>.parser(in: context).map(Output.onDeleteCommand).eraseToAnyParser(),
-_onDisappearModifier<R>.name: _onDisappearModifier<R>.parser(in: context).map(Output.onDisappear).eraseToAnyParser(),
-_onExitCommandModifier<R>.name: _onExitCommandModifier<R>.parser(in: context).map(Output.onExitCommand).eraseToAnyParser(),
-_onHoverModifier<R>.name: _onHoverModifier<R>.parser(in: context).map(Output.onHover).eraseToAnyParser(),
-_onLongPressGestureModifier<R>.name: _onLongPressGestureModifier<R>.parser(in: context).map(Output.onLongPressGesture).eraseToAnyParser(),
-_onLongTouchGestureModifier<R>.name: _onLongTouchGestureModifier<R>.parser(in: context).map(Output.onLongTouchGesture).eraseToAnyParser(),
-_onMoveCommandModifier<R>.name: _onMoveCommandModifier<R>.parser(in: context).map(Output.onMoveCommand).eraseToAnyParser(),
-_onPlayPauseCommandModifier<R>.name: _onPlayPauseCommandModifier<R>.parser(in: context).map(Output.onPlayPauseCommand).eraseToAnyParser(),
-_onTapGestureModifier<R>.name: _onTapGestureModifier<R>.parser(in: context).map(Output.onTapGesture).eraseToAnyParser(),
-_opacityModifier<R>.name: _opacityModifier<R>.parser(in: context).map(Output.opacity).eraseToAnyParser(),
-_overlayModifier<R>.name: _overlayModifier<R>.parser(in: context).map(Output.overlay).eraseToAnyParser(),
-_paddingModifier<R>.name: _paddingModifier<R>.parser(in: context).map(Output.padding).eraseToAnyParser(),
-_persistentSystemOverlaysModifier<R>.name: _persistentSystemOverlaysModifier<R>.parser(in: context).map(Output.persistentSystemOverlays).eraseToAnyParser(),
-_pickerStyleModifier<R>.name: _pickerStyleModifier<R>.parser(in: context).map(Output.pickerStyle).eraseToAnyParser(),
-_popoverModifier<R>.name: _popoverModifier<R>.parser(in: context).map(Output.popover).eraseToAnyParser(),
-_positionModifier<R>.name: _positionModifier<R>.parser(in: context).map(Output.position).eraseToAnyParser(),
-_preferredColorSchemeModifier<R>.name: _preferredColorSchemeModifier<R>.parser(in: context).map(Output.preferredColorScheme).eraseToAnyParser(),
-_presentationBackgroundModifier<R>.name: _presentationBackgroundModifier<R>.parser(in: context).map(Output.presentationBackground).eraseToAnyParser(),
-_presentationBackgroundInteractionModifier<R>.name: _presentationBackgroundInteractionModifier<R>.parser(in: context).map(Output.presentationBackgroundInteraction).eraseToAnyParser(),
-_presentationCompactAdaptationModifier<R>.name: _presentationCompactAdaptationModifier<R>.parser(in: context).map(Output.presentationCompactAdaptation).eraseToAnyParser(),
-_presentationContentInteractionModifier<R>.name: _presentationContentInteractionModifier<R>.parser(in: context).map(Output.presentationContentInteraction).eraseToAnyParser(),
-_presentationCornerRadiusModifier<R>.name: _presentationCornerRadiusModifier<R>.parser(in: context).map(Output.presentationCornerRadius).eraseToAnyParser(),
-_presentationDragIndicatorModifier<R>.name: _presentationDragIndicatorModifier<R>.parser(in: context).map(Output.presentationDragIndicator).eraseToAnyParser(),
-_previewDisplayNameModifier<R>.name: _previewDisplayNameModifier<R>.parser(in: context).map(Output.previewDisplayName).eraseToAnyParser(),
-_privacySensitiveModifier<R>.name: _privacySensitiveModifier<R>.parser(in: context).map(Output.privacySensitive).eraseToAnyParser(),
-_progressViewStyleModifier<R>.name: _progressViewStyleModifier<R>.parser(in: context).map(Output.progressViewStyle).eraseToAnyParser(),
-_projectionEffectModifier<R>.name: _projectionEffectModifier<R>.parser(in: context).map(Output.projectionEffect).eraseToAnyParser(),
-_redactedModifier<R>.name: _redactedModifier<R>.parser(in: context).map(Output.redacted).eraseToAnyParser(),
-_refreshableModifier<R>.name: _refreshableModifier<R>.parser(in: context).map(Output.refreshable).eraseToAnyParser(),
-_renameActionModifier<R>.name: _renameActionModifier<R>.parser(in: context).map(Output.renameAction).eraseToAnyParser(),
-_replaceDisabledModifier<R>.name: _replaceDisabledModifier<R>.parser(in: context).map(Output.replaceDisabled).eraseToAnyParser(),
-_rotationEffectModifier<R>.name: _rotationEffectModifier<R>.parser(in: context).map(Output.rotationEffect).eraseToAnyParser(),
-_safeAreaInsetModifier<R>.name: _safeAreaInsetModifier<R>.parser(in: context).map(Output.safeAreaInset).eraseToAnyParser(),
-_saturationModifier<R>.name: _saturationModifier<R>.parser(in: context).map(Output.saturation).eraseToAnyParser(),
-_scaleEffectModifier<R>.name: _scaleEffectModifier<R>.parser(in: context).map(Output.scaleEffect).eraseToAnyParser(),
-_scaledToFillModifier<R>.name: _scaledToFillModifier<R>.parser(in: context).map(Output.scaledToFill).eraseToAnyParser(),
-_scaledToFitModifier<R>.name: _scaledToFitModifier<R>.parser(in: context).map(Output.scaledToFit).eraseToAnyParser(),
-_scenePaddingModifier<R>.name: _scenePaddingModifier<R>.parser(in: context).map(Output.scenePadding).eraseToAnyParser(),
-_scrollBounceBehaviorModifier<R>.name: _scrollBounceBehaviorModifier<R>.parser(in: context).map(Output.scrollBounceBehavior).eraseToAnyParser(),
-_scrollClipDisabledModifier<R>.name: _scrollClipDisabledModifier<R>.parser(in: context).map(Output.scrollClipDisabled).eraseToAnyParser(),
-_scrollContentBackgroundModifier<R>.name: _scrollContentBackgroundModifier<R>.parser(in: context).map(Output.scrollContentBackground).eraseToAnyParser(),
-_scrollDisabledModifier<R>.name: _scrollDisabledModifier<R>.parser(in: context).map(Output.scrollDisabled).eraseToAnyParser(),
-_scrollDismissesKeyboardModifier<R>.name: _scrollDismissesKeyboardModifier<R>.parser(in: context).map(Output.scrollDismissesKeyboard).eraseToAnyParser(),
-_scrollIndicatorsModifier<R>.name: _scrollIndicatorsModifier<R>.parser(in: context).map(Output.scrollIndicators).eraseToAnyParser(),
-_scrollIndicatorsFlashModifier<R>.name: _scrollIndicatorsFlashModifier<R>.parser(in: context).map(Output.scrollIndicatorsFlash).eraseToAnyParser(),
-_scrollPositionModifier<R>.name: _scrollPositionModifier<R>.parser(in: context).map(Output.scrollPosition).eraseToAnyParser(),
-_scrollTargetBehaviorModifier<R>.name: _scrollTargetBehaviorModifier<R>.parser(in: context).map(Output.scrollTargetBehavior).eraseToAnyParser(),
-_scrollTargetLayoutModifier<R>.name: _scrollTargetLayoutModifier<R>.parser(in: context).map(Output.scrollTargetLayout).eraseToAnyParser(),
-_searchDictationBehaviorModifier<R>.name: _searchDictationBehaviorModifier<R>.parser(in: context).map(Output.searchDictationBehavior).eraseToAnyParser(),
-_searchPresentationToolbarBehaviorModifier<R>.name: _searchPresentationToolbarBehaviorModifier<R>.parser(in: context).map(Output.searchPresentationToolbarBehavior).eraseToAnyParser(),
-_searchSuggestionsModifier<R>.name: _searchSuggestionsModifier<R>.parser(in: context).map(Output.searchSuggestions).eraseToAnyParser(),
-_searchableModifier<R>.name: _searchableModifier<R>.parser(in: context).map(Output.searchable).eraseToAnyParser(),
-_selectionDisabledModifier<R>.name: _selectionDisabledModifier<R>.parser(in: context).map(Output.selectionDisabled).eraseToAnyParser(),
-_shadowModifier<R>.name: _shadowModifier<R>.parser(in: context).map(Output.shadow).eraseToAnyParser(),
-_sheetModifier<R>.name: _sheetModifier<R>.parser(in: context).map(Output.sheet).eraseToAnyParser(),
-_simultaneousGestureModifier<R>.name: _simultaneousGestureModifier<R>.parser(in: context).map(Output.simultaneousGesture).eraseToAnyParser(),
-_speechAdjustedPitchModifier<R>.name: _speechAdjustedPitchModifier<R>.parser(in: context).map(Output.speechAdjustedPitch).eraseToAnyParser(),
-_speechAlwaysIncludesPunctuationModifier<R>.name: _speechAlwaysIncludesPunctuationModifier<R>.parser(in: context).map(Output.speechAlwaysIncludesPunctuation).eraseToAnyParser(),
-_speechAnnouncementsQueuedModifier<R>.name: _speechAnnouncementsQueuedModifier<R>.parser(in: context).map(Output.speechAnnouncementsQueued).eraseToAnyParser(),
-_speechSpellsOutCharactersModifier<R>.name: _speechSpellsOutCharactersModifier<R>.parser(in: context).map(Output.speechSpellsOutCharacters).eraseToAnyParser(),
-_statusBarHiddenModifier<R>.name: _statusBarHiddenModifier<R>.parser(in: context).map(Output.statusBarHidden).eraseToAnyParser(),
-_strikethroughModifier<R>.name: _strikethroughModifier<R>.parser(in: context).map(Output.strikethrough).eraseToAnyParser(),
-_submitLabelModifier<R>.name: _submitLabelModifier<R>.parser(in: context).map(Output.submitLabel).eraseToAnyParser(),
-_submitScopeModifier<R>.name: _submitScopeModifier<R>.parser(in: context).map(Output.submitScope).eraseToAnyParser(),
-_swipeActionsModifier<R>.name: _swipeActionsModifier<R>.parser(in: context).map(Output.swipeActions).eraseToAnyParser(),
-_symbolEffectsRemovedModifier<R>.name: _symbolEffectsRemovedModifier<R>.parser(in: context).map(Output.symbolEffectsRemoved).eraseToAnyParser(),
-_symbolRenderingModeModifier<R>.name: _symbolRenderingModeModifier<R>.parser(in: context).map(Output.symbolRenderingMode).eraseToAnyParser(),
-_symbolVariantModifier<R>.name: _symbolVariantModifier<R>.parser(in: context).map(Output.symbolVariant).eraseToAnyParser(),
-_tabItemModifier<R>.name: _tabItemModifier<R>.parser(in: context).map(Output.tabItem).eraseToAnyParser(),
-_tabViewStyleModifier<R>.name: _tabViewStyleModifier<R>.parser(in: context).map(Output.tabViewStyle).eraseToAnyParser(),
-_tableStyleModifier<R>.name: _tableStyleModifier<R>.parser(in: context).map(Output.tableStyle).eraseToAnyParser(),
-_textCaseModifier<R>.name: _textCaseModifier<R>.parser(in: context).map(Output.textCase).eraseToAnyParser(),
-_textContentTypeModifier<R>.name: _textContentTypeModifier<R>.parser(in: context).map(Output.textContentType).eraseToAnyParser(),
-_textEditorStyleModifier<R>.name: _textEditorStyleModifier<R>.parser(in: context).map(Output.textEditorStyle).eraseToAnyParser(),
-_textFieldStyleModifier<R>.name: _textFieldStyleModifier<R>.parser(in: context).map(Output.textFieldStyle).eraseToAnyParser(),
-_textInputAutocapitalizationModifier<R>.name: _textInputAutocapitalizationModifier<R>.parser(in: context).map(Output.textInputAutocapitalization).eraseToAnyParser(),
-_textScaleModifier<R>.name: _textScaleModifier<R>.parser(in: context).map(Output.textScale).eraseToAnyParser(),
-_textSelectionModifier<R>.name: _textSelectionModifier<R>.parser(in: context).map(Output.textSelection).eraseToAnyParser(),
-_tintModifier<R>.name: _tintModifier<R>.parser(in: context).map(Output.tint).eraseToAnyParser(),
-_toggleStyleModifier<R>.name: _toggleStyleModifier<R>.parser(in: context).map(Output.toggleStyle).eraseToAnyParser(),
-_toolbarModifier<R>.name: _toolbarModifier<R>.parser(in: context).map(Output.toolbar).eraseToAnyParser(),
-_toolbarBackgroundModifier<R>.name: _toolbarBackgroundModifier<R>.parser(in: context).map(Output.toolbarBackground).eraseToAnyParser(),
-_toolbarColorSchemeModifier<R>.name: _toolbarColorSchemeModifier<R>.parser(in: context).map(Output.toolbarColorScheme).eraseToAnyParser(),
-_toolbarRoleModifier<R>.name: _toolbarRoleModifier<R>.parser(in: context).map(Output.toolbarRole).eraseToAnyParser(),
-_toolbarTitleDisplayModeModifier<R>.name: _toolbarTitleDisplayModeModifier<R>.parser(in: context).map(Output.toolbarTitleDisplayMode).eraseToAnyParser(),
-_toolbarTitleMenuModifier<R>.name: _toolbarTitleMenuModifier<R>.parser(in: context).map(Output.toolbarTitleMenu).eraseToAnyParser(),
-_touchBarCustomizationLabelModifier<R>.name: _touchBarCustomizationLabelModifier<R>.parser(in: context).map(Output.touchBarCustomizationLabel).eraseToAnyParser(),
-_touchBarItemPrincipalModifier<R>.name: _touchBarItemPrincipalModifier<R>.parser(in: context).map(Output.touchBarItemPrincipal).eraseToAnyParser(),
-_trackingModifier<R>.name: _trackingModifier<R>.parser(in: context).map(Output.tracking).eraseToAnyParser(),
-_transformEffectModifier<R>.name: _transformEffectModifier<R>.parser(in: context).map(Output.transformEffect).eraseToAnyParser(),
-_transitionModifier<R>.name: _transitionModifier<R>.parser(in: context).map(Output.transition).eraseToAnyParser(),
-_truncationModeModifier<R>.name: _truncationModeModifier<R>.parser(in: context).map(Output.truncationMode).eraseToAnyParser(),
-_underlineModifier<R>.name: _underlineModifier<R>.parser(in: context).map(Output.underline).eraseToAnyParser(),
-_unredactedModifier<R>.name: _unredactedModifier<R>.parser(in: context).map(Output.unredacted).eraseToAnyParser(),
-_zIndexModifier<R>.name: _zIndexModifier<R>.parser(in: context).map(Output.zIndex).eraseToAnyParser(),
-                    LiveViewNative._LineIntersectionModifier.name: LiveViewNative._LineIntersectionModifier.parser(in: context).map(Output._LineIntersectionModifier).eraseToAnyParser(),
-LiveViewNative._Rotation3DEffectModifier<R>.name: LiveViewNative._Rotation3DEffectModifier<R>.parser(in: context).map(Output._Rotation3DEffectModifier).eraseToAnyParser(),
+                    _accessibilityActionModifier<R>.name: _accessibilityActionModifier<R>.parser(in: context).map({ Output.chunk0(.accessibilityAction($0)) }).eraseToAnyParser(),
+_accessibilityActionsModifier<R>.name: _accessibilityActionsModifier<R>.parser(in: context).map({ Output.chunk0(.accessibilityActions($0)) }).eraseToAnyParser(),
+_accessibilityChildrenModifier<R>.name: _accessibilityChildrenModifier<R>.parser(in: context).map({ Output.chunk0(.accessibilityChildren($0)) }).eraseToAnyParser(),
+_accessibilityIgnoresInvertColorsModifier<R>.name: _accessibilityIgnoresInvertColorsModifier<R>.parser(in: context).map({ Output.chunk0(.accessibilityIgnoresInvertColors($0)) }).eraseToAnyParser(),
+_accessibilityRepresentationModifier<R>.name: _accessibilityRepresentationModifier<R>.parser(in: context).map({ Output.chunk0(.accessibilityRepresentation($0)) }).eraseToAnyParser(),
+_accessibilityShowsLargeContentViewerModifier<R>.name: _accessibilityShowsLargeContentViewerModifier<R>.parser(in: context).map({ Output.chunk0(.accessibilityShowsLargeContentViewer($0)) }).eraseToAnyParser(),
+_alertModifier<R>.name: _alertModifier<R>.parser(in: context).map({ Output.chunk0(.alert($0)) }).eraseToAnyParser(),
+_allowsHitTestingModifier<R>.name: _allowsHitTestingModifier<R>.parser(in: context).map({ Output.chunk0(.allowsHitTesting($0)) }).eraseToAnyParser(),
+_allowsTighteningModifier<R>.name: _allowsTighteningModifier<R>.parser(in: context).map({ Output.chunk0(.allowsTightening($0)) }).eraseToAnyParser(),
+_animationModifier<R>.name: _animationModifier<R>.parser(in: context).map({ Output.chunk0(.animation($0)) }).eraseToAnyParser(),
+_aspectRatioModifier<R>.name: _aspectRatioModifier<R>.parser(in: context).map({ Output.chunk1(.aspectRatio($0)) }).eraseToAnyParser(),
+_autocorrectionDisabledModifier<R>.name: _autocorrectionDisabledModifier<R>.parser(in: context).map({ Output.chunk1(.autocorrectionDisabled($0)) }).eraseToAnyParser(),
+_backgroundModifier<R>.name: _backgroundModifier<R>.parser(in: context).map({ Output.chunk1(.background($0)) }).eraseToAnyParser(),
+_backgroundStyleModifier<R>.name: _backgroundStyleModifier<R>.parser(in: context).map({ Output.chunk1(.backgroundStyle($0)) }).eraseToAnyParser(),
+_badgeModifier<R>.name: _badgeModifier<R>.parser(in: context).map({ Output.chunk1(.badge($0)) }).eraseToAnyParser(),
+_baselineOffsetModifier<R>.name: _baselineOffsetModifier<R>.parser(in: context).map({ Output.chunk1(.baselineOffset($0)) }).eraseToAnyParser(),
+_blendModeModifier<R>.name: _blendModeModifier<R>.parser(in: context).map({ Output.chunk1(.blendMode($0)) }).eraseToAnyParser(),
+_blurModifier<R>.name: _blurModifier<R>.parser(in: context).map({ Output.chunk1(.blur($0)) }).eraseToAnyParser(),
+_boldModifier<R>.name: _boldModifier<R>.parser(in: context).map({ Output.chunk1(.bold($0)) }).eraseToAnyParser(),
+_borderModifier<R>.name: _borderModifier<R>.parser(in: context).map({ Output.chunk1(.border($0)) }).eraseToAnyParser(),
+_brightnessModifier<R>.name: _brightnessModifier<R>.parser(in: context).map({ Output.chunk2(.brightness($0)) }).eraseToAnyParser(),
+_buttonBorderShapeModifier<R>.name: _buttonBorderShapeModifier<R>.parser(in: context).map({ Output.chunk2(.buttonBorderShape($0)) }).eraseToAnyParser(),
+_buttonStyleModifier<R>.name: _buttonStyleModifier<R>.parser(in: context).map({ Output.chunk2(.buttonStyle($0)) }).eraseToAnyParser(),
+_clipShapeModifier<R>.name: _clipShapeModifier<R>.parser(in: context).map({ Output.chunk2(.clipShape($0)) }).eraseToAnyParser(),
+_clippedModifier<R>.name: _clippedModifier<R>.parser(in: context).map({ Output.chunk2(.clipped($0)) }).eraseToAnyParser(),
+_colorInvertModifier<R>.name: _colorInvertModifier<R>.parser(in: context).map({ Output.chunk2(.colorInvert($0)) }).eraseToAnyParser(),
+_colorMultiplyModifier<R>.name: _colorMultiplyModifier<R>.parser(in: context).map({ Output.chunk2(.colorMultiply($0)) }).eraseToAnyParser(),
+_compositingGroupModifier<R>.name: _compositingGroupModifier<R>.parser(in: context).map({ Output.chunk2(.compositingGroup($0)) }).eraseToAnyParser(),
+_confirmationDialogModifier<R>.name: _confirmationDialogModifier<R>.parser(in: context).map({ Output.chunk2(.confirmationDialog($0)) }).eraseToAnyParser(),
+_containerRelativeFrameModifier<R>.name: _containerRelativeFrameModifier<R>.parser(in: context).map({ Output.chunk2(.containerRelativeFrame($0)) }).eraseToAnyParser(),
+_containerShapeModifier<R>.name: _containerShapeModifier<R>.parser(in: context).map({ Output.chunk3(.containerShape($0)) }).eraseToAnyParser(),
+_contentShapeModifier<R>.name: _contentShapeModifier<R>.parser(in: context).map({ Output.chunk3(.contentShape($0)) }).eraseToAnyParser(),
+_contentTransitionModifier<R>.name: _contentTransitionModifier<R>.parser(in: context).map({ Output.chunk3(.contentTransition($0)) }).eraseToAnyParser(),
+_contextMenuModifier<R>.name: _contextMenuModifier<R>.parser(in: context).map({ Output.chunk3(.contextMenu($0)) }).eraseToAnyParser(),
+_contrastModifier<R>.name: _contrastModifier<R>.parser(in: context).map({ Output.chunk3(.contrast($0)) }).eraseToAnyParser(),
+_controlGroupStyleModifier<R>.name: _controlGroupStyleModifier<R>.parser(in: context).map({ Output.chunk3(.controlGroupStyle($0)) }).eraseToAnyParser(),
+_controlSizeModifier<R>.name: _controlSizeModifier<R>.parser(in: context).map({ Output.chunk3(.controlSize($0)) }).eraseToAnyParser(),
+_coordinateSpaceModifier<R>.name: _coordinateSpaceModifier<R>.parser(in: context).map({ Output.chunk3(.coordinateSpace($0)) }).eraseToAnyParser(),
+_datePickerStyleModifier<R>.name: _datePickerStyleModifier<R>.parser(in: context).map({ Output.chunk3(.datePickerStyle($0)) }).eraseToAnyParser(),
+_defaultScrollAnchorModifier<R>.name: _defaultScrollAnchorModifier<R>.parser(in: context).map({ Output.chunk3(.defaultScrollAnchor($0)) }).eraseToAnyParser(),
+_defaultWheelPickerItemHeightModifier<R>.name: _defaultWheelPickerItemHeightModifier<R>.parser(in: context).map({ Output.chunk4(.defaultWheelPickerItemHeight($0)) }).eraseToAnyParser(),
+_defersSystemGesturesModifier<R>.name: _defersSystemGesturesModifier<R>.parser(in: context).map({ Output.chunk4(.defersSystemGestures($0)) }).eraseToAnyParser(),
+_deleteDisabledModifier<R>.name: _deleteDisabledModifier<R>.parser(in: context).map({ Output.chunk4(.deleteDisabled($0)) }).eraseToAnyParser(),
+_dialogSuppressionToggleModifier<R>.name: _dialogSuppressionToggleModifier<R>.parser(in: context).map({ Output.chunk4(.dialogSuppressionToggle($0)) }).eraseToAnyParser(),
+_digitalCrownAccessoryModifier<R>.name: _digitalCrownAccessoryModifier<R>.parser(in: context).map({ Output.chunk4(.digitalCrownAccessory($0)) }).eraseToAnyParser(),
+_disabledModifier<R>.name: _disabledModifier<R>.parser(in: context).map({ Output.chunk4(.disabled($0)) }).eraseToAnyParser(),
+_drawingGroupModifier<R>.name: _drawingGroupModifier<R>.parser(in: context).map({ Output.chunk4(.drawingGroup($0)) }).eraseToAnyParser(),
+_dynamicTypeSizeModifier<R>.name: _dynamicTypeSizeModifier<R>.parser(in: context).map({ Output.chunk4(.dynamicTypeSize($0)) }).eraseToAnyParser(),
+_fileDialogCustomizationIDModifier<R>.name: _fileDialogCustomizationIDModifier<R>.parser(in: context).map({ Output.chunk4(.fileDialogCustomizationID($0)) }).eraseToAnyParser(),
+_fileDialogImportsUnresolvedAliasesModifier<R>.name: _fileDialogImportsUnresolvedAliasesModifier<R>.parser(in: context).map({ Output.chunk4(.fileDialogImportsUnresolvedAliases($0)) }).eraseToAnyParser(),
+_findDisabledModifier<R>.name: _findDisabledModifier<R>.parser(in: context).map({ Output.chunk5(.findDisabled($0)) }).eraseToAnyParser(),
+_findNavigatorModifier<R>.name: _findNavigatorModifier<R>.parser(in: context).map({ Output.chunk5(.findNavigator($0)) }).eraseToAnyParser(),
+_fixedSizeModifier<R>.name: _fixedSizeModifier<R>.parser(in: context).map({ Output.chunk5(.fixedSize($0)) }).eraseToAnyParser(),
+_flipsForRightToLeftLayoutDirectionModifier<R>.name: _flipsForRightToLeftLayoutDirectionModifier<R>.parser(in: context).map({ Output.chunk5(.flipsForRightToLeftLayoutDirection($0)) }).eraseToAnyParser(),
+_focusEffectDisabledModifier<R>.name: _focusEffectDisabledModifier<R>.parser(in: context).map({ Output.chunk5(.focusEffectDisabled($0)) }).eraseToAnyParser(),
+_focusSectionModifier<R>.name: _focusSectionModifier<R>.parser(in: context).map({ Output.chunk5(.focusSection($0)) }).eraseToAnyParser(),
+_focusableModifier<R>.name: _focusableModifier<R>.parser(in: context).map({ Output.chunk5(.focusable($0)) }).eraseToAnyParser(),
+_fontModifier<R>.name: _fontModifier<R>.parser(in: context).map({ Output.chunk5(.font($0)) }).eraseToAnyParser(),
+_fontDesignModifier<R>.name: _fontDesignModifier<R>.parser(in: context).map({ Output.chunk5(.fontDesign($0)) }).eraseToAnyParser(),
+_fontWeightModifier<R>.name: _fontWeightModifier<R>.parser(in: context).map({ Output.chunk5(.fontWeight($0)) }).eraseToAnyParser(),
+_fontWidthModifier<R>.name: _fontWidthModifier<R>.parser(in: context).map({ Output.chunk6(.fontWidth($0)) }).eraseToAnyParser(),
+_foregroundStyleModifier<R>.name: _foregroundStyleModifier<R>.parser(in: context).map({ Output.chunk6(.foregroundStyle($0)) }).eraseToAnyParser(),
+_formStyleModifier<R>.name: _formStyleModifier<R>.parser(in: context).map({ Output.chunk6(.formStyle($0)) }).eraseToAnyParser(),
+_frameModifier<R>.name: _frameModifier<R>.parser(in: context).map({ Output.chunk6(.frame($0)) }).eraseToAnyParser(),
+_fullScreenCoverModifier<R>.name: _fullScreenCoverModifier<R>.parser(in: context).map({ Output.chunk6(.fullScreenCover($0)) }).eraseToAnyParser(),
+_gaugeStyleModifier<R>.name: _gaugeStyleModifier<R>.parser(in: context).map({ Output.chunk6(.gaugeStyle($0)) }).eraseToAnyParser(),
+_geometryGroupModifier<R>.name: _geometryGroupModifier<R>.parser(in: context).map({ Output.chunk6(.geometryGroup($0)) }).eraseToAnyParser(),
+_gestureModifier<R>.name: _gestureModifier<R>.parser(in: context).map({ Output.chunk6(.gesture($0)) }).eraseToAnyParser(),
+_grayscaleModifier<R>.name: _grayscaleModifier<R>.parser(in: context).map({ Output.chunk6(.grayscale($0)) }).eraseToAnyParser(),
+_gridCellAnchorModifier<R>.name: _gridCellAnchorModifier<R>.parser(in: context).map({ Output.chunk6(.gridCellAnchor($0)) }).eraseToAnyParser(),
+_gridCellColumnsModifier<R>.name: _gridCellColumnsModifier<R>.parser(in: context).map({ Output.chunk7(.gridCellColumns($0)) }).eraseToAnyParser(),
+_gridCellUnsizedAxesModifier<R>.name: _gridCellUnsizedAxesModifier<R>.parser(in: context).map({ Output.chunk7(.gridCellUnsizedAxes($0)) }).eraseToAnyParser(),
+_gridColumnAlignmentModifier<R>.name: _gridColumnAlignmentModifier<R>.parser(in: context).map({ Output.chunk7(.gridColumnAlignment($0)) }).eraseToAnyParser(),
+_groupBoxStyleModifier<R>.name: _groupBoxStyleModifier<R>.parser(in: context).map({ Output.chunk7(.groupBoxStyle($0)) }).eraseToAnyParser(),
+_headerProminenceModifier<R>.name: _headerProminenceModifier<R>.parser(in: context).map({ Output.chunk7(.headerProminence($0)) }).eraseToAnyParser(),
+_helpModifier<R>.name: _helpModifier<R>.parser(in: context).map({ Output.chunk7(.help($0)) }).eraseToAnyParser(),
+_hiddenModifier<R>.name: _hiddenModifier<R>.parser(in: context).map({ Output.chunk7(.hidden($0)) }).eraseToAnyParser(),
+_highPriorityGestureModifier<R>.name: _highPriorityGestureModifier<R>.parser(in: context).map({ Output.chunk7(.highPriorityGesture($0)) }).eraseToAnyParser(),
+_horizontalRadioGroupLayoutModifier<R>.name: _horizontalRadioGroupLayoutModifier<R>.parser(in: context).map({ Output.chunk7(.horizontalRadioGroupLayout($0)) }).eraseToAnyParser(),
+_hoverEffectModifier<R>.name: _hoverEffectModifier<R>.parser(in: context).map({ Output.chunk7(.hoverEffect($0)) }).eraseToAnyParser(),
+_hoverEffectDisabledModifier<R>.name: _hoverEffectDisabledModifier<R>.parser(in: context).map({ Output.chunk8(.hoverEffectDisabled($0)) }).eraseToAnyParser(),
+_hueRotationModifier<R>.name: _hueRotationModifier<R>.parser(in: context).map({ Output.chunk8(.hueRotation($0)) }).eraseToAnyParser(),
+_ignoresSafeAreaModifier<R>.name: _ignoresSafeAreaModifier<R>.parser(in: context).map({ Output.chunk8(.ignoresSafeArea($0)) }).eraseToAnyParser(),
+_imageScaleModifier<R>.name: _imageScaleModifier<R>.parser(in: context).map({ Output.chunk8(.imageScale($0)) }).eraseToAnyParser(),
+_indexViewStyleModifier<R>.name: _indexViewStyleModifier<R>.parser(in: context).map({ Output.chunk8(.indexViewStyle($0)) }).eraseToAnyParser(),
+_inspectorModifier<R>.name: _inspectorModifier<R>.parser(in: context).map({ Output.chunk8(.inspector($0)) }).eraseToAnyParser(),
+_inspectorColumnWidthModifier<R>.name: _inspectorColumnWidthModifier<R>.parser(in: context).map({ Output.chunk8(.inspectorColumnWidth($0)) }).eraseToAnyParser(),
+_interactionActivityTrackingTagModifier<R>.name: _interactionActivityTrackingTagModifier<R>.parser(in: context).map({ Output.chunk8(.interactionActivityTrackingTag($0)) }).eraseToAnyParser(),
+_interactiveDismissDisabledModifier<R>.name: _interactiveDismissDisabledModifier<R>.parser(in: context).map({ Output.chunk8(.interactiveDismissDisabled($0)) }).eraseToAnyParser(),
+_invalidatableContentModifier<R>.name: _invalidatableContentModifier<R>.parser(in: context).map({ Output.chunk8(.invalidatableContent($0)) }).eraseToAnyParser(),
+_italicModifier<R>.name: _italicModifier<R>.parser(in: context).map({ Output.chunk9(.italic($0)) }).eraseToAnyParser(),
+_kerningModifier<R>.name: _kerningModifier<R>.parser(in: context).map({ Output.chunk9(.kerning($0)) }).eraseToAnyParser(),
+_keyboardShortcutModifier<R>.name: _keyboardShortcutModifier<R>.parser(in: context).map({ Output.chunk9(.keyboardShortcut($0)) }).eraseToAnyParser(),
+_keyboardTypeModifier<R>.name: _keyboardTypeModifier<R>.parser(in: context).map({ Output.chunk9(.keyboardType($0)) }).eraseToAnyParser(),
+_labelStyleModifier<R>.name: _labelStyleModifier<R>.parser(in: context).map({ Output.chunk9(.labelStyle($0)) }).eraseToAnyParser(),
+_labeledContentStyleModifier<R>.name: _labeledContentStyleModifier<R>.parser(in: context).map({ Output.chunk9(.labeledContentStyle($0)) }).eraseToAnyParser(),
+_labelsHiddenModifier<R>.name: _labelsHiddenModifier<R>.parser(in: context).map({ Output.chunk9(.labelsHidden($0)) }).eraseToAnyParser(),
+_layoutPriorityModifier<R>.name: _layoutPriorityModifier<R>.parser(in: context).map({ Output.chunk9(.layoutPriority($0)) }).eraseToAnyParser(),
+_lineLimitModifier<R>.name: _lineLimitModifier<R>.parser(in: context).map({ Output.chunk9(.lineLimit($0)) }).eraseToAnyParser(),
+_lineSpacingModifier<R>.name: _lineSpacingModifier<R>.parser(in: context).map({ Output.chunk9(.lineSpacing($0)) }).eraseToAnyParser(),
+_listItemTintModifier<R>.name: _listItemTintModifier<R>.parser(in: context).map({ Output.chunk10(.listItemTint($0)) }).eraseToAnyParser(),
+_listRowBackgroundModifier<R>.name: _listRowBackgroundModifier<R>.parser(in: context).map({ Output.chunk10(.listRowBackground($0)) }).eraseToAnyParser(),
+_listRowHoverEffectModifier<R>.name: _listRowHoverEffectModifier<R>.parser(in: context).map({ Output.chunk10(.listRowHoverEffect($0)) }).eraseToAnyParser(),
+_listRowHoverEffectDisabledModifier<R>.name: _listRowHoverEffectDisabledModifier<R>.parser(in: context).map({ Output.chunk10(.listRowHoverEffectDisabled($0)) }).eraseToAnyParser(),
+_listRowInsetsModifier<R>.name: _listRowInsetsModifier<R>.parser(in: context).map({ Output.chunk10(.listRowInsets($0)) }).eraseToAnyParser(),
+_listRowSeparatorModifier<R>.name: _listRowSeparatorModifier<R>.parser(in: context).map({ Output.chunk10(.listRowSeparator($0)) }).eraseToAnyParser(),
+_listRowSeparatorTintModifier<R>.name: _listRowSeparatorTintModifier<R>.parser(in: context).map({ Output.chunk10(.listRowSeparatorTint($0)) }).eraseToAnyParser(),
+_listRowSpacingModifier<R>.name: _listRowSpacingModifier<R>.parser(in: context).map({ Output.chunk10(.listRowSpacing($0)) }).eraseToAnyParser(),
+_listSectionSeparatorModifier<R>.name: _listSectionSeparatorModifier<R>.parser(in: context).map({ Output.chunk10(.listSectionSeparator($0)) }).eraseToAnyParser(),
+_listSectionSeparatorTintModifier<R>.name: _listSectionSeparatorTintModifier<R>.parser(in: context).map({ Output.chunk10(.listSectionSeparatorTint($0)) }).eraseToAnyParser(),
+_listSectionSpacingModifier<R>.name: _listSectionSpacingModifier<R>.parser(in: context).map({ Output.chunk11(.listSectionSpacing($0)) }).eraseToAnyParser(),
+_listStyleModifier<R>.name: _listStyleModifier<R>.parser(in: context).map({ Output.chunk11(.listStyle($0)) }).eraseToAnyParser(),
+_luminanceToAlphaModifier<R>.name: _luminanceToAlphaModifier<R>.parser(in: context).map({ Output.chunk11(.luminanceToAlpha($0)) }).eraseToAnyParser(),
+_menuIndicatorModifier<R>.name: _menuIndicatorModifier<R>.parser(in: context).map({ Output.chunk11(.menuIndicator($0)) }).eraseToAnyParser(),
+_menuOrderModifier<R>.name: _menuOrderModifier<R>.parser(in: context).map({ Output.chunk11(.menuOrder($0)) }).eraseToAnyParser(),
+_menuStyleModifier<R>.name: _menuStyleModifier<R>.parser(in: context).map({ Output.chunk11(.menuStyle($0)) }).eraseToAnyParser(),
+_minimumScaleFactorModifier<R>.name: _minimumScaleFactorModifier<R>.parser(in: context).map({ Output.chunk11(.minimumScaleFactor($0)) }).eraseToAnyParser(),
+_monospacedModifier<R>.name: _monospacedModifier<R>.parser(in: context).map({ Output.chunk11(.monospaced($0)) }).eraseToAnyParser(),
+_monospacedDigitModifier<R>.name: _monospacedDigitModifier<R>.parser(in: context).map({ Output.chunk11(.monospacedDigit($0)) }).eraseToAnyParser(),
+_moveDisabledModifier<R>.name: _moveDisabledModifier<R>.parser(in: context).map({ Output.chunk11(.moveDisabled($0)) }).eraseToAnyParser(),
+_multilineTextAlignmentModifier<R>.name: _multilineTextAlignmentModifier<R>.parser(in: context).map({ Output.chunk12(.multilineTextAlignment($0)) }).eraseToAnyParser(),
+_navigationBarBackButtonHiddenModifier<R>.name: _navigationBarBackButtonHiddenModifier<R>.parser(in: context).map({ Output.chunk12(.navigationBarBackButtonHidden($0)) }).eraseToAnyParser(),
+_navigationBarTitleDisplayModeModifier<R>.name: _navigationBarTitleDisplayModeModifier<R>.parser(in: context).map({ Output.chunk12(.navigationBarTitleDisplayMode($0)) }).eraseToAnyParser(),
+_navigationDestinationModifier<R>.name: _navigationDestinationModifier<R>.parser(in: context).map({ Output.chunk12(.navigationDestination($0)) }).eraseToAnyParser(),
+_navigationSplitViewColumnWidthModifier<R>.name: _navigationSplitViewColumnWidthModifier<R>.parser(in: context).map({ Output.chunk12(.navigationSplitViewColumnWidth($0)) }).eraseToAnyParser(),
+_navigationSplitViewStyleModifier<R>.name: _navigationSplitViewStyleModifier<R>.parser(in: context).map({ Output.chunk12(.navigationSplitViewStyle($0)) }).eraseToAnyParser(),
+_navigationSubtitleModifier<R>.name: _navigationSubtitleModifier<R>.parser(in: context).map({ Output.chunk12(.navigationSubtitle($0)) }).eraseToAnyParser(),
+_navigationTitleModifier<R>.name: _navigationTitleModifier<R>.parser(in: context).map({ Output.chunk12(.navigationTitle($0)) }).eraseToAnyParser(),
+_offsetModifier<R>.name: _offsetModifier<R>.parser(in: context).map({ Output.chunk12(.offset($0)) }).eraseToAnyParser(),
+_onAppearModifier<R>.name: _onAppearModifier<R>.parser(in: context).map({ Output.chunk12(.onAppear($0)) }).eraseToAnyParser(),
+_onDeleteCommandModifier<R>.name: _onDeleteCommandModifier<R>.parser(in: context).map({ Output.chunk13(.onDeleteCommand($0)) }).eraseToAnyParser(),
+_onDisappearModifier<R>.name: _onDisappearModifier<R>.parser(in: context).map({ Output.chunk13(.onDisappear($0)) }).eraseToAnyParser(),
+_onExitCommandModifier<R>.name: _onExitCommandModifier<R>.parser(in: context).map({ Output.chunk13(.onExitCommand($0)) }).eraseToAnyParser(),
+_onHoverModifier<R>.name: _onHoverModifier<R>.parser(in: context).map({ Output.chunk13(.onHover($0)) }).eraseToAnyParser(),
+_onLongPressGestureModifier<R>.name: _onLongPressGestureModifier<R>.parser(in: context).map({ Output.chunk13(.onLongPressGesture($0)) }).eraseToAnyParser(),
+_onLongTouchGestureModifier<R>.name: _onLongTouchGestureModifier<R>.parser(in: context).map({ Output.chunk13(.onLongTouchGesture($0)) }).eraseToAnyParser(),
+_onMoveCommandModifier<R>.name: _onMoveCommandModifier<R>.parser(in: context).map({ Output.chunk13(.onMoveCommand($0)) }).eraseToAnyParser(),
+_onPlayPauseCommandModifier<R>.name: _onPlayPauseCommandModifier<R>.parser(in: context).map({ Output.chunk13(.onPlayPauseCommand($0)) }).eraseToAnyParser(),
+_onTapGestureModifier<R>.name: _onTapGestureModifier<R>.parser(in: context).map({ Output.chunk13(.onTapGesture($0)) }).eraseToAnyParser(),
+_opacityModifier<R>.name: _opacityModifier<R>.parser(in: context).map({ Output.chunk13(.opacity($0)) }).eraseToAnyParser(),
+_overlayModifier<R>.name: _overlayModifier<R>.parser(in: context).map({ Output.chunk14(.overlay($0)) }).eraseToAnyParser(),
+_paddingModifier<R>.name: _paddingModifier<R>.parser(in: context).map({ Output.chunk14(.padding($0)) }).eraseToAnyParser(),
+_persistentSystemOverlaysModifier<R>.name: _persistentSystemOverlaysModifier<R>.parser(in: context).map({ Output.chunk14(.persistentSystemOverlays($0)) }).eraseToAnyParser(),
+_pickerStyleModifier<R>.name: _pickerStyleModifier<R>.parser(in: context).map({ Output.chunk14(.pickerStyle($0)) }).eraseToAnyParser(),
+_popoverModifier<R>.name: _popoverModifier<R>.parser(in: context).map({ Output.chunk14(.popover($0)) }).eraseToAnyParser(),
+_positionModifier<R>.name: _positionModifier<R>.parser(in: context).map({ Output.chunk14(.position($0)) }).eraseToAnyParser(),
+_preferredColorSchemeModifier<R>.name: _preferredColorSchemeModifier<R>.parser(in: context).map({ Output.chunk14(.preferredColorScheme($0)) }).eraseToAnyParser(),
+_presentationBackgroundModifier<R>.name: _presentationBackgroundModifier<R>.parser(in: context).map({ Output.chunk14(.presentationBackground($0)) }).eraseToAnyParser(),
+_presentationBackgroundInteractionModifier<R>.name: _presentationBackgroundInteractionModifier<R>.parser(in: context).map({ Output.chunk14(.presentationBackgroundInteraction($0)) }).eraseToAnyParser(),
+_presentationCompactAdaptationModifier<R>.name: _presentationCompactAdaptationModifier<R>.parser(in: context).map({ Output.chunk14(.presentationCompactAdaptation($0)) }).eraseToAnyParser(),
+_presentationContentInteractionModifier<R>.name: _presentationContentInteractionModifier<R>.parser(in: context).map({ Output.chunk15(.presentationContentInteraction($0)) }).eraseToAnyParser(),
+_presentationCornerRadiusModifier<R>.name: _presentationCornerRadiusModifier<R>.parser(in: context).map({ Output.chunk15(.presentationCornerRadius($0)) }).eraseToAnyParser(),
+_presentationDragIndicatorModifier<R>.name: _presentationDragIndicatorModifier<R>.parser(in: context).map({ Output.chunk15(.presentationDragIndicator($0)) }).eraseToAnyParser(),
+_previewDisplayNameModifier<R>.name: _previewDisplayNameModifier<R>.parser(in: context).map({ Output.chunk15(.previewDisplayName($0)) }).eraseToAnyParser(),
+_privacySensitiveModifier<R>.name: _privacySensitiveModifier<R>.parser(in: context).map({ Output.chunk15(.privacySensitive($0)) }).eraseToAnyParser(),
+_progressViewStyleModifier<R>.name: _progressViewStyleModifier<R>.parser(in: context).map({ Output.chunk15(.progressViewStyle($0)) }).eraseToAnyParser(),
+_projectionEffectModifier<R>.name: _projectionEffectModifier<R>.parser(in: context).map({ Output.chunk15(.projectionEffect($0)) }).eraseToAnyParser(),
+_redactedModifier<R>.name: _redactedModifier<R>.parser(in: context).map({ Output.chunk15(.redacted($0)) }).eraseToAnyParser(),
+_refreshableModifier<R>.name: _refreshableModifier<R>.parser(in: context).map({ Output.chunk15(.refreshable($0)) }).eraseToAnyParser(),
+_renameActionModifier<R>.name: _renameActionModifier<R>.parser(in: context).map({ Output.chunk15(.renameAction($0)) }).eraseToAnyParser(),
+_replaceDisabledModifier<R>.name: _replaceDisabledModifier<R>.parser(in: context).map({ Output.chunk16(.replaceDisabled($0)) }).eraseToAnyParser(),
+_rotationEffectModifier<R>.name: _rotationEffectModifier<R>.parser(in: context).map({ Output.chunk16(.rotationEffect($0)) }).eraseToAnyParser(),
+_safeAreaInsetModifier<R>.name: _safeAreaInsetModifier<R>.parser(in: context).map({ Output.chunk16(.safeAreaInset($0)) }).eraseToAnyParser(),
+_saturationModifier<R>.name: _saturationModifier<R>.parser(in: context).map({ Output.chunk16(.saturation($0)) }).eraseToAnyParser(),
+_scaleEffectModifier<R>.name: _scaleEffectModifier<R>.parser(in: context).map({ Output.chunk16(.scaleEffect($0)) }).eraseToAnyParser(),
+_scaledToFillModifier<R>.name: _scaledToFillModifier<R>.parser(in: context).map({ Output.chunk16(.scaledToFill($0)) }).eraseToAnyParser(),
+_scaledToFitModifier<R>.name: _scaledToFitModifier<R>.parser(in: context).map({ Output.chunk16(.scaledToFit($0)) }).eraseToAnyParser(),
+_scenePaddingModifier<R>.name: _scenePaddingModifier<R>.parser(in: context).map({ Output.chunk16(.scenePadding($0)) }).eraseToAnyParser(),
+_scrollBounceBehaviorModifier<R>.name: _scrollBounceBehaviorModifier<R>.parser(in: context).map({ Output.chunk16(.scrollBounceBehavior($0)) }).eraseToAnyParser(),
+_scrollClipDisabledModifier<R>.name: _scrollClipDisabledModifier<R>.parser(in: context).map({ Output.chunk16(.scrollClipDisabled($0)) }).eraseToAnyParser(),
+_scrollContentBackgroundModifier<R>.name: _scrollContentBackgroundModifier<R>.parser(in: context).map({ Output.chunk17(.scrollContentBackground($0)) }).eraseToAnyParser(),
+_scrollDisabledModifier<R>.name: _scrollDisabledModifier<R>.parser(in: context).map({ Output.chunk17(.scrollDisabled($0)) }).eraseToAnyParser(),
+_scrollDismissesKeyboardModifier<R>.name: _scrollDismissesKeyboardModifier<R>.parser(in: context).map({ Output.chunk17(.scrollDismissesKeyboard($0)) }).eraseToAnyParser(),
+_scrollIndicatorsModifier<R>.name: _scrollIndicatorsModifier<R>.parser(in: context).map({ Output.chunk17(.scrollIndicators($0)) }).eraseToAnyParser(),
+_scrollIndicatorsFlashModifier<R>.name: _scrollIndicatorsFlashModifier<R>.parser(in: context).map({ Output.chunk17(.scrollIndicatorsFlash($0)) }).eraseToAnyParser(),
+_scrollPositionModifier<R>.name: _scrollPositionModifier<R>.parser(in: context).map({ Output.chunk17(.scrollPosition($0)) }).eraseToAnyParser(),
+_scrollTargetBehaviorModifier<R>.name: _scrollTargetBehaviorModifier<R>.parser(in: context).map({ Output.chunk17(.scrollTargetBehavior($0)) }).eraseToAnyParser(),
+_scrollTargetLayoutModifier<R>.name: _scrollTargetLayoutModifier<R>.parser(in: context).map({ Output.chunk17(.scrollTargetLayout($0)) }).eraseToAnyParser(),
+_searchDictationBehaviorModifier<R>.name: _searchDictationBehaviorModifier<R>.parser(in: context).map({ Output.chunk17(.searchDictationBehavior($0)) }).eraseToAnyParser(),
+_searchPresentationToolbarBehaviorModifier<R>.name: _searchPresentationToolbarBehaviorModifier<R>.parser(in: context).map({ Output.chunk17(.searchPresentationToolbarBehavior($0)) }).eraseToAnyParser(),
+_searchSuggestionsModifier<R>.name: _searchSuggestionsModifier<R>.parser(in: context).map({ Output.chunk18(.searchSuggestions($0)) }).eraseToAnyParser(),
+_searchableModifier<R>.name: _searchableModifier<R>.parser(in: context).map({ Output.chunk18(.searchable($0)) }).eraseToAnyParser(),
+_selectionDisabledModifier<R>.name: _selectionDisabledModifier<R>.parser(in: context).map({ Output.chunk18(.selectionDisabled($0)) }).eraseToAnyParser(),
+_shadowModifier<R>.name: _shadowModifier<R>.parser(in: context).map({ Output.chunk18(.shadow($0)) }).eraseToAnyParser(),
+_sheetModifier<R>.name: _sheetModifier<R>.parser(in: context).map({ Output.chunk18(.sheet($0)) }).eraseToAnyParser(),
+_simultaneousGestureModifier<R>.name: _simultaneousGestureModifier<R>.parser(in: context).map({ Output.chunk18(.simultaneousGesture($0)) }).eraseToAnyParser(),
+_speechAdjustedPitchModifier<R>.name: _speechAdjustedPitchModifier<R>.parser(in: context).map({ Output.chunk18(.speechAdjustedPitch($0)) }).eraseToAnyParser(),
+_speechAlwaysIncludesPunctuationModifier<R>.name: _speechAlwaysIncludesPunctuationModifier<R>.parser(in: context).map({ Output.chunk18(.speechAlwaysIncludesPunctuation($0)) }).eraseToAnyParser(),
+_speechAnnouncementsQueuedModifier<R>.name: _speechAnnouncementsQueuedModifier<R>.parser(in: context).map({ Output.chunk18(.speechAnnouncementsQueued($0)) }).eraseToAnyParser(),
+_speechSpellsOutCharactersModifier<R>.name: _speechSpellsOutCharactersModifier<R>.parser(in: context).map({ Output.chunk18(.speechSpellsOutCharacters($0)) }).eraseToAnyParser(),
+_statusBarHiddenModifier<R>.name: _statusBarHiddenModifier<R>.parser(in: context).map({ Output.chunk19(.statusBarHidden($0)) }).eraseToAnyParser(),
+_strikethroughModifier<R>.name: _strikethroughModifier<R>.parser(in: context).map({ Output.chunk19(.strikethrough($0)) }).eraseToAnyParser(),
+_submitLabelModifier<R>.name: _submitLabelModifier<R>.parser(in: context).map({ Output.chunk19(.submitLabel($0)) }).eraseToAnyParser(),
+_submitScopeModifier<R>.name: _submitScopeModifier<R>.parser(in: context).map({ Output.chunk19(.submitScope($0)) }).eraseToAnyParser(),
+_swipeActionsModifier<R>.name: _swipeActionsModifier<R>.parser(in: context).map({ Output.chunk19(.swipeActions($0)) }).eraseToAnyParser(),
+_symbolEffectsRemovedModifier<R>.name: _symbolEffectsRemovedModifier<R>.parser(in: context).map({ Output.chunk19(.symbolEffectsRemoved($0)) }).eraseToAnyParser(),
+_symbolRenderingModeModifier<R>.name: _symbolRenderingModeModifier<R>.parser(in: context).map({ Output.chunk19(.symbolRenderingMode($0)) }).eraseToAnyParser(),
+_symbolVariantModifier<R>.name: _symbolVariantModifier<R>.parser(in: context).map({ Output.chunk19(.symbolVariant($0)) }).eraseToAnyParser(),
+_tabItemModifier<R>.name: _tabItemModifier<R>.parser(in: context).map({ Output.chunk19(.tabItem($0)) }).eraseToAnyParser(),
+_tabViewStyleModifier<R>.name: _tabViewStyleModifier<R>.parser(in: context).map({ Output.chunk19(.tabViewStyle($0)) }).eraseToAnyParser(),
+_tableStyleModifier<R>.name: _tableStyleModifier<R>.parser(in: context).map({ Output.chunk20(.tableStyle($0)) }).eraseToAnyParser(),
+_textCaseModifier<R>.name: _textCaseModifier<R>.parser(in: context).map({ Output.chunk20(.textCase($0)) }).eraseToAnyParser(),
+_textContentTypeModifier<R>.name: _textContentTypeModifier<R>.parser(in: context).map({ Output.chunk20(.textContentType($0)) }).eraseToAnyParser(),
+_textEditorStyleModifier<R>.name: _textEditorStyleModifier<R>.parser(in: context).map({ Output.chunk20(.textEditorStyle($0)) }).eraseToAnyParser(),
+_textFieldStyleModifier<R>.name: _textFieldStyleModifier<R>.parser(in: context).map({ Output.chunk20(.textFieldStyle($0)) }).eraseToAnyParser(),
+_textInputAutocapitalizationModifier<R>.name: _textInputAutocapitalizationModifier<R>.parser(in: context).map({ Output.chunk20(.textInputAutocapitalization($0)) }).eraseToAnyParser(),
+_textScaleModifier<R>.name: _textScaleModifier<R>.parser(in: context).map({ Output.chunk20(.textScale($0)) }).eraseToAnyParser(),
+_textSelectionModifier<R>.name: _textSelectionModifier<R>.parser(in: context).map({ Output.chunk20(.textSelection($0)) }).eraseToAnyParser(),
+_tintModifier<R>.name: _tintModifier<R>.parser(in: context).map({ Output.chunk20(.tint($0)) }).eraseToAnyParser(),
+_toggleStyleModifier<R>.name: _toggleStyleModifier<R>.parser(in: context).map({ Output.chunk20(.toggleStyle($0)) }).eraseToAnyParser(),
+_toolbarModifier<R>.name: _toolbarModifier<R>.parser(in: context).map({ Output.chunk21(.toolbar($0)) }).eraseToAnyParser(),
+_toolbarBackgroundModifier<R>.name: _toolbarBackgroundModifier<R>.parser(in: context).map({ Output.chunk21(.toolbarBackground($0)) }).eraseToAnyParser(),
+_toolbarColorSchemeModifier<R>.name: _toolbarColorSchemeModifier<R>.parser(in: context).map({ Output.chunk21(.toolbarColorScheme($0)) }).eraseToAnyParser(),
+_toolbarRoleModifier<R>.name: _toolbarRoleModifier<R>.parser(in: context).map({ Output.chunk21(.toolbarRole($0)) }).eraseToAnyParser(),
+_toolbarTitleDisplayModeModifier<R>.name: _toolbarTitleDisplayModeModifier<R>.parser(in: context).map({ Output.chunk21(.toolbarTitleDisplayMode($0)) }).eraseToAnyParser(),
+_toolbarTitleMenuModifier<R>.name: _toolbarTitleMenuModifier<R>.parser(in: context).map({ Output.chunk21(.toolbarTitleMenu($0)) }).eraseToAnyParser(),
+_touchBarCustomizationLabelModifier<R>.name: _touchBarCustomizationLabelModifier<R>.parser(in: context).map({ Output.chunk21(.touchBarCustomizationLabel($0)) }).eraseToAnyParser(),
+_touchBarItemPrincipalModifier<R>.name: _touchBarItemPrincipalModifier<R>.parser(in: context).map({ Output.chunk21(.touchBarItemPrincipal($0)) }).eraseToAnyParser(),
+_trackingModifier<R>.name: _trackingModifier<R>.parser(in: context).map({ Output.chunk21(.tracking($0)) }).eraseToAnyParser(),
+_transformEffectModifier<R>.name: _transformEffectModifier<R>.parser(in: context).map({ Output.chunk21(.transformEffect($0)) }).eraseToAnyParser(),
+_transitionModifier<R>.name: _transitionModifier<R>.parser(in: context).map({ Output.chunk22(.transition($0)) }).eraseToAnyParser(),
+_truncationModeModifier<R>.name: _truncationModeModifier<R>.parser(in: context).map({ Output.chunk22(.truncationMode($0)) }).eraseToAnyParser(),
+_underlineModifier<R>.name: _underlineModifier<R>.parser(in: context).map({ Output.chunk22(.underline($0)) }).eraseToAnyParser(),
+_unredactedModifier<R>.name: _unredactedModifier<R>.parser(in: context).map({ Output.chunk22(.unredacted($0)) }).eraseToAnyParser(),
+_zIndexModifier<R>.name: _zIndexModifier<R>.parser(in: context).map({ Output.chunk22(.zIndex($0)) }).eraseToAnyParser(),
+                    LiveViewNative._TransformModifier.name: LiveViewNative._TransformModifier.parser(in: context).map(Output._TransformModifier).eraseToAnyParser(),
 LiveViewNative._IntersectionModifier.name: LiveViewNative._IntersectionModifier.parser(in: context).map(Output._IntersectionModifier).eraseToAnyParser(),
-LiveViewNative._MaskModifier<R>.name: LiveViewNative._MaskModifier<R>.parser(in: context).map(Output._MaskModifier).eraseToAnyParser(),
-LiveViewNative._StrokeModifier<R>.name: LiveViewNative._StrokeModifier<R>.parser(in: context).map(Output._StrokeModifier).eraseToAnyParser(),
-LiveViewNative._PresentationDetentsModifier.name: LiveViewNative._PresentationDetentsModifier.parser(in: context).map(Output._PresentationDetentsModifier).eraseToAnyParser(),
-LiveViewNative._PrefersDefaultFocusModifier<R>.name: LiveViewNative._PrefersDefaultFocusModifier<R>.parser(in: context).map(Output._PrefersDefaultFocusModifier).eraseToAnyParser(),
-LiveViewNative._UnionModifier.name: LiveViewNative._UnionModifier.parser(in: context).map(Output._UnionModifier).eraseToAnyParser(),
 LiveViewNative._SubtractingModifier.name: LiveViewNative._SubtractingModifier.parser(in: context).map(Output._SubtractingModifier).eraseToAnyParser(),
-LiveViewNative._SearchCompletionModifier<R>.name: LiveViewNative._SearchCompletionModifier<R>.parser(in: context).map(Output._SearchCompletionModifier).eraseToAnyParser(),
-LiveViewNative._TransformModifier.name: LiveViewNative._TransformModifier.parser(in: context).map(Output._TransformModifier).eraseToAnyParser(),
+LiveViewNative._Rotation3DEffectModifier<R>.name: LiveViewNative._Rotation3DEffectModifier<R>.parser(in: context).map(Output._Rotation3DEffectModifier).eraseToAnyParser(),
+LiveViewNative._PresentationDetentsModifier.name: LiveViewNative._PresentationDetentsModifier.parser(in: context).map(Output._PresentationDetentsModifier).eraseToAnyParser(),
+LiveViewNative._SymmetricDifferenceModifier.name: LiveViewNative._SymmetricDifferenceModifier.parser(in: context).map(Output._SymmetricDifferenceModifier).eraseToAnyParser(),
 LiveViewNative._OnSubmitModifier.name: LiveViewNative._OnSubmitModifier.parser(in: context).map(Output._OnSubmitModifier).eraseToAnyParser(),
 LiveViewNative._LineSubtractionModifier.name: LiveViewNative._LineSubtractionModifier.parser(in: context).map(Output._LineSubtractionModifier).eraseToAnyParser(),
-LiveViewNative._MatchedGeometryEffectModifier<R>.name: LiveViewNative._MatchedGeometryEffectModifier<R>.parser(in: context).map(Output._MatchedGeometryEffectModifier).eraseToAnyParser(),
-LiveViewNative._RenderingModeModifier.name: LiveViewNative._RenderingModeModifier.parser(in: context).map(Output._RenderingModeModifier).eraseToAnyParser(),
-LiveViewNative._RotationModifier.name: LiveViewNative._RotationModifier.parser(in: context).map(Output._RotationModifier).eraseToAnyParser(),
+LiveViewNative._PrefersDefaultFocusModifier<R>.name: LiveViewNative._PrefersDefaultFocusModifier<R>.parser(in: context).map(Output._PrefersDefaultFocusModifier).eraseToAnyParser(),
 LiveViewNative._SearchScopesModifier<R>.name: LiveViewNative._SearchScopesModifier<R>.parser(in: context).map(Output._SearchScopesModifier).eraseToAnyParser(),
-LiveViewNative._FocusScopeModifier<R>.name: LiveViewNative._FocusScopeModifier<R>.parser(in: context).map(Output._FocusScopeModifier).eraseToAnyParser(),
-LiveViewNative._ResizableModifier.name: LiveViewNative._ResizableModifier.parser(in: context).map(Output._ResizableModifier).eraseToAnyParser(),
-LiveViewNative._ScaleModifier<R>.name: LiveViewNative._ScaleModifier<R>.parser(in: context).map(Output._ScaleModifier).eraseToAnyParser(),
+LiveViewNative._MatchedGeometryEffectModifier<R>.name: LiveViewNative._MatchedGeometryEffectModifier<R>.parser(in: context).map(Output._MatchedGeometryEffectModifier).eraseToAnyParser(),
 LiveViewNative._FillModifier.name: LiveViewNative._FillModifier.parser(in: context).map(Output._FillModifier).eraseToAnyParser(),
-LiveViewNative._SymmetricDifferenceModifier.name: LiveViewNative._SymmetricDifferenceModifier.parser(in: context).map(Output._SymmetricDifferenceModifier).eraseToAnyParser(),
+LiveViewNative._SearchCompletionModifier<R>.name: LiveViewNative._SearchCompletionModifier<R>.parser(in: context).map(Output._SearchCompletionModifier).eraseToAnyParser(),
+LiveViewNative._LineIntersectionModifier.name: LiveViewNative._LineIntersectionModifier.parser(in: context).map(Output._LineIntersectionModifier).eraseToAnyParser(),
+LiveViewNative._StrokeModifier<R>.name: LiveViewNative._StrokeModifier<R>.parser(in: context).map(Output._StrokeModifier).eraseToAnyParser(),
+LiveViewNative._ScaleModifier<R>.name: LiveViewNative._ScaleModifier<R>.parser(in: context).map(Output._ScaleModifier).eraseToAnyParser(),
+LiveViewNative._RotationModifier.name: LiveViewNative._RotationModifier.parser(in: context).map(Output._RotationModifier).eraseToAnyParser(),
+LiveViewNative._ResizableModifier.name: LiveViewNative._ResizableModifier.parser(in: context).map(Output._ResizableModifier).eraseToAnyParser(),
+LiveViewNative._UnionModifier.name: LiveViewNative._UnionModifier.parser(in: context).map(Output._UnionModifier).eraseToAnyParser(),
+LiveViewNative._FocusScopeModifier<R>.name: LiveViewNative._FocusScopeModifier<R>.parser(in: context).map(Output._FocusScopeModifier).eraseToAnyParser(),
+LiveViewNative._MaskModifier<R>.name: LiveViewNative._MaskModifier<R>.parser(in: context).map(Output._MaskModifier).eraseToAnyParser(),
+LiveViewNative._RenderingModeModifier.name: LiveViewNative._RenderingModeModifier.parser(in: context).map(Output._RenderingModeModifier).eraseToAnyParser(),
                 ]
 
                 let deprecations = [
@@ -12629,14 +12905,14 @@ ConstantAtomLiteral("plusLighter").map({ () -> Self in
     }
 }
 
-#if os(macOS) || os(watchOS) || os(tvOS) || os(iOS)
-@available(macOS 14.0,watchOS 10.0,tvOS 17.0,iOS 17.0, *)
+#if os(tvOS) || os(iOS) || os(macOS) || os(watchOS)
+@available(tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0, *)
 extension ButtonRepeatBehavior: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             ConstantAtomLiteral("automatic").map({ () -> Self in
-#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+#if os(tvOS) || os(iOS) || os(macOS) || os(watchOS)
 
     return Self.automatic
 
@@ -12645,7 +12921,7 @@ fatalError("'automatic' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("enabled").map({ () -> Self in
-#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+#if os(tvOS) || os(iOS) || os(macOS) || os(watchOS)
 
     return Self.enabled
 
@@ -12654,7 +12930,7 @@ fatalError("'enabled' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("disabled").map({ () -> Self in
-#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+#if os(tvOS) || os(iOS) || os(macOS) || os(watchOS)
 
     return Self.disabled
 
@@ -12734,8 +13010,8 @@ ConstantAtomLiteral("dark").map({ () -> Self in
     }
 }
 
-#if os(macOS) || os(watchOS) || os(tvOS) || os(iOS)
-@available(macOS 14.0,watchOS 10.0,tvOS 17.0,iOS 17.0, *)
+#if os(macOS) || os(tvOS) || os(watchOS) || os(iOS)
+@available(macOS 14.0,tvOS 17.0,watchOS 10.0,iOS 17.0, *)
 extension ContainerBackgroundPlacement: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -12763,14 +13039,14 @@ fatalError("'navigation' is not available on this OS")
     }
 }
 #endif
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
-@available(macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0, *)
+#if os(macOS) || os(watchOS) || os(tvOS) || os(iOS)
+@available(macOS 14.0,watchOS 10.0,tvOS 17.0,iOS 17.0, *)
 extension ContentMarginPlacement: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             ConstantAtomLiteral("automatic").map({ () -> Self in
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+#if os(macOS) || os(watchOS) || os(tvOS) || os(iOS)
 
     return Self.automatic
 
@@ -12779,7 +13055,7 @@ fatalError("'automatic' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("scrollContent").map({ () -> Self in
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+#if os(macOS) || os(watchOS) || os(tvOS) || os(iOS)
 
     return Self.scrollContent
 
@@ -12788,7 +13064,7 @@ fatalError("'scrollContent' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("scrollIndicators").map({ () -> Self in
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+#if os(macOS) || os(watchOS) || os(tvOS) || os(iOS)
 
     return Self.scrollIndicators
 
@@ -12818,7 +13094,7 @@ extension ContentShapeKinds: ParseableModifierValue {
 })
 ConstantAtomLiteral("dragPreview").map({ () -> Self in
 #if os(macOS) || os(iOS)
-if #available(macOS 12.0,watchOS 8.0,tvOS 15.0,iOS 15.0, *) {
+if #available(tvOS 15.0,macOS 12.0,watchOS 8.0,iOS 15.0, *) {
     return Self.dragPreview
 } else { fatalError("'dragPreview' is not available in this OS version") }
 #else
@@ -12827,7 +13103,7 @@ fatalError("'dragPreview' is not available on this OS")
 })
 ConstantAtomLiteral("contextMenuPreview").map({ () -> Self in
 #if os(tvOS) || os(iOS)
-if #available(watchOS 8.0,macOS 12.0,tvOS 17.0,iOS 15.0, *) {
+if #available(tvOS 17.0,macOS 12.0,watchOS 8.0,iOS 15.0, *) {
     return Self.contextMenuPreview
 } else { fatalError("'contextMenuPreview' is not available in this OS version") }
 #else
@@ -12836,7 +13112,7 @@ fatalError("'contextMenuPreview' is not available on this OS")
 })
 ConstantAtomLiteral("hoverEffect").map({ () -> Self in
 #if os(iOS)
-if #available(watchOS 8.0,macOS 12.0,tvOS 15.0,iOS 15.0, *) {
+if #available(tvOS 15.0,macOS 12.0,watchOS 8.0,iOS 15.0, *) {
     return Self.hoverEffect
 } else { fatalError("'hoverEffect' is not available in this OS version") }
 #else
@@ -12844,8 +13120,8 @@ fatalError("'hoverEffect' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("focusEffect").map({ () -> Self in
-#if os(watchOS) || os(macOS)
-if #available(watchOS 8.0,macOS 12.0,tvOS 15.0,iOS 15.0, *) {
+#if os(macOS) || os(watchOS)
+if #available(tvOS 15.0,macOS 12.0,watchOS 8.0,iOS 15.0, *) {
     return Self.focusEffect
 } else { fatalError("'focusEffect' is not available in this OS version") }
 #else
@@ -12853,8 +13129,8 @@ fatalError("'focusEffect' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("accessibility").map({ () -> Self in
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
-if #available(macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0, *) {
+#if os(watchOS) || os(tvOS) || os(macOS) || os(iOS)
+if #available(watchOS 10.0,tvOS 17.0,macOS 14.0,iOS 17.0, *) {
     return Self.accessibility
 } else { fatalError("'accessibility' is not available in this OS version") }
 #else
@@ -12866,8 +13142,8 @@ fatalError("'accessibility' is not available on this OS")
     }
 }
 
-#if os(iOS) || os(macOS) || os(watchOS)
-@available(iOS 15.0,macOS 10.15,watchOS 9.0, *)
+#if os(watchOS) || os(iOS) || os(macOS)
+@available(watchOS 9.0,iOS 15.0,macOS 10.15, *)
 extension ControlSize: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -12891,7 +13167,7 @@ fatalError("'small' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("regular").map({ () -> Self in
-#if os(iOS) || os(macOS) || os(watchOS)
+#if os(watchOS) || os(iOS) || os(macOS)
 
     return Self.regular
 
@@ -12900,8 +13176,8 @@ fatalError("'regular' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("large").map({ () -> Self in
-#if os(iOS) || os(macOS) || os(watchOS)
-if #available(iOS 15.0,macOS 11.0,watchOS 9.0, *) {
+#if os(watchOS) || os(iOS) || os(macOS)
+if #available(watchOS 9.0,iOS 15.0,macOS 11.0, *) {
     return Self.large
 } else { fatalError("'large' is not available in this OS version") }
 #else
@@ -12909,8 +13185,8 @@ fatalError("'large' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("extraLarge").map({ () -> Self in
-#if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
-if #available(iOS 17.0,macOS 14.0,visionOS 1.0,watchOS 10.0, *) {
+#if os(watchOS) || os(macOS) || os(visionOS) || os(iOS)
+if #available(watchOS 10.0,macOS 14.0,visionOS 1.0,iOS 17.0, *) {
     return Self.extraLarge
 } else { fatalError("'extraLarge' is not available in this OS version") }
 #else
@@ -12951,14 +13227,14 @@ ConstantAtomLiteral("userInitiated").map({ () -> Self in
     }
 }
 
-#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-@available(iOS 17.0,macOS 13.0,tvOS 17.0,watchOS 10.0, *)
+#if os(watchOS) || os(tvOS) || os(macOS) || os(iOS)
+@available(watchOS 10.0,tvOS 17.0,macOS 13.0,iOS 17.0, *)
 extension DialogSeverity: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             ConstantAtomLiteral("automatic").map({ () -> Self in
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+#if os(watchOS) || os(tvOS) || os(macOS) || os(iOS)
 
     return Self.automatic
 
@@ -12967,7 +13243,7 @@ fatalError("'automatic' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("critical").map({ () -> Self in
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+#if os(watchOS) || os(tvOS) || os(macOS) || os(iOS)
 
     return Self.critical
 
@@ -12976,8 +13252,8 @@ fatalError("'critical' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("standard").map({ () -> Self in
-#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-if #available(iOS 17.0,macOS 14.0,tvOS 17.0,watchOS 10.0, *) {
+#if os(watchOS) || os(tvOS) || os(macOS) || os(iOS)
+if #available(watchOS 10.0,tvOS 17.0,macOS 14.0,iOS 17.0, *) {
     return Self.standard
 } else { fatalError("'standard' is not available in this OS version") }
 #else
@@ -13110,14 +13386,14 @@ ConstantAtomLiteral("all").map({ () -> Self in
     }
 }
 
-#if os(macOS) || os(iOS)
-@available(macOS 14.0,iOS 17.0, *)
+#if os(iOS) || os(macOS)
+@available(iOS 17.0,macOS 14.0, *)
 extension FileDialogBrowserOptions: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             ConstantAtomLiteral("enumeratePackages").map({ () -> Self in
-#if os(macOS) || os(iOS)
+#if os(iOS) || os(macOS)
 
     return Self.enumeratePackages
 
@@ -13126,7 +13402,7 @@ fatalError("'enumeratePackages' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("includeHiddenFiles").map({ () -> Self in
-#if os(macOS) || os(iOS)
+#if os(iOS) || os(macOS)
 
     return Self.includeHiddenFiles
 
@@ -13135,7 +13411,7 @@ fatalError("'includeHiddenFiles' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("displayFileExtensions").map({ () -> Self in
-#if os(macOS) || os(iOS)
+#if os(iOS) || os(macOS)
 
     return Self.displayFileExtensions
 
@@ -13148,14 +13424,14 @@ fatalError("'displayFileExtensions' is not available on this OS")
     }
 }
 #endif
-#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-@available(iOS 17.0,macOS 14.0,tvOS 17.0,watchOS 10.0, *)
+#if os(tvOS) || os(iOS) || os(macOS) || os(watchOS)
+@available(tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0, *)
 extension FocusInteractions: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             ConstantAtomLiteral("activate").map({ () -> Self in
-#if os(macOS) || os(watchOS) || os(iOS) || os(tvOS)
+#if os(tvOS) || os(iOS) || os(macOS) || os(watchOS)
 
     return Self.activate
 
@@ -13164,7 +13440,7 @@ fatalError("'activate' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("edit").map({ () -> Self in
-#if os(macOS) || os(watchOS) || os(iOS) || os(tvOS)
+#if os(tvOS) || os(iOS) || os(macOS) || os(watchOS)
 
     return Self.edit
 
@@ -13173,7 +13449,7 @@ fatalError("'edit' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("automatic").map({ () -> Self in
-#if os(macOS) || os(watchOS) || os(iOS) || os(tvOS)
+#if os(tvOS) || os(iOS) || os(macOS) || os(watchOS)
 
     return Self.automatic
 
@@ -13267,8 +13543,8 @@ ConstantAtomLiteral("trailing").map({ () -> Self in
 
 })
 ConstantAtomLiteral("listRowSeparatorLeading").map({ () -> Self in
-#if os(macOS) || os(iOS)
-if #available(macOS 13.0,iOS 16.0, *) {
+#if os(iOS) || os(macOS)
+if #available(iOS 16.0,macOS 13.0, *) {
     return Self.listRowSeparatorLeading
 } else { fatalError("'listRowSeparatorLeading' is not available in this OS version") }
 #else
@@ -13276,8 +13552,8 @@ fatalError("'listRowSeparatorLeading' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("listRowSeparatorTrailing").map({ () -> Self in
-#if os(macOS) || os(iOS)
-if #available(macOS 13.0,iOS 16.0, *) {
+#if os(iOS) || os(macOS)
+if #available(iOS 16.0,macOS 13.0, *) {
     return Self.listRowSeparatorTrailing
 } else { fatalError("'listRowSeparatorTrailing' is not available in this OS version") }
 #else
@@ -13440,7 +13716,7 @@ extension MenuOrder: ParseableModifierValue {
 })
 ConstantAtomLiteral("priority").map({ () -> Self in
 #if os(iOS)
-if #available(tvOS 16.0,watchOS 9.0,iOS 16.0,macOS 13.0, *) {
+if #available(tvOS 16.0,watchOS 9.0,macOS 13.0,iOS 16.0, *) {
     return Self.priority
 } else { fatalError("'priority' is not available in this OS version") }
 #else
@@ -13461,14 +13737,14 @@ ConstantAtomLiteral("fixed").map({ () -> Self in
     }
 }
 
-#if os(macOS) || os(watchOS) || os(tvOS) || os(iOS)
-@available(macOS 13.3,watchOS 9.4,tvOS 16.4,iOS 16.4, *)
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+@available(macOS 13.3,iOS 16.4,watchOS 9.4,tvOS 16.4, *)
 extension PresentationAdaptation: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             ConstantAtomLiteral("automatic").map({ () -> Self in
-#if os(macOS) || os(watchOS) || os(tvOS) || os(iOS)
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 
     return Self.automatic
 
@@ -13477,7 +13753,7 @@ fatalError("'automatic' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("none").map({ () -> Self in
-#if os(macOS) || os(watchOS) || os(tvOS) || os(iOS)
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 
     return Self.none
 
@@ -13486,7 +13762,7 @@ fatalError("'none' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("popover").map({ () -> Self in
-#if os(macOS) || os(watchOS) || os(tvOS) || os(iOS)
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 
     return Self.popover
 
@@ -13495,7 +13771,7 @@ fatalError("'popover' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("sheet").map({ () -> Self in
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 
     return Self.sheet
 
@@ -13504,7 +13780,7 @@ fatalError("'sheet' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("fullScreenCover").map({ () -> Self in
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 
     return Self.fullScreenCover
 
@@ -13517,14 +13793,14 @@ fatalError("'fullScreenCover' is not available on this OS")
     }
 }
 #endif
-#if os(macOS) || os(watchOS) || os(iOS) || os(tvOS)
-@available(macOS 13.3,watchOS 9.4,iOS 16.4,tvOS 16.4, *)
+#if os(tvOS) || os(iOS) || os(macOS) || os(watchOS)
+@available(tvOS 16.4,iOS 16.4,macOS 13.3,watchOS 9.4, *)
 extension PresentationContentInteraction: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             ConstantAtomLiteral("automatic").map({ () -> Self in
-#if os(macOS) || os(watchOS) || os(iOS) || os(tvOS)
+#if os(tvOS) || os(iOS) || os(macOS) || os(watchOS)
 
     return Self.automatic
 
@@ -13533,7 +13809,7 @@ fatalError("'automatic' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("resizes").map({ () -> Self in
-#if os(macOS) || os(watchOS) || os(iOS) || os(tvOS)
+#if os(tvOS) || os(iOS) || os(macOS) || os(watchOS)
 
     return Self.resizes
 
@@ -13542,7 +13818,7 @@ fatalError("'resizes' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("scrolls").map({ () -> Self in
-#if os(macOS) || os(watchOS) || os(iOS) || os(tvOS)
+#if os(tvOS) || os(iOS) || os(macOS) || os(watchOS)
 
     return Self.scrolls
 
@@ -13609,8 +13885,8 @@ ConstantAtomLiteral("privacy").map({ () -> Self in
 
 })
 ConstantAtomLiteral("invalidated").map({ () -> Self in
-#if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
-if #available(iOS 17.0,macOS 14.0,watchOS 10.0,tvOS 17.0, *) {
+#if os(iOS) || os(tvOS) || os(macOS) || os(watchOS)
+if #available(iOS 17.0,tvOS 17.0,macOS 14.0,watchOS 10.0, *) {
     return Self.invalidated
 } else { fatalError("'invalidated' is not available in this OS version") }
 #else
@@ -13706,7 +13982,7 @@ extension ScenePadding: ParseableModifierValue {
 })
 ConstantAtomLiteral("navigationBar").map({ () -> Self in
 #if os(watchOS)
-if #available(iOS 16.0,macOS 13.0,tvOS 16.0,watchOS 9.0, *) {
+if #available(macOS 13.0,watchOS 9.0,tvOS 16.0,iOS 16.0, *) {
     return Self.navigationBar
 } else { fatalError("'navigationBar' is not available in this OS version") }
 #else
@@ -13718,14 +13994,14 @@ fatalError("'navigationBar' is not available on this OS")
     }
 }
 
-#if os(macOS) || os(watchOS) || os(tvOS) || os(iOS)
-@available(macOS 13.3,watchOS 9.4,tvOS 16.4,iOS 16.4, *)
+#if os(tvOS) || os(macOS) || os(watchOS) || os(iOS)
+@available(tvOS 16.4,macOS 13.3,watchOS 9.4,iOS 16.4, *)
 extension ScrollBounceBehavior: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             ConstantAtomLiteral("automatic").map({ () -> Self in
-#if os(macOS) || os(watchOS) || os(tvOS) || os(iOS)
+#if os(tvOS) || os(macOS) || os(watchOS) || os(iOS)
 
     return Self.automatic
 
@@ -13734,7 +14010,7 @@ fatalError("'automatic' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("always").map({ () -> Self in
-#if os(macOS) || os(watchOS) || os(tvOS) || os(iOS)
+#if os(tvOS) || os(macOS) || os(watchOS) || os(iOS)
 
     return Self.always
 
@@ -13743,7 +14019,7 @@ fatalError("'always' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("basedOnSize").map({ () -> Self in
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+#if os(tvOS) || os(macOS) || os(watchOS) || os(iOS)
 
     return Self.basedOnSize
 
@@ -13756,8 +14032,8 @@ fatalError("'basedOnSize' is not available on this OS")
     }
 }
 #endif
-#if os(watchOS) || os(macOS) || os(tvOS) || os(iOS)
-@available(watchOS 9.0,macOS 13.0,tvOS 16.0,iOS 16.0, *)
+#if os(tvOS) || os(macOS) || os(watchOS) || os(iOS)
+@available(tvOS 16.0,macOS 13.0,watchOS 9.0,iOS 16.0, *)
 extension ScrollDismissesKeyboardMode: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -13866,7 +14142,7 @@ fatalError("'automatic' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("onTextEntry").map({ () -> Self in
-#if os(macOS) || os(watchOS) || os(iOS)
+#if os(iOS) || os(macOS) || os(watchOS)
 
     return Self.onTextEntry
 
@@ -13875,7 +14151,7 @@ fatalError("'onTextEntry' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("onSearchPresentation").map({ () -> Self in
-#if os(macOS) || os(watchOS) || os(iOS)
+#if os(iOS) || os(macOS) || os(watchOS)
 
     return Self.onSearchPresentation
 
@@ -13926,14 +14202,14 @@ ConstantAtomLiteral("content").map({ () -> Self in
     }
 }
 
-#if os(tvOS) || os(watchOS) || os(iOS) || os(macOS)
-@available(tvOS 17.0,watchOS 10.0,iOS 17.0,macOS 14.0, *)
+#if os(tvOS) || os(macOS) || os(watchOS) || os(iOS)
+@available(tvOS 17.0,macOS 14.0,watchOS 10.0,iOS 17.0, *)
 extension SpringLoadingBehavior: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             ConstantAtomLiteral("automatic").map({ () -> Self in
-#if os(tvOS) || os(watchOS) || os(iOS) || os(macOS)
+#if os(tvOS) || os(macOS) || os(watchOS) || os(iOS)
 
     return Self.automatic
 
@@ -13942,7 +14218,7 @@ fatalError("'automatic' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("enabled").map({ () -> Self in
-#if os(tvOS) || os(watchOS) || os(iOS) || os(macOS)
+#if os(tvOS) || os(macOS) || os(watchOS) || os(iOS)
 
     return Self.enabled
 
@@ -13951,7 +14227,7 @@ fatalError("'enabled' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("disabled").map({ () -> Self in
-#if os(tvOS) || os(watchOS) || os(iOS) || os(macOS)
+#if os(tvOS) || os(macOS) || os(watchOS) || os(iOS)
 
     return Self.disabled
 
@@ -14085,14 +14361,14 @@ ConstantAtomLiteral("search").map({ () -> Self in
     }
 }
 
-#if os(macOS) || os(watchOS) || os(tvOS) || os(iOS)
-@available(macOS 14.0,watchOS 10.0,tvOS 17.0,iOS 17.0, *)
+#if os(watchOS) || os(tvOS) || os(macOS) || os(iOS)
+@available(watchOS 10.0,tvOS 17.0,macOS 14.0,iOS 17.0, *)
 extension ToolbarDefaultItemKind: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             ConstantAtomLiteral("sidebarToggle").map({ () -> Self in
-#if os(macOS) || os(watchOS) || os(tvOS) || os(iOS)
+#if os(watchOS) || os(tvOS) || os(macOS) || os(iOS)
 
     return Self.sidebarToggle
 
@@ -14121,8 +14397,8 @@ extension ToolbarRole: ParseableModifierValue {
 
 })
 ConstantAtomLiteral("navigationStack").map({ () -> Self in
-#if os(watchOS) || os(tvOS) || os(iOS)
-if #available(macOS 13.0,watchOS 9.0,tvOS 16.0,iOS 16.0, *) {
+#if os(tvOS) || os(iOS) || os(watchOS)
+if #available(tvOS 16.0,iOS 16.0,macOS 13.0,watchOS 9.0, *) {
     return Self.navigationStack
 } else { fatalError("'navigationStack' is not available in this OS version") }
 #else
@@ -14131,7 +14407,7 @@ fatalError("'navigationStack' is not available on this OS")
 })
 ConstantAtomLiteral("browser").map({ () -> Self in
 #if os(iOS)
-if #available(macOS 13.0,watchOS 9.0,iOS 16.0,tvOS 16.0, *) {
+if #available(tvOS 16.0,iOS 16.0,macOS 13.0,watchOS 9.0, *) {
     return Self.browser
 } else { fatalError("'browser' is not available in this OS version") }
 #else
@@ -14139,8 +14415,8 @@ fatalError("'browser' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("editor").map({ () -> Self in
-#if os(macOS) || os(iOS)
-if #available(macOS 13.0,watchOS 9.0,iOS 16.0,tvOS 16.0, *) {
+#if os(iOS) || os(macOS)
+if #available(tvOS 16.0,iOS 16.0,macOS 13.0,watchOS 9.0, *) {
     return Self.editor
 } else { fatalError("'editor' is not available in this OS version") }
 #else
@@ -14152,14 +14428,14 @@ fatalError("'editor' is not available on this OS")
     }
 }
 
-#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-@available(iOS 17.0,macOS 14.0,tvOS 17.0,watchOS 10.0, *)
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+@available(macOS 14.0,iOS 17.0,watchOS 10.0,tvOS 17.0, *)
 extension ToolbarTitleDisplayMode: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             ConstantAtomLiteral("automatic").map({ () -> Self in
-#if os(macOS) || os(watchOS) || os(tvOS) || os(iOS)
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 
     return Self.automatic
 
@@ -14168,7 +14444,7 @@ fatalError("'automatic' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("large").map({ () -> Self in
-#if os(watchOS) || os(iOS)
+#if os(iOS) || os(watchOS)
 
     return Self.large
 
@@ -14186,7 +14462,7 @@ fatalError("'inlineLarge' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("inline").map({ () -> Self in
-#if os(macOS) || os(watchOS) || os(tvOS) || os(iOS)
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 
     return Self.inline
 

--- a/Sources/ModifierGenerator/ModifierGenerator.swift
+++ b/Sources/ModifierGenerator/ModifierGenerator.swift
@@ -371,13 +371,13 @@ struct ModifierGenerator: ParsableCommand {
             
             extension BuiltinRegistry {
                 enum BuiltinModifier: ViewModifier, ParseableModifierValue {
-                    \#((0..<chunks.count).map({ i in "case chunk\(i)(_BuiltinModifierChunk\(i))" }).joined(separator: "\n"))
+                    \#(chunks.indices.map({ i in "case chunk\(i)(_BuiltinModifierChunk\(i))" }).joined(separator: "\n"))
                     \#(Self.extraModifierTypes.map({ "case \($0.split(separator: "<").first!)(LiveViewNative.\($0))" }).joined(separator: "\n"))
                     case _customRegistryModifier(R.CustomModifier)
                     
                     func body(content: Content) -> some View {
                         switch self {
-                        \#((0..<chunks.count).map({
+                        \#(chunks.indices.map({
                             """
                             case let .chunk\($0)(chunk):
                                 content.modifier(chunk)
@@ -502,6 +502,7 @@ struct ModifierGenerator: ParsableCommand {
                                 .compactMap({ $0.argument.as(PlatformVersionSyntax.self)?.platform.text })
                                 .filter({ !unavailable.contains($0) })
                                 .map({ $0 == "macCatalyst" ? "targetEnvironment(macCatalyst)" : "os(\($0))" })
+                                .sorted()
                                 .joined(separator: " || ")
                         )
                         """
@@ -538,6 +539,7 @@ struct ModifierGenerator: ParsableCommand {
                                                 .compactMap({ $0.argument.as(PlatformVersionSyntax.self)?.platform.text })
                                                 .filter({ !memberUnavailable.contains($0) })
                                                 .map({ $0 == "macCatalyst" ? "targetEnvironment(macCatalyst)" : "os(\($0))" })
+                                                .sorted()
                                                 .joined(separator: " || "))
                                         """
                                     )

--- a/Sources/ModifierGenerator/Signature.swift
+++ b/Sources/ModifierGenerator/Signature.swift
@@ -52,6 +52,7 @@ struct Signature {
                     .compactMap({ $0.argument.as(PlatformVersionSyntax.self)?.platform.text })
                     .filter({ !unavailable.contains($0) })
                     .map({ $0 == "macCatalyst" ? "targetEnvironment(macCatalyst)" : "os(\($0))" })
+                    .sorted()
                     .joined(separator: " || "))
             """
 


### PR DESCRIPTION
Closes #1245 

This was related to a similar issue #806.

To resolve this, a new `chunk-size` option was added to the modifier generator. This will split the builtin modifier enum into chunks, which the main `BuiltinModifier` type defers to.