### PR TITLE
Display dead render until connected

### DIFF
--- a/Sources/LiveViewNative/Coordinators/LiveSessionCoordinator.swift
+++ b/Sources/LiveViewNative/Coordinators/LiveSessionCoordinator.swift
@@ -154,6 +154,8 @@ public class LiveSessionCoordinator<R: RootRegistry>: ObservableObject {
             
             self.domValues = domValues
             
+            navigationPath.first!.coordinator.document = try LiveViewNativeCore.Document.parse(mainDiv.html())
+            
             if socket == nil {
                 try await self.connectSocket(domValues)
             }


### PR DESCRIPTION
Closes #1229 

The dead render is displayed with the `disabled` modifier, so no interaction is permitted until the channel connection is established.