### PR TITLE
Restore navigation path after live reloading

### DIFF
--- a/Sources/LiveViewNative/Coordinators/LiveSessionCoordinator.swift
+++ b/Sources/LiveViewNative/Coordinators/LiveSessionCoordinator.swift
@@ -183,8 +183,10 @@ public class LiveSessionCoordinator<R: RootRegistry>: ObservableObject {
     ///
     /// This can be used to force the LiveView to reset, for example after an unrecoverable error occurs.
     public func reconnect() async {
+        let previousNavigationPath = self.navigationPath
         await self.disconnect()
         await self.connect()
+        self.navigationPath = previousNavigationPath
     }
     
     /// Creates a publisher that can be used to listen for server-sent LiveView events.


### PR DESCRIPTION
Closes #1263 

This will still perform the reconnect on the original URL, but then perform a navigation back to the path when it lost connection.

I can change the implementation if it should instead do the dead render connection from the last URL in the path.