### PR TITLE
Support `NavigationLink` for split view by creating separate socket connections

### DIFF
--- a/Sources/LiveViewNative/Coordinators/LiveSessionCoordinator.swift
+++ b/Sources/LiveViewNative/Coordinators/LiveSessionCoordinator.swift
@@ -48,7 +48,7 @@ public class LiveSessionCoordinator<R: RootRegistry>: ObservableObject {
     // Socket connection
     var socket: Socket?
     
-    private var domValues: DOMValues!
+    private(set) var domValues: DOMValues!
     
     private var liveReloadSocket: Socket?
     private var liveReloadChannel: Channel?

--- a/Sources/LiveViewNative/LiveView.swift
+++ b/Sources/LiveViewNative/LiveView.swift
@@ -195,6 +195,16 @@ public struct LiveView<
             else { return }
             stylesheets[ObjectIdentifier(R.self)] = stylesheet
         }
+        .environment(\.buildDetachedLiveView, {
+            AnyView(Self(
+                session: .init($0),
+                phaseView: phaseView,
+                connectingView: connectingView,
+                disconnectedView: disconnectedView,
+                reconnectingView: reconnectingView,
+                errorView: errorView
+            ))
+        })
         .environmentObject(session)
         .environmentObject(liveViewModel)
         .task {

--- a/Sources/LiveViewNative/LiveView.swift
+++ b/Sources/LiveViewNative/LiveView.swift
@@ -197,7 +197,7 @@ public struct LiveView<
         }
         .environment(\.buildDetachedLiveView, {
             AnyView(Self(
-                session: .init($0),
+                session: .init($0, config: session.configuration),
                 phaseView: phaseView,
                 connectingView: connectingView,
                 disconnectedView: disconnectedView,

--- a/Sources/LiveViewNative/NavStackEntryView.swift
+++ b/Sources/LiveViewNative/NavStackEntryView.swift
@@ -68,3 +68,30 @@ struct NavStackEntryView<R: RootRegistry>: View {
         .animation(coordinator.session.configuration.transition.map({ _ in .default }), value: coordinator.state.isConnected)
     }
 }
+
+struct DetachedNavEntryView<R: RootRegistry>: View {
+    private var url: URL
+    @Environment(\.buildDetachedLiveView) private var buildDetachedLiveView
+    
+    init(url: URL) {
+        self.url = url
+    }
+    
+    var body: some View {
+        buildDetachedLiveView(url)
+            .id(url)
+    }
+}
+
+extension EnvironmentValues {
+    private enum BuildDetachedLiveViewKey: EnvironmentKey {
+        static let defaultValue = { (_: URL) -> AnyView in AnyView(EmptyView()) }
+    }
+    
+    /// Create an instance of ``LiveView`` for a given route.
+    /// Used by ``DetachedNavEntryView`` to establish secondary connections.
+    var buildDetachedLiveView: (URL) -> AnyView {
+        get { self[BuildDetachedLiveViewKey.self] }
+        set { self[BuildDetachedLiveViewKey.self] = newValue }
+    }
+}

--- a/Sources/LiveViewNative/Views/Navigation/NavigationSplitView.swift
+++ b/Sources/LiveViewNative/Views/Navigation/NavigationSplitView.swift
@@ -25,15 +25,16 @@ struct NavigationSplitView<R: RootRegistry>: View {
                     detail
                 }
             )
+            .environment(\.navigationSplitViewContext, true)
         } else {
             SwiftUI.NavigationSplitView(
                 sidebar: {
                     sidebar
                 }, detail: {
-                    content
                     detail
                 }
             )
+            .environment(\.navigationSplitViewContext, true)
         }
     }
     
@@ -56,5 +57,20 @@ struct NavigationSplitView<R: RootRegistry>: View {
     }
     var detail: some View {
         context.buildChildren(of: element, forTemplate: "detail", includeDefaultSlot: false)
+    }
+}
+
+extension EnvironmentValues {
+    private enum NavigationSplitViewContext: EnvironmentKey {
+        static let defaultValue = false
+    }
+    
+    /// Whether the navigation structure is a `NavigationSplitView`.
+    /// Set to `true` by `NavigationSplitView` and `false` by `NavigationStack`.
+    ///
+    /// Used by `NavigationLink` to determine how navigation connections are established.
+    var navigationSplitViewContext: Bool {
+        get { self[NavigationSplitViewContext.self] }
+        set { self[NavigationSplitViewContext.self] = newValue }
     }
 }

--- a/Sources/LiveViewNative/Views/Navigation/NavigationSplitView.swift
+++ b/Sources/LiveViewNative/Views/Navigation/NavigationSplitView.swift
@@ -12,29 +12,34 @@ struct NavigationSplitView<R: RootRegistry>: View {
     @ObservedElement private var element
     
     @EnvironmentObject private var session: LiveSessionCoordinator<R>
+    @Environment(\.navigationSplitViewContext) private var navigationSplitViewContext
     
     var body: some View {
-        if hasContent && hasDetail {
-            SwiftUI.NavigationSplitView(
-                sidebar: {
-                    sidebar
-                },
-                content: {
-                    content
-                }, detail: {
-                    detail
-                }
-            )
-            .environment(\.navigationSplitViewContext, true)
+        if navigationSplitViewContext {
+            sidebar
         } else {
-            SwiftUI.NavigationSplitView(
-                sidebar: {
-                    sidebar
-                }, detail: {
-                    detail
-                }
-            )
-            .environment(\.navigationSplitViewContext, true)
+            if hasContent && hasDetail {
+                SwiftUI.NavigationSplitView(
+                    sidebar: {
+                        sidebar
+                    },
+                    content: {
+                        content
+                    }, detail: {
+                        detail
+                    }
+                )
+                .environment(\.navigationSplitViewContext, true)
+            } else {
+                SwiftUI.NavigationSplitView(
+                    sidebar: {
+                        sidebar
+                    }, detail: {
+                        detail
+                    }
+                )
+                .environment(\.navigationSplitViewContext, true)
+            }
         }
     }
     

--- a/Sources/LiveViewNative/Views/Navigation/NavigationStack.swift
+++ b/Sources/LiveViewNative/Views/Navigation/NavigationStack.swift
@@ -26,5 +26,6 @@ struct NavigationStack<R: RootRegistry>: View {
                 NavStackEntryView(destination)
             }
         }
+        .environment(\.navigationSplitViewContext, false)
     }
 }


### PR DESCRIPTION
Ideally, we would be able to re-use the socket. However, I was not able to find a way to initiate a separate LiveView from the client without the first LiveView being replaced/disconnected.

> [!NOTE]
> ~~If you put the `<NavigationSplitView>` in the root layout, it will be rendered in all columns. Either use a different layout for the secondary columns, or put the split view directly in the first column's template.~~
> [This has been changed](https://github.com/liveview-native/liveview-client-swiftui/pull/1270/commits/2c90ad48e50a6bc4b8ae243bcd900d2883f5b459) so if a `NavigationSplitView` is used within another `NavigationSplitView`, it will only render its sidebar content.


https://github.com/liveview-native/liveview-client-swiftui/assets/13581484/5ff103ad-b2ce-40d5-94e4-a0dbbf9e2404

