### PR TITLE
Convert missed attributes to camel case

### DIFF
--- a/Sources/LiveViewNative/Views/Accessibility/ScaledMetric.swift
+++ b/Sources/LiveViewNative/Views/Accessibility/ScaledMetric.swift
@@ -12,7 +12,7 @@ import SwiftUI
 /// Use this element to scale a value with the accessibility dynamic type size.
 ///
 /// ```html
-/// <ScaledMetric phx-change="scaled-value-changed" value={100} relativeTo="large-title">
+/// <ScaledMetric phx-change="scaled-value-changed" value={100} relativeTo="largeTitle">
 ///   <Image systemName="heart" resizable modifiers={frame(width: @scaled_value, height: @scaled_value)}>
 /// </ScaledMetric>
 /// ```

--- a/Sources/LiveViewNative/Views/Controls and Indicators/Pickers/Picker.swift
+++ b/Sources/LiveViewNative/Views/Controls and Indicators/Pickers/Picker.swift
@@ -17,9 +17,9 @@ import SwiftUI
 /// <Picker selection={@transport} phx-change="transport-changed">
 ///     <Text template={:label}>Transportation</Text>
 ///     <Group template={:content}>
-///         <Label system-image="car" tag="car">Car</Label>
-///         <Label system-image="bus" tag="bus">Bus</Label>
-///         <Label system-image="tram" tag="tram">Tram</Label>
+///         <Label systemImage="car" tag="car">Car</Label>
+///         <Label systemImage="bus" tag="bus">Bus</Label>
+///         <Label systemImage="tram" tag="tram">Tram</Label>
 ///     </Group>
 /// </Picker>
 /// ```

--- a/Sources/LiveViewNative/Views/Controls and Indicators/Value Inputs/Toggle.swift
+++ b/Sources/LiveViewNative/Views/Controls and Indicators/Value Inputs/Toggle.swift
@@ -12,7 +12,7 @@ import SwiftUI
 /// Add elements within the toggle to provide a label.
 ///
 /// ```html
-/// <Toggle is-on={@lights_on} phx-change="toggled-lights">
+/// <Toggle isOn={@lights_on} phx-change="toggled-lights">
 ///     Lights On
 /// </Toggle>
 /// ```
@@ -24,7 +24,7 @@ struct Toggle<R: RootRegistry>: View {
     @ObservedElement private var element: ElementNode
     @LiveContext<R> private var context
     
-    @FormState("is-on", default: false) var value: Bool
+    @FormState("isOn", default: false) var value: Bool
     
     public var body: some View {
         SwiftUI.Toggle(isOn: $value) {

--- a/Sources/LiveViewNative/Views/Images/ImageView.swift
+++ b/Sources/LiveViewNative/Views/Images/ImageView.swift
@@ -81,8 +81,8 @@ struct ImageView<R: RootRegistry>: View {
     
     init(element: ElementNode) {
         self._element = .init(element: element)
-        self._systemName = .init("system-name", element: element)
-        self._variableValue = .init("variable-value", element: element)
+        self._systemName = .init("systemName", element: element)
+        self._variableValue = .init("variableValue", element: element)
         self._name = .init("name", element: element)
     }
     

--- a/Sources/LiveViewNative/Views/Layout Containers/Collection Containers/Table.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Collection Containers/Table.swift
@@ -47,7 +47,7 @@ import LiveViewNativeCore
 /// Use the ``sortOrder`` attribute to handle changes in the sorting options.
 ///
 /// ```html
-/// <Table sort-order={@sports_sort_order} phx-change="sort-changed">
+/// <Table sortOrder={@sports_sort_order} phx-change="sort-changed">
 ///     ...
 ///     <Group template={:rows}>
 ///         <%= for sport <- Enum.sort_by(
@@ -121,7 +121,7 @@ struct Table<R: RootRegistry>: View {
     /// The value of `id` matches the `id` attribute of the `<TableColumn>`, or its index if there is no `id` attribute.
     /// The value of `order` matches [`Foundation.SortOrder`](https://developer.apple.com/documentation/Foundation/SortOrder).
     @_documentation(visibility: public)
-    @ChangeTracked(attribute: "sort-order") private var sortOrder = TableColumnSortContainer(value: [])
+    @ChangeTracked(attribute: "sortOrder") private var sortOrder = TableColumnSortContainer(value: [])
     
     public var body: some View {
         #if os(iOS) || os(macOS)
@@ -250,9 +250,9 @@ struct Table<R: RootRegistry>: View {
             }
             .width(item.element.attributeValue(for: "width").flatMap(Double.init(_:)).flatMap(CGFloat.init))
             .width(
-                min: item.element.attributeValue(for: "min-width").flatMap(Double.init(_:)).flatMap(CGFloat.init),
-                ideal: item.element.attributeValue(for: "ideal-width").flatMap(Double.init(_:)).flatMap(CGFloat.init),
-                max: item.element.attributeValue(for: "max-width").flatMap(Double.init(_:)).flatMap(CGFloat.init)
+                min: item.element.attributeValue(for: "minWidth").flatMap(Double.init(_:)).flatMap(CGFloat.init),
+                ideal: item.element.attributeValue(for: "idealWidth").flatMap(Double.init(_:)).flatMap(CGFloat.init),
+                max: item.element.attributeValue(for: "maxWidth").flatMap(Double.init(_:)).flatMap(CGFloat.init)
             )
         }
     }

--- a/Sources/LiveViewNative/Views/Layout Containers/Groups/DisclosureGroup.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Groups/DisclosureGroup.swift
@@ -25,7 +25,7 @@ import SwiftUI
 /// To synchronize the expansion state with the server, use the ``isExpanded`` attribute.
 ///
 /// ```html
-/// <DisclosureGroup is-expanded={@actions_open} phx-change="actions-group-changed">
+/// <DisclosureGroup isExpanded={@actions_open} phx-change="actions-group-changed">
 ///     ...
 /// </DisclosureGroup>
 /// ```
@@ -48,7 +48,7 @@ struct DisclosureGroup<R: RootRegistry>: View {
     
     /// Synchronizes the expansion state with the server.
     @_documentation(visibility: public)
-    @ChangeTracked(attribute: "is-expanded") private var isExpanded = false
+    @ChangeTracked(attribute: "isExpanded") private var isExpanded = false
 
     public var body: some View {
 #if os(iOS) || os(macOS)

--- a/Sources/LiveViewNative/Views/Layout Containers/Presentation Containers/HSplitView.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Presentation Containers/HSplitView.swift
@@ -15,8 +15,8 @@ import SwiftUI
 ///
 /// ```html
 /// <HSplitView>
-///     <Rectangle fill-color="system-red" />
-///     <Rectangle fill-color="system-blue" />
+///     <Rectangle fillColor="system-red" />
+///     <Rectangle fillColor="system-blue" />
 /// </HSplitView>
 /// ```
 @_documentation(visibility: public)

--- a/Sources/LiveViewNative/Views/Layout Containers/Presentation Containers/TabView.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Presentation Containers/TabView.swift
@@ -13,9 +13,9 @@ import SwiftUI
 ///
 /// ```html
 /// <TabView modifiers={tab_view_style(:page)}>
-///     <Rectangle fill-color="system-red" />
-///     <Rectangle fill-color="system-red" />
-///     <Rectangle fill-color="system-red" />
+///     <Rectangle fillColor="system-red" />
+///     <Rectangle fillColor="system-red" />
+///     <Rectangle fillColor="system-red" />
 /// </TabView>
 /// ```
 ///

--- a/Sources/LiveViewNative/Views/Layout Containers/Presentation Containers/VSplitView.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Presentation Containers/VSplitView.swift
@@ -15,8 +15,8 @@ import SwiftUI
 ///
 /// ```html
 /// <VSplitView>
-///     <Rectangle fill-color="system-red" />
-///     <Rectangle fill-color="system-blue" />
+///     <Rectangle fillColor="system-red" />
+///     <Rectangle fillColor="system-blue" />
 /// </VSplitView>
 /// ```
 @_documentation(visibility: public)

--- a/Sources/LiveViewNative/Views/Layout Containers/Scroll Views/ScrollView.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Scroll Views/ScrollView.swift
@@ -13,7 +13,7 @@ import SwiftUI
 /// <ScrollView>
 ///     <VStack>
 ///         <%= for color <- @colors %>
-///             <Rectangle id={color} fill-color={color} modifiers={frame(height: 100)} />
+///             <Rectangle id={color} fillColor={color} modifiers={frame(height: 100)} />
 ///         <% end %>
 ///     </VStack>
 /// </ScrollView>

--- a/Sources/LiveViewNative/Views/Text Input and Output/Text.swift
+++ b/Sources/LiveViewNative/Views/Text Input and Output/Text.swift
@@ -139,7 +139,7 @@ struct Text<R: RootRegistry>: View {
     /// - Note: The value is expected to be in ISO 8601 format (with optional time)
     ///
     /// ```html
-    /// <Text date={DateTime.utc_now()} date-style="date" />
+    /// <Text date={DateTime.utc_now()} dateStyle="date" />
     /// ```
     @_documentation(visibility: public)
     @Attribute("date", transform: Self.formatDate(_:)) private var date: Date?

--- a/Sources/LiveViewNative/Views/Text Input and Output/TextField.swift
+++ b/Sources/LiveViewNative/Views/Text Input and Output/TextField.swift
@@ -21,7 +21,7 @@ import SwiftUI
 ///
 /// ```html
 /// <TextField text="last_name">
-///     <Text font-weight="bold" font="caption">Last Name</Text>
+///     <Text fontWeight="bold" font="caption">Last Name</Text>
 /// </TextField>
 /// ```
 ///

--- a/Sources/LiveViewNative/Views/Toolbars/ToolbarItem.swift
+++ b/Sources/LiveViewNative/Views/Toolbars/ToolbarItem.swift
@@ -12,7 +12,7 @@ import SwiftUI
 /// Optionally specify a ``placement`` to reposition the element.
 ///
 /// ```html
-/// <ToolbarItem placement="destructive-action">
+/// <ToolbarItem placement="destructiveAction">
 ///     <Button phx-click="delete">Delete</Button>
 /// </ToolbarItem>
 /// ```
@@ -130,8 +130,8 @@ struct CustomizableToolbarItem<R: RootRegistry>: CustomizableToolbarContent {
             default: return .automatic
             }
         }, element: element)
-        self._alwaysAvailable = .init(wrappedValue: false, "always-available", element: element)
-        self._customizationBehavior = .init(wrappedValue: .default, "customization-behavior", transform: {
+        self._alwaysAvailable = .init(wrappedValue: false, "alwaysAvailable", element: element)
+        self._customizationBehavior = .init(wrappedValue: .default, "customizationBehavior", transform: {
             switch $0?.value {
             case "disabled": return .disabled
             case "reorderable": return .reorderable
@@ -160,21 +160,21 @@ enum ToolbarItemPlacement: String, AttributeDecodable {
     case navigation
     /// `primary-action`
     @_documentation(visibility: public)
-    case primaryAction = "primary-action"
+    case primaryAction
     /// `secondary-action`
     @_documentation(visibility: public)
-    case secondaryAction = "secondary-action"
+    case secondaryAction
     @_documentation(visibility: public)
     case status
     /// `confirmation-action`
     @_documentation(visibility: public)
-    case confirmationAction = "confirmation-action"
+    case confirmationAction
     /// `cancellation-action`
     @_documentation(visibility: public)
-    case cancellationAction = "cancellation-action"
+    case cancellationAction
     /// `destructive-action`
     @_documentation(visibility: public)
-    case destructiveAction = "destructive-action"
+    case destructiveAction
     @_documentation(visibility: public)
     case keyboard
     

--- a/Sources/LiveViewNative/Views/Toolbars/ToolbarItemGroup.swift
+++ b/Sources/LiveViewNative/Views/Toolbars/ToolbarItemGroup.swift
@@ -12,7 +12,7 @@ import SwiftUI
 /// Optionally specify a ``placement`` to reposition the elements.
 ///
 /// ```html
-/// <ToolbarItemGroup placement="destructive-action">
+/// <ToolbarItemGroup placement="destructiveAction">
 ///     <Button phx-click="delete">Delete</Button>
 ///     <Button phx-click="destroy">Destroy</Button>
 ///     <Button phx-click="eradicate">Eradicate</Button>

--- a/Tests/RenderingTests/TextTests.swift
+++ b/Tests/RenderingTests/TextTests.swift
@@ -21,7 +21,7 @@ final class TextTests: XCTestCase {
     func testTextNesting() throws {
         try assertMatch(#"""
 <Text>
-    <Image system-name="person.crop.circle.fill" />
+    <Image systemName="person.crop.circle.fill" />
     <Text verbatim=" " />
     <Text>John Doe</Text>
     <Text verbatim="


### PR DESCRIPTION
Some property values were missed in #1257. This also updates any documentation that was still using `kebab-case` attributes.