### PR TITLE
Allow list selection when default is `nil` but `phx-change` is present

### DIFF
--- a/Sources/LiveViewNative/Utils/Selection.swift
+++ b/Sources/LiveViewNative/Utils/Selection.swift
@@ -16,7 +16,7 @@ enum Selection: Codable, AttributeDecodable, Equatable {
     
     var single: String? {
         get {
-            guard case let .single(selection) = self else { fatalError() }
+            guard case let .single(selection) = self else { return nil }
             return selection
         }
         set {
@@ -26,7 +26,7 @@ enum Selection: Codable, AttributeDecodable, Equatable {
     
     var multiple: Set<String> {
         get {
-            guard case let .multiple(selection) = self else { fatalError() }
+            guard case let .multiple(selection) = self else { return [] }
             return selection
         }
         set {

--- a/Sources/LiveViewNative/Views/Layout Containers/Collection Containers/List.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Collection Containers/List.swift
@@ -149,16 +149,17 @@ struct List<R: RootRegistry>: View {
         }
         #else
         switch selection {
-        case .none:
-            SwiftUI.List {
+        case .multiple:
+            SwiftUI.List(selection: $selection.multiple) {
                 content
             }
-        case .single:
+        case .single,
+             _ where element.attribute(named: "phx-change") != nil:
             SwiftUI.List(selection: $selection.single) {
                 content
             }
-        case .multiple:
-            SwiftUI.List(selection: $selection.multiple) {
+        case .none:
+            SwiftUI.List {
                 content
             }
         }


### PR DESCRIPTION
Previously, if the `selection` value was `nil` to start (the attribute is missing), List selection was disabled.

With this PR, when the `selection` attribute is `nil` but the `phx-change` attribute is present, it will allow selection.