### PR TITLE
Safely unwrap `NavigationLink` and `Link` URLs

### DIFF
--- a/Sources/LiveViewNative/Views/Controls and Indicators/Links/Link.swift
+++ b/Sources/LiveViewNative/Views/Controls and Indicators/Links/Link.swift
@@ -6,6 +6,9 @@
 //
 
 import SwiftUI
+import OSLog
+
+private let logger = Logger(subsystem: "LiveViewNative", category: "Link")
 
 /// Opens a URL when tapped.
 ///
@@ -26,10 +29,10 @@ struct Link<R: RootRegistry>: View {
     
     /// A valid URL to open when tapped.
     @_documentation(visibility: public)
-    @Attribute("destination", transform: { $0?.value.flatMap(URL.init(string:)) }) private var destination: URL?
+    @Attribute("destination") private var destination: String?
     
     public var body: some View {
-        if let destination {
+        if let destination = destination.flatMap({ URL(string: $0, relativeTo: context.coordinator.url) })?.appending(path: "").absoluteURL {
             SwiftUI.Link(
                 destination: destination
             ) {
@@ -37,6 +40,9 @@ struct Link<R: RootRegistry>: View {
             }
         } else {
             context.buildChildren(of: element)
+                .task {
+                    logger.error("Missing or invalid `destination` on `<Link>\(element.innerText())</Link>`")
+                }
         }
     }
 }

--- a/Sources/LiveViewNative/Views/Controls and Indicators/Links/Link.swift
+++ b/Sources/LiveViewNative/Views/Controls and Indicators/Links/Link.swift
@@ -29,9 +29,13 @@ struct Link<R: RootRegistry>: View {
     @Attribute("destination", transform: { $0?.value.flatMap(URL.init(string:)) }) private var destination: URL?
     
     public var body: some View {
-        SwiftUI.Link(
-            destination: destination!
-        ) {
+        if let destination {
+            SwiftUI.Link(
+                destination: destination
+            ) {
+                context.buildChildren(of: element)
+            }
+        } else {
             context.buildChildren(of: element)
         }
     }

--- a/Sources/LiveViewNative/Views/Layout Containers/Presentation Containers/NavigationLink.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Presentation Containers/NavigationLink.swift
@@ -34,20 +34,20 @@ struct NavigationLink<R: RootRegistry>: View {
     @_documentation(visibility: public)
     @Attribute("disabled") private var disabled: Bool
     
-    var url: URL {
-        URL(string: destination, relativeTo: context.coordinator.url)!.appending(path: "").absoluteURL
-    }
-    
     @ViewBuilder
     public var body: some View {
-        SwiftUI.NavigationLink(
-            value: LiveNavigationEntry(
-                url: url,
-                coordinator: LiveViewCoordinator(session: context.coordinator.session, url: url)
-            )
-        ) {
+        if let url = URL(string: destination, relativeTo: context.coordinator.url)?.appending(path: "").absoluteURL {
+            SwiftUI.NavigationLink(
+                value: LiveNavigationEntry(
+                    url: url,
+                    coordinator: LiveViewCoordinator(session: context.coordinator.session, url: url)
+                )
+            ) {
+                context.buildChildren(of: element)
+            }
+            .disabled(disabled)
+        } else {
             context.buildChildren(of: element)
         }
-        .disabled(disabled)
     }
 }


### PR DESCRIPTION
Closes #1256 

If the URL is invalid, the content of the View will be rendered instead.