### PR TITLE
Add `role` attribute to `Button` and remove `disabled`

### DIFF
--- a/Sources/LiveViewNative/Utils/ButtonRole.swift
+++ b/Sources/LiveViewNative/Utils/ButtonRole.swift
@@ -1,0 +1,29 @@
+//
+//  ButtonRole.swift
+//
+//
+//  Created by Carson Katri on 2/29/24.
+//
+
+import SwiftUI
+import LiveViewNativeCore
+
+/// The semantic role of a ``Button``.
+///
+/// Possible values:
+/// * `destructive`
+/// * `cancel`
+extension ButtonRole: AttributeDecodable {
+    public init(from attribute: LiveViewNativeCore.Attribute?) throws {
+        guard let value = attribute?.value
+        else { throw AttributeDecodingError.missingAttribute(Self.self) }
+        switch value {
+        case "destructive":
+            self = .destructive
+        case "cancel":
+            self = .cancel
+        default:
+            throw AttributeDecodingError.badValue(Self.self)
+        }
+    }
+}

--- a/Sources/LiveViewNative/Views/Controls and Indicators/Buttons/Button.swift
+++ b/Sources/LiveViewNative/Views/Controls and Indicators/Buttons/Button.swift
@@ -22,8 +22,8 @@ import SwiftUI
 /// ```
 /// 
 /// ## Attributes
-/// * ``disabled``
-/// 
+/// * ``role``
+///
 /// ## Events
 /// * ``click``
 @_documentation(visibility: public)
@@ -38,19 +38,22 @@ public struct Button<R: RootRegistry>: View {
     @_documentation(visibility: public)
     @Event("phx-click", type: "click") private var click
     
-    /// Boolean attribute that indicates whether the button is tappable.
+    /// The semantic role of the button.
+    ///
+    /// Possible values:
+    /// * `destructive`
+    /// * `cancel`
     @_documentation(visibility: public)
-    @Attribute("disabled") private var disabled: Bool
+    @Attribute("role") private var role: ButtonRole?
     
     @_spi(LiveForm) public init(action: (() -> Void)? = nil) {
         self.action = action
     }
     
     public var body: some View {
-        SwiftUI.Button(action: self.handleClick) {
+        SwiftUI.Button(role: role, action: self.handleClick) {
             context.buildChildren(of: element)
         }
-        .disabled(disabled)
         .preference(key: _ProvidedBindingsKey.self, value: ["phx-click"])
     }
     


### PR DESCRIPTION
Closes #1278 

This adds support for the `role` attribute on `Button`.
It also removes the `disabled` attribute, which should be applied with a modifier.

```heex
<Button role="destructive">
  <Label systemImage="arrow.uturn.backward">Undo Send</Label>
</Button>
```

<img width="269" alt="Screenshot 2024-02-29 at 11 23 41 AM" src="https://github.com/liveview-native/liveview-client-swiftui/assets/13581484/8c2bfaff-a097-4994-8510-3c2d7ae7c72c">
