### PR TITLE
Add `NSPasteboard` to Copy Error button

### DIFF
--- a/priv/xcodegen/Sources/TemplateApp/ErrorView.swift
+++ b/priv/xcodegen/Sources/TemplateApp/ErrorView.swift
@@ -18,7 +18,11 @@ struct ErrorView: View {
                     description
                 } actions: {
                     Button {
+                        #if os(iOS)
                         UIPasteboard.general.string = error.localizedDescription
+                        #elseif os(macOS)
+                        NSPasteboard.general.setString(error.localizedDescription, forType: .string)
+                        #endif
                     } label: {
                         Label("Copy Error", systemImage: "doc.on.doc")
                     }


### PR DESCRIPTION
The Copy Error button used `UIPasteboard`, which is not available on macOS.