### PR TITLE
Attribute casing refactor

### DIFF
--- a/Sources/LiveViewNative/Utils/Alignment.swift
+++ b/Sources/LiveViewNative/Utils/Alignment.swift
@@ -11,17 +11,17 @@ import LiveViewNativeCore
 /// Decodes a 2-axis alignment from a string.
 ///
 /// Possible values:
-/// - `top-leading`
+/// - `topLeading`
 /// - `top`
-/// - `top-trailing`
+/// - `topTrailing`
 /// - `leading`
 /// - `center`
 /// - `trailing`
-/// - `bottom-leading`
+/// - `bottomLeading`
 /// - `bottom`
-/// - `bottom-trailing`
-/// - `leading-last-text-baseline`
-/// - `trailing-last-text-baseline`
+/// - `bottomTrailing`
+/// - `leadingLastTextBaseline`
+/// - `trailingLastTextBaseline`
 extension Alignment: Decodable, AttributeDecodable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
@@ -35,11 +35,11 @@ extension Alignment: Decodable, AttributeDecodable {
     
     init?(string: String) {
         switch string {
-        case "top-leading", "top_leading":
+        case "topLeading":
             self = .topLeading
         case "top":
             self = .top
-        case "top-trailing", "top_trailing":
+        case "topTrailing":
             self = .topTrailing
         case "leading":
             self = .leading
@@ -47,15 +47,15 @@ extension Alignment: Decodable, AttributeDecodable {
             self = .center
         case "trailing":
             self = .trailing
-        case "bottom-leading", "bottom_leading":
+        case "bottomLeading":
             self = .bottomTrailing
         case "bottom":
             self = .bottom
-        case "bottom-trailing", "bottom_trailing":
+        case "bottomTrailing":
             self = .bottomTrailing
-        case "leading-last-text-baseline", "leading_last_text_baseline":
+        case "leadingLastTextBaseline":
             self = .leadingLastTextBaseline
-        case "trailing-last-text-baseline", "trailing_last_text_baseline":
+        case "trailingLastTextBaseline":
             self = .trailingLastTextBaseline
         default:
             return nil

--- a/Sources/LiveViewNative/Utils/Font.swift
+++ b/Sources/LiveViewNative/Utils/Font.swift
@@ -11,7 +11,7 @@ import LiveViewNativeCore
 /// A system text style.
 ///
 /// Possible values:
-/// * `large_title`
+/// * `largeTitle`
 /// * `title`
 /// * `title2`
 /// * `title3`
@@ -34,7 +34,7 @@ extension Font.TextStyle: AttributeDecodable {
 extension Font.TextStyle {
     init(from string: String) throws {
         switch string {
-        case "large_title", "large-title": self = .largeTitle
+        case "largeTitle": self = .largeTitle
         case "title": self = .title
         case "title2": self = .title2
         case "title3": self = .title3

--- a/Sources/LiveViewNative/Utils/PinnedScrollableViews.swift
+++ b/Sources/LiveViewNative/Utils/PinnedScrollableViews.swift
@@ -11,8 +11,8 @@ import LiveViewNativeCore
 /// Configuration used to pin section headers/footers in lazy containers.
 ///
 /// Possible values:
-/// * `section-headers`
-/// * `section-footers`
+/// * `sectionHeaders`
+/// * `sectionFooters`
 /// * `all`
 ///
 /// In this example, the current section header will always be visible on the leading edge of the screen, up until the next section is scrolled past the left edge.
@@ -21,7 +21,7 @@ import LiveViewNativeCore
 /// <ScrollView axes="horizontal">
 ///     <LazyHGrid
 ///         rows={...}
-///         pinned-views="section-headers"
+///         pinnedViews="sectionHeaders"
 ///     >
 ///         <Section>
 ///             <Section:header>1-50</Section:header>
@@ -45,9 +45,9 @@ import LiveViewNativeCore
 extension PinnedScrollableViews: AttributeDecodable {
     init(string: String) {
         switch string {
-        case "section-headers":
+        case "sectionHeaders":
             self = .sectionHeaders
-        case "section-footers":
+        case "sectionFooters":
             self = .sectionFooters
         case "all":
             self = [.sectionHeaders, .sectionFooters]

--- a/Sources/LiveViewNative/Utils/UnitPoint.swift
+++ b/Sources/LiveViewNative/Utils/UnitPoint.swift
@@ -20,10 +20,10 @@ import RegexBuilder
 /// - `trailing`
 /// - `top`
 /// - `bottom`
-/// - `top-leading`
-/// - `top-trailing`
-/// - `bottom-leading`
-/// - `bottom-trailing`
+/// - `topLeading`
+/// - `topTrailing`
+/// - `bottomLeading`
+/// - `bottomTrailing`
 extension UnitPoint: AttributeDecodable {
     public init(from attribute: LiveViewNativeCore.Attribute?, on element: ElementNode) throws {
         guard let value = attribute?.value else { throw AttributeDecodingError.missingAttribute(Self.self) }
@@ -46,13 +46,13 @@ extension UnitPoint {
             self = .top
         case "bottom":
             self = .bottom
-        case "top-leading", "top_leading":
+        case "topLeading":
             self = .topLeading
-        case "top-trailing", "top_trailing":
+        case "topTrailing":
             self = .topTrailing
-        case "bottom-leading", "bottom_leading":
+        case "bottomLeading":
             self = .bottomLeading
-        case "bottom-trailing", "bottom_trailing":
+        case "bottomTrailing":
             self = .bottomTrailing
         default:
             let doublePattern = Regex {

--- a/Sources/LiveViewNative/Views/Accessibility/ScaledMetric.swift
+++ b/Sources/LiveViewNative/Views/Accessibility/ScaledMetric.swift
@@ -12,8 +12,8 @@ import SwiftUI
 /// Use this element to scale a value with the accessibility dynamic type size.
 ///
 /// ```html
-/// <ScaledMetric phx-change="scaled-value-changed" value={100} relative-to="large-title">
-///   <Image system-name="heart" resizable modifiers={frame(width: @scaled_value, height: @scaled_value)}>
+/// <ScaledMetric phx-change="scaled-value-changed" value={100} relativeTo="large-title">
+///   <Image systemName="heart" resizable modifiers={frame(width: @scaled_value, height: @scaled_value)}>
 /// </ScaledMetric>
 /// ```
 ///
@@ -52,7 +52,7 @@ struct ScaledMetric<R: RootRegistry>: View {
     /// The ``LiveViewNative/SwiftUI/Font/TextStyle`` to scale with.
     /// Defaults to `body`.
     @_documentation(visibility: public)
-    @Attribute("relative-to") private var relativeStyle: Font.TextStyle = .body
+    @Attribute("relativeTo") private var relativeStyle: Font.TextStyle = .body
     
     var body: some View {
         ScaledMetricObserver(

--- a/Sources/LiveViewNative/Views/Controls and Indicators/Indicators/Gauge.swift
+++ b/Sources/LiveViewNative/Views/Controls and Indicators/Indicators/Gauge.swift
@@ -13,10 +13,10 @@ import SwiftUI
 ///
 /// ```html
 /// <Gauge value="0.5">
-///     <Text template={:label}>50%</Text>
-///     <Text template={:"current-value-label"}>0.5</Text>
-///     <Text template={:"minimum-value-label"}>0</Text>
-///     <Text template={:"maximum-value-label"}>1</Text>
+///     <Text template="label">50%</Text>
+///     <Text template="currentValueLabel">0.5</Text>
+///     <Text template="minimumValueLabel">0</Text>
+///     <Text template="maximumValueLabel">1</Text>
 /// </Gauge>
 /// ```
 ///
@@ -26,9 +26,9 @@ import SwiftUI
 /// * ``upperBound``
 ///
 /// ## Children
-/// * `current-value-label` - Describes the current value.
-/// * `minimum-value-label` - Describes the lowest possible value.
-/// * `maximum-value-label` - Describes the highest possible value.
+/// * `currentValueLabel` - Describes the current value.
+/// * `minimumValueLabel` - Describes the lowest possible value.
+/// * `maximumValueLabel` - Describes the highest possible value.
 @_documentation(visibility: public)
 struct Gauge<R: RootRegistry>: View {
     @ObservedElement private var element: ElementNode
@@ -39,17 +39,17 @@ struct Gauge<R: RootRegistry>: View {
     @Attribute("value") private var value: Double = 0
     /// The lowest possible value of the gauge.
     @_documentation(visibility: public)
-    @Attribute("lower-bound") private var lowerBound: Double = 0
+    @Attribute("lowerBound") private var lowerBound: Double = 0
     /// The highest possible value of the gauge.
     @_documentation(visibility: public)
-    @Attribute("upper-bound") private var upperBound: Double = 1
+    @Attribute("upperBound") private var upperBound: Double = 1
     
     public var body: some View {
         #if !os(tvOS)
         SwiftUI.Group {
-            if context.hasTemplate(of: element, withName: "current-value-label") ||
-               context.hasTemplate(of: element, withName: "minimum-value-label") ||
-               context.hasTemplate(of: element, withName: "maximum-value-label")
+            if context.hasTemplate(of: element, withName: "currentValueLabel") ||
+               context.hasTemplate(of: element, withName: "minimumValueLabel") ||
+               context.hasTemplate(of: element, withName: "maximumValueLabel")
             {
                 SwiftUI.Gauge(
                     value: self.value,
@@ -57,11 +57,11 @@ struct Gauge<R: RootRegistry>: View {
                 ) {
                     label
                 } currentValueLabel: {
-                    context.buildChildren(of: element, forTemplate: "current-value-label")
+                    context.buildChildren(of: element, forTemplate: "currentValueLabel")
                 } minimumValueLabel: {
-                    context.buildChildren(of: element, forTemplate: "minimum-value-label")
+                    context.buildChildren(of: element, forTemplate: "minimumValueLabel")
                 } maximumValueLabel: {
-                    context.buildChildren(of: element, forTemplate: "maximum-value-label")
+                    context.buildChildren(of: element, forTemplate: "maximumValueLabel")
                 }
             } else {
                 SwiftUI.Gauge(

--- a/Sources/LiveViewNative/Views/Controls and Indicators/Indicators/ProgressView.swift
+++ b/Sources/LiveViewNative/Views/Controls and Indicators/Indicators/ProgressView.swift
@@ -21,7 +21,7 @@ import SwiftUI
 /// <ProgressView value={0.5} />
 /// <ProgressView value={0.5} total={2}>
 ///     <Text template={:label}>Completed Percentage</Text>
-///     <Text template={:current-value-label}>25%</Text>
+///     <Text template="currentValueLabel">25%</Text>
 /// </ProgressView>
 /// ```
 ///
@@ -30,8 +30,8 @@ import SwiftUI
 /// ```html
 /// <ProgressView
 ///     counts-down
-///     timer-interval-start={DateTime.utc_now()}
-///     timer-interval-end={DateTime.utc_now() |> DateTime.add(5, :minute)}
+///     timerInterval:start={DateTime.utc_now()}
+///     timerInterval:end={DateTime.utc_now() |> DateTime.add(5, :minute)}
 /// />
 /// ```
 ///
@@ -44,7 +44,7 @@ import SwiftUI
 ///
 /// ## Children
 /// * `label` - Describes the purpose of the element.
-/// * `current-value-label` - Describes the current value.
+/// * `currentValueLabel` - Describes the current value.
 ///
 /// ## Topics
 /// ### Displaying Specific Values
@@ -66,19 +66,19 @@ struct ProgressView<R: RootRegistry>: View {
     ///
     /// This attribute has no effect without ``timerIntervalEnd``.
     @_documentation(visibility: public)
-    @Attribute("timer-interval-start") private var timerIntervalStart: Date?
+    @Attribute("timerInterval:start") private var timerIntervalStart: Date?
     /// The end date for a timer.
     ///
     /// Expected to be in the ISO8601 format produced by Elixir's `DateTime`.
     ///
     /// This attribute has no effect without ``timerIntervalStart``.
     @_documentation(visibility: public)
-    @Attribute("timer-interval-end") private var timerIntervalEnd: Date?
+    @Attribute("timerInterval:end") private var timerIntervalEnd: Date?
     /// Reverses the direction of a timer progress view.
     ///
     /// This attribute has no effect without ``timerIntervalStart`` and ``timerIntervalEnd``.
     @_documentation(visibility: public)
-    @Attribute("counts-down") private var countsDown: Bool
+    @Attribute("countsDown") private var countsDown: Bool
     
     /// Completed amount, out of ``total``.
     @_documentation(visibility: public)
@@ -94,14 +94,14 @@ struct ProgressView<R: RootRegistry>: View {
             {
                 // SwiftUI's default `currentValueLabel` is not present unless the argument is not included in the initializer.
                 // Check if we have it first otherwise use the default.
-                if context.hasTemplate(of: element, withName: "current-value-label") {
+                if context.hasTemplate(of: element, withName: "currentValueLabel") {
                     SwiftUI.ProgressView(
                         timerInterval: timerIntervalStart...timerIntervalEnd,
                         countsDown: countsDown
                     ) {
                         context.buildChildren(of: element, forTemplate: "label", includeDefaultSlot: true)
                     } currentValueLabel: {
-                        context.buildChildren(of: element, forTemplate: "current-value-label")
+                        context.buildChildren(of: element, forTemplate: "currentValueLabel")
                     }
                 } else {
                     SwiftUI.ProgressView(
@@ -118,7 +118,7 @@ struct ProgressView<R: RootRegistry>: View {
                 ) {
                     context.buildChildren(of: element, forTemplate: "label", includeDefaultSlot: true)
                 } currentValueLabel: {
-                    context.buildChildren(of: element, forTemplate: "current-value-label")
+                    context.buildChildren(of: element, forTemplate: "currentValueLabel")
                 }
             } else {
                 SwiftUI.ProgressView {

--- a/Sources/LiveViewNative/Views/Controls and Indicators/Pickers/ColorPicker.swift
+++ b/Sources/LiveViewNative/Views/Controls and Indicators/Pickers/ColorPicker.swift
@@ -13,7 +13,7 @@ import LiveViewNativeCore
 /// The color is stored as a map with the keys `r`, `g`, `b`, and optionally `a`.
 ///
 /// ```html
-/// <ColorPicker selection={@favorite_color} phx-change="color-changed" supports-opacity>
+/// <ColorPicker selection={@favorite_color} phx-change="color-changed" supportsOpacity>
 ///     Favorite Color
 /// </ColorPicker>
 /// ```
@@ -39,7 +39,7 @@ struct ColorPicker<R: RootRegistry>: View {
     
     /// Enables the selection of transparent colors.
     @_documentation(visibility: public)
-    @Attribute("supports-opacity") private var supportsOpacity: Bool
+    @Attribute("supportsOpacity") private var supportsOpacity: Bool
     
     struct CodableColor: AttributeDecodable, Codable, Equatable {
         init(from attribute: LiveViewNativeCore.Attribute?, on element: ElementNode) throws {

--- a/Sources/LiveViewNative/Views/Controls and Indicators/Value Inputs/Slider.swift
+++ b/Sources/LiveViewNative/Views/Controls and Indicators/Value Inputs/Slider.swift
@@ -20,8 +20,8 @@ import SwiftUI
 /// ```html
 /// <Slider
 ///     value="progress"
-///     lower-bound={-1}
-///     upper-bound={2}
+///     lowerBound={-1}
+///     upperBound={2}
 /// />
 /// ```
 ///
@@ -30,8 +30,8 @@ import SwiftUI
 /// ```html
 /// <Slider
 ///     value="progress"
-///     lower-bound={0}
-///     upper-bound={10}
+///     lowerBound={0}
+///     upperBound={10}
 ///     step={1}
 /// />
 /// ```
@@ -40,9 +40,9 @@ import SwiftUI
 ///
 /// ```html
 /// <Slider value="value">
-///     <Text template={:label}>Percent Completed</Text>
-///     <Text template={:"minimum-value-label"}>0%</Text>
-///     <Text template={:"maximum-value-label"}>100%</Text>
+///     <Text template="label">Percent Completed</Text>
+///     <Text template="minimumValueLabel">0%</Text>
+///     <Text template="maximumValueLabel">100%</Text>
 /// </Slider>
 /// ```
 ///
@@ -54,8 +54,8 @@ import SwiftUI
 ///
 /// ## Children
 /// * `label`
-/// * `minimum-value-label`
-/// * `maximum-value-label`
+/// * `minimumValueLabel`
+/// * `maximumValueLabel`
 ///
 /// ## See Also
 /// * [LiveView Native Live Form](https://github.com/liveview-native/liveview-native-live-form)
@@ -69,11 +69,11 @@ struct Slider<R: RootRegistry>: View {
     
     /// The lowest allowed value.
     @_documentation(visibility: public)
-    @Attribute("lower-bound") private var lowerBound: Double = 0
+    @Attribute("lowerBound") private var lowerBound: Double = 0
     
     /// The highest allowed value.
     @_documentation(visibility: public)
-    @Attribute("upper-bound") private var upperBound: Double = 1
+    @Attribute("upperBound") private var upperBound: Double = 1
     
     /// The distance between allowed values.
     @_documentation(visibility: public)
@@ -89,9 +89,9 @@ struct Slider<R: RootRegistry>: View {
             ) {
                 context.buildChildren(of: element, forTemplate: "label", includeDefaultSlot: true)
             } minimumValueLabel: {
-                context.buildChildren(of: element, forTemplate: "minimum-value-label")
+                context.buildChildren(of: element, forTemplate: "minimumValueLabel")
             } maximumValueLabel: {
-                context.buildChildren(of: element, forTemplate: "maximum-value-label")
+                context.buildChildren(of: element, forTemplate: "maximumValueLabel")
             }
         } else {
             SwiftUI.Slider(
@@ -100,9 +100,9 @@ struct Slider<R: RootRegistry>: View {
             ) {
                 context.buildChildren(of: element, forTemplate: "label", includeDefaultSlot: true)
             } minimumValueLabel: {
-                context.buildChildren(of: element, forTemplate: "minimum-value-label")
+                context.buildChildren(of: element, forTemplate: "minimumValueLabel")
             } maximumValueLabel: {
-                context.buildChildren(of: element, forTemplate: "maximum-value-label")
+                context.buildChildren(of: element, forTemplate: "maximumValueLabel")
             }
         }
         #endif

--- a/Sources/LiveViewNative/Views/Controls and Indicators/Value Inputs/Stepper.swift
+++ b/Sources/LiveViewNative/Views/Controls and Indicators/Value Inputs/Stepper.swift
@@ -24,8 +24,8 @@ import SwiftUI
 /// ```html
 /// <Stepper
 ///     value="attendees"
-///     lower-bound={0}
-///     upper-bound={16}
+///     lowerBound={0}
+///     upperBound={16}
 ///     step={2}
 /// >
 ///     Attendees
@@ -54,11 +54,11 @@ struct Stepper<R: RootRegistry>: View {
     
     /// The lowest allowed value.
     @_documentation(visibility: public)
-    @Attribute("lower-bound") private var lowerBound: Double?
+    @Attribute("lowerBound") private var lowerBound: Double?
     
     /// The highest allowed value.
     @_documentation(visibility: public)
-    @Attribute("upper-bound") private var upperBound: Double?
+    @Attribute("upperBound") private var upperBound: Double?
     
     public var body: some View {
         #if !os(tvOS)

--- a/Sources/LiveViewNative/Views/Drawing and Graphics/ColorView.swift
+++ b/Sources/LiveViewNative/Views/Drawing and Graphics/ColorView.swift
@@ -73,7 +73,7 @@ struct ColorView: View {
     /// * `srgb-linear`
     /// * `display-p3`
     @_documentation(visibility: public)
-    @Attribute("color-space") private var colorSpace: SwiftUI.Color.RGBColorSpace = .sRGB
+    @Attribute("colorSpace") private var colorSpace: SwiftUI.Color.RGBColorSpace = .sRGB
     
     var body: some View {
         if let named = name.flatMap(SwiftUI.Color.init(fromNamedOrCSSHex:)) {

--- a/Sources/LiveViewNative/Views/Drawing and Graphics/ColorView.swift
+++ b/Sources/LiveViewNative/Views/Drawing and Graphics/ColorView.swift
@@ -115,9 +115,9 @@ extension SwiftUI.Color.RGBColorSpace: AttributeDecodable, Decodable {
 
     init?(string: String) {
         switch string {
-        case "srgb": self = .sRGB
-        case "srgb-linear": self = .sRGBLinear
-        case "display-p3": self = .displayP3
+        case "sRGB": self = .sRGB
+        case "sRGBLinear": self = .sRGBLinear
+        case "displayP3": self = .displayP3
         default: return nil
         }
     }

--- a/Sources/LiveViewNative/Views/Images/AsyncImage.swift
+++ b/Sources/LiveViewNative/Views/Images/AsyncImage.swift
@@ -10,7 +10,7 @@ import SwiftUI
 /// Displays an image asynchronously loaded from a URL.
 ///
 /// ```html
-/// <AsyncImage url="http://localhost:4000/example.jpg" content-mode="fit" />
+/// <AsyncImage url="http://localhost:4000/example.jpg" contentMode="fit" />
 /// ```
 ///
 /// While the image is loading, a circular progress view is shown. If the image fails to load, text containing the error message is shown.
@@ -41,7 +41,7 @@ struct AsyncImage<R: RootRegistry>: View {
     /// - `fill`: The image fills the view (meaning the edges may be croppped).
     /// - `fit` (deafult): The image is displayed at its native aspect ratio centered in the view.
     @_documentation(visibility: public)
-    @Attribute("content-mode", transform: { $0?.value == "fill" ? .fill : .fit }) private var contentMode: ContentMode
+    @Attribute("contentMode", transform: { $0?.value == "fill" ? .fill : .fit }) private var contentMode: ContentMode
     
     public var body: some View {
         // todo: do we want to customize the loading state for this

--- a/Sources/LiveViewNative/Views/Images/ImageView.swift
+++ b/Sources/LiveViewNative/Views/Images/ImageView.swift
@@ -12,7 +12,7 @@ import SwiftUI
 /// There are two possible sources for images: system-provided images (SF Symbols) or the app's asset catalog.
 ///
 /// ### SF Symbols
-/// The platform provides a wide variety of symbol images which are specified with the `system-name` attribute.
+/// The platform provides a wide variety of symbol images which are specified with the ``systemName`` attribute.
 /// See [Apple's documentation](https://developer.apple.com/sf-symbols/) for more information.
 ///
 /// ### Asset Catalog
@@ -25,9 +25,9 @@ import SwiftUI
 /// Some symbols and asset images support a value input. Use the ``variableValue`` attribute to set this value.
 ///
 /// ```html
-/// <Image system-name="chart.bar.fill" variable-value={0.3} />
-/// <Image system-name="chart.bar.fill" variable-value={0.6} />
-/// <Image system-name="chart.bar.fill" variable-value={1.0} />
+/// <Image systemName="chart.bar.fill" variableValue={0.3} />
+/// <Image systemName="chart.bar.fill" variableValue={0.6} />
+/// <Image systemName="chart.bar.fill" variableValue={1.0} />
 /// ```
 ///
 /// ### Image Labels
@@ -43,7 +43,7 @@ import SwiftUI
 /// Use image modifiers to customize the appearance of an image.
 ///
 /// ```html
-/// <Image system-name="heart.fill" modifiers={resizable([]) |> symbol_rendering_mode(mode: :multicolor)} />
+/// <Image systemName="heart.fill" modifiers={resizable([]) |> symbol_rendering_mode(mode: :multicolor)} />
 /// ```
 ///
 /// These modifiers can be used on ``Image`` elements:
@@ -66,14 +66,14 @@ struct ImageView<R: RootRegistry>: View {
     ///
     /// See [Apple's documentation](https://developer.apple.com/sf-symbols/) for more information.
     @_documentation(visibility: public)
-    @Attribute("system-name") private var systemName: String?
+    @Attribute("systemName") private var systemName: String?
     /// The name of an image in the app's asset catalog.
     @_documentation(visibility: public)
     @Attribute("name") private var name: String?
     
     /// The value represented by this image, in the range `0.0` to `1.0`.
     @_documentation(visibility: public)
-    @Attribute("variable-value") private var variableValue: Double?
+    @Attribute("variableValue") private var variableValue: Double?
     
     @Environment(\.imageModifiers) private var modifiers
     

--- a/Sources/LiveViewNative/Views/Layout Containers/Forms/Form.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Forms/Form.swift
@@ -10,47 +10,14 @@ import SwiftUI
 /// A container for grouping labeled form controls in a consistent style.
 ///
 /// - Note: This element does not provide a form data model. See [LiveView Native Live Form](https://github.com/liveview-native/liveview-native-live-form).
-///
-/// ## Attributes
-/// - ``style``
-///
-/// ## Topics
-/// ### Supporting Types
-/// - ``FormStyle``
 @_documentation(visibility: public)
 struct Form<R: RootRegistry>: View {
     @ObservedElement private var element
     @LiveContext<R> private var context
     
-    /// The style of the form.
-    @_documentation(visibility: public)
-    @Attribute("form-style") private var style: FormStyle = .automatic
-    
     var body: some View {
         SwiftUI.Form {
             context.buildChildren(of: element)
-        }
-        .applyFormStyle(style)
-    }
-}
-
-/// The visual style of a form.
-@_documentation(visibility: public)
-private enum FormStyle: String, AttributeDecodable {
-    @_documentation(visibility: public)
-    case automatic, columns, grouped
-}
-
-private extension View {
-    @ViewBuilder
-    func applyFormStyle(_ style: FormStyle) -> some View {
-        switch style {
-        case .automatic:
-            self.formStyle(.automatic)
-        case .columns:
-            self.formStyle(.columns)
-        case .grouped:
-            self.formStyle(.grouped)
         }
     }
 }

--- a/Sources/LiveViewNative/Views/Layout Containers/Forms/LabeledContent.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Forms/LabeledContent.swift
@@ -13,8 +13,8 @@ import SwiftUI
 ///
 /// ```html
 /// <LabeledContent>
-///     <Text template={:label}>Price</Text>
-///     <Text template={:content}>$100.00</Text>
+///     <Text template="label">Price</Text>
+///     <Text template="content">$100.00</Text>
 /// </LabeledContent>
 /// ```
 ///
@@ -25,14 +25,13 @@ import SwiftUI
 /// For more details on formatting options, see ``Text``.
 ///
 /// ```html
-/// <LabeledContent value={100} format="currency" currency-code="usd">
+/// <LabeledContent value={100} format="currency" currencyCode="usd">
 ///     Price
 /// </LabeledContent>
 /// ```
 ///
 /// ## Attributes
 /// * ``format``
-/// * ``style``
 ///
 /// ## Children
 /// * `content` - The element to label.
@@ -41,10 +40,6 @@ import SwiftUI
 /// ## See Also
 /// ### Formatting Values
 /// * ``Text``
-///
-/// ## Topics
-/// ### Supporting Types
-/// - ``LabeledContentStyle``
 @_documentation(visibility: public)
 struct LabeledContent<R: RootRegistry>: View {
     @ObservedElement private var element
@@ -55,9 +50,6 @@ struct LabeledContent<R: RootRegistry>: View {
     /// For more details on formatting options, see ``Text``.
     @_documentation(visibility: public)
     @Attribute("format") private var format: String?
-    /// The style to use for this labeled content.
-    @_documentation(visibility: public)
-    @Attribute("labeled-content-style") private var style: LabeledContentStyle = .automatic
     
     var body: some View {
         SwiftUI.Group {
@@ -74,22 +66,6 @@ struct LabeledContent<R: RootRegistry>: View {
                     context.buildChildren(of: element, forTemplate: "label")
                 }
             }
-        }
-        .applyLabeledContentStyle(style)
-    }
-}
-
-@_documentation(visibility: public)
-private enum LabeledContentStyle: String, AttributeDecodable {
-    @_documentation(visibility: public)
-    case automatic
-}
-
-private extension View {
-    @ViewBuilder
-    func applyLabeledContentStyle(_ style: LabeledContentStyle) -> some View {
-        switch style {
-        case .automatic: self.labeledContentStyle(.automatic)
         }
     }
 }

--- a/Sources/LiveViewNative/Views/Layout Containers/Grids/Grid.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Grids/Grid.swift
@@ -48,10 +48,10 @@ struct Grid<R: RootRegistry>: View {
     @Attribute("alignment") private var alignment: Alignment = .center
     /// The spacing between elements in a ``GridRow``.
     @_documentation(visibility: public)
-    @Attribute("horizontal-spacing") private var horizontalSpacing: Double?
+    @Attribute("horizontalSpacing") private var horizontalSpacing: Double?
     /// The spacing between ``GridRow`` elements.
     @_documentation(visibility: public)
-    @Attribute("vertical-spacing") private var verticalSpacing: Double?
+    @Attribute("verticalSpacing") private var verticalSpacing: Double?
     
     public var body: some View {
         SwiftUI.Grid(

--- a/Sources/LiveViewNative/Views/Layout Containers/Groups/GroupBox.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Groups/GroupBox.swift
@@ -34,15 +34,10 @@ import SwiftUI
 ///
 /// ## Attributes
 /// * ``title``
-/// * ``style``
 ///
 /// ## Children
 /// * `label` - Describes the content of the group box.
 /// * `content` - The elements to group together.
-///
-/// ## Topics
-/// ### Supporting Types
-/// - ``GroupBoxStyle``
 @_documentation(visibility: public)
 struct GroupBox<R: RootRegistry>: View {
     @ObservedElement private var element: ElementNode

--- a/Sources/LiveViewNative/Views/Layout Containers/Lazy Grids/LazyHGrid.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Lazy Grids/LazyHGrid.swift
@@ -63,7 +63,7 @@ struct LazyHGrid<R: RootRegistry>: View {
     ///
     /// See ``LiveViewNative/SwiftUI/PinnedScrollableViews``.
     @_documentation(visibility: public)
-    @Attribute("pinned-views") private var pinnedViews: PinnedScrollableViews = []
+    @Attribute("pinnedViews") private var pinnedViews: PinnedScrollableViews = []
 
     public var body: some View {
         SwiftUI.LazyHGrid(

--- a/Sources/LiveViewNative/Views/Layout Containers/Lazy Grids/LazyVGrid.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Lazy Grids/LazyVGrid.swift
@@ -63,7 +63,7 @@ struct LazyVGrid<R: RootRegistry>: View {
     ///
     /// See ``LiveViewNative/SwiftUI/PinnedScrollableViews``.
     @_documentation(visibility: public)
-    @Attribute("pinned-views") private var pinnedViews: PinnedScrollableViews = []
+    @Attribute("pinnedViews") private var pinnedViews: PinnedScrollableViews = []
     
     public var body: some View {
         SwiftUI.LazyVGrid(

--- a/Sources/LiveViewNative/Views/Layout Containers/Lazy Stacks/LazyHStack.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Lazy Stacks/LazyHStack.swift
@@ -48,7 +48,7 @@ struct LazyHStack<R: RootRegistry>: View {
     ///
     /// See ``LiveViewNative/SwiftUI/PinnedScrollableViews``.
     @_documentation(visibility: public)
-    @Attribute("pinned-views") private var pinnedViews: PinnedScrollableViews = []
+    @Attribute("pinnedViews") private var pinnedViews: PinnedScrollableViews = []
     
     public var body: some View {
         SwiftUI.LazyHStack(

--- a/Sources/LiveViewNative/Views/Layout Containers/Lazy Stacks/LazyVStack.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Lazy Stacks/LazyVStack.swift
@@ -48,7 +48,7 @@ struct LazyVStack<R: RootRegistry>: View {
     ///
     /// See ``LiveViewNative/SwiftUI/PinnedScrollableViews``.
     @_documentation(visibility: public)
-    @Attribute("pinned-views") private var pinnedViews: PinnedScrollableViews = []
+    @Attribute("pinnedViews") private var pinnedViews: PinnedScrollableViews = []
     
     public var body: some View {
         SwiftUI.LazyVStack(

--- a/Sources/LiveViewNative/Views/Layout Containers/Scroll Views/ScrollView.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Scroll Views/ScrollView.swift
@@ -34,20 +34,20 @@ struct ScrollView<R: RootRegistry>: View {
     @Attribute("axes") private var axes: Axis.Set = .vertical
     /// Whether the scroll indicators are shown (defaults to true).
     @_documentation(visibility: public)
-    @Attribute("shows-indicators") private var showsIndicators: Bool = true
+    @Attribute("showsIndicators") private var showsIndicators: Bool = true
     
     /// When the scroll view appears, and whenever this attribute changes, it will scroll to the view with the corresponding `id` attribute.
     ///
     /// The ``scrollPositionAnchor`` attribute governs where in the scroll view the target will be positioned.
     @_documentation(visibility: public)
-    @Attribute("scroll-position") private var scrollPosition: String?
+    @Attribute("scrollPosition") private var scrollPosition: String?
     /// Where in the scroll view the view that is being scrolled to is positioned.
     ///
     /// For example, specifying `top` will scroll the target to be at the top of the scroll view.
     ///
     /// See ``LiveViewNative/SwiftUI/UnitPoint`` for how values can be specified.
     @_documentation(visibility: public)
-    @Attribute("scroll-position-anchor") private var scrollPositionAnchor: UnitPoint?
+    @Attribute("scrollPositionAnchor") private var scrollPositionAnchor: UnitPoint?
     
     public var body: some View {
         SwiftUI.ScrollViewReader { proxy in

--- a/Sources/LiveViewNative/Views/Layout Containers/Separators/Spacer.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Separators/Spacer.swift
@@ -12,7 +12,7 @@ import SwiftUI
 /// ```html
 /// <VStack>
 ///     <Text>First</Text>
-///     <Spacer min-length="50" />
+///     <Spacer minLength="50" />
 ///     <Text>Second</Text>
 /// </VStack>
 /// ```
@@ -26,7 +26,7 @@ import SwiftUI
 struct Spacer: View {
     /// The minimum size of the spacer. If not provided, the minimum length is the system spacing.
     @_documentation(visibility: public)
-    @Attribute("min-length") private var minLength: Double?
+    @Attribute("minLength") private var minLength: Double?
     
     public var body: some View {
         SwiftUI.Spacer(minLength: minLength.flatMap(CGFloat.init))

--- a/Sources/LiveViewNative/Views/Layout Containers/Sizing/ViewThatFits.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Sizing/ViewThatFits.swift
@@ -14,7 +14,7 @@ import SwiftUI
 /// ```html
 /// <ViewThatFits>
 ///     <Text>Long text content ... </Text>
-///     <Image system-name="doc.text" />
+///     <Image systemName="doc.text" />
 /// </ViewThatFits>
 /// ```
 ///

--- a/Sources/LiveViewNative/Views/Shapes/Shape.swift
+++ b/Sources/LiveViewNative/Views/Shapes/Shape.swift
@@ -24,12 +24,12 @@ struct Shape<S: SwiftUI.InsettableShape>: View {
     ///
     /// See ``LiveViewNative/SwiftUI/Color/init?(fromNamedOrCSSHex:)`` for more details.
     @_documentation(visibility: public)
-    @Attribute("fill-color") private var fillColor: SwiftUI.Color? = nil
+    @Attribute("fillColor") private var fillColor: SwiftUI.Color? = nil
     /// The ``LiveViewNative/SwiftUI/Color`` the shape stroke is drawn with.
     ///
     /// See ``LiveViewNative/SwiftUI/Color/init?(fromNamedOrCSSHex:)`` for more details.
     @_documentation(visibility: public)
-    @Attribute("stroke-color") private var strokeColor: SwiftUI.Color? = nil
+    @Attribute("strokeColor") private var strokeColor: SwiftUI.Color? = nil
     
     @Environment(\.shapeModifiers) private var shapeModifiers: [any ShapeModifier]
     @Environment(\.shapeFinalizerModifier) private var shapeFinalizerModifier: (any ShapeFinalizerModifier)?
@@ -61,24 +61,24 @@ struct Shape<S: SwiftUI.InsettableShape>: View {
 /// A rounded rectangle shape.
 ///
 /// ```html
-/// <RoundedRectangle corner-radius="8" style="continuous" fill-color="#0000ff" />
+/// <RoundedRectangle cornerRadius="8" style="continuous" fillColor="#0000ff" />
 /// ```
 ///
 /// Attributes:
-/// - `corner-radius` (double): The radius of the shape's corners.
-/// - `corner-width` (double): The width of the shape's corners (has precedence over `corner-radius`).
-/// - `corner-height` (double): The height of the shape's corners (has precedence over `corner-radius`).
+/// - `cornerRadius` (double): The radius of the shape's corners.
+/// - `cornerWidth` (double): The width of the shape's corners (has precedence over `corner-radius`).
+/// - `cornerHeight` (double): The height of the shape's corners (has precedence over `corner-radius`).
 /// - `style`: Whether the corners are rounded with the quarter-circle style or continuously. Possible values:
 ///     - `circular`
 ///     - `continuous`
 @_documentation(visibility: public)
 extension RoundedRectangle {
     init(from element: ElementNode) {
-        let radius = element.attributeValue(for: "corner-radius").flatMap(Double.init) ?? 0
+        let radius = element.attributeValue(for: "cornerRadius").flatMap(Double.init) ?? 0
         self.init(
             cornerSize: .init(
-                width: element.attributeValue(for: "corner-width").flatMap(Double.init) ?? radius,
-                height: element.attributeValue(for: "corner-height").flatMap(Double.init) ?? radius
+                width: element.attributeValue(for: "cornerWidth").flatMap(Double.init) ?? radius,
+                height: element.attributeValue(for: "cornerHeight").flatMap(Double.init) ?? radius
             ),
             style: (try? RoundedCornerStyle(from: element.attribute(named: "style"), on: element)) ?? .circular
         )

--- a/Sources/LiveViewNative/Views/Text Input and Output/Label.swift
+++ b/Sources/LiveViewNative/Views/Text Input and Output/Label.swift
@@ -14,14 +14,14 @@ import SwiftUI
 /// ```html
 /// <Label>
 ///     <Text template={:title}>John Doe</Text>
-///     <Image template={:icon} system-name="person.crop.circle.fill" />
+///     <Image template={:icon} systemName="person.crop.circle.fill" />
 /// </Label>
 /// ```
 ///
 /// When using a symbol as the icon, use the ``systemImage`` attribute.
 ///
 /// ```html
-/// <Label system-image="person.crop.circle.fill">
+/// <Label systemImage="person.crop.circle.fill">
 ///     <Text>John Doe</Text>
 /// </Label>
 /// ```
@@ -37,9 +37,9 @@ struct Label<R: RootRegistry>: View {
     ///
     /// This attribute takes precedence over the `icon` child.
     ///
-    /// This is equivalent to the `system-name` attribute on ``Image``.
+    /// This is equivalent to the `systemName` attribute on ``Image``.
     @_documentation(visibility: public)
-    @Attribute("system-image") private var systemImage: String?
+    @Attribute("systemImage") private var systemImage: String?
     
     public var body: some View {
         SwiftUI.Label {

--- a/Sources/LiveViewNative/Views/Text Input and Output/Text.swift
+++ b/Sources/LiveViewNative/Views/Text Input and Output/Text.swift
@@ -210,13 +210,13 @@ struct Text<R: RootRegistry>: View {
         )
         self._dateStart = .init(
             wrappedValue: nil,
-            "date-start",
+            "date:start",
             transform: Self.formatDate(_:),
             element: element
         )
         self._dateEnd = .init(
             wrappedValue: nil,
-            "date-end",
+            "date:end",
             transform: Self.formatDate(_:),
             element: element
         )
@@ -254,7 +254,7 @@ struct Text<R: RootRegistry>: View {
         } else if let format {
             let innerText = value ?? element.innerText()
             switch format {
-            case "date-time":
+            case "dateTime":
                 if let date = try? Self.formatDate(innerText) {
                     return SwiftUI.Text(date, format: .dateTime)
                 } else {

--- a/Sources/LiveViewNative/Views/Text Input and Output/Text.swift
+++ b/Sources/LiveViewNative/Views/Text Input and Output/Text.swift
@@ -23,12 +23,12 @@ import LiveViewNativeCore
 /// Valid date styles are `date` (default), `time`, `relative`, `offset`, and `timer`.
 /// The displayed date is formatted with the user's locale.
 /// ```html
-/// <Text date="2023-03-14T15:19:00.000Z" date-style="date"/>
+/// <Text date="2023-03-14T15:19:00.000Z" dateStyle="date"/>
 /// ```
 /// ### Date Ranges
 /// Displays a localized date range between the given ISO 8601-formatted ``dateStart`` and ``dateEnd``.
 /// ```html
-/// <Text date-start="2023-01-01" date-end="2024-01-01"/>
+/// <Text date:start="2023-01-01" date:end="2024-01-01"/>
 /// ```
 /// ### Markdown
 /// The value of the ``markdown`` attribute is parsed as Markdown and displayed. Only inline Markdown formatting is shown.
@@ -39,17 +39,17 @@ import LiveViewNativeCore
 ///
 /// ### Formatted Values
 /// A value should provided in the `value` attribute, or in the inner text of the element. The value is formatted according to the `format` attribute:
-/// - `date-time`: The `value` is an ISO 8601 date (with optional time).
+/// - `dateTime`: The `value` is an ISO 8601 date (with optional time).
 /// - `url`: The value is a URL.
 /// - `iso8601`: The `value` is an ISO 8601 date (with optional time).
 /// - `number`: The value is a `Double`. Shown in a localized number format.
 /// - `percent`: The value is a `Double`.
-/// - `currency`: The value is a `Double` and is shown as a localized currency value using the currency specified in the `currency-code` attribute.
-/// - `name`: The value is a string interpreted as a person's name. The `name-style` attribute determines the format of the name and may be `short`, `medium` (default), `long`, or `abbreviated`.
+/// - `currency`: The value is a `Double` and is shown as a localized currency value using the currency specified in the `currencyCode` attribute.
+/// - `name`: The value is a string interpreted as a person's name. The `nameStyle` attribute determines the format of the name and may be `short`, `medium` (default), `long`, or `abbreviated`.
 ///
 /// ```html
-/// <Text value={15.99} format="currency" currency-code="usd" />
-/// <Text value="Doe John" format="name" name-style="short" />
+/// <Text value={15.99} format="currency" currencyCode="usd" />
+/// <Text value="Doe John" format="name" nameStyle="short" />
 /// ```
 ///
 /// ## Formatting Text
@@ -87,7 +87,7 @@ import LiveViewNativeCore
 ///
 /// ```html
 /// <Text>
-///     <Image system-name="person.crop.circle.fill" /><Text value="Doe John" format="name" modifiers={foreground_color(:blue) |> bold()} />
+///     <Image systemName="person.crop.circle.fill" /><Text value="Doe John" format="name" modifiers={foreground_color(:blue) |> bold()} />
 ///     <Text verbatim={"\n"} />
 ///     Check out this thing I made: <Link destination="mysite.com">mysite.com</Link>
 /// </Text>
@@ -150,10 +150,10 @@ struct Text<R: RootRegistry>: View {
     /// - Note: The value is expected to be in ISO 8601 format (with optional time)
     ///
     /// ```html
-    /// <Text date-start={DateTime.utc_now()} date-end={DateTime.add(DateTime.utc_now(), 3, :day)} />
+    /// <Text date:start={DateTime.utc_now()} date:end={DateTime.add(DateTime.utc_now(), 3, :day)} />
     /// ```
     @_documentation(visibility: public)
-    @Attribute("date-start", transform: Self.formatDate(_:)) private var dateStart: Date?
+    @Attribute("date:start", transform: Self.formatDate(_:)) private var dateStart: Date?
     /// The upper bound of a date range.
     ///
     /// Use this attribute with the ``dateStart`` attribute to display a date range.
@@ -161,10 +161,10 @@ struct Text<R: RootRegistry>: View {
     /// - Note: The value is expected to be in ISO 8601 format (with optional time)
     ///
     /// ```html
-    /// <Text date-start={DateTime.utc_now()} date-end={DateTime.add(DateTime.utc_now(), 3, :day)} />
+    /// <Text date:start={DateTime.utc_now()} date:end={DateTime.add(DateTime.utc_now(), 3, :day)} />
     /// ```
     @_documentation(visibility: public)
-    @Attribute("date-end", transform: Self.formatDate(_:)) private var dateEnd: Date?
+    @Attribute("date:end", transform: Self.formatDate(_:)) private var dateEnd: Date?
     
     /// A value to format.
     ///
@@ -185,17 +185,17 @@ struct Text<R: RootRegistry>: View {
     @Attribute("format") private var format: String?
     /// The currency code to use with the `currency` format.
     @_documentation(visibility: public)
-    @Attribute("currency-code") private var currencyCode: String?
+    @Attribute("currencyCode") private var currencyCode: String?
     /// The style for a `name` format.
     ///
     /// See ``LiveViewNative/Foundation/PersonNameComponents/FormatStyle/Style`` for a list of possible values.
     @_documentation(visibility: public)
-    @Attribute("name-style") private var nameStyle: PersonNameComponents.FormatStyle.Style = .medium
+    @Attribute("nameStyle") private var nameStyle: PersonNameComponents.FormatStyle.Style = .medium
     /// The style for a ``date`` value.
     ///
     /// See ``LiveViewNative/SwiftUI/Text/DateStyle`` for a list of possible values.
     @_documentation(visibility: public)
-    @Attribute("date-style") private var dateStyle: SwiftUI.Text.DateStyle = .date
+    @Attribute("dateStyle") private var dateStyle: SwiftUI.Text.DateStyle = .date
     
     init() {}
     
@@ -223,9 +223,9 @@ struct Text<R: RootRegistry>: View {
         self._markdown = .init(wrappedValue: nil, "markdown", element: element)
         self._format = .init(wrappedValue: nil, "format", element: element)
         self._value = .init(wrappedValue: nil, "value", element: element)
-        self._currencyCode = .init(wrappedValue: nil, "currency-code", element: element)
-        self._nameStyle = .init(wrappedValue: .medium, "name-style", element: element)
-        self._dateStyle = .init(wrappedValue: .date, "date-style", element: element)
+        self._currencyCode = .init(wrappedValue: nil, "currencyCode", element: element)
+        self._nameStyle = .init(wrappedValue: .medium, "nameStyle", element: element)
+        self._dateStyle = .init(wrappedValue: .date, "dateStyle", element: element)
     }
     
     public var body: SwiftUI.Text {

--- a/Sources/LiveViewNative/Views/Text Input and Output/TextField.swift
+++ b/Sources/LiveViewNative/Views/Text Input and Output/TextField.swift
@@ -50,7 +50,7 @@ import SwiftUI
 ///     <TextField
 ///         text="amount"
 ///         format="currency"
-///         currency-code="usd"
+///         currencyCode="usd"
 ///         modifier={keyboard_type(:decimal_pad)}
 ///     >
 ///         Enter Amount
@@ -110,7 +110,7 @@ struct TextField<R: RootRegistry>: TextFieldProtocol {
     ///
     /// Example currency codes include `USD`, `EUR`, and `JPY`.
     @_documentation(visibility: public)
-    @Attribute("currency-code") private var currencyCode: String?
+    @Attribute("currencyCode") private var currencyCode: String?
     
     /// A type used to format a person’s name with a style appropriate for the given locale.
     /// 
@@ -121,7 +121,7 @@ struct TextField<R: RootRegistry>: TextFieldProtocol {
     /// * `abbreviated`
     @_documentation(visibility: public)
     @Attribute(
-        "name-style",
+        "nameStyle",
         transform: {
             switch $0?.value {
             case "short":
@@ -149,7 +149,7 @@ struct TextField<R: RootRegistry>: TextFieldProtocol {
     private var field: some View {
         if let format {
             switch format {
-            case "date-time":
+            case "dateTime":
                 SwiftUI.TextField(
                     value: valueBinding(format: .dateTime),
                     format: .dateTime,

--- a/Sources/LiveViewNative/Views/Toolbars/ToolbarItem.swift
+++ b/Sources/LiveViewNative/Views/Toolbars/ToolbarItem.swift
@@ -37,7 +37,7 @@ import SwiftUI
 /// To prevent customization of an item in a customizable toolbar, set the ``CustomizableToolbarItem/customizationBehavior`` attribute to `disabled`.
 ///
 /// ```html
-/// <ToolbarItem id="delete" customization-behavior="disabled">
+/// <ToolbarItem id="delete" customizationBehavior="disabled">
 ///     ...
 /// </ToolbarItem>
 /// ```
@@ -45,7 +45,7 @@ import SwiftUI
 /// The default visibility and options can be configured with the ``CustomizableToolbarItem/defaultVisibility`` and ``CustomizableToolbarItem/alwaysAvailable`` attributes.
 ///
 /// ```html
-/// <ToolbarItem id="delete" default-visibility="hidden" always-available>
+/// <ToolbarItem id="delete" defaultVisibility="hidden" alwaysAvailable>
 ///     ...
 /// </ToolbarItem>
 /// ```
@@ -105,11 +105,11 @@ struct CustomizableToolbarItem<R: RootRegistry>: CustomizableToolbarContent {
     ///
     /// When set to `hidden`, the item must be added to the toolbar by the user to be visible.
     @_documentation(visibility: public)
-    @Attribute("default-visibility", transform: { _ in fatalError() }) private var defaultVisibility: Visibility
+    @Attribute("defaultVisibility", transform: { _ in fatalError() }) private var defaultVisibility: Visibility
     
     /// Ensures the item is available in the overflow menu if removed from the toolbar.
     @_documentation(visibility: public)
-    @Attribute("always-available") private var alwaysAvailable: Bool = false
+    @Attribute("alwaysAvailable") private var alwaysAvailable: Bool = false
     
     /// Changes the level of customization for this item.
     ///
@@ -118,7 +118,7 @@ struct CustomizableToolbarItem<R: RootRegistry>: CustomizableToolbarContent {
     /// * `disabled` - The item is not customizable.
     /// * `reorderable` - The item can be reordered, but not removed.
     @_documentation(visibility: public)
-    @Attribute("customization-behavior", transform: { _ in fatalError() }) private var customizationBehavior: ToolbarCustomizationBehavior
+    @Attribute("customizationBehavior", transform: { _ in fatalError() }) private var customizationBehavior: ToolbarCustomizationBehavior
     
     init(element: ElementNode) {
         self._element = .init(element: element)

--- a/Tests/LiveViewNativeTests/DecodeUnitPointTests.swift
+++ b/Tests/LiveViewNativeTests/DecodeUnitPointTests.swift
@@ -18,10 +18,10 @@ final class DecodeUnitPointTests: XCTestCase {
         XCTAssertEqual(try UnitPoint(from: "trailing"), .trailing)
         XCTAssertEqual(try UnitPoint(from: "top"), .top)
         XCTAssertEqual(try UnitPoint(from: "bottom"), .bottom)
-        XCTAssertEqual(try UnitPoint(from: "top-leading"), .topLeading)
-        XCTAssertEqual(try UnitPoint(from: "top-trailing"), .topTrailing)
-        XCTAssertEqual(try UnitPoint(from: "bottom-leading"), .bottomLeading)
-        XCTAssertEqual(try UnitPoint(from: "bottom-trailing"), .bottomTrailing)
+        XCTAssertEqual(try UnitPoint(from: "topLeading"), .topLeading)
+        XCTAssertEqual(try UnitPoint(from: "topTrailing"), .topTrailing)
+        XCTAssertEqual(try UnitPoint(from: "bottomLeading"), .bottomLeading)
+        XCTAssertEqual(try UnitPoint(from: "bottomTrailing"), .bottomTrailing)
     }
     
     func testInteger() throws {

--- a/Tests/RenderingTests/ButtonTests.swift
+++ b/Tests/RenderingTests/ButtonTests.swift
@@ -21,7 +21,7 @@ final class ButtonTests: XCTestCase {
             #"""
             <Button>
                 <HStack>
-                    <Image system-name="circle.fill" />
+                    <Image systemName="circle.fill" />
                     <Text>Tap Here</Text>
                 </HStack>
             </Button>

--- a/Tests/RenderingTests/FormTests.swift
+++ b/Tests/RenderingTests/FormTests.swift
@@ -31,47 +31,6 @@ final class FormTests: XCTestCase {
             }
         }
     }
-
-    func testFormStyles() throws {
-        let markupContent = #"""
-        <Text id="0">0</Text>
-        <Text id="1">1</Text>
-        <Text id="2">2</Text>
-        """#
-        @ViewBuilder
-        var content: some View {
-            Text("0")
-            Text("1")
-            Text("2")
-        }
-        try assertMatch(
-            #"<Form form-style="automatic">\#(markupContent)</Form>"#,
-            size: .init(width: 300, height: 300)
-        ) {
-            Form {
-                content
-            }
-            .formStyle(.automatic)
-        }
-        try assertMatch(
-            #"<Form form-style="columns">\#(markupContent)</Form>"#,
-            size: .init(width: 300, height: 300)
-        ) {
-            Form {
-                content
-            }
-            .formStyle(.columns)
-        }
-        try assertMatch(
-            #"<Form form-style="grouped">\#(markupContent)</Form>"#,
-            size: .init(width: 300, height: 300)
-        ) {
-            Form {
-                content
-            }
-            .formStyle(.grouped)
-        }
-    }
     
     // MARK: LabeledContent
     
@@ -113,7 +72,7 @@ final class FormTests: XCTestCase {
     
     func testLabeledContentFormat() throws {
         try assertMatch(
-            #"<LabeledContent value="100" format="currency" currency-code="usd">Label</LabeledContent>"#,
+            #"<LabeledContent value="100" format="currency" currencyCode="usd">Label</LabeledContent>"#,
             size: .init(width: 300, height: 100)
         ) {
             LabeledContent("Label", value: 100, format: .currency(code: "usd"))

--- a/Tests/RenderingTests/GridTests.swift
+++ b/Tests/RenderingTests/GridTests.swift
@@ -17,20 +17,20 @@ final class GridTests: XCTestCase {
             <Grid>
                 <GridRow alignment="top">
                     <Text>Row 1</Text>
-                    <Rectangle fill-color="system-red" />
+                    <Rectangle fillColor="system-red" />
                 </GridRow>
                 <Divider />
                 <GridRow>
                     <Text>Row 2</Text>
-                    <Rectangle fill-color="system-green" />
-                    <Rectangle fill-color="system-green" />
+                    <Rectangle fillColor="system-green" />
+                    <Rectangle fillColor="system-green" />
                 </GridRow>
                 <Divider />
                 <GridRow alignment="bottom">
                     <Text>Row 3</Text>
-                    <Rectangle fill-color="system-blue" />
-                    <Rectangle fill-color="system-blue" />
-                    <Rectangle fill-color="system-blue" />
+                    <Rectangle fillColor="system-blue" />
+                    <Rectangle fillColor="system-blue" />
+                    <Rectangle fillColor="system-blue" />
                 </GridRow>
             </Grid>
             """#,

--- a/Tests/RenderingTests/ImageTests.swift
+++ b/Tests/RenderingTests/ImageTests.swift
@@ -14,7 +14,7 @@ final class ImageTests: XCTestCase {
     func testSystemImage() throws {
         try assertMatch(
             #"""
-            <Image system-name="person.crop.circle.fill" />
+            <Image systemName="person.crop.circle.fill" />
             """#
         ) {
             Image(systemName: "person.crop.circle.fill")

--- a/Tests/RenderingTests/IndicatorTests.swift
+++ b/Tests/RenderingTests/IndicatorTests.swift
@@ -33,7 +33,7 @@ final class IndicatorTests: XCTestCase {
     }
     
     func testGaugeBounds() throws {
-        try assertMatch(#"<Gauge value="0.25" lower-bound="0.1" upper-bound="2">0.25</Gauge>"#, size: .init(width: 100, height: 50), lifetime: .keepAlways) {
+        try assertMatch(#"<Gauge value="0.25" lowerBound="0.1" upperBound="2">0.25</Gauge>"#, size: .init(width: 100, height: 50), lifetime: .keepAlways) {
             Gauge(value: 0.25, in: 0.1...2) {
                 Text("0.25")
             }
@@ -45,9 +45,9 @@ final class IndicatorTests: XCTestCase {
             #"""
             <Gauge value="0.5">
                 <Text template="label">50%</Text>
-                <Text template="current-value-label">0.5</Text>
-                <Text template="minimum-value-label">0</Text>
-                <Text template="maximum-value-label">1</Text>
+                <Text template="currentValueLabel">0.5</Text>
+                <Text template="minimumValueLabel">0</Text>
+                <Text template="maximumValueLabel">1</Text>
             </Gauge>
             """#
         ) {
@@ -66,9 +66,9 @@ final class IndicatorTests: XCTestCase {
             #"""
             <Gauge value="0.5">
                 50%
-                <Text template="current-value-label">0.5</Text>
-                <Text template="minimum-value-label">0</GText>
-                <Text template="maximum-value-label">1</GText>
+                <Text template="currentValueLabel">0.5</Text>
+                <Text template="minimumValueLabel">0</GText>
+                <Text template="maximumValueLabel">1</GText>
             </Gauge>
             """#
         ) {

--- a/Tests/RenderingTests/LinkTests.swift
+++ b/Tests/RenderingTests/LinkTests.swift
@@ -21,7 +21,7 @@ final class LinkTests: XCTestCase {
         try assertMatch(#"""
 <Link destination="https://apple.com">
     <HStack>
-        <Image system-name="link" />
+        <Image systemName="link" />
         <Text>Click the link</Text>
     </HStack>
 </Link>

--- a/Tests/RenderingTests/PickerTests.swift
+++ b/Tests/RenderingTests/PickerTests.swift
@@ -46,9 +46,9 @@ final class PickerTests: XCTestCase {
             <Picker value="paperplane">
                 <Text template="label">Pick an icon</Text>
                 <Group template="content">
-                    <Label system-image="paperplane" tag="paperplane"><Text>paperplane</Text></Label>
-                    <Label system-image="graduationcap" tag="graduationcap"><Text>graduationcap</Text></Label>
-                    <Label system-image="ellipsis.bubble" tag="ellipsis.bubble"><Text>ellipsis.bubble</Text></Label>
+                    <Label systemImage="paperplane" tag="paperplane"><Text>paperplane</Text></Label>
+                    <Label systemImage="graduationcap" tag="graduationcap"><Text>graduationcap</Text></Label>
+                    <Label systemImage="ellipsis.bubble" tag="ellipsis.bubble"><Text>ellipsis.bubble</Text></Label>
                 </Group>
             </Picker>
             """#) {

--- a/Tests/RenderingTests/ShapeTests.swift
+++ b/Tests/RenderingTests/ShapeTests.swift
@@ -18,19 +18,19 @@ final class ShapeTests: XCTestCase {
     }
     
     func testRoundedRectangle() throws {
-        try assertMatch(#"<RoundedRectangle corner-radius="5" />"#, size: .init(width: 100, height: 50)) {
+        try assertMatch(#"<RoundedRectangle cornerRadius="5" />"#, size: .init(width: 100, height: 50)) {
             RoundedRectangle(cornerRadius: 5, style: .circular)
         }
-        try assertMatch(#"<RoundedRectangle corner-width="5" corner-height="10" />"#, size: .init(width: 100, height: 50)) {
+        try assertMatch(#"<RoundedRectangle cornerWidth="5" cornerHeight="10" />"#, size: .init(width: 100, height: 50)) {
             RoundedRectangle(cornerSize: .init(width: 5, height: 10), style: .circular)
         }
-        try assertMatch(#"<RoundedRectangle corner-width="5" corner-radius="15" />"#, size: .init(width: 100, height: 50)) {
+        try assertMatch(#"<RoundedRectangle cornerWidth="5" cornerRadius="15" />"#, size: .init(width: 100, height: 50)) {
             RoundedRectangle(cornerSize: .init(width: 5, height: 15), style: .circular)
         }
-        try assertMatch(#"<RoundedRectangle corner-height="5" corner-radius="15" />"#, size: .init(width: 100, height: 50)) {
+        try assertMatch(#"<RoundedRectangle cornerHeight="5" cornerRadius="15" />"#, size: .init(width: 100, height: 50)) {
             RoundedRectangle(cornerSize: .init(width: 15, height: 5), style: .circular)
         }
-        try assertMatch(#"<RoundedRectangle corner-radius="10" style="continuous" />"#, size: .init(width: 100, height: 50)) {
+        try assertMatch(#"<RoundedRectangle cornerRadius="10" style="continuous" />"#, size: .init(width: 100, height: 50)) {
             RoundedRectangle(cornerRadius: 10, style: .continuous)
         }
     }
@@ -80,13 +80,13 @@ final class ShapeTests: XCTestCase {
     }
     
     func testRGBColorSpace() throws {
-        try assertMatch(#"<Color red="1" green="0.5" blue="0.25" color-space="srgb" />"#, size: .init(width: 50, height: 50)) {
+        try assertMatch(#"<Color red="1" green="0.5" blue="0.25" colorSpace="sRGB" />"#, size: .init(width: 50, height: 50)) {
             Color(.sRGB, red: 1, green: 0.5, blue: 0.25)
         }
-        try assertMatch(#"<Color red="1" green="0.5" blue="0.25" color-space="srgb-linear" />"#, size: .init(width: 50, height: 50)) {
+        try assertMatch(#"<Color red="1" green="0.5" blue="0.25" colorSpace="sRGBLinear" />"#, size: .init(width: 50, height: 50)) {
             Color(.sRGBLinear, red: 1, green: 0.5, blue: 0.25)
         }
-        try assertMatch(#"<Color red="1" green="0.5" blue="0.25" color-space="display-p3" />"#, size: .init(width: 50, height: 50)) {
+        try assertMatch(#"<Color red="1" green="0.5" blue="0.25" colorSpace="displayP3" />"#, size: .init(width: 50, height: 50)) {
             Color(.displayP3, red: 1, green: 0.5, blue: 0.25)
         }
     }

--- a/Tests/RenderingTests/TextTests.swift
+++ b/Tests/RenderingTests/TextTests.swift
@@ -53,14 +53,14 @@ This is some markdown text [click me](apple.com)
     func testTextDate() throws {
         let date = Date(timeIntervalSince1970: 1673931600.0)
         for style in [(Text.DateStyle.time, "time"), (.date, "date"), (.relative, "relative"), (.offset, "offset"), (.timer, "timer")] {
-            try assertMatch(#"<Text date="\#(date.formatted(.elixirDateTime))" date-style="\#(style.1)" />"#) {
+            try assertMatch(#"<Text date="\#(date.formatted(.elixirDateTime))" dateStyle="\#(style.1)" />"#) {
                 Text(date, style: style.0)
             }
         }
     }
     
     func testTextFormat() throws {
-        try assertMatch(#"<Text format="date-time" value="0001-01-01T00:00:00.000Z" />"#) {
+        try assertMatch(#"<Text format="dateTime" value="0001-01-01T00:00:00.000Z" />"#) {
             Text(Date.distantPast, format: .dateTime)
         }
         try assertMatch(#"<Text format="url">apple.com</Text>"#) {
@@ -75,10 +75,10 @@ This is some markdown text [click me](apple.com)
         try assertMatch(#"<Text format="percent" value="0.42" />"#) {
             Text(0.42, format: .percent)
         }
-        try assertMatch(#"<Text format="currency" currency-code="mxn" value="42" />"#) {
+        try assertMatch(#"<Text format="currency" currencyCode="mxn" value="42" />"#) {
             Text(42, format: .currency(code: "mxn"))
         }
-        try assertMatch(#"<Text format="name" name-style="short">John Doe</Text>"#) {
+        try assertMatch(#"<Text format="name" nameStyle="short">John Doe</Text>"#) {
             Text(try! PersonNameComponents("John Doe", strategy: .name), format: .name(style: .short))
         }
     }
@@ -103,7 +103,7 @@ This is some markdown text [click me](apple.com)
     
     // MARK: Label
     func testLabelSimple() throws {
-        try assertMatch(#"<Label system-image="bolt.fill">Lightning<Label>"#) {
+        try assertMatch(#"<Label systemImage="bolt.fill">Lightning<Label>"#) {
             Label("Lightning", systemImage: "bolt.fill")
         }
     }
@@ -112,7 +112,7 @@ This is some markdown text [click me](apple.com)
         try assertMatch(
             #"""
             <Label>
-                <Image template="icon" system-name="bolt.fill" />
+                <Image template="icon" systemName="bolt.fill" />
                 <Text template="title">Lightning</Text>
             <Label>
             """#

--- a/Tests/RenderingTests/ValueInputTests.swift
+++ b/Tests/RenderingTests/ValueInputTests.swift
@@ -24,8 +24,8 @@ final class ValueInputTests: XCTestCase {
         try assertMatch(#"""
 <Slider>
     <Text template="label">Label</Text>
-    <Text template="minimum-value-label">Min</Text>
-    <Text template="maximum-value-label">Max</Text>
+    <Text template="minimumValueLabel">Min</Text>
+    <Text template="maximumValueLabel">Max</Text>
 </Slider>
 """#, size: .init(width: 300, height: 100)) {
             Slider(value: .constant(0)) {


### PR DESCRIPTION
Closes #1241 

This replaces all `snake-case` attributes with `camelCase`:

```diff
- <Image system-name="circle.fill" />
+ <Image systemName="circle.fill" />
```

This extends to the value of attributes too:

```diff
- <ZStack alignment="top-leading">
+ <ZStack alignment="topLeading">
```

And template names:

```diff
<Slider>
-   <Text template="minimum-value-label">Min</Text>
+   <Text template="minimumValueLabel">Min</Text>
</Slider>

```