### PR TITLE
Avoid accessing `StateObject` or `Environment` when in a nested View context

### DIFF
--- a/Sources/LiveViewNative/Property Wrappers/Attribute.swift
+++ b/Sources/LiveViewNative/Property Wrappers/Attribute.swift
@@ -90,7 +90,9 @@ public struct Attribute<T>: DynamicProperty {
     /// If no default value was provided, the app will crash.
     public var wrappedValue: T {
         // Use the cached value if possible. Otherwise, decode on demand.
-        guard let value = storage.value else {
+        guard !_element.isConstant,
+              let value = storage.value
+        else {
             return decode()
         }
         return value

--- a/Sources/LiveViewNative/Property Wrappers/ObservedElement.swift
+++ b/Sources/LiveViewNative/Property Wrappers/ObservedElement.swift
@@ -56,6 +56,11 @@ public struct ObservedElement {
     @EnvironmentObject private var observer: Observer
     
     private let overrideElement: ElementNode?
+    /// Indicates whether the element value was overridden.
+    /// When true, assume this element is not mounted in the View tree, and is instead being processed as a nested element.
+    var isConstant: Bool {
+        overrideElement != nil
+    }
     
     /// Creates an `ObservedElement` that observes changes to the view's element.
     public init(observeChildren: Bool = false) {

--- a/Sources/LiveViewNative/Views/Images/ImageView.swift
+++ b/Sources/LiveViewNative/Views/Images/ImageView.swift
@@ -87,8 +87,10 @@ struct ImageView<R: RootRegistry>: View {
     }
     
     public var body: SwiftUI.Image? {
-        image.flatMap({
-            modifiers.reduce($0) { image, modifier in
+        image.flatMap({ (image: SwiftUI.Image) -> SwiftUI.Image in
+            guard !_element.isConstant
+            else { return image }
+            return modifiers.reduce(image) { image, modifier in
                 modifier.apply(to: image)
             }
         })


### PR DESCRIPTION
Closes #1254 