### PR TITLE
Extract state views into their own views and address warnings

### DIFF
--- a/priv/xcodegen/Sources/TemplateApp/ContentView.swift
+++ b/priv/xcodegen/Sources/TemplateApp/ContentView.swift
@@ -15,78 +15,14 @@ struct ContentView: View {
             ),
             addons: []
         ) {
+          // connecting
             ProgressView()
         } disconnected: {
-            if #available(iOS 17, macOS 14, tvOS 17, watchOS 10, *) {
-                ContentUnavailableView {
-                    Label("No Connection", systemImage: "network.slash")
-                } description: {
-                    Text("The app will reconnect when network connection is regained.")
-                }
-            } else {
-                VStack {
-                    Label("No Connection", systemImage: "network.slash")
-                        .font(.headline)
-                    Text("The app will reconnect when network connection is regained.")
-                        .foregroundStyle(.secondary)
-                }
-            }
+            DisconnectedView()
         } reconnecting: { content, isReconnecting in
-            content
-                .safeAreaInset(edge: .top) {
-                    if isReconnecting {
-                        VStack {
-                            Label("No Connection", systemImage: "wifi.slash")
-                                .bold()
-                            Text("Reconnecting")
-                                .foregroundStyle(.secondary)
-                        }
-                            .font(.caption)
-                            .padding(8)
-                            .frame(maxWidth: .infinity)
-                            #if os(watchOS)
-                            .background(.background)
-                            #else
-                            .background(.regularMaterial)
-                            #endif
-                            .transition(.move(edge: .top).combined(with: .opacity))
-                    }
-                }
-                .animation(.default, value: isReconnecting)
+            ReconnectingView(content: content, isReconnecting: isReconnecting)
         } error: { error in
-            LiveErrorView(error: error) {
-                let description = Group {
-                    #if DEBUG
-                    ScrollView {
-                        Text(error.localizedDescription)
-                            .font(.caption.monospaced())
-                            .multilineTextAlignment(.leading)
-                    }
-                    #else
-                    Text("The app will reconnect when network connection is regained.")
-                    #endif
-                }
-                if #available(iOS 17, macOS 14, tvOS 17, watchOS 10, *) {
-                    ContentUnavailableView {
-                        Label("Connection Failed", systemImage: "network.slash")
-                    } description: {
-                        description
-                    } actions: {
-                        Button {
-                            UIPasteboard.general.string = error.localizedDescription
-                        } label: {
-                            Label("Copy Error", systemImage: "doc.on.doc")
-                        }
-                    }
-                } else {
-                    VStack {
-                        Label("Connection Failed", systemImage: "network.slash")
-                            .font(.headline)
-                        description
-                            .foregroundStyle(.secondary)
-                    }
-                }
-            }
+            ErrorView(error: error)
         }
     }
 }

--- a/priv/xcodegen/Sources/TemplateApp/DisconnectedView.swift
+++ b/priv/xcodegen/Sources/TemplateApp/DisconnectedView.swift
@@ -1,0 +1,29 @@
+//
+//  DisconnectedView.swift
+//  DisconnectedView
+//
+
+import SwiftUI
+
+struct DisconnectedView: View {
+    var body: some View {
+        if #available(iOS 17, macOS 14, tvOS 17, watchOS 10, *) {
+            ContentUnavailableView {
+                Label("No Connection", systemImage: "network.slash")
+            } description: {
+                Text("The app will reconnect when network connection is regained.")
+            }
+        } else {
+            VStack {
+                Label("No Connection", systemImage: "network.slash")
+                    .font(.headline)
+                Text("The app will reconnect when network connection is regained.")
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+}
+
+#Preview {
+    DisconnectedView()
+}

--- a/priv/xcodegen/Sources/TemplateApp/ErrorView.swift
+++ b/priv/xcodegen/Sources/TemplateApp/ErrorView.swift
@@ -1,0 +1,50 @@
+//
+//  ErrorView.swift
+//  ErrorView
+//
+
+import SwiftUI
+import LiveViewNative
+
+struct ErrorView: View {
+    var error: Error
+    var body: some View {
+        LiveErrorView(error: error) {
+            let description = Group {
+                #if DEBUG
+                ScrollView {
+                    Text(error.localizedDescription)
+                        .font(.caption.monospaced())
+                        .multilineTextAlignment(.leading)
+                }
+                #else
+                Text("The app will reconnect when network connection is regained.")
+                #endif
+            }
+            if #available(iOS 17, macOS 14, tvOS 17, watchOS 10, *) {
+                ContentUnavailableView {
+                    Label("Connection Failed", systemImage: "network.slash")
+                } description: {
+                    description
+                } actions: {
+                    Button {
+                        UIPasteboard.general.string = error.localizedDescription
+                    } label: {
+                        Label("Copy Error", systemImage: "doc.on.doc")
+                    }
+                }
+            } else {
+                VStack {
+                    Label("Connection Failed", systemImage: "network.slash")
+                        .font(.headline)
+                    description
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+    }
+}
+
+//#Preview {
+//    ErrorView()
+//}

--- a/priv/xcodegen/Sources/TemplateApp/ReconnectingView.swift
+++ b/priv/xcodegen/Sources/TemplateApp/ReconnectingView.swift
@@ -1,0 +1,42 @@
+//
+//  ReconnectingView.swift
+//  ReconnectingView
+//
+
+import SwiftUI
+
+struct ReconnectingView: View {
+    var content: AnyView
+    var isReconnecting: Bool
+    
+    var body: some View {
+        content
+            .safeAreaInset(edge: .top) {
+                if isReconnecting {
+                    VStack {
+                        Label("No Connection", systemImage: "wifi.slash")
+                            .bold()
+                        Text("Reconnecting")
+                            .foregroundStyle(.secondary)
+                    }
+                        .font(.caption)
+                        .padding(8)
+                        .frame(maxWidth: .infinity)
+                        #if os(watchOS)
+                        .background(.background)
+                        #else
+                        .background(.regularMaterial)
+                        #endif
+                        .transition(.move(edge: .top).combined(with: .opacity))
+                }
+            }
+            .animation(.default, value: isReconnecting)
+    }
+}
+
+//#Preview {
+//    ReconnectingView(
+//        content: Text("Test"),
+//        isReconnecting: true
+//    )
+//}

--- a/priv/xcodegen/base_spec.yml
+++ b/priv/xcodegen/base_spec.yml
@@ -10,7 +10,7 @@ options:
 packages:
   LiveViewNative:
     url: https://github.com/liveview-native/liveview-client-swiftui
-    version: 0.3.0-alpha.3
+    from: 0.3.0-alpha.4
 settings:
   CURRENT_PROJECT_VERSION: 1.0
   INFOPLIST_KEY_CFBundleDisplayName: ${LVN_APP_NAME}
@@ -19,3 +19,6 @@ settings:
   INFOPLIST_KEY_UILaunchScreen_Generation: YES
   GENERATE_INFOPLIST_FILE: YES
   MARKETING_VERSION: 1.0
+  DEAD_CODE_STRIPPING: YES
+  ENABLE_USER_SCRIPT_SANDBOXING: YES
+  ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS: YES


### PR DESCRIPTION
The state views are extracted into their own views to make the ContentView less cluttered and to provide a clean location to make changes. This also allows Previews to be used.

Also suppress the recommended changes warnings when generating a new project