### PR TITLE
Add `gesture_state` prototype

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,18 +21,15 @@ jobs:
         shell: bash
         run: |
           sudo xcode-select --switch /Applications/Xcode_15.4.app
-      - name: Cache xcode builds
-        uses: actions/cache@v4
-        id: xcode-build-cache
+      - uses: irgaly/xcode-cache@v1
         with:
-          path: |
-            xcode-build/
-          key: xcode-build-${{ github.workflow }}-${{ github.job }}-${{ runner.os }}-${{runner.arch}}
+          key: xcode-cache-deriveddata-${{ github.workflow }}-${{ github.sha }}
+          restore-keys: xcode-cache-deriveddata-${{ github.workflow }}-
       - name: Run tests on iOS Simulator
         shell: bash
         run: |
-          xcodebuild -scheme BuiltinRegistryGenerator -destination "platform=macOS" -derivedDataPath xcode-build/
-          xcodebuild test -scheme LiveViewNative-Package -destination "platform=iOS Simulator,name=iPhone 15 Pro" -enableCodeCoverage YES -resultBundlePath TestResults -skipMacroValidation -skipPackagePluginValidation -derivedDataPath xcode-build/
+          xcodebuild -scheme BuiltinRegistryGenerator -destination "platform=macOS"
+          xcodebuild test -scheme LiveViewNative-Package -destination "platform=iOS Simulator,name=iPhone 15 Pro" -enableCodeCoverage YES -resultBundlePath TestResults -skipMacroValidation -skipPackagePluginValidation
       - uses: kishikawakatsumi/xcresulttool@v1
         with:
           path: TestResults.xcresult
@@ -51,12 +48,12 @@ jobs:
       - name: Build for macOS
         shell: bash
         run: |
-          xcodebuild -scheme LiveViewNative-Package -destination "platform=macOS" -skipMacroValidation -skipPackagePluginValidation -derivedDataPath xcode-build/
+          xcodebuild -scheme LiveViewNative-Package -destination "platform=macOS" -skipMacroValidation -skipPackagePluginValidation
       - name: Build for watchOS
         shell: bash
         run: |
-          xcodebuild -scheme LiveViewNative-Package -destination "platform=watchOS Simulator,name=Apple Watch Series 9 (45mm)" -skipMacroValidation -skipPackagePluginValidation -derivedDataPath xcode-build/
+          xcodebuild -scheme LiveViewNative-Package -destination "platform=watchOS Simulator,name=Apple Watch Series 9 (45mm)" -skipMacroValidation -skipPackagePluginValidation
       - name: Build for tvOS
         shell: bash
         run: |
-          xcodebuild -scheme LiveViewNative-Package -destination "name=Any tvOS Device" -skipMacroValidation -skipPackagePluginValidation -derivedDataPath xcode-build/
+          xcodebuild -scheme LiveViewNative-Package -destination "name=Any tvOS Device" -skipMacroValidation -skipPackagePluginValidation

--- a/Sources/LiveViewNative/Property Wrappers/Event.swift
+++ b/Sources/LiveViewNative/Property Wrappers/Event.swift
@@ -329,5 +329,18 @@ public struct Event: DynamicProperty, Decodable {
             }
             await owner.handler.channel.send((owner.type, event, owner.params ?? value, owner.target ?? owner.element.attributeValue(for: "phx-target").flatMap(Int.init)))
         }
+        
+        public func callAsFunction<R: RootRegistry>(value: Any = [String:String](), in context: LiveContext<R>) async throws {
+            guard let event else {
+                return
+            }
+            let handler = Handler()
+            handler.update(
+                coordinator: CoordinatorEnvironment(context.coordinator, document: context.coordinator.document!),
+                debounce: owner.debounce,
+                throttle: owner.throttle
+            )
+            await handler.channel.send((owner.type, event, owner.params ?? value, owner.target))
+        }
     }
 }

--- a/Sources/LiveViewNative/Property Wrappers/LiveContext.swift
+++ b/Sources/LiveViewNative/Property Wrappers/LiveContext.swift
@@ -23,6 +23,15 @@ import LiveViewNativeCore
 @propertyWrapper
 public struct LiveContext<R: RootRegistry>: DynamicProperty {
     @Environment(\.anyLiveContextStorage) private var anyStorage
+    
+    @Environment(\.gestureState) private var environmentGestureState
+    internal var overrideGestureState: GestureState<[String:Any]>?
+    /// The `GestureState` value in the environment.
+    /// Uses the ``overrideGestureState`` if present.
+    var gestureState: GestureState<[String:Any]> {
+        overrideGestureState ?? environmentGestureState
+    }
+    
     var storage: LiveContextStorage<R> {
         anyStorage as! LiveContextStorage<R>
     }
@@ -42,6 +51,14 @@ public struct LiveContext<R: RootRegistry>: DynamicProperty {
     }
     
     public init() {
+    }
+    
+    /// Add an ``overrideGestureState`` to the context.
+    /// This will take precedence over the environment value.
+    internal func withGestureState(_ state: GestureState<[String:Any]>) -> Self {
+        var copy = self
+        copy.overrideGestureState = state
+        return copy
     }
     
     /// Builds a view representing the given element in the current context.

--- a/Sources/LiveViewNative/Stylesheets/AttributeReference.swift
+++ b/Sources/LiveViewNative/Stylesheets/AttributeReference.swift
@@ -5,6 +5,7 @@
 //  Created by Carson Katri on 10/24/23.
 //
 
+import SwiftUI
 import LiveViewNativeStylesheet
 import LiveViewNativeCore
 
@@ -22,9 +23,10 @@ import LiveViewNativeCore
 ///
 /// The attribute will be automatically decoded to the correct type using the conformance to ``AttributeDecodable``.
 public struct AttributeReference<Value: ParseableModifierValue & AttributeDecodable>: ParseableModifierValue {
-    public enum Storage {
+    enum Storage {
         case constant(Value)
         case reference(AttributeName)
+        case gestureState(String, GestureStateReference.PropertyReference, defaultValue: Value?)
     }
     
     let storage: Storage
@@ -41,20 +43,145 @@ public struct AttributeReference<Value: ParseableModifierValue & AttributeDecoda
         OneOf {
             Value.parser(in: context).map(Storage.constant)
             AttributeName.parser(in: context).map(Storage.reference)
+            GestureStateReference.parser(in: context).map(\.value)
         }
         .map(Self.init)
     }
     
     public func resolve<R: RootRegistry>(on element: ElementNode, in context: LiveContext<R>) -> Value {
-        resolve(on: element)
-    }
-    
-    public func resolve(on element: ElementNode) -> Value {
         switch storage {
         case .constant(let value):
             return value
         case .reference(let name):
             return try! element.attributeValue(Value.self, for: name)
+        case let .gestureState(name, body, defaultValue):
+            let castValue = { (value: CGFloat) -> Value in
+                switch Value.self {
+                case is String.Type:
+                    return String(describing: value) as! Value
+                case is Double.Type:
+                    return Double(value) as! Value
+                default:
+                    return value as! Value
+                }
+            }
+            let defaultValue: Value = defaultValue ?? castValue(0.0)
+            
+            guard let value = context.gestureState.wrappedValue[name]
+            else { return defaultValue }
+            
+            switch body.base {
+            case .translation:
+                guard let value = value as? DragGesture.Value,
+                      let member = body.member
+                else { return defaultValue }
+                switch member {
+                case .width:
+                    return castValue(value.translation.width)
+                case .height:
+                    return castValue(value.translation.height)
+                default:
+                    return defaultValue
+                }
+            case .magnification:
+                #if os(iOS) || os(macOS)
+                if #available(iOS 17.0, macOS 14.0, *) {
+                    guard let value = value as? MagnifyGesture.Value else { return defaultValue }
+                    return castValue(value.magnification)
+                } else {
+                    return defaultValue
+                }
+                #else
+                return defaultValue
+                #endif
+            case .rotation:
+                #if os(iOS) || os(macOS)
+                if #available(iOS 17.0, macOS 14.0, *) {
+                    guard let value = value as? RotateGesture.Value else { return defaultValue }
+                    switch body.member {
+                    case .radians:
+                        return castValue(CGFloat(value.rotation.radians))
+                    case .degrees:
+                        return castValue(CGFloat(value.rotation.degrees))
+                    default:
+                        return value.rotation as! Value
+                    }
+                } else {
+                    return defaultValue
+                }
+                #else
+                return defaultValue
+                #endif
+            case .startAnchor:
+                #if os(iOS) || os(macOS)
+                if #available(iOS 17.0, macOS 14.0, *) {
+                    if let value = value as? MagnifyGesture.Value {
+                        return value.startAnchor as! Value
+                    } else if let value = value as? RotateGesture.Value {
+                        return value.startAnchor as! Value
+                    } else {
+                        return defaultValue
+                    }
+                } else {
+                    return defaultValue
+                }
+                #else
+                return defaultValue
+                #endif
+            }
+        }
+    }
+    
+    @ParseableExpression
+    struct GestureStateReference {
+        static var name: String { "gesture_state" }
+        
+        let value: Storage
+        
+        struct PropertyReference: ParseableModifierValue {
+            let base: Base
+            let member: Member?
+            
+            enum Base: String, CaseIterable {
+                case translation
+                
+                case magnification
+                
+                case rotation
+                
+                case startAnchor
+            }
+            enum Member: String, CaseIterable {
+                case width
+                case height
+                
+                case radians
+                case degrees
+            }
+            
+            static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
+                MemberExpression {
+                    NilLiteral()
+                } member: {
+                    OneOf {
+                        MemberExpression {
+                            EnumParser<Base>()
+                        } member: {
+                            EnumParser<Member>()
+                        }
+                        .map { (base, member) in
+                            Self.init(base: base, member: member)
+                        }
+                        EnumParser<Base>()
+                            .map({ Self.init(base: $0, member: nil) })
+                    }
+                }
+                .map(\.member)
+            }
+        }
+        
+        init(_ name: String, _ body: PropertyReference, defaultValue: Value? = nil) {
+            self.value = .gestureState(name, body, defaultValue: defaultValue)
         }
     }
     
@@ -64,6 +191,8 @@ public struct AttributeReference<Value: ParseableModifierValue & AttributeDecoda
             return value
         case .reference:
             return `default`
+        case let .gestureState(_, _, defaultValue):
+            return defaultValue ?? `default`
         }
     }
 }

--- a/Sources/LiveViewNative/Stylesheets/AttributeReference.swift
+++ b/Sources/LiveViewNative/Stylesheets/AttributeReference.swift
@@ -221,7 +221,15 @@ public struct AttributeReference<Value: ParseableModifierValue & AttributeDecoda
             return value
         case .reference:
             return `default`
-        case let .gestureState(_, _, defaultValue):
+        case let .gestureState(
+            _,
+            _,
+            defaultValue,
+            _,
+            _,
+            _,
+            _
+        ):
             return defaultValue ?? `default`
         }
     }

--- a/Sources/LiveViewNative/Stylesheets/AttributeReference.swift
+++ b/Sources/LiveViewNative/Stylesheets/AttributeReference.swift
@@ -156,7 +156,7 @@ public struct AttributeReference<Value: ParseableModifierValue & AttributeDecoda
     
     @ParseableExpression
     struct GestureStateReference {
-        static var name: String { "gesture_state" }
+        static var name: String { "__gesture_state__" }
         
         let value: Storage
         

--- a/Sources/LiveViewNative/Stylesheets/Modifiers/Shapes/FillModifier.swift
+++ b/Sources/LiveViewNative/Stylesheets/Modifiers/Shapes/FillModifier.swift
@@ -26,8 +26,8 @@ import LiveViewNativeStylesheet
 /// ```
 @_documentation(visibility: public)
 @ParseableExpression
-struct _FillModifier: ShapeFinalizerModifier {
-    static let name = "fill"
+struct _FillModifier<Root: RootRegistry>: ShapeFinalizerModifier {
+    static var name: String { "fill" }
     
     let content: AnyShapeStyle.Resolvable
     let style: FillStyle
@@ -38,7 +38,7 @@ struct _FillModifier: ShapeFinalizerModifier {
     }
     
     @ViewBuilder
-    func apply(to shape: AnyShape, on element: ElementNode) -> some View {
-        shape.fill(content.resolve(on: element), style: style)
+    func apply(to shape: AnyShape, on element: ElementNode, in context: LiveContext<Root>) -> some View {
+        shape.fill(content.resolve(on: element, in: context), style: style)
     }
 }

--- a/Sources/LiveViewNative/Stylesheets/Modifiers/Shapes/RotationModifier.swift
+++ b/Sources/LiveViewNative/Stylesheets/Modifiers/Shapes/RotationModifier.swift
@@ -26,21 +26,21 @@ import LiveViewNativeStylesheet
 /// ```
 @_documentation(visibility: public)
 @ParseableExpression
-struct _RotationModifier: ShapeModifier {
-    static let name = "rotation"
+struct _RotationModifier<Root: RootRegistry>: ShapeModifier {
+    static var name: String { "rotation" }
 
-    let angle: Angle
-    let anchor: UnitPoint
+    let angle: AttributeReference<Angle>
+    let anchor: AttributeReference<UnitPoint>
     
     init(
-        _ angle: Angle,
-        anchor: UnitPoint = .center
+        _ angle: AttributeReference<Angle>,
+        anchor: AttributeReference<UnitPoint> = .init(.center)
     ) {
         self.angle = angle
         self.anchor = anchor
     }
 
-    func apply(to shape: AnyShape, on element: ElementNode) -> some SwiftUI.Shape {
-        return shape.rotation(angle, anchor: anchor)
+    func apply(to shape: AnyShape, on element: ElementNode, in context: LiveContext<Root>) -> some SwiftUI.Shape {
+        return shape.rotation(angle.resolve(on: element, in: context), anchor: anchor.resolve(on: element, in: context))
     }
 }

--- a/Sources/LiveViewNative/Stylesheets/Modifiers/Shapes/ScaleModifier.swift
+++ b/Sources/LiveViewNative/Stylesheets/Modifiers/Shapes/ScaleModifier.swift
@@ -24,7 +24,7 @@ import LiveViewNativeStylesheet
 /// ```
 @_documentation(visibility: public)
 @ParseableExpression
-struct _ScaleModifier<R: RootRegistry>: ShapeModifier {
+struct _ScaleModifier<Root: RootRegistry>: ShapeModifier {
     static var name: String { "scale" }
 
     enum Value {
@@ -33,9 +33,6 @@ struct _ScaleModifier<R: RootRegistry>: ShapeModifier {
     }
 
     let value: Value
-
-    @ObservedElement private var element
-    @LiveContext<R> private var context
     
     init(
         x: AttributeReference<CGFloat> = .init(storage: .constant(1)),
@@ -49,7 +46,7 @@ struct _ScaleModifier<R: RootRegistry>: ShapeModifier {
         self.value = ._1(scale: scale, anchor: anchor)
     }
 
-    func apply(to shape: AnyShape, on element: ElementNode) -> some SwiftUI.Shape {
+    func apply(to shape: AnyShape, on element: ElementNode, in context: LiveContext<Root>) -> some SwiftUI.Shape {
         switch value {
         case let ._0(x, y, anchor):
             return shape.scale(x: x.resolve(on: element, in: context), y: y.resolve(on: element, in: context), anchor: anchor)

--- a/Sources/LiveViewNative/Stylesheets/Modifiers/Shapes/ShapeBooleanModifiers.swift
+++ b/Sources/LiveViewNative/Stylesheets/Modifiers/Shapes/ShapeBooleanModifiers.swift
@@ -26,20 +26,20 @@ import LiveViewNativeStylesheet
 /// ```
 @_documentation(visibility: public)
 @ParseableExpression
-struct _IntersectionModifier: ShapeModifier {
-    static let name = "intersection"
+struct _IntersectionModifier<Root: RootRegistry>: ShapeModifier {
+    static var name: String { "intersection" }
 
     let other: AnyShape
-    let eoFill: Bool
+    let eoFill: AttributeReference<Bool>
     
-    init(_ other: AnyShape, eoFill: Bool = false) {
+    init(_ other: AnyShape, eoFill: AttributeReference<Bool> = .init(false)) {
         self.other = other
         self.eoFill = eoFill
     }
 
-    func apply(to shape: AnyShape, on element: ElementNode) -> some SwiftUI.Shape {
+    func apply(to shape: AnyShape, on element: ElementNode, in context: LiveContext<Root>) -> some SwiftUI.Shape {
         if #available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *) {
-            return AnyShape(shape.intersection(other, eoFill: eoFill))
+            return AnyShape(shape.intersection(other, eoFill: eoFill.resolve(on: element, in: context)))
         } else {
             return shape
         }
@@ -64,20 +64,20 @@ struct _IntersectionModifier: ShapeModifier {
 /// ```
 @_documentation(visibility: public)
 @ParseableExpression
-struct _UnionModifier: ShapeModifier {
-    static let name = "union"
+struct _UnionModifier<Root: RootRegistry>: ShapeModifier {
+    static var name: String { "union" }
 
     let other: AnyShape
-    let eoFill: Bool
+    let eoFill: AttributeReference<Bool>
     
-    init(_ other: AnyShape, eoFill: Bool = false) {
+    init(_ other: AnyShape, eoFill: AttributeReference<Bool> = .init(false)) {
         self.other = other
         self.eoFill = eoFill
     }
 
-    func apply(to shape: AnyShape, on element: ElementNode) -> some SwiftUI.Shape {
+    func apply(to shape: AnyShape, on element: ElementNode, in context: LiveContext<Root>) -> some SwiftUI.Shape {
         if #available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *) {
-            return AnyShape(shape.union(other, eoFill: eoFill))
+            return AnyShape(shape.union(other, eoFill: eoFill.resolve(on: element, in: context)))
         } else {
             return shape
         }
@@ -102,20 +102,20 @@ struct _UnionModifier: ShapeModifier {
 /// ```
 @_documentation(visibility: public)
 @ParseableExpression
-struct _SubtractingModifier: ShapeModifier {
-    static let name = "subtracting"
+struct _SubtractingModifier<Root: RootRegistry>: ShapeModifier {
+    static var name: String { "subtracting" }
 
     let other: AnyShape
-    let eoFill: Bool
+    let eoFill: AttributeReference<Bool>
     
-    init(_ other: AnyShape, eoFill: Bool = false) {
+    init(_ other: AnyShape, eoFill: AttributeReference<Bool> = .init(false)) {
         self.other = other
         self.eoFill = eoFill
     }
 
-    func apply(to shape: AnyShape, on element: ElementNode) -> some SwiftUI.Shape {
+    func apply(to shape: AnyShape, on element: ElementNode, in context: LiveContext<Root>) -> some SwiftUI.Shape {
         if #available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *) {
-            return AnyShape(shape.subtracting(other, eoFill: eoFill))
+            return AnyShape(shape.subtracting(other, eoFill: eoFill.resolve(on: element, in: context)))
         } else {
             return shape
         }
@@ -140,20 +140,20 @@ struct _SubtractingModifier: ShapeModifier {
 /// ```
 @_documentation(visibility: public)
 @ParseableExpression
-struct _SymmetricDifferenceModifier: ShapeModifier {
-    static let name = "symmetricDifference"
+struct _SymmetricDifferenceModifier<Root: RootRegistry>: ShapeModifier {
+    static var name: String { "symmetricDifference" }
 
     let other: AnyShape
-    let eoFill: Bool
+    let eoFill: AttributeReference<Bool>
     
-    init(_ other: AnyShape, eoFill: Bool = false) {
+    init(_ other: AnyShape, eoFill: AttributeReference<Bool> = .init(false)) {
         self.other = other
         self.eoFill = eoFill
     }
 
-    func apply(to shape: AnyShape, on element: ElementNode) -> some SwiftUI.Shape {
+    func apply(to shape: AnyShape, on element: ElementNode, in context: LiveContext<Root>) -> some SwiftUI.Shape {
         if #available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *) {
-            return AnyShape(shape.symmetricDifference(other, eoFill: eoFill))
+            return AnyShape(shape.symmetricDifference(other, eoFill: eoFill.resolve(on: element, in: context)))
         } else {
             return shape
         }
@@ -178,20 +178,20 @@ struct _SymmetricDifferenceModifier: ShapeModifier {
 /// ```
 @_documentation(visibility: public)
 @ParseableExpression
-struct _LineIntersectionModifier: ShapeModifier {
-    static let name = "lineIntersection"
+struct _LineIntersectionModifier<Root: RootRegistry>: ShapeModifier {
+    static var name: String { "lineIntersection" }
 
     let other: AnyShape
-    let eoFill: Bool
+    let eoFill: AttributeReference<Bool>
     
-    init(_ other: AnyShape, eoFill: Bool = false) {
+    init(_ other: AnyShape, eoFill: AttributeReference<Bool> = .init(false)) {
         self.other = other
         self.eoFill = eoFill
     }
 
-    func apply(to shape: AnyShape, on element: ElementNode) -> some SwiftUI.Shape {
+    func apply(to shape: AnyShape, on element: ElementNode, in context: LiveContext<Root>) -> some SwiftUI.Shape {
         if #available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *) {
-            return AnyShape(shape.lineIntersection(other, eoFill: eoFill))
+            return AnyShape(shape.lineIntersection(other, eoFill: eoFill.resolve(on: element, in: context)))
         } else {
             return shape
         }
@@ -216,20 +216,20 @@ struct _LineIntersectionModifier: ShapeModifier {
 /// ```
 @_documentation(visibility: public)
 @ParseableExpression
-struct _LineSubtractionModifier: ShapeModifier {
-    static let name = "lineSubtraction"
+struct _LineSubtractionModifier<Root: RootRegistry>: ShapeModifier {
+    static var name: String { "lineSubtraction" }
 
     let other: AnyShape
-    let eoFill: Bool
+    let eoFill: AttributeReference<Bool>
     
-    init(_ other: AnyShape, eoFill: Bool = false) {
+    init(_ other: AnyShape, eoFill: AttributeReference<Bool> = .init(false)) {
         self.other = other
         self.eoFill = eoFill
     }
 
-    func apply(to shape: AnyShape, on element: ElementNode) -> some SwiftUI.Shape {
+    func apply(to shape: AnyShape, on element: ElementNode, in context: LiveContext<Root>) -> some SwiftUI.Shape {
         if #available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *) {
-            return AnyShape(shape.lineSubtraction(other, eoFill: eoFill))
+            return AnyShape(shape.lineSubtraction(other, eoFill: eoFill.resolve(on: element, in: context)))
         } else {
             return shape
         }

--- a/Sources/LiveViewNative/Stylesheets/Modifiers/Shapes/ShapeModifier.swift
+++ b/Sources/LiveViewNative/Stylesheets/Modifiers/Shapes/ShapeModifier.swift
@@ -9,18 +9,20 @@ import SwiftUI
 import LiveViewNativeStylesheet
 
 /// A `ViewModifier` that can be applied directly to `Shape`.
-protocol ShapeModifier {
+protocol ShapeModifier<Root> {
+    associatedtype Root: RootRegistry
     associatedtype ModifiedShape: SwiftUI.Shape
     
-    func apply(to shape: SwiftUI.AnyShape, on element: ElementNode) -> ModifiedShape
+    func apply(to shape: SwiftUI.AnyShape, on element: ElementNode, in context: LiveContext<Root>) -> ModifiedShape
 }
 
 /// A `ViewModifier` that can be applied directly to `Shape`.
-protocol ShapeFinalizerModifier {
+protocol ShapeFinalizerModifier<Root> {
+    associatedtype Root: RootRegistry
     associatedtype FinalizedShape: SwiftUI.View
     
     @ViewBuilder
-    func apply(to shape: SwiftUI.AnyShape, on element: ElementNode) -> FinalizedShape
+    func apply(to shape: SwiftUI.AnyShape, on element: ElementNode, in context: LiveContext<Root>) -> FinalizedShape
 }
 
 extension SwiftUI.Shape {
@@ -30,81 +32,81 @@ extension SwiftUI.Shape {
 }
 
 /// A type-erased `ShapeModifier`, which can be applied to a `View` or directly on `Shape`.
-enum _AnyShapeModifier<R: RootRegistry>: ViewModifier, ShapeModifier, ParseableModifierValue {
-    case rotation(_RotationModifier)
-    case scale(_ScaleModifier<R>)
-    case intersection(_IntersectionModifier)
-    case union(_UnionModifier)
-    case subtracting(_SubtractingModifier)
-    case symmetricDifference(_SymmetricDifferenceModifier)
-    case lineIntersection(_LineIntersectionModifier)
-    case lineSubtraction(_LineSubtractionModifier)
-    case transform(_TransformModifier)
+enum _AnyShapeModifier<Root: RootRegistry>: ViewModifier, ShapeModifier, ParseableModifierValue {
+    case rotation(_RotationModifier<Root>)
+    case scale(_ScaleModifier<Root>)
+    case intersection(_IntersectionModifier<Root>)
+    case union(_UnionModifier<Root>)
+    case subtracting(_SubtractingModifier<Root>)
+    case symmetricDifference(_SymmetricDifferenceModifier<Root>)
+    case lineIntersection(_LineIntersectionModifier<Root>)
+    case lineSubtraction(_LineSubtractionModifier<Root>)
+    case transform(_TransformModifier<Root>)
     
     func body(content: Content) -> some View {
         content
     }
     
-    func apply(to shape: SwiftUI.AnyShape, on element: ElementNode) -> SwiftUI.AnyShape {
+    func apply(to shape: SwiftUI.AnyShape, on element: ElementNode, in context: LiveContext<Root>) -> SwiftUI.AnyShape {
         switch self {
         case let .rotation(modifier):
-            return modifier.apply(to: shape, on: element).erasedToAnyShape()
+            return modifier.apply(to: shape, on: element, in: context).erasedToAnyShape()
         case let .scale(modifier):
-            return modifier.apply(to: shape, on: element).erasedToAnyShape()
+            return modifier.apply(to: shape, on: element, in: context).erasedToAnyShape()
         case let .intersection(modifier):
-            return modifier.apply(to: shape, on: element).erasedToAnyShape()
+            return modifier.apply(to: shape, on: element, in: context).erasedToAnyShape()
         case let .union(modifier):
-            return modifier.apply(to: shape, on: element).erasedToAnyShape()
+            return modifier.apply(to: shape, on: element, in: context).erasedToAnyShape()
         case let .subtracting(modifier):
-            return modifier.apply(to: shape, on: element).erasedToAnyShape()
+            return modifier.apply(to: shape, on: element, in: context).erasedToAnyShape()
         case let .symmetricDifference(modifier):
-            return modifier.apply(to: shape, on: element).erasedToAnyShape()
+            return modifier.apply(to: shape, on: element, in: context).erasedToAnyShape()
         case let .lineIntersection(modifier):
-            return modifier.apply(to: shape, on: element).erasedToAnyShape()
+            return modifier.apply(to: shape, on: element, in: context).erasedToAnyShape()
         case let .lineSubtraction(modifier):
-            return modifier.apply(to: shape, on: element).erasedToAnyShape()
+            return modifier.apply(to: shape, on: element, in: context).erasedToAnyShape()
         case let .transform(modifier):
-            return modifier.apply(to: shape, on: element).erasedToAnyShape()
+            return modifier.apply(to: shape, on: element, in: context).erasedToAnyShape()
         }
     }
     
     static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         OneOf {
-            _RotationModifier.parser(in: context).map(Self.rotation)
-            _ScaleModifier<R>.parser(in: context).map(Self.scale)
-            _IntersectionModifier.parser(in: context).map(Self.intersection)
-            _UnionModifier.parser(in: context).map(Self.union)
-            _SubtractingModifier.parser(in: context).map(Self.subtracting)
-            _SymmetricDifferenceModifier.parser(in: context).map(Self.symmetricDifference)
-            _LineIntersectionModifier.parser(in: context).map(Self.lineIntersection)
-            _LineSubtractionModifier.parser(in: context).map(Self.lineSubtraction)
-            _TransformModifier.parser(in: context).map(Self.transform)
+            _RotationModifier<Root>.parser(in: context).map(Self.rotation)
+            _ScaleModifier<Root>.parser(in: context).map(Self.scale)
+            _IntersectionModifier<Root>.parser(in: context).map(Self.intersection)
+            _UnionModifier<Root>.parser(in: context).map(Self.union)
+            _SubtractingModifier<Root>.parser(in: context).map(Self.subtracting)
+            _SymmetricDifferenceModifier<Root>.parser(in: context).map(Self.symmetricDifference)
+            _LineIntersectionModifier<Root>.parser(in: context).map(Self.lineIntersection)
+            _LineSubtractionModifier<Root>.parser(in: context).map(Self.lineSubtraction)
+            _TransformModifier<Root>.parser(in: context).map(Self.transform)
         }
     }
 }
 
 /// A type-erased `ShapeFinalizerModifier`, which can be applied to a `View` or directly on `Shape`.
-enum _AnyShapeFinalizerModifier<R: RootRegistry>: ViewModifier, ShapeFinalizerModifier, ParseableModifierValue {
-    case fill(_FillModifier)
-    case stroke(_StrokeModifier<R>)
+enum _AnyShapeFinalizerModifier<Root: RootRegistry>: ViewModifier, ShapeFinalizerModifier, ParseableModifierValue {
+    case fill(_FillModifier<Root>)
+    case stroke(_StrokeModifier<Root>)
     
     func body(content: Content) -> some View {
         content
     }
     
-    func apply(to shape: SwiftUI.AnyShape, on element: ElementNode) -> some View {
+    func apply(to shape: SwiftUI.AnyShape, on element: ElementNode, in context: LiveContext<Root>) -> some View {
         switch self {
         case let .fill(modifier):
-            modifier.apply(to: shape, on: element)
+            modifier.apply(to: shape, on: element, in: context)
         case let .stroke(modifier):
-            modifier.apply(to: shape, on: element)
+            modifier.apply(to: shape, on: element, in: context)
         }
     }
     
     static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         OneOf {
-            _FillModifier.parser(in: context).map(Self.fill)
-            _StrokeModifier<R>.parser(in: context).map(Self.stroke)
+            _FillModifier<Root>.parser(in: context).map(Self.fill)
+            _StrokeModifier<Root>.parser(in: context).map(Self.stroke)
         }
     }
 }

--- a/Sources/LiveViewNative/Stylesheets/Modifiers/Shapes/StrokeModifier.swift
+++ b/Sources/LiveViewNative/Stylesheets/Modifiers/Shapes/StrokeModifier.swift
@@ -37,7 +37,7 @@ import LiveViewNativeStylesheet
 /// ```
 @_documentation(visibility: public)
 @ParseableExpression
-struct _StrokeModifier<R: RootRegistry>: ShapeFinalizerModifier {
+struct _StrokeModifier<Root: RootRegistry>: ShapeFinalizerModifier {
     static var name: String { "stroke" }
     
     enum Storage {
@@ -56,19 +56,19 @@ struct _StrokeModifier<R: RootRegistry>: ShapeFinalizerModifier {
     }
     
     @ViewBuilder
-    func apply(to shape: AnyShape, on element: ElementNode) -> some View {
+    func apply(to shape: AnyShape, on element: ElementNode, in context: LiveContext<Root>) -> some View {
         switch storage {
         case ._0(let content, let style, let antialiased):
             if #available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *) {
-                shape.stroke(content.resolve(on: element), style: style, antialiased: antialiased.resolve(on: element))
+                shape.stroke(content.resolve(on: element, in: context), style: style, antialiased: antialiased.resolve(on: element, in: context))
             } else {
-                shape.stroke(content.resolve(on: element), style: style)
+                shape.stroke(content.resolve(on: element, in: context), style: style)
             }
         case ._1(let content, let lineWidth, let antialiased):
             if #available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *) {
-                shape.stroke(content.resolve(on: element), lineWidth: lineWidth.resolve(on: element), antialiased: antialiased.resolve(on: element))
+                shape.stroke(content.resolve(on: element, in: context), lineWidth: lineWidth.resolve(on: element, in: context), antialiased: antialiased.resolve(on: element, in: context))
             } else {
-                shape.stroke(content.resolve(on: element), lineWidth: lineWidth.resolve(on: element))
+                shape.stroke(content.resolve(on: element, in: context), lineWidth: lineWidth.resolve(on: element, in: context))
             }
         }
     }

--- a/Sources/LiveViewNative/Stylesheets/Modifiers/Shapes/TransformModifier.swift
+++ b/Sources/LiveViewNative/Stylesheets/Modifiers/Shapes/TransformModifier.swift
@@ -25,8 +25,8 @@ import LiveViewNativeStylesheet
 /// ```
 @_documentation(visibility: public)
 @ParseableExpression
-struct _TransformModifier: ShapeModifier {
-    static let name = "transform"
+struct _TransformModifier<Root: RootRegistry>: ShapeModifier {
+    static var name: String { "transform" }
 
     let transform: CGAffineTransform
     
@@ -34,7 +34,7 @@ struct _TransformModifier: ShapeModifier {
         self.transform = transform
     }
 
-    func apply(to shape: AnyShape, on element: ElementNode) -> some SwiftUI.Shape {
+    func apply(to shape: AnyShape, on element: ElementNode, in context: LiveContext<Root>) -> some SwiftUI.Shape {
         return shape.transform(transform)
     }
 }

--- a/Sources/LiveViewNative/Stylesheets/Modifiers/Text/BaselineOffsetModifier.swift
+++ b/Sources/LiveViewNative/Stylesheets/Modifiers/Text/BaselineOffsetModifier.swift
@@ -22,13 +22,13 @@ import LiveViewNativeStylesheet
 /// ```
 @_documentation(visibility: public)
 @ParseableExpression
-struct _BaselineOffsetModifier<R: RootRegistry>: TextModifier {
+struct _BaselineOffsetModifier<Root: RootRegistry>: TextModifier {
     static var name: String { "baselineOffset" }
 
     let baselineOffset: AttributeReference<CoreFoundation.CGFloat>
 
     @ObservedElement private var element
-    @LiveContext<R> private var context
+    @LiveContext<Root> private var context
     
     init(_ baselineOffset: AttributeReference<CoreFoundation.CGFloat>) {
         self.baselineOffset = baselineOffset
@@ -43,7 +43,7 @@ struct _BaselineOffsetModifier<R: RootRegistry>: TextModifier {
             .baselineOffset(baselineOffset.resolve(on: element, in: context))
     }
     
-    func apply(to text: SwiftUI.Text, on element: ElementNode) -> SwiftUI.Text {
-        text.baselineOffset(baselineOffset.resolve(on: element))
+    func apply<R: RootRegistry>(to text: SwiftUI.Text, on element: ElementNode, in context: LiveContext<R>) -> SwiftUI.Text {
+        text.baselineOffset(baselineOffset.resolve(on: element, in: context))
     }
 }

--- a/Sources/LiveViewNative/Stylesheets/Modifiers/Text/BoldModifier.swift
+++ b/Sources/LiveViewNative/Stylesheets/Modifiers/Text/BoldModifier.swift
@@ -22,13 +22,13 @@ import LiveViewNativeStylesheet
 /// ```
 @_documentation(visibility: public)
 @ParseableExpression
-struct _BoldModifier<R: RootRegistry>: TextModifier {
+struct _BoldModifier<Root: RootRegistry>: TextModifier {
     static var name: String { "bold" }
 
     let isActive: AttributeReference<Bool>
 
     @ObservedElement private var element
-    @LiveContext<R> private var context
+    @LiveContext<Root> private var context
     
     init(_ isActive: AttributeReference<Bool> = .init(storage: .constant(true))) {
         self.isActive = isActive
@@ -38,7 +38,7 @@ struct _BoldModifier<R: RootRegistry>: TextModifier {
         content.bold(isActive.resolve(on: element, in: context))
     }
     
-    func apply(to text: SwiftUI.Text, on element: ElementNode) -> SwiftUI.Text {
-        text.bold(isActive.resolve(on: element))
+    func apply<R: RootRegistry>(to text: SwiftUI.Text, on element: ElementNode, in context: LiveContext<R>) -> SwiftUI.Text {
+        text.bold(isActive.resolve(on: element, in: context))
     }
 }

--- a/Sources/LiveViewNative/Stylesheets/Modifiers/Text/FontDesignModifier.swift
+++ b/Sources/LiveViewNative/Stylesheets/Modifiers/Text/FontDesignModifier.swift
@@ -25,7 +25,7 @@ import LiveViewNativeStylesheet
 /// ```
 @_documentation(visibility: public)
 @ParseableExpression
-struct _FontDesignModifier<R: RootRegistry>: TextModifier {
+struct _FontDesignModifier<Root: RootRegistry>: TextModifier {
     static var name: String { "fontDesign" }
     
     let design: Any?
@@ -43,8 +43,8 @@ struct _FontDesignModifier<R: RootRegistry>: TextModifier {
         }
     }
     
-    func apply(to text: SwiftUI.Text, on element: ElementNode) -> SwiftUI.Text {
-        if #available(watchOS 9.1,tvOS 16.1,iOS 16.1,macOS 13.0, visionOS 1, *) {
+    func apply<R: RootRegistry>(to text: SwiftUI.Text, on element: ElementNode, in context: LiveContext<R>) -> SwiftUI.Text {
+        if #available(watchOS 9.1, tvOS 16.1, iOS 16.1, macOS 13.0, visionOS 1, *) {
             return text.fontDesign(design as? SwiftUI.Font.Design)
         } else {
             return text

--- a/Sources/LiveViewNative/Stylesheets/Modifiers/Text/FontModifier.swift
+++ b/Sources/LiveViewNative/Stylesheets/Modifiers/Text/FontModifier.swift
@@ -25,7 +25,7 @@ import LiveViewNativeStylesheet
 /// ```
 @_documentation(visibility: public)
 @ParseableExpression
-struct _FontModifier<R: RootRegistry>: TextModifier {
+struct _FontModifier<Root: RootRegistry>: TextModifier {
     static var name: String { "font" }
 
     let font: SwiftUI.Font?
@@ -38,7 +38,7 @@ struct _FontModifier<R: RootRegistry>: TextModifier {
         content.font(font)
     }
     
-    func apply(to text: SwiftUI.Text, on element: ElementNode) -> SwiftUI.Text {
+    func apply<R: RootRegistry>(to text: SwiftUI.Text, on element: ElementNode, in context: LiveContext<R>) -> SwiftUI.Text {
         text.font(font)
     }
 }

--- a/Sources/LiveViewNative/Stylesheets/Modifiers/Text/FontWeightModifier.swift
+++ b/Sources/LiveViewNative/Stylesheets/Modifiers/Text/FontWeightModifier.swift
@@ -25,7 +25,7 @@ import LiveViewNativeStylesheet
 /// ```
 @_documentation(visibility: public)
 @ParseableExpression
-struct _FontWeightModifier<R: RootRegistry>: TextModifier {
+struct _FontWeightModifier<Root: RootRegistry>: TextModifier {
     static var name: String { "fontWeight" }
 
     let weight: SwiftUI.Font.Weight?
@@ -38,7 +38,7 @@ struct _FontWeightModifier<R: RootRegistry>: TextModifier {
         content.fontWeight(weight)
     }
     
-    func apply(to text: SwiftUI.Text, on element: ElementNode) -> SwiftUI.Text {
+    func apply<R: RootRegistry>(to text: SwiftUI.Text, on element: ElementNode, in context: LiveContext<R>) -> SwiftUI.Text {
         text.fontWeight(weight)
     }
 }

--- a/Sources/LiveViewNative/Stylesheets/Modifiers/Text/FontWidthModifier.swift
+++ b/Sources/LiveViewNative/Stylesheets/Modifiers/Text/FontWidthModifier.swift
@@ -25,7 +25,7 @@ import LiveViewNativeStylesheet
 /// ```
 @_documentation(visibility: public)
 @ParseableExpression
-struct _FontWidthModifier<R: RootRegistry>: TextModifier {
+struct _FontWidthModifier<Root: RootRegistry>: TextModifier {
     static var name: String { "fontWidth" }
 
     let width: SwiftUI.Font.Width?
@@ -38,7 +38,7 @@ struct _FontWidthModifier<R: RootRegistry>: TextModifier {
         content.fontWidth(width)
     }
     
-    func apply(to text: SwiftUI.Text, on element: ElementNode) -> SwiftUI.Text {
+    func apply<R: RootRegistry>(to text: SwiftUI.Text, on element: ElementNode, in context: LiveContext<R>) -> SwiftUI.Text {
         text.fontWidth(width)
     }
 }

--- a/Sources/LiveViewNative/Stylesheets/Modifiers/Text/ForegroundStyleModifier.swift
+++ b/Sources/LiveViewNative/Stylesheets/Modifiers/Text/ForegroundStyleModifier.swift
@@ -54,7 +54,7 @@ import LiveViewNativeStylesheet
 /// ```
 @_documentation(visibility: public)
 @ParseableExpression
-struct _ForegroundStyleModifier<R: RootRegistry>: TextModifier {
+struct _ForegroundStyleModifier<Root: RootRegistry>: TextModifier {
     static var name: String { "foregroundStyle" }
 
     enum Value {
@@ -66,6 +66,7 @@ struct _ForegroundStyleModifier<R: RootRegistry>: TextModifier {
     let value: Value
     
     @ObservedElement private var element
+    @LiveContext<Root> private var context
     
     init(_ style: AnyShapeStyle.Resolvable) {
         self.value = ._0(style: style)
@@ -82,19 +83,19 @@ struct _ForegroundStyleModifier<R: RootRegistry>: TextModifier {
     func body(content: Content) -> some View {
         switch value {
         case let ._0(style):
-            content.foregroundStyle(style.resolve(on: element))
+            content.foregroundStyle(style.resolve(on: element, in: context))
         case let ._1(primary, secondary):
-            content.foregroundStyle(primary.resolve(on: element), secondary.resolve(on: element))
+            content.foregroundStyle(primary.resolve(on: element, in: context), secondary.resolve(on: element, in: context))
         case let ._2(primary, secondary, tertiary):
-            content.foregroundStyle(primary.resolve(on: element), secondary.resolve(on: element), tertiary.resolve(on: element))
+            content.foregroundStyle(primary.resolve(on: element, in: context), secondary.resolve(on: element, in: context), tertiary.resolve(on: element, in: context))
         }
     }
     
-    func apply(to text: SwiftUI.Text, on element: ElementNode) -> SwiftUI.Text {
+    func apply<R: RootRegistry>(to text: SwiftUI.Text, on element: ElementNode, in context: LiveContext<R>) -> SwiftUI.Text {
         if #available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *),
            case let ._0(style) = value
         {
-            return text.foregroundStyle(style.resolve(on: element))
+            return text.foregroundStyle(style.resolve(on: element, in: context))
         } else {
             return text
         }

--- a/Sources/LiveViewNative/Stylesheets/Modifiers/Text/ItalicModifier.swift
+++ b/Sources/LiveViewNative/Stylesheets/Modifiers/Text/ItalicModifier.swift
@@ -22,13 +22,13 @@ import LiveViewNativeStylesheet
 /// ```
 @_documentation(visibility: public)
 @ParseableExpression
-struct _ItalicModifier<R: RootRegistry>: TextModifier {
+struct _ItalicModifier<Root: RootRegistry>: TextModifier {
     static var name: String { "italic" }
     
     let isActive: AttributeReference<Bool>
 
     @ObservedElement private var element
-    @LiveContext<R> private var context
+    @LiveContext<Root> private var context
 
     init(_ isActive: AttributeReference<Bool> = .init(storage: .constant(true)) ) {
         self.isActive = isActive
@@ -38,7 +38,7 @@ struct _ItalicModifier<R: RootRegistry>: TextModifier {
         content.italic(isActive.resolve(on: element, in: context))
     }
     
-    func apply(to text: SwiftUI.Text, on element: ElementNode) -> SwiftUI.Text {
-        text.italic(isActive.resolve(on: element))
+    func apply<R: RootRegistry>(to text: SwiftUI.Text, on element: ElementNode, in context: LiveContext<R>) -> SwiftUI.Text {
+        text.italic(isActive.resolve(on: element, in: context))
     }
 }

--- a/Sources/LiveViewNative/Stylesheets/Modifiers/Text/KerningModifier.swift
+++ b/Sources/LiveViewNative/Stylesheets/Modifiers/Text/KerningModifier.swift
@@ -22,13 +22,13 @@ import LiveViewNativeStylesheet
 /// ```
 @_documentation(visibility: public)
 @ParseableExpression
-struct _KerningModifier<R: RootRegistry>: TextModifier {
+struct _KerningModifier<Root: RootRegistry>: TextModifier {
     static var name: String { "kerning" }
 
     let kerning: AttributeReference<CoreFoundation.CGFloat>
 
     @ObservedElement private var element
-    @LiveContext<R> private var context
+    @LiveContext<Root> private var context
     
     init(_ kerning: AttributeReference<CoreFoundation.CGFloat>) {
         self.kerning = kerning
@@ -39,7 +39,7 @@ struct _KerningModifier<R: RootRegistry>: TextModifier {
             .kerning(kerning.resolve(on: element, in: context))
     }
     
-    func apply(to text: SwiftUI.Text, on element: ElementNode) -> SwiftUI.Text {
-        text.kerning(kerning.resolve(on: element))
+    func apply<R: RootRegistry>(to text: SwiftUI.Text, on element: ElementNode, in context: LiveContext<R>) -> SwiftUI.Text {
+        text.kerning(kerning.resolve(on: element, in: context))
     }
 }

--- a/Sources/LiveViewNative/Stylesheets/Modifiers/Text/MonospacedDigitModifier.swift
+++ b/Sources/LiveViewNative/Stylesheets/Modifiers/Text/MonospacedDigitModifier.swift
@@ -23,7 +23,7 @@ import LiveViewNativeStylesheet
 /// ```
 @_documentation(visibility: public)
 @ParseableExpression
-struct _MonospacedDigitModifier<R: RootRegistry>: TextModifier {
+struct _MonospacedDigitModifier<Root: RootRegistry>: TextModifier {
     static var name: String { "monospacedDigit" }
 
     init() {}
@@ -32,7 +32,7 @@ struct _MonospacedDigitModifier<R: RootRegistry>: TextModifier {
         content.monospacedDigit()
     }
     
-    func apply(to text: SwiftUI.Text, on element: ElementNode) -> SwiftUI.Text {
+    func apply<R: RootRegistry>(to text: SwiftUI.Text, on element: ElementNode, in context: LiveContext<R>) -> SwiftUI.Text {
         text.monospacedDigit()
     }
 }

--- a/Sources/LiveViewNative/Stylesheets/Modifiers/Text/MonospacedModifier.swift
+++ b/Sources/LiveViewNative/Stylesheets/Modifiers/Text/MonospacedModifier.swift
@@ -22,13 +22,13 @@ import LiveViewNativeStylesheet
 /// ```
 @_documentation(visibility: public)
 @ParseableExpression
-struct _MonospacedModifier<R: RootRegistry>: TextModifier {
+struct _MonospacedModifier<Root: RootRegistry>: TextModifier {
     static var name: String { "monospaced" }
 
     let isActive: AttributeReference<Bool>
 
     @ObservedElement private var element
-    @LiveContext<R> private var context
+    @LiveContext<Root> private var context
 
     init(_ isActive: AttributeReference<Bool> = .init(storage: .constant(true))) {
         self.isActive = isActive
@@ -39,9 +39,9 @@ struct _MonospacedModifier<R: RootRegistry>: TextModifier {
         content.monospaced(isActive.resolve(on: element, in: context))
     }
     
-    func apply(to text: SwiftUI.Text, on element: ElementNode) -> SwiftUI.Text {
+    func apply<R: RootRegistry>(to text: SwiftUI.Text, on element: ElementNode, in context: LiveContext<R>) -> SwiftUI.Text {
         if #available(iOS 16.4, macOS 13.3, tvOS 16.4, watchOS 9.4, *) {
-            return text.monospaced(isActive.resolve(on: element))
+            return text.monospaced(isActive.resolve(on: element, in: context))
         } else {
             return text
         }

--- a/Sources/LiveViewNative/Stylesheets/Modifiers/Text/StrikethroughModifier.swift
+++ b/Sources/LiveViewNative/Stylesheets/Modifiers/Text/StrikethroughModifier.swift
@@ -24,7 +24,7 @@ import LiveViewNativeStylesheet
 /// ```
 @_documentation(visibility: public)
 @ParseableExpression
-struct _StrikethroughModifier<R: RootRegistry>: TextModifier {
+struct _StrikethroughModifier<Root: RootRegistry>: TextModifier {
     static var name: String { "strikethrough" }
 
     let isActive: AttributeReference<Bool>
@@ -32,7 +32,7 @@ struct _StrikethroughModifier<R: RootRegistry>: TextModifier {
     let color: Color.Resolvable?
 
     @ObservedElement private var element
-    @LiveContext<R> private var context
+    @LiveContext<Root> private var context
     
     init(
         _ isActive: AttributeReference<Bool> = .init(storage: .constant(true)),
@@ -53,12 +53,12 @@ struct _StrikethroughModifier<R: RootRegistry>: TextModifier {
             )
     }
     
-    func apply(to text: SwiftUI.Text, on element: ElementNode) -> SwiftUI.Text {
+    func apply<R: RootRegistry>(to text: SwiftUI.Text, on element: ElementNode, in context: LiveContext<R>) -> SwiftUI.Text {
         text
             .strikethrough(
-                isActive.resolve(on: element),
+                isActive.resolve(on: element, in: context),
                 pattern: pattern,
-                color: color?.resolve(on: element)
+                color: color?.resolve(on: element, in: context)
             )
     }
 }

--- a/Sources/LiveViewNative/Stylesheets/Modifiers/Text/TextModifier.swift
+++ b/Sources/LiveViewNative/Stylesheets/Modifiers/Text/TextModifier.swift
@@ -10,26 +10,26 @@ import LiveViewNativeStylesheet
 
 /// A `ViewModifier` that can be applied directly to `Text`.
 protocol TextModifier: ViewModifier {
-    func apply(to text: SwiftUI.Text, on element: ElementNode) -> SwiftUI.Text
+    func apply<R: RootRegistry>(to text: SwiftUI.Text, on element: ElementNode, in context: LiveContext<R>) -> SwiftUI.Text
 }
 
 /// A type-erased `TextModifier`, which can be applied to a `View` or directly on `Text`.
-enum _AnyTextModifier<R: RootRegistry>: ViewModifier, TextModifier, ParseableModifierValue {
-    case font(_FontModifier<R>)
-    case fontWeight(_FontWeightModifier<R>)
-    case fontDesign(_FontDesignModifier<R>)
-    case fontWidth(_FontWidthModifier<R>)
-    case foregroundStyle(_ForegroundStyleModifier<R>)
-    case bold(_BoldModifier<R>)
-    case italic(_ItalicModifier<R>)
-    case strikethrough(_StrikethroughModifier<R>)
-    case underline(_UnderlineModifier<R>)
-    case monospaced(_MonospacedModifier<R>)
-    case monospacedDigit(_MonospacedDigitModifier<R>)
-    case kerning(_KerningModifier<R>)
-    case tracking(_TrackingModifier<R>)
-    case baselineOffset(_BaselineOffsetModifier<R>)
-    case textScale(_TextScaleModifier<R>)
+enum _AnyTextModifier<Root: RootRegistry>: ViewModifier, TextModifier, ParseableModifierValue {
+    case font(_FontModifier<Root>)
+    case fontWeight(_FontWeightModifier<Root>)
+    case fontDesign(_FontDesignModifier<Root>)
+    case fontWidth(_FontWidthModifier<Root>)
+    case foregroundStyle(_ForegroundStyleModifier<Root>)
+    case bold(_BoldModifier<Root>)
+    case italic(_ItalicModifier<Root>)
+    case strikethrough(_StrikethroughModifier<Root>)
+    case underline(_UnderlineModifier<Root>)
+    case monospaced(_MonospacedModifier<Root>)
+    case monospacedDigit(_MonospacedDigitModifier<Root>)
+    case kerning(_KerningModifier<Root>)
+    case tracking(_TrackingModifier<Root>)
+    case baselineOffset(_BaselineOffsetModifier<Root>)
+    case textScale(_TextScaleModifier<Root>)
     
     func body(content: Content) -> some View {
         switch self {
@@ -66,58 +66,58 @@ enum _AnyTextModifier<R: RootRegistry>: ViewModifier, TextModifier, ParseableMod
         }
     }
     
-    func apply(to text: SwiftUI.Text, on element: ElementNode) -> SwiftUI.Text {
+    func apply<R: RootRegistry>(to text: SwiftUI.Text, on element: ElementNode, in context: LiveContext<R>) -> SwiftUI.Text {
         switch self {
         case let .font(modifier):
-            return modifier.apply(to: text, on: element)
+            return modifier.apply(to: text, on: element, in: context)
         case let .fontWeight(modifier):
-            return modifier.apply(to: text, on: element)
+            return modifier.apply(to: text, on: element, in: context)
         case let .fontDesign(modifier):
-            return modifier.apply(to: text, on: element)
+            return modifier.apply(to: text, on: element, in: context)
         case let .fontWidth(modifier):
-            return modifier.apply(to: text, on: element)
+            return modifier.apply(to: text, on: element, in: context)
         case let .foregroundStyle(modifier):
-            return modifier.apply(to: text, on: element)
+            return modifier.apply(to: text, on: element, in: context)
         case let .bold(modifier):
-            return modifier.apply(to: text, on: element)
+            return modifier.apply(to: text, on: element, in: context)
         case let .italic(modifier):
-            return modifier.apply(to: text, on: element)
+            return modifier.apply(to: text, on: element, in: context)
         case let .strikethrough(modifier):
-            return modifier.apply(to: text, on: element)
+            return modifier.apply(to: text, on: element, in: context)
         case let .underline(modifier):
-            return modifier.apply(to: text, on: element)
+            return modifier.apply(to: text, on: element, in: context)
         case let .monospaced(modifier):
-            return modifier.apply(to: text, on: element)
+            return modifier.apply(to: text, on: element, in: context)
         case let .monospacedDigit(modifier):
-            return modifier.apply(to: text, on: element)
+            return modifier.apply(to: text, on: element, in: context)
         case let .kerning(modifier):
-            return modifier.apply(to: text, on: element)
+            return modifier.apply(to: text, on: element, in: context)
         case let .tracking(modifier):
-            return modifier.apply(to: text, on: element)
+            return modifier.apply(to: text, on: element, in: context)
         case let .baselineOffset(modifier):
-            return modifier.apply(to: text, on: element)
+            return modifier.apply(to: text, on: element, in: context)
         case let .textScale(modifier):
-            return modifier.apply(to: text, on: element)
+            return modifier.apply(to: text, on: element, in: context)
         }
     }
     
     static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         OneOf {
-            _FontModifier<R>.parser(in: context).map(Self.font)
-            _FontWeightModifier<R>.parser(in: context).map(Self.fontWeight)
-            _FontDesignModifier<R>.parser(in: context).map(Self.fontDesign)
-            _FontWidthModifier<R>.parser(in: context).map(Self.fontWidth)
-            _ForegroundStyleModifier<R>.parser(in: context).map(Self.foregroundStyle)
-            _BoldModifier<R>.parser(in: context).map(Self.bold)
-            _ItalicModifier<R>.parser(in: context).map(Self.italic)
-            _StrikethroughModifier<R>.parser(in: context).map(Self.strikethrough)
-            _UnderlineModifier<R>.parser(in: context).map(Self.underline)
-            _MonospacedModifier<R>.parser(in: context).map(Self.monospaced)
-            _MonospacedDigitModifier<R>.parser(in: context).map(Self.monospacedDigit)
-            _KerningModifier<R>.parser(in: context).map(Self.kerning)
-            _TrackingModifier<R>.parser(in: context).map(Self.tracking)
-            _BaselineOffsetModifier<R>.parser(in: context).map(Self.baselineOffset)
-            _TextScaleModifier<R>.parser(in: context).map(Self.textScale)
+            _FontModifier<Root>.parser(in: context).map(Self.font)
+            _FontWeightModifier<Root>.parser(in: context).map(Self.fontWeight)
+            _FontDesignModifier<Root>.parser(in: context).map(Self.fontDesign)
+            _FontWidthModifier<Root>.parser(in: context).map(Self.fontWidth)
+            _ForegroundStyleModifier<Root>.parser(in: context).map(Self.foregroundStyle)
+            _BoldModifier<Root>.parser(in: context).map(Self.bold)
+            _ItalicModifier<Root>.parser(in: context).map(Self.italic)
+            _StrikethroughModifier<Root>.parser(in: context).map(Self.strikethrough)
+            _UnderlineModifier<Root>.parser(in: context).map(Self.underline)
+            _MonospacedModifier<Root>.parser(in: context).map(Self.monospaced)
+            _MonospacedDigitModifier<Root>.parser(in: context).map(Self.monospacedDigit)
+            _KerningModifier<Root>.parser(in: context).map(Self.kerning)
+            _TrackingModifier<Root>.parser(in: context).map(Self.tracking)
+            _BaselineOffsetModifier<Root>.parser(in: context).map(Self.baselineOffset)
+            _TextScaleModifier<Root>.parser(in: context).map(Self.textScale)
         }
     }
 }

--- a/Sources/LiveViewNative/Stylesheets/Modifiers/Text/TextScaleModifier.swift
+++ b/Sources/LiveViewNative/Stylesheets/Modifiers/Text/TextScaleModifier.swift
@@ -23,14 +23,14 @@ import LiveViewNativeStylesheet
 /// ```
 @_documentation(visibility: public)
 @ParseableExpression
-struct _TextScaleModifier<R: RootRegistry>: TextModifier {
+struct _TextScaleModifier<Root: RootRegistry>: TextModifier {
     static var name: String { "textScale" }
 
     let scale: Any
     let isEnabled: AttributeReference<Bool>
 
     @ObservedElement private var element
-    @LiveContext<R> private var context
+    @LiveContext<Root> private var context
 
     @available(tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0, visionOS 1, *)
     init(_ scale: SwiftUI.Text.Scale, isEnabled: AttributeReference<Bool> = .init(storage: .constant(true))) {
@@ -47,10 +47,10 @@ struct _TextScaleModifier<R: RootRegistry>: TextModifier {
         }
     }
     
-    func apply(to text: SwiftUI.Text, on element: ElementNode) -> SwiftUI.Text {
+    func apply<R: RootRegistry>(to text: SwiftUI.Text, on element: ElementNode, in context: LiveContext<R>) -> SwiftUI.Text {
         if #available(tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0, visionOS 1, *) {
             return text
-                .textScale(scale as! SwiftUI.Text.Scale, isEnabled: isEnabled.resolve(on: element))
+                .textScale(scale as! SwiftUI.Text.Scale, isEnabled: isEnabled.resolve(on: element, in: context))
         } else {
             return text
         }

--- a/Sources/LiveViewNative/Stylesheets/Modifiers/Text/TrackingModifier.swift
+++ b/Sources/LiveViewNative/Stylesheets/Modifiers/Text/TrackingModifier.swift
@@ -22,13 +22,13 @@ import LiveViewNativeStylesheet
 /// ```
 @_documentation(visibility: public)
 @ParseableExpression
-struct _TrackingModifier<R: RootRegistry>: TextModifier {
+struct _TrackingModifier<Root: RootRegistry>: TextModifier {
     static var name: String { "tracking" }
 
     let tracking: AttributeReference<CoreFoundation.CGFloat>
 
     @ObservedElement private var element
-    @LiveContext<R> private var context
+    @LiveContext<Root> private var context
     
     init(_ tracking: AttributeReference<CoreFoundation.CGFloat>) {
         self.tracking = tracking
@@ -39,8 +39,8 @@ struct _TrackingModifier<R: RootRegistry>: TextModifier {
             .tracking(tracking.resolve(on: element, in: context))
     }
     
-    func apply(to text: SwiftUI.Text, on element: ElementNode) -> SwiftUI.Text {
+    func apply<R: RootRegistry>(to text: SwiftUI.Text, on element: ElementNode, in context: LiveContext<R>) -> SwiftUI.Text {
         text
-            .tracking(tracking.resolve(on: element))
+            .tracking(tracking.resolve(on: element, in: context))
     }
 }

--- a/Sources/LiveViewNative/Stylesheets/Modifiers/Text/UnderlineModifier.swift
+++ b/Sources/LiveViewNative/Stylesheets/Modifiers/Text/UnderlineModifier.swift
@@ -24,7 +24,7 @@ import LiveViewNativeStylesheet
 /// ```
 @_documentation(visibility: public)
 @ParseableExpression
-struct _UnderlineModifier<R: RootRegistry>: ViewModifier {
+struct _UnderlineModifier<Root: RootRegistry>: ViewModifier {
     static var name: String { "underline" }
 
     let isActive: AttributeReference<Bool>
@@ -32,7 +32,7 @@ struct _UnderlineModifier<R: RootRegistry>: ViewModifier {
     let color: Color.Resolvable?
 
     @ObservedElement private var element
-    @LiveContext<R> private var context
+    @LiveContext<Root> private var context
     
     init(
         _ isActive: AttributeReference<Bool> = .init(storage: .constant(true)),
@@ -53,12 +53,12 @@ struct _UnderlineModifier<R: RootRegistry>: ViewModifier {
             )
     }
     
-    func apply(to text: SwiftUI.Text, on element: ElementNode) -> SwiftUI.Text {
+    func apply<R: RootRegistry>(to text: SwiftUI.Text, on element: ElementNode, in context: LiveContext<R>) -> SwiftUI.Text {
         text
             .underline(
-                isActive.resolve(on: element),
+                isActive.resolve(on: element, in: context),
                 pattern: pattern,
-                color: color?.resolve(on: element)
+                color: color?.resolve(on: element, in: context)
             )
     }
 }

--- a/Sources/LiveViewNative/Stylesheets/ParseableTypes/AnyGesture+ParseableModifierValue.swift
+++ b/Sources/LiveViewNative/Stylesheets/ParseableTypes/AnyGesture+ParseableModifierValue.swift
@@ -236,28 +236,6 @@ struct _AnyGesture: ParseableModifierValue {
                                     "height": drag.velocity.height
                                 ]
                             ]
-                        } else if #available(iOS 17, macOS 14, *),
-                                  let magnify = value as? MagnifyGesture.Value
-                        {
-                            eventValue = [
-                                "magnification": magnify.magnification,
-                                "startLocation": [
-                                    "x": magnify.startLocation.x,
-                                    "y": magnify.startLocation.y
-                                ],
-                                "velocity": magnify.velocity
-                            ]
-                        } else if #available(iOS 17, macOS 14, *),
-                                  let rotate = value as? RotateGesture.Value
-                        {
-                            eventValue = [
-                                "rotation": rotate.rotation.radians,
-                                "startLocation": [
-                                    "x": rotate.startLocation.x,
-                                    "y": rotate.startLocation.y
-                                ],
-                                "velocity": rotate.velocity
-                            ]
                         } else if let spatialTap = value as? SpatialTapGesture.Value {
                             eventValue = [
                                 "location": [
@@ -267,6 +245,31 @@ struct _AnyGesture: ParseableModifierValue {
                             ]
                         } else {
                             eventValue = [:]
+                            #if os(iOS) || os(macOS) || os(visionOS)
+                            if #available(iOS 17, macOS 14, *),
+                                      let magnify = value as? MagnifyGesture.Value
+                            {
+                                eventValue = [
+                                    "magnification": magnify.magnification,
+                                    "startLocation": [
+                                        "x": magnify.startLocation.x,
+                                        "y": magnify.startLocation.y
+                                    ],
+                                    "velocity": magnify.velocity
+                                ]
+                            } else if #available(iOS 17, macOS 14, *),
+                                      let rotate = value as? RotateGesture.Value
+                            {
+                                eventValue = [
+                                    "rotation": rotate.rotation.radians,
+                                    "startLocation": [
+                                        "x": rotate.startLocation.x,
+                                        "y": rotate.startLocation.y
+                                    ],
+                                    "velocity": rotate.velocity
+                                ]
+                            }
+                            #endif
                         }
                         eventValue.merge(element.buildPhxValuePayload(), uniquingKeysWith: { $1 })
                         try await onEnded.action(value: eventValue, in: context)

--- a/Sources/LiveViewNative/Stylesheets/ParseableTypes/AnyGesture+ParseableModifierValue.swift
+++ b/Sources/LiveViewNative/Stylesheets/ParseableTypes/AnyGesture+ParseableModifierValue.swift
@@ -207,67 +207,68 @@ struct _AnyGesture: ParseableModifierValue {
                 return AnyGesture<Any>(gesture.simultaneously(with: simultaneously.other.resolve(on: element, in: context)).map({ $0 as Any }))
             case .onEnded(let onEnded):
                 return AnyGesture<Any>(gesture.onEnded({ value in
-                    let eventValue: [String:Any]
-                    if let drag = value as? DragGesture.Value {
-                        eventValue = [
-                            "translation": [
-                                "width": drag.translation.width,
-                                "height": drag.translation.height
-                            ],
-                            "startLocation": [
-                                "x": drag.startLocation.x,
-                                "y": drag.startLocation.y
-                            ],
-                            "location": [
-                                "x": drag.location.x,
-                                "y": drag.location.y
-                            ],
-                            "predictedEndLocation": [
-                                "x": drag.predictedEndLocation.x,
-                                "y": drag.predictedEndLocation.y
-                            ],
-                            "predictedEndTranslation": [
-                                "width": drag.predictedEndTranslation.width,
-                                "height": drag.predictedEndTranslation.height
-                            ],
-                            "velocity": [
-                                "width": drag.velocity.width,
-                                "height": drag.velocity.height
-                            ]
-                        ]
-                    } else if #available(iOS 17, macOS 14, *),
-                              let magnify = value as? MagnifyGesture.Value
-                    {
-                        eventValue = [
-                            "magnification": magnify.magnification,
-                            "startLocation": [
-                                "x": magnify.startLocation.x,
-                                "y": magnify.startLocation.y
-                            ],
-                            "velocity": magnify.velocity
-                        ]
-                    } else if #available(iOS 17, macOS 14, *),
-                              let rotate = value as? RotateGesture.Value
-                    {
-                        eventValue = [
-                            "rotation": rotate.rotation.radians,
-                            "startLocation": [
-                                "x": rotate.startLocation.x,
-                                "y": rotate.startLocation.y
-                            ],
-                            "velocity": rotate.velocity
-                        ]
-                    } else if let spatialTap = value as? SpatialTapGesture.Value {
-                        eventValue = [
-                            "location": [
-                                "x": spatialTap.location.x,
-                                "y": spatialTap.location.y
-                            ]
-                        ]
-                    } else {
-                        eventValue = [:]
-                    }
                     Task {
+                        var eventValue: [String:Any]
+                        if let drag = value as? DragGesture.Value {
+                            eventValue = [
+                                "translation": [
+                                    "width": drag.translation.width,
+                                    "height": drag.translation.height
+                                ],
+                                "startLocation": [
+                                    "x": drag.startLocation.x,
+                                    "y": drag.startLocation.y
+                                ],
+                                "location": [
+                                    "x": drag.location.x,
+                                    "y": drag.location.y
+                                ],
+                                "predictedEndLocation": [
+                                    "x": drag.predictedEndLocation.x,
+                                    "y": drag.predictedEndLocation.y
+                                ],
+                                "predictedEndTranslation": [
+                                    "width": drag.predictedEndTranslation.width,
+                                    "height": drag.predictedEndTranslation.height
+                                ],
+                                "velocity": [
+                                    "width": drag.velocity.width,
+                                    "height": drag.velocity.height
+                                ]
+                            ]
+                        } else if #available(iOS 17, macOS 14, *),
+                                  let magnify = value as? MagnifyGesture.Value
+                        {
+                            eventValue = [
+                                "magnification": magnify.magnification,
+                                "startLocation": [
+                                    "x": magnify.startLocation.x,
+                                    "y": magnify.startLocation.y
+                                ],
+                                "velocity": magnify.velocity
+                            ]
+                        } else if #available(iOS 17, macOS 14, *),
+                                  let rotate = value as? RotateGesture.Value
+                        {
+                            eventValue = [
+                                "rotation": rotate.rotation.radians,
+                                "startLocation": [
+                                    "x": rotate.startLocation.x,
+                                    "y": rotate.startLocation.y
+                                ],
+                                "velocity": rotate.velocity
+                            ]
+                        } else if let spatialTap = value as? SpatialTapGesture.Value {
+                            eventValue = [
+                                "location": [
+                                    "x": spatialTap.location.x,
+                                    "y": spatialTap.location.y
+                                ]
+                            ]
+                        } else {
+                            eventValue = [:]
+                        }
+                        eventValue.merge(element.buildPhxValuePayload(), uniquingKeysWith: { $1 })
                         try await onEnded.action(value: eventValue, in: context)
                     }
                 }).map({ $0 as Any }))

--- a/Sources/LiveViewNative/Stylesheets/ParseableTypes/AnyGesture+ParseableModifierValue.swift
+++ b/Sources/LiveViewNative/Stylesheets/ParseableTypes/AnyGesture+ParseableModifierValue.swift
@@ -106,17 +106,24 @@ import LiveViewNativeStylesheet
 /// def handle_event("tapped", gesture_value, socket), do: ...
 /// ```
 @_documentation(visibility: public)
-extension AnyGesture: ParseableModifierValue where Value == Any {
-    public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
+struct _AnyGesture: ParseableModifierValue {
+    let gesture: AnyGesture<Any>
+    let members: [Member]
+    
+    func resolve<R: RootRegistry>(on element: ElementNode, in context: LiveContext<R>) -> AnyGesture<Any> {
+        members.reduce(gesture) { gesture, member in
+            member.apply(to: gesture, on: element, in: context)
+        }
+    }
+    
+    static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ChainedMemberExpression {
             baseParser(in: context)
         } member: {
             Member.parser(in: context)
         }
         .map { (base, members) in
-            return members.reduce(into: base) { result, member in
-                result = member.apply(to: result)
-            }
+            self.init(gesture: base, members: members)
         }
     }
     
@@ -125,14 +132,15 @@ extension AnyGesture: ParseableModifierValue where Value == Any {
         case simultaneously(Simultaneously)
         case onEnded(OnEnded)
         case exclusively(Exclusively)
+        case updating(Updating)
         
         @ParseableExpression
         struct Sequenced {
             static let name = "sequenced"
             
-            let other: AnyGesture<Any>
+            let other: _AnyGesture
             
-            init(before other: AnyGesture<Any>) {
+            init(before other: _AnyGesture) {
                 self.other = other
             }
         }
@@ -141,9 +149,9 @@ extension AnyGesture: ParseableModifierValue where Value == Any {
         struct Simultaneously {
             static let name = "simultaneously"
             
-            let other: AnyGesture<Any>
+            let other: _AnyGesture
             
-            init(with other: AnyGesture<Any>) {
+            init(with other: _AnyGesture) {
                 self.other = other
             }
         }
@@ -163,10 +171,21 @@ extension AnyGesture: ParseableModifierValue where Value == Any {
         struct Exclusively {
             static let name = "exclusively"
             
-            let other: AnyGesture<Any>
+            let other: _AnyGesture
             
-            init(before other: AnyGesture<Any>) {
+            init(before other: _AnyGesture) {
                 self.other = other
+            }
+        }
+        
+        @ParseableExpression
+        struct Updating {
+            static let name = "updating"
+            
+            let name: String
+            
+            init(_ name: String) {
+                self.name = name
             }
         }
         
@@ -176,15 +195,16 @@ extension AnyGesture: ParseableModifierValue where Value == Any {
                 Simultaneously.parser(in: context).map(Self.simultaneously)
                 OnEnded.parser(in: context).map(Self.onEnded)
                 Exclusively.parser(in: context).map(Self.exclusively)
+                Updating.parser(in: context).map(Self.updating)
             }
         }
         
-        func apply(to gesture: AnyGesture<Any>) -> AnyGesture<Any> {
+        func apply<R: RootRegistry>(to gesture: AnyGesture<Any>, on element: ElementNode, in context: LiveContext<R>) -> AnyGesture<Any> {
             switch self {
             case .sequenced(let sequenced):
-                return AnyGesture<Any>(gesture.sequenced(before: sequenced.other).map({ $0 as Any }))
+                return AnyGesture<Any>(gesture.sequenced(before: sequenced.other.resolve(on: element, in: context)).map({ $0 as Any }))
             case .simultaneously(let simultaneously):
-                return AnyGesture<Any>(gesture.simultaneously(with: simultaneously.other).map({ $0 as Any }))
+                return AnyGesture<Any>(gesture.simultaneously(with: simultaneously.other.resolve(on: element, in: context)).map({ $0 as Any }))
             case .onEnded(let onEnded):
                 return AnyGesture<Any>(gesture.onEnded({ value in
                     Task {
@@ -192,25 +212,31 @@ extension AnyGesture: ParseableModifierValue where Value == Any {
                     }
                 }).map({ $0 as Any }))
             case .exclusively(let exclusively):
-                return AnyGesture<Any>(gesture.exclusively(before: exclusively.other).map({ $0 as Any }))
+                return AnyGesture<Any>(gesture.exclusively(before: exclusively.other.resolve(on: element, in: context)).map({ $0 as Any }))
+            case .updating(let updating):
+                return AnyGesture<Any>(
+                    gesture.updating(context.gestureState, body: { value, state, transaction in
+                        state[updating.name] = value
+                    })
+                )
             }
         }
     }
     
-    static func baseParser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
+    static func baseParser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, AnyGesture<Any>> {
         OneOf {
             #if !os(tvOS)
-            Drag.parser(in: context).map({ Self.init($0.value.map({ $0 as Any })) })
+            Drag.parser(in: context).map({ AnyGesture<Any>($0.value.map({ $0 as Any })) })
             #endif
-            LongPress.parser(in: context).map({ Self.init($0.value.map({ $0 as Any })) })
+            LongPress.parser(in: context).map({ AnyGesture<Any>($0.value.map({ $0 as Any })) })
             #if os(iOS) || os(macOS)
-            Magnify.parser(in: context).map({ Self.init($0.value.map({ $0 as Any })) })
-            Rotate.parser(in: context).map({ Self.init($0.value.map({ $0 as Any })) })
+            Magnify.parser(in: context).map({ AnyGesture<Any>($0.value.map({ $0 as Any })) })
+            Rotate.parser(in: context).map({ AnyGesture<Any>($0.value.map({ $0 as Any })) })
             #endif
             #if !os(tvOS)
-            SpatialTap.parser(in: context).map({ Self.init($0.value.map({ $0 as Any })) })
+            SpatialTap.parser(in: context).map({ AnyGesture<Any>($0.value.map({ $0 as Any })) })
             #endif
-            Tap.parser(in: context).map({ Self.init($0.value.map({ $0 as Any })) })
+            Tap.parser(in: context).map({ AnyGesture<Any>($0.value.map({ $0 as Any })) })
         }
     }
     
@@ -295,3 +321,13 @@ extension AnyGesture: ParseableModifierValue where Value == Any {
     }
 }
 
+extension EnvironmentValues {
+    private enum GestureStateKey: EnvironmentKey {
+        static let defaultValue: GestureState<[String:Any]> = .init(initialValue: [:])
+    }
+    
+    var gestureState: GestureState<[String:Any]> {
+        get { self[GestureStateKey.self] }
+        set { self[GestureStateKey.self] = newValue }
+    }
+}

--- a/Sources/LiveViewNative/Stylesheets/ParseableTypes/ShapeStyles/AnyShapeStyle+ParseableModifierValue.swift
+++ b/Sources/LiveViewNative/Stylesheets/ParseableTypes/ShapeStyles/AnyShapeStyle+ParseableModifierValue.swift
@@ -163,36 +163,32 @@ public extension AnyShapeStyle {
         let storage: Storage
         let modifiers: [StyleModifier]
         
-        public func resolve(on element: ElementNode) -> AnyShapeStyle {
+        public func resolve<R: RootRegistry>(on element: ElementNode, in context: LiveContext<R>) -> AnyShapeStyle {
             let base: any ShapeStyle = switch storage {
             case .value(let value):
                 value
             case .color(let color):
-                color.resolve(on: element)
+                color.resolve(on: element, in: context)
             case let .gradient(gradient):
-                gradient.resolve(on: element)
+                gradient.resolve(on: element, in: context)
             case let .anyGradient(gradient):
-                gradient.resolve(on: element)
+                gradient.resolve(on: element, in: context)
             case let .angularGradient(gradient):
-                gradient.resolve(on: element)
+                gradient.resolve(on: element, in: context)
             case let .conicGradient(gradient):
-                gradient.resolve(on: element)
+                gradient.resolve(on: element, in: context)
             case let .ellipticalGradient(gradient):
-                gradient.resolve(on: element)
+                gradient.resolve(on: element, in: context)
             case let .linearGradient(gradient):
-                gradient.resolve(on: element)
+                gradient.resolve(on: element, in: context)
             case let .radialGradient(gradient):
-                gradient.resolve(on: element)
+                gradient.resolve(on: element, in: context)
             case let .modifier(modifier):
-                modifier.resolve(on: element)
+                modifier.resolve(on: element, in: context)
             }
             return modifiers.reduce(AnyShapeStyle(base)) {
-                AnyShapeStyle($1.apply(to: $0, on: element))
+                AnyShapeStyle($1.apply(to: $0, on: element, in: context))
             }
-        }
-        
-        public func resolve<R: RootRegistry>(on element: ElementNode, in context: LiveContext<R>) -> AnyShapeStyle {
-            resolve(on: element)
         }
         
         public init(_ constant: AnyShapeStyle) {
@@ -336,16 +332,16 @@ public extension AnyShapeStyle {
                 self = .stops(stops: stops, center: center, startAngle: startAngle, endAngle: endAngle)
             }
             
-            func resolve(on element: ElementNode) -> any ShapeStyle {
+            func resolve<R: RootRegistry>(on element: ElementNode, in context: LiveContext<R>) -> any ShapeStyle {
                 switch self {
                 case .anyGradient(let gradient, let center, let startAngle, let endAngle):
-                    AngularGradient.angularGradient(gradient.resolve(on: element), center: center.resolve(on: element), startAngle: startAngle.resolve(on: element), endAngle: endAngle.resolve(on: element))
+                    AngularGradient.angularGradient(gradient.resolve(on: element, in: context), center: center.resolve(on: element, in: context), startAngle: startAngle.resolve(on: element, in: context), endAngle: endAngle.resolve(on: element, in: context))
                 case .gradient(let gradient, let center, let startAngle, let endAngle):
-                    AngularGradient.angularGradient(gradient.resolve(on: element), center: center.resolve(on: element), startAngle: startAngle.resolve(on: element), endAngle: endAngle.resolve(on: element))
+                    AngularGradient.angularGradient(gradient.resolve(on: element, in: context), center: center.resolve(on: element, in: context), startAngle: startAngle.resolve(on: element, in: context), endAngle: endAngle.resolve(on: element, in: context))
                 case .colors(let colors, let center, let startAngle, let endAngle):
-                    AngularGradient.angularGradient(colors: colors.map({ $0.resolve(on: element) }), center: center.resolve(on: element), startAngle: startAngle.resolve(on: element), endAngle: endAngle.resolve(on: element))
+                    AngularGradient.angularGradient(colors: colors.map({ $0.resolve(on: element, in: context) }), center: center.resolve(on: element, in: context), startAngle: startAngle.resolve(on: element, in: context), endAngle: endAngle.resolve(on: element, in: context))
                 case .stops(let stops, let center, let startAngle, let endAngle):
-                    AngularGradient.angularGradient(stops: stops.map({ $0.resolve(on: element) }), center: center.resolve(on: element), startAngle: startAngle.resolve(on: element), endAngle: endAngle.resolve(on: element))
+                    AngularGradient.angularGradient(stops: stops.map({ $0.resolve(on: element, in: context) }), center: center.resolve(on: element, in: context), startAngle: startAngle.resolve(on: element, in: context), endAngle: endAngle.resolve(on: element, in: context))
                 }
             }
         }
@@ -375,16 +371,16 @@ public extension AnyShapeStyle {
                 self = .stops(stops: stops, center: center, angle: angle)
             }
             
-            func resolve(on element: ElementNode) -> any ShapeStyle {
+            func resolve(on element: ElementNode, in context: LiveContext<some RootRegistry>) -> any ShapeStyle {
                 switch self {
                 case .anyGradient(let gradient, let center, let angle):
-                    AngularGradient.conicGradient(gradient.resolve(on: element), center: center.resolve(on: element), angle: angle.resolve(on: element))
+                    AngularGradient.conicGradient(gradient.resolve(on: element, in: context), center: center.resolve(on: element, in: context), angle: angle.resolve(on: element, in: context))
                 case .gradient(let gradient, let center, let angle):
-                    AngularGradient.conicGradient(gradient.resolve(on: element), center: center.resolve(on: element), angle: angle.resolve(on: element))
+                    AngularGradient.conicGradient(gradient.resolve(on: element, in: context), center: center.resolve(on: element, in: context), angle: angle.resolve(on: element, in: context))
                 case .colors(let colors, let center, let angle):
-                    AngularGradient.conicGradient(colors: colors.map({ $0.resolve(on: element) }), center: center.resolve(on: element), angle: angle.resolve(on: element))
+                    AngularGradient.conicGradient(colors: colors.map({ $0.resolve(on: element, in: context) }), center: center.resolve(on: element, in: context), angle: angle.resolve(on: element, in: context))
                 case .stops(let stops, let center, let angle):
-                    AngularGradient.conicGradient(stops: stops.map({ $0.resolve(on: element) }), center: center.resolve(on: element), angle: angle.resolve(on: element))
+                    AngularGradient.conicGradient(stops: stops.map({ $0.resolve(on: element, in: context) }), center: center.resolve(on: element, in: context), angle: angle.resolve(on: element, in: context))
                 }
             }
         }
@@ -414,16 +410,16 @@ public extension AnyShapeStyle {
                 self = .anyGradient(gradient: gradient, center: center, startRadiusFraction: startRadiusFraction, endRadiusFraction: endRadiusFraction)
             }
             
-            func resolve(on element: ElementNode) -> any ShapeStyle {
+            func resolve(on element: ElementNode, in context: LiveContext<some RootRegistry>) -> any ShapeStyle {
                 switch self {
                 case .gradient(let gradient, let center, let startRadiusFraction, let endRadiusFraction):
-                    EllipticalGradient.ellipticalGradient(gradient.resolve(on: element), center: center.resolve(on: element), startRadiusFraction: startRadiusFraction.resolve(on: element), endRadiusFraction: endRadiusFraction.resolve(on: element))
+                    EllipticalGradient.ellipticalGradient(gradient.resolve(on: element, in: context), center: center.resolve(on: element, in: context), startRadiusFraction: startRadiusFraction.resolve(on: element, in: context), endRadiusFraction: endRadiusFraction.resolve(on: element, in: context))
                 case .colors(let colors, let center, let startRadiusFraction, let endRadiusFraction):
-                    EllipticalGradient.ellipticalGradient(colors: colors.map({ $0.resolve(on: element) }), center: center.resolve(on: element), startRadiusFraction: startRadiusFraction.resolve(on: element), endRadiusFraction: endRadiusFraction.resolve(on: element))
+                    EllipticalGradient.ellipticalGradient(colors: colors.map({ $0.resolve(on: element, in: context) }), center: center.resolve(on: element, in: context), startRadiusFraction: startRadiusFraction.resolve(on: element, in: context), endRadiusFraction: endRadiusFraction.resolve(on: element, in: context))
                 case .stops(let stops, let center, let startRadiusFraction, let endRadiusFraction):
-                    EllipticalGradient.ellipticalGradient(stops: stops.map({ $0.resolve(on: element) }), center: center.resolve(on: element), startRadiusFraction: startRadiusFraction.resolve(on: element), endRadiusFraction: endRadiusFraction.resolve(on: element))
+                    EllipticalGradient.ellipticalGradient(stops: stops.map({ $0.resolve(on: element, in: context) }), center: center.resolve(on: element, in: context), startRadiusFraction: startRadiusFraction.resolve(on: element, in: context), endRadiusFraction: endRadiusFraction.resolve(on: element, in: context))
                 case .anyGradient(let gradient, let center, let startRadiusFraction, let endRadiusFraction):
-                    EllipticalGradient.ellipticalGradient(gradient.resolve(on: element), center: center.resolve(on: element), startRadiusFraction: startRadiusFraction.resolve(on: element), endRadiusFraction: endRadiusFraction.resolve(on: element))
+                    EllipticalGradient.ellipticalGradient(gradient.resolve(on: element, in: context), center: center.resolve(on: element, in: context), startRadiusFraction: startRadiusFraction.resolve(on: element, in: context), endRadiusFraction: endRadiusFraction.resolve(on: element, in: context))
                 }
             }
         }
@@ -453,16 +449,16 @@ public extension AnyShapeStyle {
                 self = .anyGradient(gradient: gradient, startPoint: startPoint, endPoint: endPoint)
             }
             
-            func resolve(on element: ElementNode) -> any ShapeStyle {
+            func resolve(on element: ElementNode, in context: LiveContext<some RootRegistry>) -> any ShapeStyle {
                 switch self {
                 case .gradient(let gradient, let startPoint, let endPoint):
-                    LinearGradient.linearGradient(gradient.resolve(on: element), startPoint: startPoint.resolve(on: element), endPoint: endPoint.resolve(on: element))
+                    LinearGradient.linearGradient(gradient.resolve(on: element, in: context), startPoint: startPoint.resolve(on: element, in: context), endPoint: endPoint.resolve(on: element, in: context))
                 case .colors(let colors, let startPoint, let endPoint):
-                    LinearGradient.linearGradient(colors: colors.map({ $0.resolve(on: element) }), startPoint: startPoint.resolve(on: element), endPoint: endPoint.resolve(on: element))
+                    LinearGradient.linearGradient(colors: colors.map({ $0.resolve(on: element, in: context) }), startPoint: startPoint.resolve(on: element, in: context), endPoint: endPoint.resolve(on: element, in: context))
                 case .stops(let stops, let startPoint, let endPoint):
-                    LinearGradient.linearGradient(stops: stops.map({ $0.resolve(on: element) }), startPoint: startPoint.resolve(on: element), endPoint: endPoint.resolve(on: element))
+                    LinearGradient.linearGradient(stops: stops.map({ $0.resolve(on: element, in: context) }), startPoint: startPoint.resolve(on: element, in: context), endPoint: endPoint.resolve(on: element, in: context))
                 case .anyGradient(let gradient, let startPoint, let endPoint):
-                    LinearGradient.linearGradient(gradient.resolve(on: element), startPoint: startPoint.resolve(on: element), endPoint: endPoint.resolve(on: element))
+                    LinearGradient.linearGradient(gradient.resolve(on: element, in: context), startPoint: startPoint.resolve(on: element, in: context), endPoint: endPoint.resolve(on: element, in: context))
                 }
             }
         }
@@ -512,35 +508,35 @@ public extension AnyShapeStyle {
                 self = .anyGradient(gradient: gradient, center: center, startRadius: startRadius, endRadius: endRadius)
             }
             
-            func resolve(on element: ElementNode) -> any ShapeStyle {
+            func resolve(on element: ElementNode, in context: LiveContext<some RootRegistry>) -> any ShapeStyle {
                 switch self {
                 case .gradient(let gradient, let center, let startRadius, let endRadius):
                     RadialGradient.radialGradient(
-                        gradient.resolve(on: element),
-                        center: center.resolve(on: element),
-                        startRadius: startRadius.resolve(on: element),
-                        endRadius: endRadius.resolve(on: element)
+                        gradient.resolve(on: element, in: context),
+                        center: center.resolve(on: element, in: context),
+                        startRadius: startRadius.resolve(on: element, in: context),
+                        endRadius: endRadius.resolve(on: element, in: context)
                     )
                 case .colors(let colors, let center, let startRadius, let endRadius):
                     RadialGradient.radialGradient(
-                        colors: colors.map({ $0.resolve(on: element) }),
-                        center: center.resolve(on: element),
-                        startRadius: startRadius.resolve(on: element),
-                        endRadius: endRadius.resolve(on: element)
+                        colors: colors.map({ $0.resolve(on: element, in: context) }),
+                        center: center.resolve(on: element, in: context),
+                        startRadius: startRadius.resolve(on: element, in: context),
+                        endRadius: endRadius.resolve(on: element, in: context)
                     )
                 case .stops(let stops, let center, let startRadius, let endRadius):
                     RadialGradient.radialGradient(
-                        stops: stops.map({ $0.resolve(on: element) }),
-                        center: center.resolve(on: element),
-                        startRadius: startRadius.resolve(on: element),
-                        endRadius: endRadius.resolve(on: element)
+                        stops: stops.map({ $0.resolve(on: element, in: context) }),
+                        center: center.resolve(on: element, in: context),
+                        startRadius: startRadius.resolve(on: element, in: context),
+                        endRadius: endRadius.resolve(on: element, in: context)
                     )
                 case .anyGradient(let gradient, let center, let startRadius, let endRadius):
                     RadialGradient.radialGradient(
-                        gradient.resolve(on: element),
-                        center: center.resolve(on: element),
-                        startRadius: startRadius.resolve(on: element),
-                        endRadius: endRadius.resolve(on: element)
+                        gradient.resolve(on: element, in: context),
+                        center: center.resolve(on: element, in: context),
+                        startRadius: startRadius.resolve(on: element, in: context),
+                        endRadius: endRadius.resolve(on: element, in: context)
                     )
                 }
             }
@@ -587,9 +583,9 @@ public extension AnyShapeStyle {
             struct _opacity {
                 static let name = "opacity"
                 
-                let value: Double
+                let value: AttributeReference<Double>
                 
-                init(_ value: Double) {
+                init(_ value: AttributeReference<Double>) {
                     self.value = value
                 }
             }
@@ -619,14 +615,14 @@ public extension AnyShapeStyle {
             }
             
             /// Apply this modifier to an existing `ShapeStyle`.
-            func apply(to style: some ShapeStyle, on element: ElementNode) -> any ShapeStyle {
+            func apply(to style: some ShapeStyle, on element: ElementNode, in context: LiveContext<some RootRegistry>) -> any ShapeStyle {
                 switch self {
                 case let .blendMode(blendMode):
                     return style.blendMode(blendMode.value)
                 case let .opacity(opacity):
-                    return style.opacity(opacity.value)
+                    return style.opacity(opacity.value.resolve(on: element, in: context))
                 case let .shadow(shadow):
-                    return style.shadow(shadow.value.resolve(on: element))
+                    return style.shadow(shadow.value.resolve(on: element, in: context))
                 case let .hierarchical(level):
                     if #available(iOS 17, macOS 14, tvOS 17, watchOS 10, visionOS 1, *) {
                         switch level {
@@ -646,14 +642,14 @@ public extension AnyShapeStyle {
             }
             
             /// Use this modifier itself as a `ShapeStyle`. SwiftUI will apply it to the foreground style.
-            func resolve(on element: ElementNode) -> any ShapeStyle {
+            func resolve(on element: ElementNode, in context: LiveContext<some RootRegistry>) -> any ShapeStyle {
                 switch self {
                 case let .blendMode(blendMode):
                     return AnyShapeStyle(.blendMode(blendMode.value))
                 case let .opacity(opacity):
-                    return AnyShapeStyle(.opacity(opacity.value))
+                    return AnyShapeStyle(.opacity(opacity.value.resolve(on: element, in: context)))
                 case let .shadow(shadow):
-                    return AnyShapeStyle(.shadow(shadow.value.resolve(on: element)))
+                    return AnyShapeStyle(.shadow(shadow.value.resolve(on: element, in: context)))
                 case let .hierarchical(level):
                     switch level {
                     case .secondary:

--- a/Sources/LiveViewNative/Stylesheets/ParseableTypes/ShapeStyles/Color+ParseableModifierValue.swift
+++ b/Sources/LiveViewNative/Stylesheets/ParseableTypes/ShapeStyles/Color+ParseableModifierValue.swift
@@ -104,41 +104,37 @@ public extension SwiftUI.Color {
         }
         
         public func resolve<R: RootRegistry>(on element: ElementNode, in context: LiveContext<R>) -> SwiftUI.Color {
-            resolve(on: element)
-        }
-        
-        public func resolve(on element: ElementNode) -> SwiftUI.Color {
             let base = switch storage {
             case let .reference(name):
                 try! element.attributeValue(SwiftUI.Color.self, for: name)
             case let .constant(constant):
                 constant
             case let .named(name):
-                SwiftUI.Color.init(name.resolve(on: element), bundle: nil)
+                SwiftUI.Color.init(name.resolve(on: element, in: context), bundle: nil)
             case let .components(colorSpace, red, green, blue, opacity):
                 SwiftUI.Color(
-                    colorSpace.resolve(on: element),
-                    red: red.resolve(on: element),
-                    green: green.resolve(on: element),
-                    blue: blue.resolve(on: element),
-                    opacity: opacity.resolve(on: element)
+                    colorSpace.resolve(on: element, in: context),
+                    red: red.resolve(on: element, in: context),
+                    green: green.resolve(on: element, in: context),
+                    blue: blue.resolve(on: element, in: context),
+                    opacity: opacity.resolve(on: element, in: context)
                 )
             case let .monochrome(colorSpace, white, opacity):
                 SwiftUI.Color(
-                    colorSpace.resolve(on: element),
-                    white: white.resolve(on: element),
-                    opacity: opacity.resolve(on: element)
+                    colorSpace.resolve(on: element, in: context),
+                    white: white.resolve(on: element, in: context),
+                    opacity: opacity.resolve(on: element, in: context)
                 )
             case let .hsb(hue, saturation, brightness, opacity):
                 SwiftUI.Color(
-                    hue: hue.resolve(on: element),
-                    saturation: saturation.resolve(on: element),
-                    brightness: brightness.resolve(on: element),
-                    opacity: opacity.resolve(on: element)
+                    hue: hue.resolve(on: element, in: context),
+                    saturation: saturation.resolve(on: element, in: context),
+                    brightness: brightness.resolve(on: element, in: context),
+                    opacity: opacity.resolve(on: element, in: context)
                 )
             }
             return modifiers.reduce(into: base) {
-                $0 = $1.apply(to: $0, on: element)
+                $0 = $1.apply(to: $0, on: element, in: context)
             }
         }
         
@@ -345,10 +341,10 @@ enum ColorModifier {
         }
     }
     
-    func apply(to color: SwiftUI.Color, on element: ElementNode) -> SwiftUI.Color {
+    func apply(to color: SwiftUI.Color, on element: ElementNode, in context: LiveContext<some RootRegistry>) -> SwiftUI.Color {
         switch self {
         case let .opacity(opacity):
-            return color.opacity(opacity.value.resolve(on: element))
+            return color.opacity(opacity.value.resolve(on: element, in: context))
         }
     }
 }

--- a/Sources/LiveViewNative/Stylesheets/ParseableTypes/ShapeStyles/Gradient+ParseableModifierValue.swift
+++ b/Sources/LiveViewNative/Stylesheets/ParseableTypes/ShapeStyles/Gradient+ParseableModifierValue.swift
@@ -34,8 +34,8 @@ extension AnyGradient {
             }
         }
         
-        func resolve(on element: ElementNode) -> AnyGradient {
-            color.resolve(on: element).gradient
+        func resolve(on element: ElementNode, in context: LiveContext<some RootRegistry>) -> AnyGradient {
+            color.resolve(on: element, in: context).gradient
         }
     }
 }
@@ -73,12 +73,12 @@ extension Gradient {
             }
         }
         
-        func resolve(on element: ElementNode) -> Gradient {
+        func resolve(on element: ElementNode, in context: LiveContext<some RootRegistry>) -> Gradient {
             switch self {
             case .colors(let colors):
-                Gradient(colors: colors.map({ $0.resolve(on: element) }))
+                Gradient(colors: colors.map({ $0.resolve(on: element, in: context) }))
             case .stops(let stops):
-                Gradient(stops: stops.map({ $0.resolve(on: element) }))
+                Gradient(stops: stops.map({ $0.resolve(on: element, in: context) }))
             }
         }
     }
@@ -120,8 +120,8 @@ extension Gradient.Stop {
             }
         }
         
-        func resolve(on element: ElementNode) -> Gradient.Stop {
-            .init(color: color.resolve(on: element), location: location.resolve(on: element))
+        func resolve(on element: ElementNode, in context: LiveContext<some RootRegistry>) -> Gradient.Stop {
+            .init(color: color.resolve(on: element, in: context), location: location.resolve(on: element, in: context))
         }
     }
 }

--- a/Sources/LiveViewNative/Stylesheets/ParseableTypes/ShapeStyles/ShadowStyle+ParseableModifierValue.swift
+++ b/Sources/LiveViewNative/Stylesheets/ParseableTypes/ShapeStyles/ShadowStyle+ParseableModifierValue.swift
@@ -51,21 +51,21 @@ enum _ShadowStyle: ParseableModifierValue {
         }
     }
     
-    func resolve(on element: ElementNode) -> ShadowStyle {
+    func resolve(on element: ElementNode, in context: LiveContext<some RootRegistry>) -> ShadowStyle {
         switch self {
         case .drop(let drop):
             .drop(
-                color: drop.color.resolve(on: element),
-                radius: drop.radius.resolve(on: element),
-                x: drop.x.resolve(on: element),
-                y: drop.y.resolve(on: element)
+                color: drop.color.resolve(on: element, in: context),
+                radius: drop.radius.resolve(on: element, in: context),
+                x: drop.x.resolve(on: element, in: context),
+                y: drop.y.resolve(on: element, in: context)
             )
         case .inner(let inner):
             .inner(
-                color: inner.color.resolve(on: element),
-                radius: inner.radius.resolve(on: element),
-                x: inner.x.resolve(on: element),
-                y: inner.y.resolve(on: element)
+                color: inner.color.resolve(on: element, in: context),
+                radius: inner.radius.resolve(on: element, in: context),
+                x: inner.x.resolve(on: element, in: context),
+                y: inner.y.resolve(on: element, in: context)
             )
         }
     }

--- a/Sources/LiveViewNative/ViewModel.swift
+++ b/Sources/LiveViewNative/ViewModel.swift
@@ -37,7 +37,7 @@ public class LiveViewModel: ObservableObject {
 /// To obtain a form model, use ``LiveViewModel/getForm(elementID:)`` or the `\.formModel` environment key.
 public class FormModel: ObservableObject, CustomDebugStringConvertible {
     let elementID: String
-    @_spi(LiveForm) public var pushEventImpl: ((String, String, Any, Int?) async throws -> Void)!
+    @_spi(LiveForm) public var pushEventImpl: ((String, String, Any, Int?) async throws -> [String:Any]?)!
     
     var changeEvent: ((Any) -> ())?
     var submitEvent: String?

--- a/Sources/LiveViewNative/Views/Shapes/Shape.swift
+++ b/Sources/LiveViewNative/Views/Shapes/Shape.swift
@@ -32,13 +32,13 @@ struct Shape<Root: RootRegistry, S: SwiftUI.InsettableShape>: View {
         var modifiers = modifiers
         var shape = shape.erasedToAnyShape()
         while case let ._anyShapeModifier(modifier) = modifiers.first {
-            shape = modifier.apply(to: shape, on: $liveElement.element).erasedToAnyShape()
+            shape = modifier.apply(to: shape, on: $liveElement.element, in: $liveElement.context).erasedToAnyShape()
             modifiers.removeFirst()
         }
         
         return SwiftUI.Group {
             if case let ._anyShapeFinalizerModifier(modifier) = modifiers.first {
-                modifier.apply(to: shape, on: $liveElement.element)
+                modifier.apply(to: shape, on: $liveElement.element, in: $liveElement.context)
             } else {
                 shape
             }

--- a/Sources/LiveViewNative/Views/Text Input and Output/Text.swift
+++ b/Sources/LiveViewNative/Views/Text Input and Output/Text.swift
@@ -137,7 +137,7 @@ struct Text<Root: RootRegistry>: View {
         if _liveElement.isConstant {
             return modifiers.reduce(text) { result, modifier in
                 if case let ._anyTextModifier(textModifier) = modifier {
-                    return textModifier.apply(to: result, on: $liveElement.element)
+                    return textModifier.apply(to: result, on: $liveElement.element, in: $liveElement.context)
                 } else {
                     return result
                 }

--- a/Sources/LiveViewNative/_GeneratedModifiers.swift
+++ b/Sources/LiveViewNative/_GeneratedModifiers.swift
@@ -20,6 +20,7 @@ struct _accessibilityActionModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 @Event private var _0_action__0: Event.EventHandler
@@ -44,6 +45,7 @@ struct _accessibilityActionModifier<R: RootRegistry>: ViewModifier {
             __content
                 .accessibilityAction(action: { __0_action__0.wrappedValue() }, label: { label.resolve(on: element, in: context) })
             
+                
             
         
         }
@@ -65,6 +67,7 @@ struct _accessibilityActionsModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
@@ -89,6 +92,7 @@ struct _accessibilityActionsModifier<R: RootRegistry>: ViewModifier {
             __content
                 .accessibilityActions({ content.resolve(on: element, in: context) })
             
+                
             
         
         }
@@ -110,6 +114,7 @@ struct _accessibilityChildrenModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
@@ -134,6 +139,7 @@ struct _accessibilityChildrenModifier<R: RootRegistry>: ViewModifier {
             __content
                 .accessibilityChildren(children: { children.resolve(on: element, in: context) })
             
+                
             
         
         }
@@ -155,6 +161,7 @@ struct _accessibilityIgnoresInvertColorsModifier<R: RootRegistry>: ViewModifier 
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
@@ -179,6 +186,7 @@ struct _accessibilityIgnoresInvertColorsModifier<R: RootRegistry>: ViewModifier 
             __content
                 .accessibilityIgnoresInvertColors(active.resolve(on: element, in: context))
             
+                
             
         
         }
@@ -200,6 +208,7 @@ struct _accessibilityRepresentationModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
@@ -224,6 +233,7 @@ struct _accessibilityRepresentationModifier<R: RootRegistry>: ViewModifier {
             __content
                 .accessibilityRepresentation(representation: { representation.resolve(on: element, in: context) })
             
+                
             
         
         }
@@ -248,6 +258,7 @@ struct _accessibilityShowsLargeContentViewerModifier<R: RootRegistry>: ViewModif
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
@@ -281,6 +292,7 @@ struct _accessibilityShowsLargeContentViewerModifier<R: RootRegistry>: ViewModif
             __content
                 .accessibilityShowsLargeContentViewer({ largeContentView.resolve(on: element, in: context) })
             
+                
             
         
         
@@ -291,6 +303,7 @@ struct _accessibilityShowsLargeContentViewerModifier<R: RootRegistry>: ViewModif
             __content
                 .accessibilityShowsLargeContentViewer()
             
+                
             
         
         }
@@ -330,6 +343,7 @@ struct _alertModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 @ChangeTracked private var _0_isPresented: Swift.Bool
 
@@ -408,6 +422,7 @@ struct _alertModifier<R: RootRegistry>: ViewModifier {
             __content
                 .alert(titleKey, isPresented: __0_isPresented.projectedValue, actions: { actions.resolve(on: element, in: context) })
             
+                
             
         
         
@@ -418,6 +433,7 @@ struct _alertModifier<R: RootRegistry>: ViewModifier {
             __content
                 .alert(title.resolve(on: element, in: context), isPresented: __1_isPresented.projectedValue, actions: { actions.resolve(on: element, in: context) })
             
+                
             
         
         
@@ -428,6 +444,7 @@ struct _alertModifier<R: RootRegistry>: ViewModifier {
             __content
                 .alert(title.resolve(on: element, in: context), isPresented: __2_isPresented.projectedValue, actions: { actions.resolve(on: element, in: context) })
             }
+                
             
         
         
@@ -438,6 +455,7 @@ struct _alertModifier<R: RootRegistry>: ViewModifier {
             __content
                 .alert(titleKey, isPresented: __3_isPresented.projectedValue, actions: { actions.resolve(on: element, in: context) }, message: { message.resolve(on: element, in: context) })
             
+                
             
         
         
@@ -448,6 +466,7 @@ struct _alertModifier<R: RootRegistry>: ViewModifier {
             __content
                 .alert(title.resolve(on: element, in: context), isPresented: __4_isPresented.projectedValue, actions: { actions.resolve(on: element, in: context) }, message: { message.resolve(on: element, in: context) })
             
+                
             
         
         
@@ -458,6 +477,7 @@ struct _alertModifier<R: RootRegistry>: ViewModifier {
             __content
                 .alert(title.resolve(on: element, in: context), isPresented: __5_isPresented.projectedValue, actions: { actions.resolve(on: element, in: context) }, message: { message.resolve(on: element, in: context) })
             }
+                
             
         
         
@@ -468,6 +488,7 @@ struct _alertModifier<R: RootRegistry>: ViewModifier {
             __content
                 .alert(isPresented: __6_isPresented.projectedValue, error: error, actions: { actions.resolve(on: element, in: context) })
             
+                
             
         
         }
@@ -489,6 +510,7 @@ struct _allowsHitTestingModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
@@ -513,6 +535,7 @@ struct _allowsHitTestingModifier<R: RootRegistry>: ViewModifier {
             __content
                 .allowsHitTesting(enabled.resolve(on: element, in: context))
             
+                
             
         
         }
@@ -534,6 +557,7 @@ struct _allowsTighteningModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
@@ -558,6 +582,7 @@ struct _allowsTighteningModifier<R: RootRegistry>: ViewModifier {
             __content
                 .allowsTightening(flag.resolve(on: element, in: context))
             
+                
             
         
         }
@@ -579,6 +604,7 @@ struct _animationModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
@@ -603,6 +629,7 @@ struct _animationModifier<R: RootRegistry>: ViewModifier {
             __content
                 .animation(animation, value: value.resolve(on: element, in: context))
             
+                
             
         
         }
@@ -627,6 +654,7 @@ struct _aspectRatioModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
@@ -660,6 +688,7 @@ struct _aspectRatioModifier<R: RootRegistry>: ViewModifier {
             __content
                 .aspectRatio(aspectRatio?.resolve(on: element, in: context), contentMode: contentMode)
             
+                
             
         
         
@@ -670,6 +699,7 @@ struct _aspectRatioModifier<R: RootRegistry>: ViewModifier {
             __content
                 .aspectRatio(aspectRatio, contentMode: contentMode)
             
+                
             
         
         }
@@ -691,6 +721,7 @@ struct _autocorrectionDisabledModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
@@ -715,6 +746,7 @@ struct _autocorrectionDisabledModifier<R: RootRegistry>: ViewModifier {
             __content
                 .autocorrectionDisabled(disable.resolve(on: element, in: context))
             
+                
             
         
         }
@@ -754,6 +786,7 @@ struct _backgroundModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
@@ -832,6 +865,7 @@ struct _backgroundModifier<R: RootRegistry>: ViewModifier {
             __content
                 .background(alignment: alignment.resolve(on: element, in: context), content: { content.resolve(on: element, in: context) })
             
+                
             
         
         
@@ -842,6 +876,7 @@ struct _backgroundModifier<R: RootRegistry>: ViewModifier {
             __content
                 .background(ignoresSafeAreaEdges: edges)
             
+                
             
         
         
@@ -852,6 +887,7 @@ struct _backgroundModifier<R: RootRegistry>: ViewModifier {
             __content
                 .background(style.resolve(on: element, in: context), ignoresSafeAreaEdges: edges)
             
+                
             
         
         
@@ -862,6 +898,7 @@ struct _backgroundModifier<R: RootRegistry>: ViewModifier {
             __content
                 .background(in: shape, fillStyle: fillStyle)
             
+                
             
         
         
@@ -872,6 +909,7 @@ struct _backgroundModifier<R: RootRegistry>: ViewModifier {
             __content
                 .background(style.resolve(on: element, in: context), in: shape, fillStyle: fillStyle)
             
+                
             
         
         
@@ -882,6 +920,7 @@ struct _backgroundModifier<R: RootRegistry>: ViewModifier {
             __content
                 .background(in: shape, fillStyle: fillStyle)
             
+                
             
         
         
@@ -892,6 +931,7 @@ struct _backgroundModifier<R: RootRegistry>: ViewModifier {
             __content
                 .background(style.resolve(on: element, in: context), in: shape, fillStyle: fillStyle)
             
+                
             
         
         }
@@ -913,6 +953,7 @@ struct _backgroundStyleModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
@@ -937,6 +978,7 @@ struct _backgroundStyleModifier<R: RootRegistry>: ViewModifier {
             __content
                 .backgroundStyle(style.resolve(on: element, in: context))
             
+                
             
         
         }
@@ -967,6 +1009,7 @@ struct _badgeModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
@@ -978,28 +1021,28 @@ struct _badgeModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 12.0,iOS 15.0,visionOS 1.0, *)
+    @available(visionOS 1.0,macOS 12.0,iOS 15.0, *)
     init(_ count: AttributeReference<Swift.Int>) {
         self.value = ._0(count: count)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 12.0,iOS 15.0,visionOS 1.0, *)
+    @available(visionOS 1.0,macOS 12.0,iOS 15.0, *)
     init(_ label: TextReference?) {
         self.value = ._1(label: label)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 12.0,iOS 15.0,visionOS 1.0, *)
+    @available(visionOS 1.0,macOS 12.0,iOS 15.0, *)
     init(_ key: SwiftUI.LocalizedStringKey?) {
         self.value = ._2(key: key)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 12.0,iOS 15.0,visionOS 1.0, *)
+    @available(iOS 15.0,macOS 12.0,visionOS 1.0, *)
     init(_ label: AttributeReference<String>) {
         self.value = ._3(label: label)
         
@@ -1012,42 +1055,46 @@ struct _badgeModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(count):
-            if #available(macOS 12.0,iOS 15.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,macOS 12.0,iOS 15.0, *) {
             let count = count as! AttributeReference<Swift.Int>
             
             __content
                 .badge(count.resolve(on: element, in: context))
             
+                
             } else { __content }
         #endif
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._1(label):
-            if #available(macOS 12.0,iOS 15.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,macOS 12.0,iOS 15.0, *) {
             let label = label as? TextReference
             __content._observeTextReference(label, on: element, in: context) { __content in
             __content
                 .badge(label?.resolve(on: element, in: context))
             }
+                
             } else { __content }
         #endif
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._2(key):
-            if #available(macOS 12.0,iOS 15.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,macOS 12.0,iOS 15.0, *) {
             let key = key as? SwiftUI.LocalizedStringKey
             
             __content
                 .badge(key)
             
+                
             } else { __content }
         #endif
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._3(label):
-            if #available(macOS 12.0,iOS 15.0,visionOS 1.0, *) {
+            if #available(iOS 15.0,macOS 12.0,visionOS 1.0, *) {
             let label = label as! AttributeReference<String>
             
             __content
                 .badge(label.resolve(on: element, in: context))
             
+                
             } else { __content }
         #endif
         }
@@ -1067,6 +1114,7 @@ struct _badgeProminenceModifier<R: RootRegistry>: ViewModifier {
 
     let value: Value
 
+    
     
     
 
@@ -1093,6 +1141,7 @@ struct _badgeProminenceModifier<R: RootRegistry>: ViewModifier {
             __content
                 .badgeProminence(prominence)
             
+                
             } else { __content }
         #endif
         }
@@ -1112,6 +1161,7 @@ struct _blendModeModifier<R: RootRegistry>: ViewModifier {
 
     let value: Value
 
+    
     
     
 
@@ -1138,6 +1188,7 @@ struct _blendModeModifier<R: RootRegistry>: ViewModifier {
             __content
                 .blendMode(blendMode)
             
+                
             
         
         }
@@ -1159,6 +1210,7 @@ struct _blurModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
@@ -1183,6 +1235,7 @@ struct _blurModifier<R: RootRegistry>: ViewModifier {
             __content
                 .blur(radius: radius.resolve(on: element, in: context), opaque: opaque.resolve(on: element, in: context))
             
+                
             
         
         }
@@ -1204,6 +1257,7 @@ struct _borderModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
@@ -1228,6 +1282,7 @@ struct _borderModifier<R: RootRegistry>: ViewModifier {
             __content
                 .border(content.resolve(on: element, in: context), width: width.resolve(on: element, in: context))
             
+                
             
         
         }
@@ -1249,6 +1304,7 @@ struct _brightnessModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
@@ -1273,6 +1329,7 @@ struct _brightnessModifier<R: RootRegistry>: ViewModifier {
             __content
                 .brightness(amount.resolve(on: element, in: context))
             
+                
             
         
         }
@@ -1292,6 +1349,7 @@ struct _buttonBorderShapeModifier<R: RootRegistry>: ViewModifier {
 
     let value: Value
 
+    
     
     
 
@@ -1318,6 +1376,7 @@ struct _buttonBorderShapeModifier<R: RootRegistry>: ViewModifier {
             __content
                 .buttonBorderShape(shape)
             
+                
             
         
         }
@@ -1340,6 +1399,7 @@ struct _buttonStyleModifier<R: RootRegistry>: ViewModifier {
 
     let value: Value
 
+    
     
     
 
@@ -1375,6 +1435,7 @@ struct _buttonStyleModifier<R: RootRegistry>: ViewModifier {
             __content
                 .buttonStyle(style)
             
+                
             
         
         
@@ -1385,6 +1446,7 @@ struct _buttonStyleModifier<R: RootRegistry>: ViewModifier {
             __content
                 .buttonStyle(style)
             
+                
             
         
         }
@@ -1404,6 +1466,7 @@ struct _clipShapeModifier<R: RootRegistry>: ViewModifier {
 
     let value: Value
 
+    
     
     
 
@@ -1430,6 +1493,7 @@ struct _clipShapeModifier<R: RootRegistry>: ViewModifier {
             __content
                 .clipShape(shape, style: style)
             
+                
             
         
         }
@@ -1451,6 +1515,7 @@ struct _clippedModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
@@ -1475,6 +1540,7 @@ struct _clippedModifier<R: RootRegistry>: ViewModifier {
             __content
                 .clipped(antialiased: antialiased.resolve(on: element, in: context))
             
+                
             
         
         }
@@ -1494,6 +1560,7 @@ struct _colorInvertModifier<R: RootRegistry>: ViewModifier {
 
     let value: Value
 
+    
     
     
 
@@ -1520,6 +1587,7 @@ struct _colorInvertModifier<R: RootRegistry>: ViewModifier {
             __content
                 .colorInvert()
             
+                
             
         
         }
@@ -1541,6 +1609,7 @@ struct _colorMultiplyModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
@@ -1565,6 +1634,7 @@ struct _colorMultiplyModifier<R: RootRegistry>: ViewModifier {
             __content
                 .colorMultiply(color.resolve(on: element, in: context))
             
+                
             
         
         }
@@ -1584,6 +1654,7 @@ struct _compositingGroupModifier<R: RootRegistry>: ViewModifier {
 
     let value: Value
 
+    
     
     
 
@@ -1610,6 +1681,7 @@ struct _compositingGroupModifier<R: RootRegistry>: ViewModifier {
             __content
                 .compositingGroup()
             
+                
             
         
         }
@@ -1646,6 +1718,7 @@ struct _confirmationDialogModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 @ChangeTracked private var _0_isPresented: Swift.Bool
 
@@ -1715,6 +1788,7 @@ struct _confirmationDialogModifier<R: RootRegistry>: ViewModifier {
             __content
                 .confirmationDialog(titleKey, isPresented: __0_isPresented.projectedValue, titleVisibility: titleVisibility.resolve(on: element, in: context), actions: { actions.resolve(on: element, in: context) })
             
+                
             
         
         
@@ -1725,6 +1799,7 @@ struct _confirmationDialogModifier<R: RootRegistry>: ViewModifier {
             __content
                 .confirmationDialog(title.resolve(on: element, in: context), isPresented: __1_isPresented.projectedValue, titleVisibility: titleVisibility.resolve(on: element, in: context), actions: { actions.resolve(on: element, in: context) })
             
+                
             
         
         
@@ -1735,6 +1810,7 @@ struct _confirmationDialogModifier<R: RootRegistry>: ViewModifier {
             __content
                 .confirmationDialog(title.resolve(on: element, in: context), isPresented: __2_isPresented.projectedValue, titleVisibility: titleVisibility.resolve(on: element, in: context), actions: { actions.resolve(on: element, in: context) })
             }
+                
             
         
         
@@ -1745,6 +1821,7 @@ struct _confirmationDialogModifier<R: RootRegistry>: ViewModifier {
             __content
                 .confirmationDialog(titleKey, isPresented: __3_isPresented.projectedValue, titleVisibility: titleVisibility.resolve(on: element, in: context), actions: { actions.resolve(on: element, in: context) }, message: { message.resolve(on: element, in: context) })
             
+                
             
         
         
@@ -1755,6 +1832,7 @@ struct _confirmationDialogModifier<R: RootRegistry>: ViewModifier {
             __content
                 .confirmationDialog(title.resolve(on: element, in: context), isPresented: __4_isPresented.projectedValue, titleVisibility: titleVisibility.resolve(on: element, in: context), actions: { actions.resolve(on: element, in: context) }, message: { message.resolve(on: element, in: context) })
             
+                
             
         
         
@@ -1765,6 +1843,7 @@ struct _confirmationDialogModifier<R: RootRegistry>: ViewModifier {
             __content
                 .confirmationDialog(title.resolve(on: element, in: context), isPresented: __5_isPresented.projectedValue, titleVisibility: titleVisibility.resolve(on: element, in: context), actions: { actions.resolve(on: element, in: context) }, message: { message.resolve(on: element, in: context) })
             }
+                
             
         
         }
@@ -1789,6 +1868,7 @@ struct _containerRelativeFrameModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
@@ -1796,14 +1876,14 @@ struct _containerRelativeFrameModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0,visionOS 1.0, *)
+    @available(watchOS 10.0,macOS 14.0,tvOS 17.0,iOS 17.0,visionOS 1.0, *)
     init(_ axes: SwiftUI.Axis.Set,alignment: AttributeReference<SwiftUI.Alignment> = .init(storage: .constant(.center)) ) {
         self.value = ._0(axes: axes, alignment: alignment)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0,visionOS 1.0, *)
+    @available(iOS 17.0,tvOS 17.0,macOS 14.0,watchOS 10.0,visionOS 1.0, *)
     init(_ axes: SwiftUI.Axis.Set,count: AttributeReference<Swift.Int>,span: AttributeReference<Swift.Int> = .init(storage: .constant(1)), spacing: AttributeReference<CoreFoundation.CGFloat>,alignment: AttributeReference<SwiftUI.Alignment> = .init(storage: .constant(.center)) ) {
         self.value = ._1(axes: axes, count: count, span: span, spacing: spacing, alignment: alignment)
         
@@ -1816,18 +1896,19 @@ struct _containerRelativeFrameModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(axes, alignment):
-            if #available(macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0,visionOS 1.0, *) {
+            if #available(watchOS 10.0,macOS 14.0,tvOS 17.0,iOS 17.0,visionOS 1.0, *) {
             let axes = axes as! SwiftUI.Axis.Set
 let alignment = alignment as! AttributeReference<SwiftUI.Alignment>
             
             __content
                 .containerRelativeFrame(axes, alignment: alignment.resolve(on: element, in: context))
             
+                
             } else { __content }
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(axes, count, span, spacing, alignment):
-            if #available(macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0,visionOS 1.0, *) {
+            if #available(iOS 17.0,tvOS 17.0,macOS 14.0,watchOS 10.0,visionOS 1.0, *) {
             let axes = axes as! SwiftUI.Axis.Set
 let count = count as! AttributeReference<Swift.Int>
 let span = span as! AttributeReference<Swift.Int>
@@ -1837,6 +1918,7 @@ let alignment = alignment as! AttributeReference<SwiftUI.Alignment>
             __content
                 .containerRelativeFrame(axes, count: count.resolve(on: element, in: context), span: span.resolve(on: element, in: context), spacing: spacing.resolve(on: element, in: context), alignment: alignment.resolve(on: element, in: context))
             
+                
             } else { __content }
         #endif
         }
@@ -1856,6 +1938,7 @@ struct _containerShapeModifier<R: RootRegistry>: ViewModifier {
 
     let value: Value
 
+    
     
     
 
@@ -1882,6 +1965,7 @@ struct _containerShapeModifier<R: RootRegistry>: ViewModifier {
             __content
                 .containerShape(shape)
             
+                
             
         
         }
@@ -1909,6 +1993,7 @@ struct _contentMarginsModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
@@ -1918,21 +2003,21 @@ struct _contentMarginsModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 10.0,visionOS 1.0,macOS 14.0,iOS 17.0,tvOS 17.0, *)
+    @available(tvOS 17.0,visionOS 1.0,watchOS 10.0,macOS 14.0,iOS 17.0, *)
     init(_ edges: SwiftUI.Edge.Set = .all, _ insets: SwiftUI.EdgeInsets,for placement: SwiftUI.ContentMarginPlacement = .automatic ) {
         self.value = ._0(edges: edges, insets: insets, placement: placement)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(iOS 17.0,visionOS 1.0,macOS 14.0,tvOS 17.0,watchOS 10.0, *)
+    @available(tvOS 17.0,visionOS 1.0,watchOS 10.0,macOS 14.0,iOS 17.0, *)
     init(_ edges: SwiftUI.Edge.Set = .all, _ length: AttributeReference<CoreFoundation.CGFloat?>?,for placement: SwiftUI.ContentMarginPlacement = .automatic ) {
         self.value = ._1(edges: edges, length: length, placement: placement)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(tvOS 17.0,watchOS 10.0,visionOS 1.0,macOS 14.0,iOS 17.0, *)
+    @available(watchOS 10.0,iOS 17.0,visionOS 1.0,macOS 14.0,tvOS 17.0, *)
     init(_ length: AttributeReference<CoreFoundation.CGFloat>,for placement: SwiftUI.ContentMarginPlacement = .automatic ) {
         self.value = ._2(length: length, placement: placement)
         
@@ -1945,7 +2030,7 @@ struct _contentMarginsModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(edges, insets, placement):
-            if #available(watchOS 10.0,visionOS 1.0,macOS 14.0,iOS 17.0,tvOS 17.0, *) {
+            if #available(tvOS 17.0,visionOS 1.0,watchOS 10.0,macOS 14.0,iOS 17.0, *) {
             let edges = edges as! SwiftUI.Edge.Set 
 let insets = insets as! SwiftUI.EdgeInsets
 let placement = placement as! SwiftUI.ContentMarginPlacement 
@@ -1953,11 +2038,12 @@ let placement = placement as! SwiftUI.ContentMarginPlacement
             __content
                 .contentMargins(edges, insets, for: placement)
             
+                
             } else { __content }
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(edges, length, placement):
-            if #available(iOS 17.0,visionOS 1.0,macOS 14.0,tvOS 17.0,watchOS 10.0, *) {
+            if #available(tvOS 17.0,visionOS 1.0,watchOS 10.0,macOS 14.0,iOS 17.0, *) {
             let edges = edges as! SwiftUI.Edge.Set 
 let length = length as? AttributeReference<CoreFoundation.CGFloat?>
 let placement = placement as! SwiftUI.ContentMarginPlacement 
@@ -1965,17 +2051,19 @@ let placement = placement as! SwiftUI.ContentMarginPlacement
             __content
                 .contentMargins(edges, length?.resolve(on: element, in: context), for: placement)
             
+                
             } else { __content }
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._2(length, placement):
-            if #available(tvOS 17.0,watchOS 10.0,visionOS 1.0,macOS 14.0,iOS 17.0, *) {
+            if #available(watchOS 10.0,iOS 17.0,visionOS 1.0,macOS 14.0,tvOS 17.0, *) {
             let length = length as! AttributeReference<CoreFoundation.CGFloat>
 let placement = placement as! SwiftUI.ContentMarginPlacement 
             
             __content
                 .contentMargins(length.resolve(on: element, in: context), for: placement)
             
+                
             } else { __content }
         #endif
         }
@@ -2000,6 +2088,7 @@ struct _contentShapeModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
@@ -2033,6 +2122,7 @@ struct _contentShapeModifier<R: RootRegistry>: ViewModifier {
             __content
                 .contentShape(shape, eoFill: eoFill.resolve(on: element, in: context))
             
+                
             
         
         
@@ -2043,6 +2133,7 @@ struct _contentShapeModifier<R: RootRegistry>: ViewModifier {
             __content
                 .contentShape(kind, shape, eoFill: eoFill.resolve(on: element, in: context))
             
+                
             
         
         }
@@ -2062,6 +2153,7 @@ struct _contentTransitionModifier<R: RootRegistry>: ViewModifier {
 
     let value: Value
 
+    
     
     
 
@@ -2088,6 +2180,7 @@ struct _contentTransitionModifier<R: RootRegistry>: ViewModifier {
             __content
                 .contentTransition(transition)
             
+                
             
         
         }
@@ -2112,6 +2205,7 @@ struct _contextMenuModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
@@ -2126,7 +2220,7 @@ struct _contextMenuModifier<R: RootRegistry>: ViewModifier {
     }
     
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS)
-    @available(visionOS 1.0,macOS 13.0,iOS 16.0,tvOS 16.0, *)
+    @available(iOS 16.0,visionOS 1.0,macOS 13.0,tvOS 16.0, *)
     init(menuItems: ViewReference=ViewReference(value: []),preview: ViewReference=ViewReference(value: [])) {
         self.value = ._1(menuItems: menuItems, preview: preview)
         
@@ -2145,17 +2239,19 @@ struct _contextMenuModifier<R: RootRegistry>: ViewModifier {
             __content
                 .contextMenu(menuItems: { menuItems.resolve(on: element, in: context) })
             
+                
             
         
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS)
         case let ._1(menuItems, preview):
-            if #available(visionOS 1.0,macOS 13.0,iOS 16.0,tvOS 16.0, *) {
+            if #available(iOS 16.0,visionOS 1.0,macOS 13.0,tvOS 16.0, *) {
             let menuItems = menuItems as! ViewReference
 let preview = preview as! ViewReference
             
             __content
                 .contextMenu(menuItems: { menuItems.resolve(on: element, in: context) }, preview: { preview.resolve(on: element, in: context) })
             
+                
             } else { __content }
         #endif
         }
@@ -2177,6 +2273,7 @@ struct _contrastModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
@@ -2201,6 +2298,7 @@ struct _contrastModifier<R: RootRegistry>: ViewModifier {
             __content
                 .contrast(amount.resolve(on: element, in: context))
             
+                
             
         
         }
@@ -2222,12 +2320,13 @@ struct _controlGroupStyleModifier<R: RootRegistry>: ViewModifier {
 
     
     
+    
 
 
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS)
-    @available(tvOS 17.0,visionOS 1.0,macOS 12.0,iOS 15.0, *)
+    @available(tvOS 17.0,iOS 15.0,macOS 12.0,visionOS 1.0, *)
     init(_ style: AnyControlGroupStyle) {
         self.value = ._0(style: style)
         
@@ -2240,12 +2339,13 @@ struct _controlGroupStyleModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS)
         case let ._0(style):
-            if #available(tvOS 17.0,visionOS 1.0,macOS 12.0,iOS 15.0, *) {
+            if #available(tvOS 17.0,iOS 15.0,macOS 12.0,visionOS 1.0, *) {
             let style = style as! AnyControlGroupStyle
             
             __content
                 .controlGroupStyle(style)
             
+                
             } else { __content }
         #endif
         }
@@ -2267,12 +2367,13 @@ struct _controlSizeModifier<R: RootRegistry>: ViewModifier {
 
     
     
+    
 
 
 
 
     #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,macOS 10.15,iOS 15.0,watchOS 9.0, *)
+    @available(watchOS 9.0,macOS 10.15,iOS 15.0,visionOS 1.0, *)
     init(_ controlSize: SwiftUI.ControlSize) {
         self.value = ._0(controlSize: controlSize)
         
@@ -2285,12 +2386,13 @@ struct _controlSizeModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
         case let ._0(controlSize):
-            if #available(visionOS 1.0,macOS 10.15,iOS 15.0,watchOS 9.0, *) {
+            if #available(watchOS 9.0,macOS 10.15,iOS 15.0,visionOS 1.0, *) {
             let controlSize = controlSize as! SwiftUI.ControlSize
             
             __content
                 .controlSize(controlSize)
             
+                
             } else { __content }
         #endif
         }
@@ -2312,12 +2414,13 @@ struct _coordinateSpaceModifier<R: RootRegistry>: ViewModifier {
 
     
     
+    
 
 
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 14.0,iOS 17.0,watchOS 10.0,visionOS 1.0,tvOS 17.0, *)
+    @available(watchOS 10.0,macOS 14.0,tvOS 17.0,iOS 17.0,visionOS 1.0, *)
     init(_ name: SwiftUI.NamedCoordinateSpace) {
         self.value = ._0(name: name)
         
@@ -2330,12 +2433,13 @@ struct _coordinateSpaceModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(name):
-            if #available(macOS 14.0,iOS 17.0,watchOS 10.0,visionOS 1.0,tvOS 17.0, *) {
+            if #available(watchOS 10.0,macOS 14.0,tvOS 17.0,iOS 17.0,visionOS 1.0, *) {
             let name = name as! SwiftUI.NamedCoordinateSpace
             
             __content
                 .coordinateSpace(name)
             
+                
             } else { __content }
         #endif
         }
@@ -2357,12 +2461,13 @@ struct _datePickerStyleModifier<R: RootRegistry>: ViewModifier {
 
     
     
+    
 
 
 
 
     #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
-    @available(macOS 10.15,watchOS 10.0,iOS 13.0,visionOS 1.0, *)
+    @available(watchOS 10.0,visionOS 1.0,iOS 13.0,macOS 10.15, *)
     init(_ style: AnyDatePickerStyle) {
         self.value = ._0(style: style)
         
@@ -2375,12 +2480,13 @@ struct _datePickerStyleModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
         case let ._0(style):
-            if #available(macOS 10.15,watchOS 10.0,iOS 13.0,visionOS 1.0, *) {
+            if #available(watchOS 10.0,visionOS 1.0,iOS 13.0,macOS 10.15, *) {
             let style = style as! AnyDatePickerStyle
             
             __content
                 .datePickerStyle(style)
             
+                
             } else { __content }
         #endif
         }
@@ -2402,12 +2508,13 @@ struct _defaultHoverEffectModifier<R: RootRegistry>: ViewModifier {
 
     
     
+    
 
 
 
 
     #if os(iOS) || os(tvOS) || os(visionOS) || os(xrOS)
-    @available(xrOS 1.0,iOS 17.0,visionOS 1.0,tvOS 17.0, *)
+    @available(xrOS 1.0,iOS 17.0,tvOS 17.0,visionOS 1.0, *)
     init(_ effect: SwiftUI.HoverEffect?) {
         self.value = ._0(effect: effect)
         
@@ -2420,12 +2527,13 @@ struct _defaultHoverEffectModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(tvOS) || os(visionOS) || os(xrOS)
         case let ._0(effect):
-            if #available(xrOS 1.0,iOS 17.0,visionOS 1.0,tvOS 17.0, *) {
+            if #available(xrOS 1.0,iOS 17.0,tvOS 17.0,visionOS 1.0, *) {
             let effect = effect as? SwiftUI.HoverEffect
             
             __content
                 .defaultHoverEffect(effect)
             
+                
             } else { __content }
         #endif
         }
@@ -2447,12 +2555,13 @@ struct _defaultScrollAnchorModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(tvOS 17.0,iOS 17.0,watchOS 10.0,visionOS 1.0,macOS 14.0, *)
+    @available(watchOS 10.0,iOS 17.0,visionOS 1.0,macOS 14.0,tvOS 17.0, *)
     init(_ anchor: AttributeReference<SwiftUI.UnitPoint?>?) {
         self.value = ._0(anchor: anchor)
         
@@ -2465,12 +2574,13 @@ struct _defaultScrollAnchorModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(anchor):
-            if #available(tvOS 17.0,iOS 17.0,watchOS 10.0,visionOS 1.0,macOS 14.0, *) {
+            if #available(watchOS 10.0,iOS 17.0,visionOS 1.0,macOS 14.0,tvOS 17.0, *) {
             let anchor = anchor as? AttributeReference<SwiftUI.UnitPoint?>
             
             __content
                 .defaultScrollAnchor(anchor?.resolve(on: element, in: context))
             
+                
             } else { __content }
         #endif
         }
@@ -2492,6 +2602,7 @@ struct _defaultWheelPickerItemHeightModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
@@ -2516,6 +2627,7 @@ struct _defaultWheelPickerItemHeightModifier<R: RootRegistry>: ViewModifier {
             __content
                 .defaultWheelPickerItemHeight(height.resolve(on: element, in: context))
             
+                
             } else { __content }
         #endif
         }
@@ -2537,12 +2649,13 @@ struct _defersSystemGesturesModifier<R: RootRegistry>: ViewModifier {
 
     
     
+    
 
 
 
 
     #if os(iOS) || os(visionOS)
-    @available(visionOS 1.0,iOS 16.0, *)
+    @available(iOS 16.0,visionOS 1.0, *)
     init(on edges: SwiftUI.Edge.Set) {
         self.value = ._0(edges: edges)
         
@@ -2555,12 +2668,13 @@ struct _defersSystemGesturesModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(visionOS)
         case let ._0(edges):
-            if #available(visionOS 1.0,iOS 16.0, *) {
+            if #available(iOS 16.0,visionOS 1.0, *) {
             let edges = edges as! SwiftUI.Edge.Set
             
             __content
                 .defersSystemGestures(on: edges)
             
+                
             } else { __content }
         #endif
         }
@@ -2582,6 +2696,7 @@ struct _deleteDisabledModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
@@ -2606,6 +2721,7 @@ struct _deleteDisabledModifier<R: RootRegistry>: ViewModifier {
             __content
                 .deleteDisabled(isDisabled.resolve(on: element, in: context))
             
+                
             
         
         }
@@ -2636,6 +2752,7 @@ struct _dialogSuppressionToggleModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 @ChangeTracked private var _0_isSuppressed: Swift.Bool
 
@@ -2647,28 +2764,28 @@ struct _dialogSuppressionToggleModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(iOS 17.0,visionOS 1.0,tvOS 17.0,macOS 14.0,watchOS 10.0, *)
+    @available(visionOS 1.0,watchOS 10.0,tvOS 17.0,iOS 17.0,macOS 14.0, *)
     init(_ titleKey: SwiftUI.LocalizedStringKey,isSuppressed: ChangeTracked<Swift.Bool>) {
         self.value = ._0(titleKey: titleKey)
         self.__0_isSuppressed = isSuppressed
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,tvOS 17.0,macOS 14.0,iOS 17.0,watchOS 10.0, *)
+    @available(visionOS 1.0,iOS 17.0,tvOS 17.0,macOS 14.0,watchOS 10.0, *)
     init(_ title: AttributeReference<String>,isSuppressed: ChangeTracked<Swift.Bool>) {
         self.value = ._1(title: title)
         self.__1_isSuppressed = isSuppressed
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,tvOS 17.0,macOS 14.0,iOS 17.0,watchOS 10.0, *)
+    @available(iOS 17.0,tvOS 17.0,watchOS 10.0,macOS 14.0,visionOS 1.0, *)
     init(_ label: TextReference,isSuppressed: ChangeTracked<Swift.Bool>) {
         self.value = ._2(label: label)
         self.__2_isSuppressed = isSuppressed
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,tvOS 17.0,macOS 14.0,iOS 17.0,watchOS 10.0, *)
+    @available(iOS 17.0,tvOS 17.0,watchOS 10.0,macOS 14.0,visionOS 1.0, *)
     init(isSuppressed: ChangeTracked<Swift.Bool>) {
         self.value = ._3
         self.__3_isSuppressed = isSuppressed
@@ -2681,42 +2798,46 @@ struct _dialogSuppressionToggleModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(titleKey):
-            if #available(iOS 17.0,visionOS 1.0,tvOS 17.0,macOS 14.0,watchOS 10.0, *) {
+            if #available(visionOS 1.0,watchOS 10.0,tvOS 17.0,iOS 17.0,macOS 14.0, *) {
             let titleKey = titleKey as! SwiftUI.LocalizedStringKey
             
             __content
                 .dialogSuppressionToggle(titleKey, isSuppressed: __0_isSuppressed.projectedValue)
             
+                
             } else { __content }
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(title):
-            if #available(visionOS 1.0,tvOS 17.0,macOS 14.0,iOS 17.0,watchOS 10.0, *) {
+            if #available(visionOS 1.0,iOS 17.0,tvOS 17.0,macOS 14.0,watchOS 10.0, *) {
             let title = title as! AttributeReference<String>
             
             __content
                 .dialogSuppressionToggle(title.resolve(on: element, in: context), isSuppressed: __1_isSuppressed.projectedValue)
             
+                
             } else { __content }
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._2(label):
-            if #available(visionOS 1.0,tvOS 17.0,macOS 14.0,iOS 17.0,watchOS 10.0, *) {
+            if #available(iOS 17.0,tvOS 17.0,watchOS 10.0,macOS 14.0,visionOS 1.0, *) {
             let label = label as! TextReference
             __content._observeTextReference(label, on: element, in: context) { __content in
             __content
                 .dialogSuppressionToggle(label.resolve(on: element, in: context), isSuppressed: __2_isSuppressed.projectedValue)
             }
+                
             } else { __content }
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case ._3:
-            if #available(visionOS 1.0,tvOS 17.0,macOS 14.0,iOS 17.0,watchOS 10.0, *) {
+            if #available(iOS 17.0,tvOS 17.0,watchOS 10.0,macOS 14.0,visionOS 1.0, *) {
             
             
             __content
                 .dialogSuppressionToggle(isSuppressed: __3_isSuppressed.projectedValue)
             
+                
             } else { __content }
         #endif
         }
@@ -2741,6 +2862,7 @@ struct _digitalCrownAccessoryModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
@@ -2748,14 +2870,14 @@ struct _digitalCrownAccessoryModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,watchOS 9.0, *)
+    @available(watchOS 9.0,visionOS 1.0, *)
     init(content: ViewReference=ViewReference(value: [])) {
         self.value = ._0(content: content)
         
     }
     #endif
     #if os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,watchOS 9.0, *)
+    @available(watchOS 9.0,visionOS 1.0, *)
     init(_ visibility: AttributeReference<SwiftUI.Visibility>) {
         self.value = ._1(visibility: visibility)
         
@@ -2768,22 +2890,24 @@ struct _digitalCrownAccessoryModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(visionOS) || os(watchOS)
         case let ._0(content):
-            if #available(visionOS 1.0,watchOS 9.0, *) {
+            if #available(watchOS 9.0,visionOS 1.0, *) {
             let content = content as! ViewReference
             
             __content
                 .digitalCrownAccessory(content: { content.resolve(on: element, in: context) })
             
+                
             } else { __content }
         #endif
         #if os(visionOS) || os(watchOS)
         case let ._1(visibility):
-            if #available(visionOS 1.0,watchOS 9.0, *) {
+            if #available(watchOS 9.0,visionOS 1.0, *) {
             let visibility = visibility as! AttributeReference<SwiftUI.Visibility>
             
             __content
                 .digitalCrownAccessory(visibility.resolve(on: element, in: context))
             
+                
             } else { __content }
         #endif
         }
@@ -2805,6 +2929,7 @@ struct _disabledModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
@@ -2829,6 +2954,7 @@ struct _disabledModifier<R: RootRegistry>: ViewModifier {
             __content
                 .disabled(disabled.resolve(on: element, in: context))
             
+                
             
         
         }
@@ -2850,6 +2976,7 @@ struct _drawingGroupModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
@@ -2874,6 +3001,7 @@ struct _drawingGroupModifier<R: RootRegistry>: ViewModifier {
             __content
                 .drawingGroup(opaque: opaque.resolve(on: element, in: context), colorMode: colorMode)
             
+                
             
         
         }
@@ -2896,6 +3024,7 @@ struct _dynamicTypeSizeModifier<R: RootRegistry>: ViewModifier {
 
     let value: Value
 
+    
     
     
 
@@ -2931,6 +3060,7 @@ struct _dynamicTypeSizeModifier<R: RootRegistry>: ViewModifier {
             __content
                 .dynamicTypeSize(size)
             
+                
             
         
         
@@ -2941,6 +3071,7 @@ struct _dynamicTypeSizeModifier<R: RootRegistry>: ViewModifier {
             __content
                 .dynamicTypeSize(range)
             
+                
             
         
         }
@@ -2962,12 +3093,13 @@ struct _fileDialogCustomizationIDModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 14.0,iOS 17.0,visionOS 1.0, *)
+    @available(iOS 17.0,macOS 14.0,visionOS 1.0, *)
     init(_ id: AttributeReference<Swift.String>) {
         self.value = ._0(id: id)
         
@@ -2980,12 +3112,13 @@ struct _fileDialogCustomizationIDModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(id):
-            if #available(macOS 14.0,iOS 17.0,visionOS 1.0, *) {
+            if #available(iOS 17.0,macOS 14.0,visionOS 1.0, *) {
             let id = id as! AttributeReference<Swift.String>
             
             __content
                 .fileDialogCustomizationID(id.resolve(on: element, in: context))
             
+                
             } else { __content }
         #endif
         }
@@ -3007,12 +3140,13 @@ struct _fileDialogImportsUnresolvedAliasesModifier<R: RootRegistry>: ViewModifie
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 14.0,iOS 17.0,visionOS 1.0, *)
+    @available(visionOS 1.0,macOS 14.0,iOS 17.0, *)
     init(_ imports: AttributeReference<Swift.Bool>) {
         self.value = ._0(imports: imports)
         
@@ -3025,12 +3159,13 @@ struct _fileDialogImportsUnresolvedAliasesModifier<R: RootRegistry>: ViewModifie
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(imports):
-            if #available(macOS 14.0,iOS 17.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,macOS 14.0,iOS 17.0, *) {
             let imports = imports as! AttributeReference<Swift.Bool>
             
             __content
                 .fileDialogImportsUnresolvedAliases(imports.resolve(on: element, in: context))
             
+                
             } else { __content }
         #endif
         }
@@ -3052,12 +3187,13 @@ struct _findDisabledModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
 
     #if os(iOS) || os(visionOS)
-    @available(iOS 16.0,visionOS 1.0, *)
+    @available(visionOS 1.0,iOS 16.0, *)
     init(_ isDisabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(isDisabled: isDisabled)
         
@@ -3070,12 +3206,13 @@ struct _findDisabledModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(visionOS)
         case let ._0(isDisabled):
-            if #available(iOS 16.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,iOS 16.0, *) {
             let isDisabled = isDisabled as! AttributeReference<Swift.Bool>
             
             __content
                 .findDisabled(isDisabled.resolve(on: element, in: context))
             
+                
             } else { __content }
         #endif
         }
@@ -3097,12 +3234,13 @@ struct _findNavigatorModifier<R: RootRegistry>: ViewModifier {
 
     
     
+    
 
 @ChangeTracked private var _0_isPresented: Swift.Bool
 
 
     #if os(iOS) || os(visionOS)
-    @available(iOS 16.0,visionOS 1.0, *)
+    @available(visionOS 1.0,iOS 16.0, *)
     init(isPresented: ChangeTracked<Swift.Bool>) {
         self.value = ._0
         self.__0_isPresented = isPresented
@@ -3115,12 +3253,13 @@ struct _findNavigatorModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(visionOS)
         case ._0:
-            if #available(iOS 16.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,iOS 16.0, *) {
             
             
             __content
                 .findNavigator(isPresented: __0_isPresented.projectedValue)
             
+                
             } else { __content }
         #endif
         }
@@ -3145,6 +3284,7 @@ struct _fixedSizeModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
@@ -3178,6 +3318,7 @@ struct _fixedSizeModifier<R: RootRegistry>: ViewModifier {
             __content
                 .fixedSize(horizontal: horizontal.resolve(on: element, in: context), vertical: vertical.resolve(on: element, in: context))
             
+                
             
         
         
@@ -3188,6 +3329,7 @@ struct _fixedSizeModifier<R: RootRegistry>: ViewModifier {
             __content
                 .fixedSize()
             
+                
             
         
         }
@@ -3209,6 +3351,7 @@ struct _flipsForRightToLeftLayoutDirectionModifier<R: RootRegistry>: ViewModifie
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
@@ -3233,6 +3376,7 @@ struct _flipsForRightToLeftLayoutDirectionModifier<R: RootRegistry>: ViewModifie
             __content
                 .flipsForRightToLeftLayoutDirection(enabled.resolve(on: element, in: context))
             
+                
             
         
         }
@@ -3254,12 +3398,13 @@ struct _focusEffectDisabledModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 14.0,iOS 17.0,watchOS 10.0,visionOS 1.0,tvOS 17.0, *)
+    @available(iOS 17.0,watchOS 10.0,tvOS 17.0,visionOS 1.0,macOS 14.0, *)
     init(_ disabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(disabled: disabled)
         
@@ -3272,12 +3417,13 @@ struct _focusEffectDisabledModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(disabled):
-            if #available(macOS 14.0,iOS 17.0,watchOS 10.0,visionOS 1.0,tvOS 17.0, *) {
+            if #available(iOS 17.0,watchOS 10.0,tvOS 17.0,visionOS 1.0,macOS 14.0, *) {
             let disabled = disabled as! AttributeReference<Swift.Bool>
             
             __content
                 .focusEffectDisabled(disabled.resolve(on: element, in: context))
             
+                
             } else { __content }
         #endif
         }
@@ -3299,12 +3445,13 @@ struct _focusSectionModifier<R: RootRegistry>: ViewModifier {
 
     
     
+    
 
 
 
 
     #if os(macOS) || os(tvOS) || os(visionOS)
-    @available(tvOS 15.0,visionOS 1.0,macOS 13.0, *)
+    @available(visionOS 1.0,macOS 13.0,tvOS 15.0, *)
     init() {
         self.value = ._0
         
@@ -3317,12 +3464,13 @@ struct _focusSectionModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(macOS) || os(tvOS) || os(visionOS)
         case ._0:
-            if #available(tvOS 15.0,visionOS 1.0,macOS 13.0, *) {
+            if #available(visionOS 1.0,macOS 13.0,tvOS 15.0, *) {
             
             
             __content
                 .focusSection()
             
+                
             } else { __content }
         #endif
         }
@@ -3347,6 +3495,7 @@ struct _focusableModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
@@ -3354,14 +3503,14 @@ struct _focusableModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 12.0,iOS 17.0,watchOS 8.0,visionOS 1.0,tvOS 15.0, *)
+    @available(macOS 12.0,visionOS 1.0,watchOS 8.0,tvOS 15.0,iOS 17.0, *)
     init(_ isFocusable: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(isFocusable: isFocusable)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 14.0,iOS 17.0,watchOS 10.0,visionOS 1.0,tvOS 17.0, *)
+    @available(macOS 14.0,visionOS 1.0,watchOS 10.0,tvOS 17.0,iOS 17.0, *)
     init(_ isFocusable: AttributeReference<Swift.Bool> = .init(storage: .constant(true)), interactions: SwiftUI.FocusInteractions) {
         self.value = ._1(isFocusable: isFocusable, interactions: interactions)
         
@@ -3374,23 +3523,25 @@ struct _focusableModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(isFocusable):
-            if #available(macOS 12.0,iOS 17.0,watchOS 8.0,visionOS 1.0,tvOS 15.0, *) {
+            if #available(macOS 12.0,visionOS 1.0,watchOS 8.0,tvOS 15.0,iOS 17.0, *) {
             let isFocusable = isFocusable as! AttributeReference<Swift.Bool>
             
             __content
                 .focusable(isFocusable.resolve(on: element, in: context))
             
+                
             } else { __content }
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(isFocusable, interactions):
-            if #available(macOS 14.0,iOS 17.0,watchOS 10.0,visionOS 1.0,tvOS 17.0, *) {
+            if #available(macOS 14.0,visionOS 1.0,watchOS 10.0,tvOS 17.0,iOS 17.0, *) {
             let isFocusable = isFocusable as! AttributeReference<Swift.Bool>
 let interactions = interactions as! SwiftUI.FocusInteractions
             
             __content
                 .focusable(isFocusable.resolve(on: element, in: context), interactions: interactions)
             
+                
             } else { __content }
         #endif
         }
@@ -3410,6 +3561,7 @@ struct _formStyleModifier<R: RootRegistry>: ViewModifier {
 
     let value: Value
 
+    
     
     
 
@@ -3436,6 +3588,7 @@ struct _formStyleModifier<R: RootRegistry>: ViewModifier {
             __content
                 .formStyle(style)
             
+                
             
         
         }
@@ -3469,6 +3622,7 @@ struct _frameModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
@@ -3482,14 +3636,14 @@ struct _frameModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(visionOS) || os(xrOS)
-    @available(visionOS 1.0,xrOS 1.0, *)
+    @available(xrOS 1.0,visionOS 1.0, *)
     init(depth: AttributeReference<CoreFoundation.CGFloat?>?,alignment: SwiftUI.DepthAlignment = .center ) {
         self.value = ._0(depth: depth, alignment: alignment)
         
     }
     #endif
     #if os(visionOS) || os(xrOS)
-    @available(xrOS 1.0,visionOS 1.0, *)
+    @available(visionOS 1.0,xrOS 1.0, *)
     init(minDepth: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), idealDepth: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), maxDepth: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), alignment: SwiftUI.DepthAlignment = .center ) {
         self.value = ._1(minDepth: minDepth, idealDepth: idealDepth, maxDepth: maxDepth, alignment: alignment)
         
@@ -3523,18 +3677,19 @@ struct _frameModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(visionOS) || os(xrOS)
         case let ._0(depth, alignment):
-            if #available(visionOS 1.0,xrOS 1.0, *) {
+            if #available(xrOS 1.0,visionOS 1.0, *) {
             let depth = depth as? AttributeReference<CoreFoundation.CGFloat?>
 let alignment = alignment as! SwiftUI.DepthAlignment 
             
             __content
                 .frame(depth: depth?.resolve(on: element, in: context), alignment: alignment)
             
+                
             } else { __content }
         #endif
         #if os(visionOS) || os(xrOS)
         case let ._1(minDepth, idealDepth, maxDepth, alignment):
-            if #available(xrOS 1.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,xrOS 1.0, *) {
             let minDepth = minDepth as? AttributeReference<CoreFoundation.CGFloat?>
 let idealDepth = idealDepth as? AttributeReference<CoreFoundation.CGFloat?>
 let maxDepth = maxDepth as? AttributeReference<CoreFoundation.CGFloat?>
@@ -3543,6 +3698,7 @@ let alignment = alignment as! SwiftUI.DepthAlignment
             __content
                 .frame(minDepth: minDepth?.resolve(on: element, in: context), idealDepth: idealDepth?.resolve(on: element, in: context), maxDepth: maxDepth?.resolve(on: element, in: context), alignment: alignment)
             
+                
             } else { __content }
         #endif
         
@@ -3553,6 +3709,7 @@ let alignment = alignment as! SwiftUI.DepthAlignment
             __content
                 .frame(width: width?.resolve(on: element, in: context), height: height?.resolve(on: element, in: context), alignment: alignment.resolve(on: element, in: context))
             
+                
             
         
         
@@ -3563,6 +3720,7 @@ let alignment = alignment as! SwiftUI.DepthAlignment
             __content
                 .frame()
             
+                
             
         
         
@@ -3573,6 +3731,7 @@ let alignment = alignment as! SwiftUI.DepthAlignment
             __content
                 .frame(minWidth: minWidth?.resolve(on: element, in: context), idealWidth: idealWidth?.resolve(on: element, in: context), maxWidth: maxWidth?.resolve(on: element, in: context), minHeight: minHeight?.resolve(on: element, in: context), idealHeight: idealHeight?.resolve(on: element, in: context), maxHeight: maxHeight?.resolve(on: element, in: context), alignment: alignment.resolve(on: element, in: context))
             
+                
             
         
         }
@@ -3594,12 +3753,13 @@ struct _fullScreenCoverModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 @ChangeTracked private var _0_isPresented: Swift.Bool
 @Event private var _0_onDismiss__0: Event.EventHandler
 
     #if os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 7.0,iOS 14.0,visionOS 1.0,tvOS 14.0, *)
+    @available(tvOS 14.0,visionOS 1.0,iOS 14.0,watchOS 7.0, *)
     init(isPresented: ChangeTracked<Swift.Bool>,onDismiss onDismiss__0: Event=Event(), content: ViewReference=ViewReference(value: [])) {
         self.value = ._0(content: content)
         self.__0_isPresented = isPresented
@@ -3613,12 +3773,13 @@ self.__0_onDismiss__0 = onDismiss__0
             fatalError("unreachable")
         #if os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(content):
-            if #available(watchOS 7.0,iOS 14.0,visionOS 1.0,tvOS 14.0, *) {
+            if #available(tvOS 14.0,visionOS 1.0,iOS 14.0,watchOS 7.0, *) {
             let content = content as! ViewReference
             
             __content
                 .fullScreenCover(isPresented: __0_isPresented.projectedValue, onDismiss: { __0_onDismiss__0.wrappedValue() }, content: { content.resolve(on: element, in: context) })
             
+                
             } else { __content }
         #endif
         }
@@ -3640,12 +3801,13 @@ struct _gaugeStyleModifier<R: RootRegistry>: ViewModifier {
 
     
     
+    
 
 
 
 
     #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,macOS 13.0,iOS 16.0,watchOS 7.0, *)
+    @available(watchOS 7.0,macOS 13.0,iOS 16.0,visionOS 1.0, *)
     init(_ style: AnyGaugeStyle) {
         self.value = ._0(style: style)
         
@@ -3658,12 +3820,13 @@ struct _gaugeStyleModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
         case let ._0(style):
-            if #available(visionOS 1.0,macOS 13.0,iOS 16.0,watchOS 7.0, *) {
+            if #available(watchOS 7.0,macOS 13.0,iOS 16.0,visionOS 1.0, *) {
             let style = style as! AnyGaugeStyle
             
             __content
                 .gaugeStyle(style)
             
+                
             } else { __content }
         #endif
         }
@@ -3685,12 +3848,13 @@ struct _geometryGroupModifier<R: RootRegistry>: ViewModifier {
 
     
     
+    
 
 
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(iOS 17.0,macOS 14.0,tvOS 17.0,visionOS 1.0,watchOS 10.0, *)
+    @available(watchOS 10.0,iOS 17.0,visionOS 1.0,macOS 14.0,tvOS 17.0, *)
     init() {
         self.value = ._0
         
@@ -3703,12 +3867,13 @@ struct _geometryGroupModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case ._0:
-            if #available(iOS 17.0,macOS 14.0,tvOS 17.0,visionOS 1.0,watchOS 10.0, *) {
+            if #available(watchOS 10.0,iOS 17.0,visionOS 1.0,macOS 14.0,tvOS 17.0, *) {
             
             
             __content
                 .geometryGroup()
             
+                
             } else { __content }
         #endif
         }
@@ -3722,21 +3887,22 @@ struct _gestureModifier<R: RootRegistry>: ViewModifier {
     enum Value {
         case _never
         
-        indirect case _0(gesture: AnyGesture<Any>,mask: SwiftUI.GestureMask = .all )
+        indirect case _0(gesture: _AnyGesture,mask: SwiftUI.GestureMask = .all )
         
     }
 
     let value: Value
 
-    
-    
+    @ObservedElement private var element
+    @LiveContext<R> private var context
+    @GestureState private var gestureState = [String:Any]()
 
 
 
 
     
     
-    init(_ gesture: AnyGesture<Any>,including mask: SwiftUI.GestureMask = .all ) {
+    init(_ gesture: _AnyGesture,including mask: SwiftUI.GestureMask = .all ) {
         self.value = ._0(gesture: gesture, mask: mask)
         
     }
@@ -3752,8 +3918,9 @@ struct _gestureModifier<R: RootRegistry>: ViewModifier {
             
             
             __content
-                .gesture(gesture, including: mask)
+                .gesture(gesture.resolve(on: element, in: context.withGestureState(_gestureState)), including: mask)
             
+                .environment(\.gestureState, _gestureState)
             
         
         }
@@ -3776,6 +3943,7 @@ struct _glassBackgroundEffectModifier<R: RootRegistry>: ViewModifier {
 
     let value: Value
 
+    
     
     
 
@@ -3811,6 +3979,7 @@ struct _glassBackgroundEffectModifier<R: RootRegistry>: ViewModifier {
             __content
                 .glassBackgroundEffect(displayMode: displayMode)
             
+                
             } else { __content }
         #endif
         #if os(visionOS) || os(xrOS)
@@ -3822,6 +3991,7 @@ let displayMode = displayMode as! SwiftUI.GlassBackgroundDisplayMode
             __content
                 .glassBackgroundEffect(in: shape, displayMode: displayMode)
             
+                
             } else { __content }
         #endif
         }
@@ -3843,6 +4013,7 @@ struct _grayscaleModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
@@ -3867,6 +4038,7 @@ struct _grayscaleModifier<R: RootRegistry>: ViewModifier {
             __content
                 .grayscale(amount.resolve(on: element, in: context))
             
+                
             
         
         }
@@ -3888,6 +4060,7 @@ struct _gridCellAnchorModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
@@ -3912,6 +4085,7 @@ struct _gridCellAnchorModifier<R: RootRegistry>: ViewModifier {
             __content
                 .gridCellAnchor(anchor.resolve(on: element, in: context))
             
+                
             
         
         }
@@ -3933,6 +4107,7 @@ struct _gridCellColumnsModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
@@ -3957,6 +4132,7 @@ struct _gridCellColumnsModifier<R: RootRegistry>: ViewModifier {
             __content
                 .gridCellColumns(count.resolve(on: element, in: context))
             
+                
             
         
         }
@@ -3976,6 +4152,7 @@ struct _gridCellUnsizedAxesModifier<R: RootRegistry>: ViewModifier {
 
     let value: Value
 
+    
     
     
 
@@ -4002,6 +4179,7 @@ struct _gridCellUnsizedAxesModifier<R: RootRegistry>: ViewModifier {
             __content
                 .gridCellUnsizedAxes(axes)
             
+                
             
         
         }
@@ -4023,6 +4201,7 @@ struct _gridColumnAlignmentModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
@@ -4047,6 +4226,7 @@ struct _gridColumnAlignmentModifier<R: RootRegistry>: ViewModifier {
             __content
                 .gridColumnAlignment(guide.resolve(on: element, in: context))
             
+                
             
         
         }
@@ -4066,6 +4246,7 @@ struct _groupBoxStyleModifier<R: RootRegistry>: ViewModifier {
 
     let value: Value
 
+    
     
     
 
@@ -4092,6 +4273,7 @@ struct _groupBoxStyleModifier<R: RootRegistry>: ViewModifier {
             __content
                 .groupBoxStyle(style)
             
+                
             } else { __content }
         #endif
         }
@@ -4111,6 +4293,7 @@ struct _headerProminenceModifier<R: RootRegistry>: ViewModifier {
 
     let value: Value
 
+    
     
     
 
@@ -4137,6 +4320,7 @@ struct _headerProminenceModifier<R: RootRegistry>: ViewModifier {
             __content
                 .headerProminence(prominence)
             
+                
             
         
         }
@@ -4164,6 +4348,7 @@ struct _helpModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
@@ -4206,6 +4391,7 @@ struct _helpModifier<R: RootRegistry>: ViewModifier {
             __content
                 .help(textKey)
             
+                
             
         
         
@@ -4216,6 +4402,7 @@ struct _helpModifier<R: RootRegistry>: ViewModifier {
             __content
                 .help(text.resolve(on: element, in: context))
             }
+                
             
         
         
@@ -4226,6 +4413,7 @@ struct _helpModifier<R: RootRegistry>: ViewModifier {
             __content
                 .help(text.resolve(on: element, in: context))
             
+                
             
         
         }
@@ -4245,6 +4433,7 @@ struct _hiddenModifier<R: RootRegistry>: ViewModifier {
 
     let value: Value
 
+    
     
     
 
@@ -4271,6 +4460,7 @@ struct _hiddenModifier<R: RootRegistry>: ViewModifier {
             __content
                 .hidden()
             
+                
             
         
         }
@@ -4284,21 +4474,22 @@ struct _highPriorityGestureModifier<R: RootRegistry>: ViewModifier {
     enum Value {
         case _never
         
-        indirect case _0(gesture: AnyGesture<Any>,mask: SwiftUI.GestureMask = .all )
+        indirect case _0(gesture: _AnyGesture,mask: SwiftUI.GestureMask = .all )
         
     }
 
     let value: Value
 
-    
-    
+    @ObservedElement private var element
+    @LiveContext<R> private var context
+    @GestureState private var gestureState = [String:Any]()
 
 
 
 
     
     
-    init(_ gesture: AnyGesture<Any>,including mask: SwiftUI.GestureMask = .all ) {
+    init(_ gesture: _AnyGesture,including mask: SwiftUI.GestureMask = .all ) {
         self.value = ._0(gesture: gesture, mask: mask)
         
     }
@@ -4314,8 +4505,9 @@ struct _highPriorityGestureModifier<R: RootRegistry>: ViewModifier {
             
             
             __content
-                .highPriorityGesture(gesture, including: mask)
+                .highPriorityGesture(gesture.resolve(on: element, in: context.withGestureState(_gestureState)), including: mask)
             
+                .environment(\.gestureState, _gestureState)
             
         
         }
@@ -4335,6 +4527,7 @@ struct _horizontalRadioGroupLayoutModifier<R: RootRegistry>: ViewModifier {
 
     let value: Value
 
+    
     
     
 
@@ -4361,6 +4554,7 @@ struct _horizontalRadioGroupLayoutModifier<R: RootRegistry>: ViewModifier {
             __content
                 .horizontalRadioGroupLayout()
             
+                
             } else { __content }
         #endif
         }
@@ -4385,6 +4579,7 @@ struct _hoverEffectModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
@@ -4392,14 +4587,14 @@ struct _hoverEffectModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(tvOS) || os(visionOS) || os(xrOS)
-    @available(iOS 13.4,xrOS 1.0,visionOS 1.0,tvOS 16.0, *)
+    @available(xrOS 1.0,iOS 13.4,tvOS 16.0,visionOS 1.0, *)
     init(_ effect: SwiftUI.HoverEffect = .automatic ) {
         self.value = ._0(effect: effect)
         
     }
     #endif
     #if os(iOS) || os(tvOS) || os(visionOS) || os(xrOS)
-    @available(iOS 17.0,xrOS 1.0,visionOS 1.0,tvOS 17.0, *)
+    @available(xrOS 1.0,iOS 17.0,tvOS 17.0,visionOS 1.0, *)
     init(_ effect: SwiftUI.HoverEffect = .automatic, isEnabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._1(effect: effect, isEnabled: isEnabled)
         
@@ -4412,23 +4607,25 @@ struct _hoverEffectModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(tvOS) || os(visionOS) || os(xrOS)
         case let ._0(effect):
-            if #available(iOS 13.4,xrOS 1.0,visionOS 1.0,tvOS 16.0, *) {
+            if #available(xrOS 1.0,iOS 13.4,tvOS 16.0,visionOS 1.0, *) {
             let effect = effect as! SwiftUI.HoverEffect 
             
             __content
                 .hoverEffect(effect)
             
+                
             } else { __content }
         #endif
         #if os(iOS) || os(tvOS) || os(visionOS) || os(xrOS)
         case let ._1(effect, isEnabled):
-            if #available(iOS 17.0,xrOS 1.0,visionOS 1.0,tvOS 17.0, *) {
+            if #available(xrOS 1.0,iOS 17.0,tvOS 17.0,visionOS 1.0, *) {
             let effect = effect as! SwiftUI.HoverEffect 
 let isEnabled = isEnabled as! AttributeReference<Swift.Bool>
             
             __content
                 .hoverEffect(effect, isEnabled: isEnabled.resolve(on: element, in: context))
             
+                
             } else { __content }
         #endif
         }
@@ -4450,12 +4647,13 @@ struct _hoverEffectDisabledModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
 
     #if os(iOS) || os(tvOS) || os(visionOS) || os(xrOS)
-    @available(xrOS 1.0,iOS 17.0,visionOS 1.0,tvOS 17.0, *)
+    @available(tvOS 17.0,visionOS 1.0,iOS 17.0,xrOS 1.0, *)
     init(_ disabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(disabled: disabled)
         
@@ -4468,12 +4666,13 @@ struct _hoverEffectDisabledModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(tvOS) || os(visionOS) || os(xrOS)
         case let ._0(disabled):
-            if #available(xrOS 1.0,iOS 17.0,visionOS 1.0,tvOS 17.0, *) {
+            if #available(tvOS 17.0,visionOS 1.0,iOS 17.0,xrOS 1.0, *) {
             let disabled = disabled as! AttributeReference<Swift.Bool>
             
             __content
                 .hoverEffectDisabled(disabled.resolve(on: element, in: context))
             
+                
             } else { __content }
         #endif
         }
@@ -4495,6 +4694,7 @@ struct _hueRotationModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
@@ -4519,6 +4719,7 @@ struct _hueRotationModifier<R: RootRegistry>: ViewModifier {
             __content
                 .hueRotation(angle.resolve(on: element, in: context))
             
+                
             
         
         }
@@ -4538,6 +4739,7 @@ struct _ignoresSafeAreaModifier<R: RootRegistry>: ViewModifier {
 
     let value: Value
 
+    
     
     
 
@@ -4564,6 +4766,7 @@ struct _ignoresSafeAreaModifier<R: RootRegistry>: ViewModifier {
             __content
                 .ignoresSafeArea(regions, edges: edges)
             
+                
             
         
         }
@@ -4583,6 +4786,7 @@ struct _imageScaleModifier<R: RootRegistry>: ViewModifier {
 
     let value: Value
 
+    
     
     
 
@@ -4609,6 +4813,7 @@ struct _imageScaleModifier<R: RootRegistry>: ViewModifier {
             __content
                 .imageScale(scale)
             
+                
             
         
         }
@@ -4630,12 +4835,13 @@ struct _indexViewStyleModifier<R: RootRegistry>: ViewModifier {
 
     
     
+    
 
 
 
 
     #if os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(iOS 14.0,visionOS 1.0,tvOS 14.0,watchOS 8.0, *)
+    @available(watchOS 8.0,tvOS 14.0,iOS 14.0,visionOS 1.0, *)
     init(_ style: AnyIndexViewStyle) {
         self.value = ._0(style: style)
         
@@ -4648,12 +4854,13 @@ struct _indexViewStyleModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(style):
-            if #available(iOS 14.0,visionOS 1.0,tvOS 14.0,watchOS 8.0, *) {
+            if #available(watchOS 8.0,tvOS 14.0,iOS 14.0,visionOS 1.0, *) {
             let style = style as! AnyIndexViewStyle
             
             __content
                 .indexViewStyle(style)
             
+                
             } else { __content }
         #endif
         }
@@ -4675,12 +4882,13 @@ struct _inspectorModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 @ChangeTracked private var _0_isPresented: Swift.Bool
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 14.0,iOS 17.0,visionOS 1.0, *)
+    @available(visionOS 1.0,iOS 17.0,macOS 14.0, *)
     init(isPresented: ChangeTracked<Swift.Bool>,content: ViewReference=ViewReference(value: [])) {
         self.value = ._0(content: content)
         self.__0_isPresented = isPresented
@@ -4693,12 +4901,13 @@ struct _inspectorModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(content):
-            if #available(macOS 14.0,iOS 17.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,iOS 17.0,macOS 14.0, *) {
             let content = content as! ViewReference
             
             __content
                 .inspector(isPresented: __0_isPresented.projectedValue, content: { content.resolve(on: element, in: context) })
             
+                
             } else { __content }
         #endif
         }
@@ -4723,6 +4932,7 @@ struct _inspectorColumnWidthModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
@@ -4730,14 +4940,14 @@ struct _inspectorColumnWidthModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 14.0,iOS 17.0,visionOS 1.0, *)
+    @available(visionOS 1.0,iOS 17.0,macOS 14.0, *)
     init(min: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), ideal: AttributeReference<CoreFoundation.CGFloat>,max: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)) ) {
         self.value = ._0(min: min, ideal: ideal, max: max)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 14.0,iOS 17.0,visionOS 1.0, *)
+    @available(visionOS 1.0,macOS 14.0,iOS 17.0, *)
     init(_ width: AttributeReference<CoreFoundation.CGFloat>) {
         self.value = ._1(width: width)
         
@@ -4750,7 +4960,7 @@ struct _inspectorColumnWidthModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(min, ideal, max):
-            if #available(macOS 14.0,iOS 17.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,iOS 17.0,macOS 14.0, *) {
             let min = min as? AttributeReference<CoreFoundation.CGFloat?>
 let ideal = ideal as! AttributeReference<CoreFoundation.CGFloat>
 let max = max as? AttributeReference<CoreFoundation.CGFloat?>
@@ -4758,16 +4968,18 @@ let max = max as? AttributeReference<CoreFoundation.CGFloat?>
             __content
                 .inspectorColumnWidth(min: min?.resolve(on: element, in: context), ideal: ideal.resolve(on: element, in: context), max: max?.resolve(on: element, in: context))
             
+                
             } else { __content }
         #endif
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._1(width):
-            if #available(macOS 14.0,iOS 17.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,macOS 14.0,iOS 17.0, *) {
             let width = width as! AttributeReference<CoreFoundation.CGFloat>
             
             __content
                 .inspectorColumnWidth(width.resolve(on: element, in: context))
             
+                
             } else { __content }
         #endif
         }
@@ -4789,6 +5001,7 @@ struct _interactionActivityTrackingTagModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
@@ -4813,6 +5026,7 @@ struct _interactionActivityTrackingTagModifier<R: RootRegistry>: ViewModifier {
             __content
                 .interactionActivityTrackingTag(tag.resolve(on: element, in: context))
             
+                
             
         
         }
@@ -4834,6 +5048,7 @@ struct _interactiveDismissDisabledModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
@@ -4858,6 +5073,7 @@ struct _interactiveDismissDisabledModifier<R: RootRegistry>: ViewModifier {
             __content
                 .interactiveDismissDisabled(isDisabled.resolve(on: element, in: context))
             
+                
             
         
         }
@@ -4879,12 +5095,13 @@ struct _invalidatableContentModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0,visionOS 1.0, *)
+    @available(tvOS 17.0,visionOS 1.0,watchOS 10.0,macOS 14.0,iOS 17.0, *)
     init(_ invalidatable: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(invalidatable: invalidatable)
         
@@ -4897,12 +5114,13 @@ struct _invalidatableContentModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(invalidatable):
-            if #available(macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0,visionOS 1.0, *) {
+            if #available(tvOS 17.0,visionOS 1.0,watchOS 10.0,macOS 14.0,iOS 17.0, *) {
             let invalidatable = invalidatable as! AttributeReference<Swift.Bool>
             
             __content
                 .invalidatableContent(invalidatable.resolve(on: element, in: context))
             
+                
             } else { __content }
         #endif
         }
@@ -4933,6 +5151,7 @@ struct _keyboardShortcutModifier<R: RootRegistry>: ViewModifier {
 
     
     
+    
 
 
 
@@ -4944,28 +5163,28 @@ struct _keyboardShortcutModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 11.0,iOS 14.0,visionOS 1.0, *)
+    @available(iOS 14.0,macOS 11.0,visionOS 1.0, *)
     init(_ key: SwiftUI.KeyEquivalent,modifiers: SwiftUI.EventModifiers = .command ) {
         self.value = ._0(key: key, modifiers: modifiers)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 11.0,iOS 14.0,visionOS 1.0, *)
+    @available(visionOS 1.0,iOS 14.0,macOS 11.0, *)
     init(_ shortcut: SwiftUI.KeyboardShortcut) {
         self.value = ._1(shortcut: shortcut)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(iOS 15.4,visionOS 1.0,macOS 12.3, *)
+    @available(visionOS 1.0,iOS 15.4,macOS 12.3, *)
     init(_ shortcut: SwiftUI.KeyboardShortcut?) {
         self.value = ._2(shortcut: shortcut)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 12.0,iOS 15.0,visionOS 1.0, *)
+    @available(iOS 15.0,macOS 12.0,visionOS 1.0, *)
     init(_ key: SwiftUI.KeyEquivalent,modifiers: SwiftUI.EventModifiers = .command, localization: SwiftUI.KeyboardShortcut.Localization) {
         self.value = ._3(key: key, modifiers: modifiers, localization: localization)
         
@@ -4978,38 +5197,41 @@ struct _keyboardShortcutModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(key, modifiers):
-            if #available(macOS 11.0,iOS 14.0,visionOS 1.0, *) {
+            if #available(iOS 14.0,macOS 11.0,visionOS 1.0, *) {
             let key = key as! SwiftUI.KeyEquivalent
 let modifiers = modifiers as! SwiftUI.EventModifiers 
             
             __content
                 .keyboardShortcut(key, modifiers: modifiers)
             
+                
             } else { __content }
         #endif
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._1(shortcut):
-            if #available(macOS 11.0,iOS 14.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,iOS 14.0,macOS 11.0, *) {
             let shortcut = shortcut as! SwiftUI.KeyboardShortcut
             
             __content
                 .keyboardShortcut(shortcut)
             
+                
             } else { __content }
         #endif
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._2(shortcut):
-            if #available(iOS 15.4,visionOS 1.0,macOS 12.3, *) {
+            if #available(visionOS 1.0,iOS 15.4,macOS 12.3, *) {
             let shortcut = shortcut as? SwiftUI.KeyboardShortcut
             
             __content
                 .keyboardShortcut(shortcut)
             
+                
             } else { __content }
         #endif
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._3(key, modifiers, localization):
-            if #available(macOS 12.0,iOS 15.0,visionOS 1.0, *) {
+            if #available(iOS 15.0,macOS 12.0,visionOS 1.0, *) {
             let key = key as! SwiftUI.KeyEquivalent
 let modifiers = modifiers as! SwiftUI.EventModifiers 
 let localization = localization as! SwiftUI.KeyboardShortcut.Localization
@@ -5017,6 +5239,7 @@ let localization = localization as! SwiftUI.KeyboardShortcut.Localization
             __content
                 .keyboardShortcut(key, modifiers: modifiers, localization: localization)
             
+                
             } else { __content }
         #endif
         }
@@ -5038,12 +5261,13 @@ struct _keyboardTypeModifier<R: RootRegistry>: ViewModifier {
 
     
     
+    
 
 
 
 
     #if os(iOS) || os(tvOS) || os(visionOS)
-    @available(iOS 13.0,tvOS 13.0,visionOS 1.0, *)
+    @available(tvOS 13.0,iOS 13.0,visionOS 1.0, *)
     init(_ type: UIKit.UIKeyboardType) {
         self.value = ._0(type: type)
         
@@ -5056,12 +5280,13 @@ struct _keyboardTypeModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(tvOS) || os(visionOS)
         case let ._0(type):
-            if #available(iOS 13.0,tvOS 13.0,visionOS 1.0, *) {
+            if #available(tvOS 13.0,iOS 13.0,visionOS 1.0, *) {
             let type = type as! UIKit.UIKeyboardType
             
             __content
                 .keyboardType(type)
             
+                
             } else { __content }
         #endif
         }
@@ -5081,6 +5306,7 @@ struct _labelStyleModifier<R: RootRegistry>: ViewModifier {
 
     let value: Value
 
+    
     
     
 
@@ -5107,6 +5333,7 @@ struct _labelStyleModifier<R: RootRegistry>: ViewModifier {
             __content
                 .labelStyle(style)
             
+                
             
         
         }
@@ -5126,6 +5353,7 @@ struct _labeledContentStyleModifier<R: RootRegistry>: ViewModifier {
 
     let value: Value
 
+    
     
     
 
@@ -5152,6 +5380,7 @@ struct _labeledContentStyleModifier<R: RootRegistry>: ViewModifier {
             __content
                 .labeledContentStyle(style)
             
+                
             
         
         }
@@ -5171,6 +5400,7 @@ struct _labelsHiddenModifier<R: RootRegistry>: ViewModifier {
 
     let value: Value
 
+    
     
     
 
@@ -5197,6 +5427,7 @@ struct _labelsHiddenModifier<R: RootRegistry>: ViewModifier {
             __content
                 .labelsHidden()
             
+                
             
         
         }
@@ -5218,6 +5449,7 @@ struct _layoutPriorityModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
@@ -5242,6 +5474,7 @@ struct _layoutPriorityModifier<R: RootRegistry>: ViewModifier {
             __content
                 .layoutPriority(value.resolve(on: element, in: context))
             
+                
             
         
         }
@@ -5275,6 +5508,7 @@ struct _lineLimitModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
@@ -5335,6 +5569,7 @@ struct _lineLimitModifier<R: RootRegistry>: ViewModifier {
             __content
                 .lineLimit(number?.resolve(on: element, in: context))
             
+                
             
         
         
@@ -5345,6 +5580,7 @@ struct _lineLimitModifier<R: RootRegistry>: ViewModifier {
             __content
                 .lineLimit(limit)
             
+                
             
         
         
@@ -5355,6 +5591,7 @@ struct _lineLimitModifier<R: RootRegistry>: ViewModifier {
             __content
                 .lineLimit(limit)
             
+                
             
         
         
@@ -5365,6 +5602,7 @@ struct _lineLimitModifier<R: RootRegistry>: ViewModifier {
             __content
                 .lineLimit(limit)
             
+                
             
         
         
@@ -5375,6 +5613,7 @@ struct _lineLimitModifier<R: RootRegistry>: ViewModifier {
             __content
                 .lineLimit(limit.resolve(on: element, in: context), reservesSpace: reservesSpace.resolve(on: element, in: context))
             
+                
             
         
         }
@@ -5396,6 +5635,7 @@ struct _lineSpacingModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
@@ -5420,6 +5660,7 @@ struct _lineSpacingModifier<R: RootRegistry>: ViewModifier {
             __content
                 .lineSpacing(lineSpacing.resolve(on: element, in: context))
             
+                
             
         
         }
@@ -5444,6 +5685,7 @@ struct _listItemTintModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
@@ -5477,6 +5719,7 @@ struct _listItemTintModifier<R: RootRegistry>: ViewModifier {
             __content
                 .listItemTint(tint?.resolve(on: element, in: context))
             
+                
             
         
         
@@ -5487,6 +5730,7 @@ struct _listItemTintModifier<R: RootRegistry>: ViewModifier {
             __content
                 .listItemTint(tint?.resolve(on: element, in: context))
             
+                
             
         
         }
@@ -5508,6 +5752,7 @@ struct _listRowBackgroundModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
@@ -5532,6 +5777,7 @@ struct _listRowBackgroundModifier<R: RootRegistry>: ViewModifier {
             __content
                 .listRowBackground(view.resolve(on: element, in: context))
             
+                
             
         
         }
@@ -5551,6 +5797,7 @@ struct _listRowHoverEffectModifier<R: RootRegistry>: ViewModifier {
 
     let value: Value
 
+    
     
     
 
@@ -5577,6 +5824,7 @@ struct _listRowHoverEffectModifier<R: RootRegistry>: ViewModifier {
             __content
                 .listRowHoverEffect(effect)
             
+                
             } else { __content }
         #endif
         }
@@ -5598,6 +5846,7 @@ struct _listRowHoverEffectDisabledModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
@@ -5622,6 +5871,7 @@ struct _listRowHoverEffectDisabledModifier<R: RootRegistry>: ViewModifier {
             __content
                 .listRowHoverEffectDisabled(disabled.resolve(on: element, in: context))
             
+                
             } else { __content }
         #endif
         }
@@ -5641,6 +5891,7 @@ struct _listRowInsetsModifier<R: RootRegistry>: ViewModifier {
 
     let value: Value
 
+    
     
     
 
@@ -5667,6 +5918,7 @@ struct _listRowInsetsModifier<R: RootRegistry>: ViewModifier {
             __content
                 .listRowInsets(insets)
             
+                
             
         
         }
@@ -5688,12 +5940,13 @@ struct _listRowSeparatorModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(iOS 15.0,visionOS 1.0,macOS 13.0, *)
+    @available(visionOS 1.0,macOS 13.0,iOS 15.0, *)
     init(_ visibility: AttributeReference<SwiftUI.Visibility>,edges: SwiftUI.VerticalEdge.Set = .all ) {
         self.value = ._0(visibility: visibility, edges: edges)
         
@@ -5706,13 +5959,14 @@ struct _listRowSeparatorModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(visibility, edges):
-            if #available(iOS 15.0,visionOS 1.0,macOS 13.0, *) {
+            if #available(visionOS 1.0,macOS 13.0,iOS 15.0, *) {
             let visibility = visibility as! AttributeReference<SwiftUI.Visibility>
 let edges = edges as! SwiftUI.VerticalEdge.Set 
             
             __content
                 .listRowSeparator(visibility.resolve(on: element, in: context), edges: edges)
             
+                
             } else { __content }
         #endif
         }
@@ -5734,12 +5988,13 @@ struct _listRowSeparatorTintModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(iOS 15.0,visionOS 1.0,macOS 13.0, *)
+    @available(visionOS 1.0,macOS 13.0,iOS 15.0, *)
     init(_ color: Color.Resolvable?,edges: SwiftUI.VerticalEdge.Set = .all ) {
         self.value = ._0(color: color, edges: edges)
         
@@ -5752,13 +6007,14 @@ struct _listRowSeparatorTintModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(color, edges):
-            if #available(iOS 15.0,visionOS 1.0,macOS 13.0, *) {
+            if #available(visionOS 1.0,macOS 13.0,iOS 15.0, *) {
             let color = color as? Color.Resolvable
 let edges = edges as! SwiftUI.VerticalEdge.Set 
             
             __content
                 .listRowSeparatorTint(color?.resolve(on: element, in: context), edges: edges)
             
+                
             } else { __content }
         #endif
         }
@@ -5780,6 +6036,7 @@ struct _listRowSpacingModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
@@ -5804,6 +6061,7 @@ struct _listRowSpacingModifier<R: RootRegistry>: ViewModifier {
             __content
                 .listRowSpacing(spacing?.resolve(on: element, in: context))
             
+                
             } else { __content }
         #endif
         }
@@ -5825,12 +6083,13 @@ struct _listSectionSeparatorModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(iOS 15.0,visionOS 1.0,macOS 13.0, *)
+    @available(visionOS 1.0,iOS 15.0,macOS 13.0, *)
     init(_ visibility: AttributeReference<SwiftUI.Visibility>,edges: SwiftUI.VerticalEdge.Set = .all ) {
         self.value = ._0(visibility: visibility, edges: edges)
         
@@ -5843,13 +6102,14 @@ struct _listSectionSeparatorModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(visibility, edges):
-            if #available(iOS 15.0,visionOS 1.0,macOS 13.0, *) {
+            if #available(visionOS 1.0,iOS 15.0,macOS 13.0, *) {
             let visibility = visibility as! AttributeReference<SwiftUI.Visibility>
 let edges = edges as! SwiftUI.VerticalEdge.Set 
             
             __content
                 .listSectionSeparator(visibility.resolve(on: element, in: context), edges: edges)
             
+                
             } else { __content }
         #endif
         }
@@ -5871,12 +6131,13 @@ struct _listSectionSeparatorTintModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 13.0,iOS 15.0,visionOS 1.0, *)
+    @available(visionOS 1.0,iOS 15.0,macOS 13.0, *)
     init(_ color: Color.Resolvable?,edges: SwiftUI.VerticalEdge.Set = .all ) {
         self.value = ._0(color: color, edges: edges)
         
@@ -5889,13 +6150,14 @@ struct _listSectionSeparatorTintModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(color, edges):
-            if #available(macOS 13.0,iOS 15.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,iOS 15.0,macOS 13.0, *) {
             let color = color as? Color.Resolvable
 let edges = edges as! SwiftUI.VerticalEdge.Set 
             
             __content
                 .listSectionSeparatorTint(color?.resolve(on: element, in: context), edges: edges)
             
+                
             } else { __content }
         #endif
         }
@@ -5920,6 +6182,7 @@ struct _listSectionSpacingModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
@@ -5927,14 +6190,14 @@ struct _listSectionSpacingModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(visionOS) || os(watchOS)
-    @available(iOS 17.0,visionOS 1.0,watchOS 10.0, *)
+    @available(visionOS 1.0,iOS 17.0,watchOS 10.0, *)
     init(_ spacing: SwiftUI.ListSectionSpacing) {
         self.value = ._0(spacing: spacing)
         
     }
     #endif
     #if os(iOS) || os(visionOS) || os(watchOS)
-    @available(iOS 17.0,visionOS 1.0,watchOS 10.0, *)
+    @available(visionOS 1.0,iOS 17.0,watchOS 10.0, *)
     init(_ spacing: AttributeReference<CoreFoundation.CGFloat>) {
         self.value = ._1(spacing: spacing)
         
@@ -5947,22 +6210,24 @@ struct _listSectionSpacingModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(visionOS) || os(watchOS)
         case let ._0(spacing):
-            if #available(iOS 17.0,visionOS 1.0,watchOS 10.0, *) {
+            if #available(visionOS 1.0,iOS 17.0,watchOS 10.0, *) {
             let spacing = spacing as! SwiftUI.ListSectionSpacing
             
             __content
                 .listSectionSpacing(spacing)
             
+                
             } else { __content }
         #endif
         #if os(iOS) || os(visionOS) || os(watchOS)
         case let ._1(spacing):
-            if #available(iOS 17.0,visionOS 1.0,watchOS 10.0, *) {
+            if #available(visionOS 1.0,iOS 17.0,watchOS 10.0, *) {
             let spacing = spacing as! AttributeReference<CoreFoundation.CGFloat>
             
             __content
                 .listSectionSpacing(spacing.resolve(on: element, in: context))
             
+                
             } else { __content }
         #endif
         }
@@ -5982,6 +6247,7 @@ struct _listStyleModifier<R: RootRegistry>: ViewModifier {
 
     let value: Value
 
+    
     
     
 
@@ -6008,6 +6274,7 @@ struct _listStyleModifier<R: RootRegistry>: ViewModifier {
             __content
                 .listStyle(style)
             
+                
             
         
         }
@@ -6027,6 +6294,7 @@ struct _luminanceToAlphaModifier<R: RootRegistry>: ViewModifier {
 
     let value: Value
 
+    
     
     
 
@@ -6053,6 +6321,7 @@ struct _luminanceToAlphaModifier<R: RootRegistry>: ViewModifier {
             __content
                 .luminanceToAlpha()
             
+                
             
         
         }
@@ -6074,12 +6343,13 @@ struct _menuIndicatorModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS)
-    @available(macOS 12.0,tvOS 17.0,iOS 15.0,visionOS 1.0, *)
+    @available(macOS 12.0,iOS 15.0,visionOS 1.0,tvOS 17.0, *)
     init(_ visibility: AttributeReference<SwiftUI.Visibility>) {
         self.value = ._0(visibility: visibility)
         
@@ -6092,12 +6362,13 @@ struct _menuIndicatorModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS)
         case let ._0(visibility):
-            if #available(macOS 12.0,tvOS 17.0,iOS 15.0,visionOS 1.0, *) {
+            if #available(macOS 12.0,iOS 15.0,visionOS 1.0,tvOS 17.0, *) {
             let visibility = visibility as! AttributeReference<SwiftUI.Visibility>
             
             __content
                 .menuIndicator(visibility.resolve(on: element, in: context))
             
+                
             } else { __content }
         #endif
         }
@@ -6117,6 +6388,7 @@ struct _menuOrderModifier<R: RootRegistry>: ViewModifier {
 
     let value: Value
 
+    
     
     
 
@@ -6143,6 +6415,7 @@ struct _menuOrderModifier<R: RootRegistry>: ViewModifier {
             __content
                 .menuOrder(order)
             
+                
             
         
         }
@@ -6164,12 +6437,13 @@ struct _menuStyleModifier<R: RootRegistry>: ViewModifier {
 
     
     
+    
 
 
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS)
-    @available(macOS 11.0,iOS 14.0,tvOS 17.0,visionOS 1.0, *)
+    @available(iOS 14.0,macOS 11.0,tvOS 17.0,visionOS 1.0, *)
     init(_ style: AnyMenuStyle) {
         self.value = ._0(style: style)
         
@@ -6182,12 +6456,13 @@ struct _menuStyleModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS)
         case let ._0(style):
-            if #available(macOS 11.0,iOS 14.0,tvOS 17.0,visionOS 1.0, *) {
+            if #available(iOS 14.0,macOS 11.0,tvOS 17.0,visionOS 1.0, *) {
             let style = style as! AnyMenuStyle
             
             __content
                 .menuStyle(style)
             
+                
             } else { __content }
         #endif
         }
@@ -6209,6 +6484,7 @@ struct _minimumScaleFactorModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
@@ -6233,6 +6509,7 @@ struct _minimumScaleFactorModifier<R: RootRegistry>: ViewModifier {
             __content
                 .minimumScaleFactor(factor.resolve(on: element, in: context))
             
+                
             
         
         }
@@ -6254,6 +6531,7 @@ struct _moveDisabledModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
@@ -6278,6 +6556,7 @@ struct _moveDisabledModifier<R: RootRegistry>: ViewModifier {
             __content
                 .moveDisabled(isDisabled.resolve(on: element, in: context))
             
+                
             
         
         }
@@ -6297,6 +6576,7 @@ struct _multilineTextAlignmentModifier<R: RootRegistry>: ViewModifier {
 
     let value: Value
 
+    
     
     
 
@@ -6323,6 +6603,7 @@ struct _multilineTextAlignmentModifier<R: RootRegistry>: ViewModifier {
             __content
                 .multilineTextAlignment(alignment)
             
+                
             
         
         }
@@ -6344,6 +6625,7 @@ struct _navigationBarBackButtonHiddenModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
@@ -6368,6 +6650,7 @@ struct _navigationBarBackButtonHiddenModifier<R: RootRegistry>: ViewModifier {
             __content
                 .navigationBarBackButtonHidden(hidesBackButton.resolve(on: element, in: context))
             
+                
             
         
         }
@@ -6387,6 +6670,7 @@ struct _navigationBarTitleDisplayModeModifier<R: RootRegistry>: ViewModifier {
 
     let value: Value
 
+    
     
     
 
@@ -6413,6 +6697,7 @@ struct _navigationBarTitleDisplayModeModifier<R: RootRegistry>: ViewModifier {
             __content
                 .navigationBarTitleDisplayMode(displayMode)
             
+                
             } else { __content }
         #endif
         }
@@ -6434,6 +6719,7 @@ struct _navigationDestinationModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 @ChangeTracked private var _0_isPresented: Swift.Bool
 
@@ -6458,6 +6744,7 @@ struct _navigationDestinationModifier<R: RootRegistry>: ViewModifier {
             __content
                 .navigationDestination(isPresented: __0_isPresented.projectedValue, destination: { destination.resolve(on: element, in: context) })
             
+                
             
         
         }
@@ -6482,6 +6769,7 @@ struct _navigationSplitViewColumnWidthModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
@@ -6515,6 +6803,7 @@ struct _navigationSplitViewColumnWidthModifier<R: RootRegistry>: ViewModifier {
             __content
                 .navigationSplitViewColumnWidth(width.resolve(on: element, in: context))
             
+                
             
         
         
@@ -6525,6 +6814,7 @@ struct _navigationSplitViewColumnWidthModifier<R: RootRegistry>: ViewModifier {
             __content
                 .navigationSplitViewColumnWidth(min: min?.resolve(on: element, in: context), ideal: ideal.resolve(on: element, in: context), max: max?.resolve(on: element, in: context))
             
+                
             
         
         }
@@ -6544,6 +6834,7 @@ struct _navigationSplitViewStyleModifier<R: RootRegistry>: ViewModifier {
 
     let value: Value
 
+    
     
     
 
@@ -6570,6 +6861,7 @@ struct _navigationSplitViewStyleModifier<R: RootRegistry>: ViewModifier {
             __content
                 .navigationSplitViewStyle(style)
             
+                
             
         
         }
@@ -6597,6 +6889,7 @@ struct _navigationSubtitleModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
@@ -6606,21 +6899,21 @@ struct _navigationSubtitleModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(macOS) || os(visionOS) || targetEnvironment(macCatalyst)
-    @available(macCatalyst 14.0,visionOS 1.0,macOS 11.0, *)
+    @available(visionOS 1.0,macCatalyst 14.0,macOS 11.0, *)
     init(_ subtitle: TextReference) {
         self.value = ._0(subtitle: subtitle)
         
     }
     #endif
     #if os(macOS) || os(visionOS) || targetEnvironment(macCatalyst)
-    @available(macCatalyst 14.0,visionOS 1.0,macOS 11.0, *)
+    @available(visionOS 1.0,macCatalyst 14.0,macOS 11.0, *)
     init(_ subtitleKey: SwiftUI.LocalizedStringKey) {
         self.value = ._1(subtitleKey: subtitleKey)
         
     }
     #endif
     #if os(macOS) || os(visionOS) || targetEnvironment(macCatalyst)
-    @available(macCatalyst 14.0,visionOS 1.0,macOS 11.0, *)
+    @available(visionOS 1.0,macCatalyst 14.0,macOS 11.0, *)
     init(_ subtitle: AttributeReference<String>) {
         self.value = ._2(subtitle: subtitle)
         
@@ -6633,32 +6926,35 @@ struct _navigationSubtitleModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(macOS) || os(visionOS) || targetEnvironment(macCatalyst)
         case let ._0(subtitle):
-            if #available(macCatalyst 14.0,visionOS 1.0,macOS 11.0, *) {
+            if #available(visionOS 1.0,macCatalyst 14.0,macOS 11.0, *) {
             let subtitle = subtitle as! TextReference
             __content._observeTextReference(subtitle, on: element, in: context) { __content in
             __content
                 .navigationSubtitle(subtitle.resolve(on: element, in: context))
             }
+                
             } else { __content }
         #endif
         #if os(macOS) || os(visionOS) || targetEnvironment(macCatalyst)
         case let ._1(subtitleKey):
-            if #available(macCatalyst 14.0,visionOS 1.0,macOS 11.0, *) {
+            if #available(visionOS 1.0,macCatalyst 14.0,macOS 11.0, *) {
             let subtitleKey = subtitleKey as! SwiftUI.LocalizedStringKey
             
             __content
                 .navigationSubtitle(subtitleKey)
             
+                
             } else { __content }
         #endif
         #if os(macOS) || os(visionOS) || targetEnvironment(macCatalyst)
         case let ._2(subtitle):
-            if #available(macCatalyst 14.0,visionOS 1.0,macOS 11.0, *) {
+            if #available(visionOS 1.0,macCatalyst 14.0,macOS 11.0, *) {
             let subtitle = subtitle as! AttributeReference<String>
             
             __content
                 .navigationSubtitle(subtitle.resolve(on: element, in: context))
             
+                
             } else { __content }
         #endif
         }
@@ -6692,6 +6988,7 @@ struct _navigationTitleModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
@@ -6726,7 +7023,7 @@ struct _navigationTitleModifier<R: RootRegistry>: ViewModifier {
     }
     
     #if os(visionOS) || os(watchOS)
-    @available(macOS 11.0,iOS 14.0,watchOS 7.0,visionOS 1.0,tvOS 14.0, *)
+    @available(visionOS 1.0,iOS 14.0,tvOS 14.0,macOS 11.0,watchOS 7.0, *)
     init(_ title: ViewReference=ViewReference(value: [])) {
         self.value = ._3(title: title)
         
@@ -6752,6 +7049,7 @@ struct _navigationTitleModifier<R: RootRegistry>: ViewModifier {
             __content
                 .navigationTitle(title.resolve(on: element, in: context))
             }
+                
             
         
         
@@ -6762,6 +7060,7 @@ struct _navigationTitleModifier<R: RootRegistry>: ViewModifier {
             __content
                 .navigationTitle(titleKey)
             
+                
             
         
         
@@ -6772,16 +7071,18 @@ struct _navigationTitleModifier<R: RootRegistry>: ViewModifier {
             __content
                 .navigationTitle(title.resolve(on: element, in: context))
             
+                
             
         
         #if os(visionOS) || os(watchOS)
         case let ._3(title):
-            if #available(macOS 11.0,iOS 14.0,watchOS 7.0,visionOS 1.0,tvOS 14.0, *) {
+            if #available(visionOS 1.0,iOS 14.0,tvOS 14.0,macOS 11.0,watchOS 7.0, *) {
             let title = title as! ViewReference
             
             __content
                 .navigationTitle({ title.resolve(on: element, in: context) })
             
+                
             } else { __content }
         #endif
         
@@ -6792,6 +7093,7 @@ struct _navigationTitleModifier<R: RootRegistry>: ViewModifier {
             __content
                 .navigationTitle(__4_title.projectedValue)
             
+                
             
         
         }
@@ -6819,6 +7121,7 @@ struct _offsetModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
@@ -6842,7 +7145,7 @@ struct _offsetModifier<R: RootRegistry>: ViewModifier {
     }
     
     #if os(visionOS) || os(xrOS)
-    @available(xrOS 1.0,visionOS 1.0, *)
+    @available(visionOS 1.0,xrOS 1.0, *)
     init(z: AttributeReference<CoreFoundation.CGFloat>) {
         self.value = ._2(z: z)
         
@@ -6861,6 +7164,7 @@ struct _offsetModifier<R: RootRegistry>: ViewModifier {
             __content
                 .offset(offset)
             
+                
             
         
         
@@ -6871,16 +7175,18 @@ struct _offsetModifier<R: RootRegistry>: ViewModifier {
             __content
                 .offset(x: x.resolve(on: element, in: context), y: y.resolve(on: element, in: context))
             
+                
             
         
         #if os(visionOS) || os(xrOS)
         case let ._2(z):
-            if #available(xrOS 1.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,xrOS 1.0, *) {
             let z = z as! AttributeReference<CoreFoundation.CGFloat>
             
             __content
                 .offset(z: z.resolve(on: element, in: context))
             
+                
             } else { __content }
         #endif
         }
@@ -6900,6 +7206,7 @@ struct _onAppearModifier<R: RootRegistry>: ViewModifier {
 
     let value: Value
 
+    
     
     
 
@@ -6926,6 +7233,7 @@ struct _onAppearModifier<R: RootRegistry>: ViewModifier {
             __content
                 .onAppear(perform: { __0_action__0.wrappedValue() })
             
+                
             
         
         }
@@ -6947,12 +7255,13 @@ struct _onDeleteCommandModifier<R: RootRegistry>: ViewModifier {
 
     
     
+    
 
 
 @Event private var _0_action__0: Event.EventHandler
 
     #if os(macOS) || os(visionOS)
-    @available(macOS 10.15,tvOS 13.0,visionOS 1.0, *)
+    @available(visionOS 1.0,tvOS 13.0,macOS 10.15, *)
     init(perform action__0: Event=Event()) {
         self.value = ._0
         self.__0_action__0 = action__0
@@ -6965,12 +7274,13 @@ struct _onDeleteCommandModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(macOS) || os(visionOS)
         case ._0:
-            if #available(macOS 10.15,tvOS 13.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,tvOS 13.0,macOS 10.15, *) {
             
             
             __content
                 .onDeleteCommand(perform: { __0_action__0.wrappedValue() })
             
+                
             } else { __content }
         #endif
         }
@@ -6990,6 +7300,7 @@ struct _onDisappearModifier<R: RootRegistry>: ViewModifier {
 
     let value: Value
 
+    
     
     
 
@@ -7016,6 +7327,7 @@ struct _onDisappearModifier<R: RootRegistry>: ViewModifier {
             __content
                 .onDisappear(perform: { __0_action__0.wrappedValue() })
             
+                
             
         
         }
@@ -7037,12 +7349,13 @@ struct _onExitCommandModifier<R: RootRegistry>: ViewModifier {
 
     
     
+    
 
 
 @Event private var _0_action__0: Event.EventHandler
 
     #if os(macOS) || os(tvOS) || os(visionOS)
-    @available(macOS 10.15,tvOS 13.0,visionOS 1.0, *)
+    @available(visionOS 1.0,tvOS 13.0,macOS 10.15, *)
     init(perform action__0: Event=Event()) {
         self.value = ._0
         self.__0_action__0 = action__0
@@ -7055,12 +7368,13 @@ struct _onExitCommandModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(macOS) || os(tvOS) || os(visionOS)
         case ._0:
-            if #available(macOS 10.15,tvOS 13.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,tvOS 13.0,macOS 10.15, *) {
             
             
             __content
                 .onExitCommand(perform: { __0_action__0.wrappedValue() })
             
+                
             } else { __content }
         #endif
         }
@@ -7082,12 +7396,13 @@ struct _onHoverModifier<R: RootRegistry>: ViewModifier {
 
     
     
+    
 
 
 @Event private var _0_action__1: Event.EventHandler
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(iOS 13.4,visionOS 1.0,macOS 10.15, *)
+    @available(iOS 13.4,macOS 10.15,visionOS 1.0, *)
     init(perform action__1: Event) {
         self.value = ._0
         self.__0_action__1 = action__1
@@ -7100,12 +7415,13 @@ struct _onHoverModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case ._0:
-            if #available(iOS 13.4,visionOS 1.0,macOS 10.15, *) {
+            if #available(iOS 13.4,macOS 10.15,visionOS 1.0, *) {
             
             
             __content
                 .onHover(perform: { __0_action__1.wrappedValue(value: $0) })
             
+                
             } else { __content }
         #endif
         }
@@ -7130,6 +7446,7 @@ struct _onLongPressGestureModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 @Event private var _0_action__0: Event.EventHandler
@@ -7139,7 +7456,7 @@ struct _onLongPressGestureModifier<R: RootRegistry>: ViewModifier {
 @Event private var _1_onPressingChanged__1: Event.EventHandler
 
     #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
-    @available(macOS 10.15,watchOS 6.0,iOS 13.0,tvOS 14.0,visionOS 1.0, *)
+    @available(iOS 13.0,visionOS 1.0,macOS 10.15,watchOS 6.0,tvOS 14.0, *)
     init(minimumDuration: AttributeReference<Swift.Double> = .init(storage: .constant(0.5)), maximumDistance: AttributeReference<CoreFoundation.CGFloat> = .init(storage: .constant(10)), perform action__0: Event,onPressingChanged onPressingChanged__1: Event=Event() ) {
         self.value = ._0(minimumDuration: minimumDuration, maximumDistance: maximumDistance)
         self.__0_action__0 = action__0
@@ -7147,7 +7464,7 @@ self.__0_onPressingChanged__1 = onPressingChanged__1
     }
     #endif
     #if os(tvOS) || os(visionOS)
-    @available(macOS 10.15,iOS 13.0,watchOS 6.0,visionOS 1.0,tvOS 14.0, *)
+    @available(watchOS 6.0,tvOS 14.0,iOS 13.0,macOS 10.15,visionOS 1.0, *)
     init(minimumDuration: AttributeReference<Swift.Double> = .init(storage: .constant(0.5)), perform action__0: Event,onPressingChanged onPressingChanged__1: Event=Event() ) {
         self.value = ._1(minimumDuration: minimumDuration)
         self.__1_action__0 = action__0
@@ -7161,23 +7478,25 @@ self.__1_onPressingChanged__1 = onPressingChanged__1
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
         case let ._0(minimumDuration, maximumDistance):
-            if #available(macOS 10.15,watchOS 6.0,iOS 13.0,tvOS 14.0,visionOS 1.0, *) {
+            if #available(iOS 13.0,visionOS 1.0,macOS 10.15,watchOS 6.0,tvOS 14.0, *) {
             let minimumDuration = minimumDuration as! AttributeReference<Swift.Double>
 let maximumDistance = maximumDistance as! AttributeReference<CoreFoundation.CGFloat>
             
             __content
                 .onLongPressGesture(minimumDuration: minimumDuration.resolve(on: element, in: context), maximumDistance: maximumDistance.resolve(on: element, in: context), perform: { __0_action__0.wrappedValue() }, onPressingChanged: { __0_onPressingChanged__1.wrappedValue(value: $0) })
             
+                
             } else { __content }
         #endif
         #if os(tvOS) || os(visionOS)
         case let ._1(minimumDuration):
-            if #available(macOS 10.15,iOS 13.0,watchOS 6.0,visionOS 1.0,tvOS 14.0, *) {
+            if #available(watchOS 6.0,tvOS 14.0,iOS 13.0,macOS 10.15,visionOS 1.0, *) {
             let minimumDuration = minimumDuration as! AttributeReference<Swift.Double>
             
             __content
                 .onLongPressGesture(minimumDuration: minimumDuration.resolve(on: element, in: context), perform: { __1_action__0.wrappedValue() }, onPressingChanged: { __1_onPressingChanged__1.wrappedValue(value: $0) })
             
+                
             } else { __content }
         #endif
         }
@@ -7199,6 +7518,7 @@ struct _onLongTouchGestureModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 @Event private var _0_action__0: Event.EventHandler
@@ -7225,6 +7545,7 @@ self.__0_onTouchingChanged__1 = onTouchingChanged__1
             __content
                 .onLongTouchGesture(minimumDuration: minimumDuration.resolve(on: element, in: context), perform: { __0_action__0.wrappedValue() }, onTouchingChanged: { __0_onTouchingChanged__1.wrappedValue(value: $0) })
             
+                
             } else { __content }
         #endif
         }
@@ -7246,12 +7567,13 @@ struct _onMoveCommandModifier<R: RootRegistry>: ViewModifier {
 
     
     
+    
 
 
 @Event private var _0_action__1: Event.EventHandler
 
     #if os(macOS) || os(tvOS) || os(visionOS)
-    @available(macOS 10.15,tvOS 13.0,visionOS 1.0, *)
+    @available(visionOS 1.0,tvOS 13.0,macOS 10.15, *)
     init(perform action__1: Event=Event()) {
         self.value = ._0
         self.__0_action__1 = action__1
@@ -7264,12 +7586,13 @@ struct _onMoveCommandModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(macOS) || os(tvOS) || os(visionOS)
         case ._0:
-            if #available(macOS 10.15,tvOS 13.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,tvOS 13.0,macOS 10.15, *) {
             
             
             __content
                 .onMoveCommand(perform: { __0_action__1.wrappedValue(value: $0) })
             
+                
             } else { __content }
         #endif
         }
@@ -7291,12 +7614,13 @@ struct _onPlayPauseCommandModifier<R: RootRegistry>: ViewModifier {
 
     
     
+    
 
 
 @Event private var _0_action__0: Event.EventHandler
 
     #if os(tvOS) || os(visionOS)
-    @available(macOS 10.15,tvOS 13.0,visionOS 1.0, *)
+    @available(visionOS 1.0,tvOS 13.0,macOS 10.15, *)
     init(perform action__0: Event=Event()) {
         self.value = ._0
         self.__0_action__0 = action__0
@@ -7309,12 +7633,13 @@ struct _onPlayPauseCommandModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(tvOS) || os(visionOS)
         case ._0:
-            if #available(macOS 10.15,tvOS 13.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,tvOS 13.0,macOS 10.15, *) {
             
             
             __content
                 .onPlayPauseCommand(perform: { __0_action__0.wrappedValue() })
             
+                
             } else { __content }
         #endif
         }
@@ -7339,6 +7664,7 @@ struct _onTapGestureModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 @Event private var _0_action__0: Event.EventHandler
@@ -7353,7 +7679,7 @@ struct _onTapGestureModifier<R: RootRegistry>: ViewModifier {
     }
     
     #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
-    @available(macOS 14.0,watchOS 10.0,iOS 17.0,visionOS 1.0, *)
+    @available(watchOS 10.0,iOS 17.0,visionOS 1.0,macOS 14.0, *)
     init(count: AttributeReference<Swift.Int> = .init(storage: .constant(1)), coordinateSpace: AnyCoordinateSpaceProtocol = .local, perform action__1: Event) {
         self.value = ._1(count: count, coordinateSpace: coordinateSpace)
         self.__1_action__1 = action__1
@@ -7372,17 +7698,19 @@ struct _onTapGestureModifier<R: RootRegistry>: ViewModifier {
             __content
                 .onTapGesture(count: count.resolve(on: element, in: context), perform: { __0_action__0.wrappedValue() })
             
+                
             
         
         #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
         case let ._1(count, coordinateSpace):
-            if #available(macOS 14.0,watchOS 10.0,iOS 17.0,visionOS 1.0, *) {
+            if #available(watchOS 10.0,iOS 17.0,visionOS 1.0,macOS 14.0, *) {
             let count = count as! AttributeReference<Swift.Int>
 let coordinateSpace = coordinateSpace as! AnyCoordinateSpaceProtocol 
             
             __content
                 .onTapGesture(count: count.resolve(on: element, in: context), coordinateSpace: coordinateSpace, perform: { __1_action__1.wrappedValue(value: $0) })
             
+                
             } else { __content }
         #endif
         }
@@ -7404,6 +7732,7 @@ struct _opacityModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
@@ -7428,6 +7757,7 @@ struct _opacityModifier<R: RootRegistry>: ViewModifier {
             __content
                 .opacity(opacity.resolve(on: element, in: context))
             
+                
             
         
         }
@@ -7449,12 +7779,13 @@ struct _ornamentModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
 
     #if os(visionOS) || os(xrOS)
-    @available(visionOS 1.0,xrOS 1.0, *)
+    @available(xrOS 1.0,visionOS 1.0, *)
     init(visibility: AttributeReference<SwiftUI.Visibility> = .init(storage: .constant(.automatic)), attachmentAnchor: SwiftUI.OrnamentAttachmentAnchor,contentAlignment: AttributeReference<SwiftUI.Alignment> = .init(storage: .constant(.center)), ornament: ViewReference=ViewReference(value: [])) {
         self.value = ._0(visibility: visibility, attachmentAnchor: attachmentAnchor, contentAlignment: contentAlignment, ornament: ornament)
         
@@ -7467,7 +7798,7 @@ struct _ornamentModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(visionOS) || os(xrOS)
         case let ._0(visibility, attachmentAnchor, contentAlignment, ornament):
-            if #available(visionOS 1.0,xrOS 1.0, *) {
+            if #available(xrOS 1.0,visionOS 1.0, *) {
             let visibility = visibility as! AttributeReference<SwiftUI.Visibility>
 let attachmentAnchor = attachmentAnchor as! SwiftUI.OrnamentAttachmentAnchor
 let contentAlignment = contentAlignment as! AttributeReference<SwiftUI.Alignment>
@@ -7476,6 +7807,7 @@ let ornament = ornament as! ViewReference
             __content
                 .ornament(visibility: visibility.resolve(on: element, in: context), attachmentAnchor: attachmentAnchor, contentAlignment: contentAlignment.resolve(on: element, in: context), ornament: { ornament.resolve(on: element, in: context) })
             
+                
             } else { __content }
         #endif
         }
@@ -7503,6 +7835,7 @@ struct _overlayModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
@@ -7545,6 +7878,7 @@ struct _overlayModifier<R: RootRegistry>: ViewModifier {
             __content
                 .overlay(alignment: alignment.resolve(on: element, in: context), content: { content.resolve(on: element, in: context) })
             
+                
             
         
         
@@ -7555,6 +7889,7 @@ struct _overlayModifier<R: RootRegistry>: ViewModifier {
             __content
                 .overlay(style.resolve(on: element, in: context), ignoresSafeAreaEdges: edges)
             
+                
             
         
         
@@ -7565,6 +7900,7 @@ struct _overlayModifier<R: RootRegistry>: ViewModifier {
             __content
                 .overlay(style.resolve(on: element, in: context), in: shape, fillStyle: fillStyle)
             
+                
             
         
         }
@@ -7592,6 +7928,7 @@ struct _paddingModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
@@ -7634,6 +7971,7 @@ struct _paddingModifier<R: RootRegistry>: ViewModifier {
             __content
                 .padding(insets)
             
+                
             
         
         
@@ -7644,6 +7982,7 @@ struct _paddingModifier<R: RootRegistry>: ViewModifier {
             __content
                 .padding(edges, length?.resolve(on: element, in: context))
             
+                
             
         
         
@@ -7654,6 +7993,7 @@ struct _paddingModifier<R: RootRegistry>: ViewModifier {
             __content
                 .padding(length.resolve(on: element, in: context))
             
+                
             
         
         }
@@ -7681,6 +8021,7 @@ struct _padding3DModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
@@ -7704,7 +8045,7 @@ struct _padding3DModifier<R: RootRegistry>: ViewModifier {
     }
     #endif
     #if os(visionOS) || os(xrOS)
-    @available(xrOS 1.0,visionOS 1.0, *)
+    @available(visionOS 1.0,xrOS 1.0, *)
     init(_ length: AttributeReference<CoreFoundation.CGFloat>) {
         self.value = ._2(length: length)
         
@@ -7723,6 +8064,7 @@ struct _padding3DModifier<R: RootRegistry>: ViewModifier {
             __content
                 .padding3D(insets)
             
+                
             } else { __content }
         #endif
         #if os(visionOS) || os(xrOS)
@@ -7734,16 +8076,18 @@ let length = length as? AttributeReference<CoreFoundation.CGFloat?>
             __content
                 .padding3D(edges, length?.resolve(on: element, in: context))
             
+                
             } else { __content }
         #endif
         #if os(visionOS) || os(xrOS)
         case let ._2(length):
-            if #available(xrOS 1.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,xrOS 1.0, *) {
             let length = length as! AttributeReference<CoreFoundation.CGFloat>
             
             __content
                 .padding3D(length.resolve(on: element, in: context))
             
+                
             } else { __content }
         #endif
         }
@@ -7765,6 +8109,7 @@ struct _persistentSystemOverlaysModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
@@ -7789,6 +8134,7 @@ struct _persistentSystemOverlaysModifier<R: RootRegistry>: ViewModifier {
             __content
                 .persistentSystemOverlays(visibility.resolve(on: element, in: context))
             
+                
             
         
         }
@@ -7808,6 +8154,7 @@ struct _pickerStyleModifier<R: RootRegistry>: ViewModifier {
 
     let value: Value
 
+    
     
     
 
@@ -7834,6 +8181,7 @@ struct _pickerStyleModifier<R: RootRegistry>: ViewModifier {
             __content
                 .pickerStyle(style)
             
+                
             
         
         }
@@ -7855,12 +8203,13 @@ struct _popoverModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 @ChangeTracked private var _0_isPresented: Swift.Bool
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(visionOS 1.0,iOS 13.0,macOS 10.15, *)
+    @available(iOS 13.0,macOS 10.15,visionOS 1.0, *)
     init(isPresented: ChangeTracked<Swift.Bool>,attachmentAnchor: SwiftUI.PopoverAttachmentAnchor = .rect(.bounds), arrowEdge: SwiftUI.Edge = .top, content: ViewReference=ViewReference(value: [])) {
         self.value = ._0(attachmentAnchor: attachmentAnchor, arrowEdge: arrowEdge, content: content)
         self.__0_isPresented = isPresented
@@ -7873,7 +8222,7 @@ struct _popoverModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(attachmentAnchor, arrowEdge, content):
-            if #available(visionOS 1.0,iOS 13.0,macOS 10.15, *) {
+            if #available(iOS 13.0,macOS 10.15,visionOS 1.0, *) {
             let attachmentAnchor = attachmentAnchor as! SwiftUI.PopoverAttachmentAnchor 
 let arrowEdge = arrowEdge as! SwiftUI.Edge 
 let content = content as! ViewReference
@@ -7881,6 +8230,7 @@ let content = content as! ViewReference
             __content
                 .popover(isPresented: __0_isPresented.projectedValue, attachmentAnchor: attachmentAnchor, arrowEdge: arrowEdge, content: { content.resolve(on: element, in: context) })
             
+                
             } else { __content }
         #endif
         }
@@ -7905,6 +8255,7 @@ struct _positionModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
@@ -7938,6 +8289,7 @@ struct _positionModifier<R: RootRegistry>: ViewModifier {
             __content
                 .position(position)
             
+                
             
         
         
@@ -7948,6 +8300,7 @@ struct _positionModifier<R: RootRegistry>: ViewModifier {
             __content
                 .position(x: x.resolve(on: element, in: context), y: y.resolve(on: element, in: context))
             
+                
             
         
         }
@@ -7969,6 +8322,7 @@ struct _preferredColorSchemeModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
@@ -7993,6 +8347,7 @@ struct _preferredColorSchemeModifier<R: RootRegistry>: ViewModifier {
             __content
                 .preferredColorScheme(colorScheme?.resolve(on: element, in: context))
             
+                
             
         
         }
@@ -8012,6 +8367,7 @@ struct _preferredSurroundingsEffectModifier<R: RootRegistry>: ViewModifier {
 
     let value: Value
 
+    
     
     
 
@@ -8038,6 +8394,7 @@ struct _preferredSurroundingsEffectModifier<R: RootRegistry>: ViewModifier {
             __content
                 .preferredSurroundingsEffect(effect)
             
+                
             } else { __content }
         #endif
         }
@@ -8062,6 +8419,7 @@ struct _presentationBackgroundModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
@@ -8069,14 +8427,14 @@ struct _presentationBackgroundModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 13.3,watchOS 9.4,iOS 16.4,tvOS 16.4,visionOS 1.0, *)
+    @available(visionOS 1.0,tvOS 16.4,watchOS 9.4,iOS 16.4,macOS 13.3, *)
     init(_ style: AnyShapeStyle.Resolvable) {
         self.value = ._0(style: style)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 13.3,watchOS 9.4,iOS 16.4,tvOS 16.4,visionOS 1.0, *)
+    @available(iOS 16.4,watchOS 9.4,tvOS 16.4,visionOS 1.0,macOS 13.3, *)
     init(alignment: AttributeReference<SwiftUI.Alignment> = .init(storage: .constant(.center)), content: ViewReference=ViewReference(value: [])) {
         self.value = ._1(alignment: alignment, content: content)
         
@@ -8089,23 +8447,25 @@ struct _presentationBackgroundModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(style):
-            if #available(macOS 13.3,watchOS 9.4,iOS 16.4,tvOS 16.4,visionOS 1.0, *) {
+            if #available(visionOS 1.0,tvOS 16.4,watchOS 9.4,iOS 16.4,macOS 13.3, *) {
             let style = style as! AnyShapeStyle.Resolvable
             
             __content
                 .presentationBackground(style.resolve(on: element, in: context))
             
+                
             } else { __content }
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(alignment, content):
-            if #available(macOS 13.3,watchOS 9.4,iOS 16.4,tvOS 16.4,visionOS 1.0, *) {
+            if #available(iOS 16.4,watchOS 9.4,tvOS 16.4,visionOS 1.0,macOS 13.3, *) {
             let alignment = alignment as! AttributeReference<SwiftUI.Alignment>
 let content = content as! ViewReference
             
             __content
                 .presentationBackground(alignment: alignment.resolve(on: element, in: context), content: { content.resolve(on: element, in: context) })
             
+                
             } else { __content }
         #endif
         }
@@ -8127,12 +8487,13 @@ struct _presentationBackgroundInteractionModifier<R: RootRegistry>: ViewModifier
 
     
     
+    
 
 
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(tvOS 16.4,watchOS 9.4,macOS 13.3,iOS 16.4,visionOS 1.0, *)
+    @available(watchOS 9.4,iOS 16.4,visionOS 1.0,macOS 13.3,tvOS 16.4, *)
     init(_ interaction: SwiftUI.PresentationBackgroundInteraction) {
         self.value = ._0(interaction: interaction)
         
@@ -8145,12 +8506,13 @@ struct _presentationBackgroundInteractionModifier<R: RootRegistry>: ViewModifier
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(interaction):
-            if #available(tvOS 16.4,watchOS 9.4,macOS 13.3,iOS 16.4,visionOS 1.0, *) {
+            if #available(watchOS 9.4,iOS 16.4,visionOS 1.0,macOS 13.3,tvOS 16.4, *) {
             let interaction = interaction as! SwiftUI.PresentationBackgroundInteraction
             
             __content
                 .presentationBackgroundInteraction(interaction)
             
+                
             } else { __content }
         #endif
         }
@@ -8175,6 +8537,7 @@ struct _presentationCompactAdaptationModifier<R: RootRegistry>: ViewModifier {
 
     
     
+    
 
 
 
@@ -8182,14 +8545,14 @@ struct _presentationCompactAdaptationModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(tvOS 16.4,watchOS 9.4,macOS 13.3,iOS 16.4,visionOS 1.0, *)
+    @available(watchOS 9.4,iOS 16.4,visionOS 1.0,macOS 13.3,tvOS 16.4, *)
     init(_ adaptation: SwiftUI.PresentationAdaptation) {
         self.value = ._0(adaptation: adaptation)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(tvOS 16.4,watchOS 9.4,macOS 13.3,iOS 16.4,visionOS 1.0, *)
+    @available(macOS 13.3,visionOS 1.0,watchOS 9.4,tvOS 16.4,iOS 16.4, *)
     init(horizontal horizontalAdaptation: SwiftUI.PresentationAdaptation,vertical verticalAdaptation: SwiftUI.PresentationAdaptation) {
         self.value = ._1(horizontalAdaptation: horizontalAdaptation, verticalAdaptation: verticalAdaptation)
         
@@ -8202,23 +8565,25 @@ struct _presentationCompactAdaptationModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(adaptation):
-            if #available(tvOS 16.4,watchOS 9.4,macOS 13.3,iOS 16.4,visionOS 1.0, *) {
+            if #available(watchOS 9.4,iOS 16.4,visionOS 1.0,macOS 13.3,tvOS 16.4, *) {
             let adaptation = adaptation as! SwiftUI.PresentationAdaptation
             
             __content
                 .presentationCompactAdaptation(adaptation)
             
+                
             } else { __content }
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(horizontalAdaptation, verticalAdaptation):
-            if #available(tvOS 16.4,watchOS 9.4,macOS 13.3,iOS 16.4,visionOS 1.0, *) {
+            if #available(macOS 13.3,visionOS 1.0,watchOS 9.4,tvOS 16.4,iOS 16.4, *) {
             let horizontalAdaptation = horizontalAdaptation as! SwiftUI.PresentationAdaptation
 let verticalAdaptation = verticalAdaptation as! SwiftUI.PresentationAdaptation
             
             __content
                 .presentationCompactAdaptation(horizontal: horizontalAdaptation, vertical: verticalAdaptation)
             
+                
             } else { __content }
         #endif
         }
@@ -8240,12 +8605,13 @@ struct _presentationContentInteractionModifier<R: RootRegistry>: ViewModifier {
 
     
     
+    
 
 
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(tvOS 16.4,watchOS 9.4,macOS 13.3,iOS 16.4,visionOS 1.0, *)
+    @available(iOS 16.4,watchOS 9.4,tvOS 16.4,visionOS 1.0,macOS 13.3, *)
     init(_ behavior: SwiftUI.PresentationContentInteraction) {
         self.value = ._0(behavior: behavior)
         
@@ -8258,12 +8624,13 @@ struct _presentationContentInteractionModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(behavior):
-            if #available(tvOS 16.4,watchOS 9.4,macOS 13.3,iOS 16.4,visionOS 1.0, *) {
+            if #available(iOS 16.4,watchOS 9.4,tvOS 16.4,visionOS 1.0,macOS 13.3, *) {
             let behavior = behavior as! SwiftUI.PresentationContentInteraction
             
             __content
                 .presentationContentInteraction(behavior)
             
+                
             } else { __content }
         #endif
         }
@@ -8285,12 +8652,13 @@ struct _presentationCornerRadiusModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(tvOS 16.4,watchOS 9.4,macOS 13.3,iOS 16.4,visionOS 1.0, *)
+    @available(watchOS 9.4,iOS 16.4,visionOS 1.0,macOS 13.3,tvOS 16.4, *)
     init(_ cornerRadius: AttributeReference<CoreFoundation.CGFloat?>?) {
         self.value = ._0(cornerRadius: cornerRadius)
         
@@ -8303,12 +8671,13 @@ struct _presentationCornerRadiusModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(cornerRadius):
-            if #available(tvOS 16.4,watchOS 9.4,macOS 13.3,iOS 16.4,visionOS 1.0, *) {
+            if #available(watchOS 9.4,iOS 16.4,visionOS 1.0,macOS 13.3,tvOS 16.4, *) {
             let cornerRadius = cornerRadius as? AttributeReference<CoreFoundation.CGFloat?>
             
             __content
                 .presentationCornerRadius(cornerRadius?.resolve(on: element, in: context))
             
+                
             } else { __content }
         #endif
         }
@@ -8330,6 +8699,7 @@ struct _presentationDragIndicatorModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
@@ -8354,6 +8724,7 @@ struct _presentationDragIndicatorModifier<R: RootRegistry>: ViewModifier {
             __content
                 .presentationDragIndicator(visibility.resolve(on: element, in: context))
             
+                
             
         
         }
@@ -8375,6 +8746,7 @@ struct _previewDisplayNameModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
@@ -8399,6 +8771,7 @@ struct _previewDisplayNameModifier<R: RootRegistry>: ViewModifier {
             __content
                 .previewDisplayName(value?.resolve(on: element, in: context))
             
+                
             
         
         }
@@ -8420,6 +8793,7 @@ struct _privacySensitiveModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
@@ -8444,6 +8818,7 @@ struct _privacySensitiveModifier<R: RootRegistry>: ViewModifier {
             __content
                 .privacySensitive(sensitive.resolve(on: element, in: context))
             
+                
             
         
         }
@@ -8463,6 +8838,7 @@ struct _progressViewStyleModifier<R: RootRegistry>: ViewModifier {
 
     let value: Value
 
+    
     
     
 
@@ -8489,6 +8865,7 @@ struct _progressViewStyleModifier<R: RootRegistry>: ViewModifier {
             __content
                 .progressViewStyle(style)
             
+                
             
         
         }
@@ -8508,6 +8885,7 @@ struct _projectionEffectModifier<R: RootRegistry>: ViewModifier {
 
     let value: Value
 
+    
     
     
 
@@ -8534,6 +8912,7 @@ struct _projectionEffectModifier<R: RootRegistry>: ViewModifier {
             __content
                 .projectionEffect(transform)
             
+                
             
         
         }
@@ -8553,6 +8932,7 @@ struct _redactedModifier<R: RootRegistry>: ViewModifier {
 
     let value: Value
 
+    
     
     
 
@@ -8579,6 +8959,7 @@ struct _redactedModifier<R: RootRegistry>: ViewModifier {
             __content
                 .redacted(reason: reason)
             
+                
             
         
         }
@@ -8598,6 +8979,7 @@ struct _refreshableModifier<R: RootRegistry>: ViewModifier {
 
     let value: Value
 
+    
     
     
 
@@ -8624,6 +9006,7 @@ struct _refreshableModifier<R: RootRegistry>: ViewModifier {
             __content
                 .refreshable(action: { __0_action__0.wrappedValue() })
             
+                
             
         
         }
@@ -8643,6 +9026,7 @@ struct _renameActionModifier<R: RootRegistry>: ViewModifier {
 
     let value: Value
 
+    
     
     
 
@@ -8669,6 +9053,7 @@ struct _renameActionModifier<R: RootRegistry>: ViewModifier {
             __content
                 .renameAction({ __0_action__0.wrappedValue() })
             
+                
             
         
         }
@@ -8690,12 +9075,13 @@ struct _replaceDisabledModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
 
     #if os(iOS) || os(visionOS)
-    @available(iOS 16.0,visionOS 1.0, *)
+    @available(visionOS 1.0,iOS 16.0, *)
     init(_ isDisabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(isDisabled: isDisabled)
         
@@ -8708,12 +9094,13 @@ struct _replaceDisabledModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(visionOS)
         case let ._0(isDisabled):
-            if #available(iOS 16.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,iOS 16.0, *) {
             let isDisabled = isDisabled as! AttributeReference<Swift.Bool>
             
             __content
                 .replaceDisabled(isDisabled.resolve(on: element, in: context))
             
+                
             } else { __content }
         #endif
         }
@@ -8735,6 +9122,7 @@ struct _rotationEffectModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
@@ -8759,6 +9147,7 @@ struct _rotationEffectModifier<R: RootRegistry>: ViewModifier {
             __content
                 .rotationEffect(angle.resolve(on: element, in: context), anchor: anchor.resolve(on: element, in: context))
             
+                
             
         
         }
@@ -8783,6 +9172,7 @@ struct _safeAreaInsetModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
@@ -8816,6 +9206,7 @@ struct _safeAreaInsetModifier<R: RootRegistry>: ViewModifier {
             __content
                 .safeAreaInset(edge: edge, alignment: alignment.resolve(on: element, in: context), spacing: spacing?.resolve(on: element, in: context), content: { content.resolve(on: element, in: context) })
             
+                
             
         
         
@@ -8826,6 +9217,7 @@ struct _safeAreaInsetModifier<R: RootRegistry>: ViewModifier {
             __content
                 .safeAreaInset(edge: edge, alignment: alignment.resolve(on: element, in: context), spacing: spacing?.resolve(on: element, in: context), content: { content.resolve(on: element, in: context) })
             
+                
             
         
         }
@@ -8853,6 +9245,7 @@ struct _safeAreaPaddingModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
@@ -8862,21 +9255,21 @@ struct _safeAreaPaddingModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 10.0,iOS 17.0,tvOS 17.0,visionOS 1.0,macOS 14.0, *)
+    @available(tvOS 17.0,visionOS 1.0,watchOS 10.0,macOS 14.0,iOS 17.0, *)
     init(_ insets: SwiftUI.EdgeInsets) {
         self.value = ._0(insets: insets)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 10.0,iOS 17.0,tvOS 17.0,visionOS 1.0,macOS 14.0, *)
+    @available(tvOS 17.0,visionOS 1.0,watchOS 10.0,macOS 14.0,iOS 17.0, *)
     init(_ edges: SwiftUI.Edge.Set = .all, _ length: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)) ) {
         self.value = ._1(edges: edges, length: length)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 10.0,iOS 17.0,tvOS 17.0,visionOS 1.0,macOS 14.0, *)
+    @available(tvOS 17.0,visionOS 1.0,watchOS 10.0,macOS 14.0,iOS 17.0, *)
     init(_ length: AttributeReference<CoreFoundation.CGFloat>) {
         self.value = ._2(length: length)
         
@@ -8889,33 +9282,36 @@ struct _safeAreaPaddingModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(insets):
-            if #available(watchOS 10.0,iOS 17.0,tvOS 17.0,visionOS 1.0,macOS 14.0, *) {
+            if #available(tvOS 17.0,visionOS 1.0,watchOS 10.0,macOS 14.0,iOS 17.0, *) {
             let insets = insets as! SwiftUI.EdgeInsets
             
             __content
                 .safeAreaPadding(insets)
             
+                
             } else { __content }
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(edges, length):
-            if #available(watchOS 10.0,iOS 17.0,tvOS 17.0,visionOS 1.0,macOS 14.0, *) {
+            if #available(tvOS 17.0,visionOS 1.0,watchOS 10.0,macOS 14.0,iOS 17.0, *) {
             let edges = edges as! SwiftUI.Edge.Set 
 let length = length as? AttributeReference<CoreFoundation.CGFloat?>
             
             __content
                 .safeAreaPadding(edges, length?.resolve(on: element, in: context))
             
+                
             } else { __content }
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._2(length):
-            if #available(watchOS 10.0,iOS 17.0,tvOS 17.0,visionOS 1.0,macOS 14.0, *) {
+            if #available(tvOS 17.0,visionOS 1.0,watchOS 10.0,macOS 14.0,iOS 17.0, *) {
             let length = length as! AttributeReference<CoreFoundation.CGFloat>
             
             __content
                 .safeAreaPadding(length.resolve(on: element, in: context))
             
+                
             } else { __content }
         #endif
         }
@@ -8937,6 +9333,7 @@ struct _saturationModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
@@ -8961,6 +9358,7 @@ struct _saturationModifier<R: RootRegistry>: ViewModifier {
             __content
                 .saturation(amount.resolve(on: element, in: context))
             
+                
             
         
         }
@@ -8997,6 +9395,7 @@ struct _scaleEffectModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
@@ -9047,7 +9446,7 @@ struct _scaleEffectModifier<R: RootRegistry>: ViewModifier {
     }
     #endif
     #if os(visionOS) || os(xrOS)
-    @available(xrOS 1.0,visionOS 1.0, *)
+    @available(visionOS 1.0,xrOS 1.0, *)
     init(x: AttributeReference<CoreFoundation.CGFloat> = .init(storage: .constant(1.0)), y: AttributeReference<CoreFoundation.CGFloat> = .init(storage: .constant(1.0)), z: AttributeReference<CoreFoundation.CGFloat> = .init(storage: .constant(1.0)), anchor: SwiftUI.UnitPoint3D = .center ) {
         self.value = ._5(x: x, y: y, z: z, anchor: anchor)
         
@@ -9066,6 +9465,7 @@ struct _scaleEffectModifier<R: RootRegistry>: ViewModifier {
             __content
                 .scaleEffect(scale, anchor: anchor.resolve(on: element, in: context))
             
+                
             
         
         
@@ -9076,6 +9476,7 @@ struct _scaleEffectModifier<R: RootRegistry>: ViewModifier {
             __content
                 .scaleEffect(s.resolve(on: element, in: context), anchor: anchor.resolve(on: element, in: context))
             
+                
             
         
         
@@ -9086,6 +9487,7 @@ struct _scaleEffectModifier<R: RootRegistry>: ViewModifier {
             __content
                 .scaleEffect(x: x.resolve(on: element, in: context), y: y.resolve(on: element, in: context), anchor: anchor.resolve(on: element, in: context))
             
+                
             
         
         #if os(visionOS) || os(xrOS)
@@ -9097,6 +9499,7 @@ let anchor = anchor as! SwiftUI.UnitPoint3D
             __content
                 .scaleEffect(scale, anchor: anchor)
             
+                
             } else { __content }
         #endif
         #if os(visionOS) || os(xrOS)
@@ -9108,11 +9511,12 @@ let anchor = anchor as! SwiftUI.UnitPoint3D
             __content
                 .scaleEffect(s.resolve(on: element, in: context), anchor: anchor)
             
+                
             } else { __content }
         #endif
         #if os(visionOS) || os(xrOS)
         case let ._5(x, y, z, anchor):
-            if #available(xrOS 1.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,xrOS 1.0, *) {
             let x = x as! AttributeReference<CoreFoundation.CGFloat>
 let y = y as! AttributeReference<CoreFoundation.CGFloat>
 let z = z as! AttributeReference<CoreFoundation.CGFloat>
@@ -9121,6 +9525,7 @@ let anchor = anchor as! SwiftUI.UnitPoint3D
             __content
                 .scaleEffect(x: x.resolve(on: element, in: context), y: y.resolve(on: element, in: context), z: z.resolve(on: element, in: context), anchor: anchor)
             
+                
             } else { __content }
         #endif
         }
@@ -9140,6 +9545,7 @@ struct _scaledToFillModifier<R: RootRegistry>: ViewModifier {
 
     let value: Value
 
+    
     
     
 
@@ -9166,6 +9572,7 @@ struct _scaledToFillModifier<R: RootRegistry>: ViewModifier {
             __content
                 .scaledToFill()
             
+                
             
         
         }
@@ -9185,6 +9592,7 @@ struct _scaledToFitModifier<R: RootRegistry>: ViewModifier {
 
     let value: Value
 
+    
     
     
 
@@ -9211,6 +9619,7 @@ struct _scaledToFitModifier<R: RootRegistry>: ViewModifier {
             __content
                 .scaledToFit()
             
+                
             
         
         }
@@ -9233,6 +9642,7 @@ struct _scenePaddingModifier<R: RootRegistry>: ViewModifier {
 
     let value: Value
 
+    
     
     
 
@@ -9268,6 +9678,7 @@ struct _scenePaddingModifier<R: RootRegistry>: ViewModifier {
             __content
                 .scenePadding(edges)
             
+                
             
         
         
@@ -9278,6 +9689,7 @@ struct _scenePaddingModifier<R: RootRegistry>: ViewModifier {
             __content
                 .scenePadding(padding, edges: edges)
             
+                
             
         
         }
@@ -9299,12 +9711,13 @@ struct _scrollBounceBehaviorModifier<R: RootRegistry>: ViewModifier {
 
     
     
+    
 
 
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(tvOS 16.4,iOS 16.4,watchOS 9.4,visionOS 1.0,macOS 13.3, *)
+    @available(iOS 16.4,tvOS 16.4,macOS 13.3,watchOS 9.4,visionOS 1.0, *)
     init(_ behavior: SwiftUI.ScrollBounceBehavior,axes: SwiftUI.Axis.Set = [.vertical] ) {
         self.value = ._0(behavior: behavior, axes: axes)
         
@@ -9317,13 +9730,14 @@ struct _scrollBounceBehaviorModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(behavior, axes):
-            if #available(tvOS 16.4,iOS 16.4,watchOS 9.4,visionOS 1.0,macOS 13.3, *) {
+            if #available(iOS 16.4,tvOS 16.4,macOS 13.3,watchOS 9.4,visionOS 1.0, *) {
             let behavior = behavior as! SwiftUI.ScrollBounceBehavior
 let axes = axes as! SwiftUI.Axis.Set 
             
             __content
                 .scrollBounceBehavior(behavior, axes: axes)
             
+                
             } else { __content }
         #endif
         }
@@ -9345,12 +9759,13 @@ struct _scrollClipDisabledModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(tvOS 17.0,iOS 17.0,watchOS 10.0,visionOS 1.0,macOS 14.0, *)
+    @available(tvOS 17.0,visionOS 1.0,macOS 14.0,iOS 17.0,watchOS 10.0, *)
     init(_ disabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(disabled: disabled)
         
@@ -9363,12 +9778,13 @@ struct _scrollClipDisabledModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(disabled):
-            if #available(tvOS 17.0,iOS 17.0,watchOS 10.0,visionOS 1.0,macOS 14.0, *) {
+            if #available(tvOS 17.0,visionOS 1.0,macOS 14.0,iOS 17.0,watchOS 10.0, *) {
             let disabled = disabled as! AttributeReference<Swift.Bool>
             
             __content
                 .scrollClipDisabled(disabled.resolve(on: element, in: context))
             
+                
             } else { __content }
         #endif
         }
@@ -9390,12 +9806,13 @@ struct _scrollContentBackgroundModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
 
     #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,macOS 13.0,iOS 16.0,watchOS 9.0, *)
+    @available(visionOS 1.0,watchOS 9.0,macOS 13.0,iOS 16.0, *)
     init(_ visibility: AttributeReference<SwiftUI.Visibility>) {
         self.value = ._0(visibility: visibility)
         
@@ -9408,12 +9825,13 @@ struct _scrollContentBackgroundModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
         case let ._0(visibility):
-            if #available(visionOS 1.0,macOS 13.0,iOS 16.0,watchOS 9.0, *) {
+            if #available(visionOS 1.0,watchOS 9.0,macOS 13.0,iOS 16.0, *) {
             let visibility = visibility as! AttributeReference<SwiftUI.Visibility>
             
             __content
                 .scrollContentBackground(visibility.resolve(on: element, in: context))
             
+                
             } else { __content }
         #endif
         }
@@ -9435,6 +9853,7 @@ struct _scrollDisabledModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
@@ -9459,6 +9878,7 @@ struct _scrollDisabledModifier<R: RootRegistry>: ViewModifier {
             __content
                 .scrollDisabled(disabled.resolve(on: element, in: context))
             
+                
             
         
         }
@@ -9480,12 +9900,13 @@ struct _scrollDismissesKeyboardModifier<R: RootRegistry>: ViewModifier {
 
     
     
+    
 
 
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(tvOS 16.0,iOS 16.0,watchOS 9.0,visionOS 1.0,macOS 13.0, *)
+    @available(iOS 16.0,tvOS 16.0,watchOS 9.0,macOS 13.0,visionOS 1.0, *)
     init(_ mode: SwiftUI.ScrollDismissesKeyboardMode) {
         self.value = ._0(mode: mode)
         
@@ -9498,12 +9919,13 @@ struct _scrollDismissesKeyboardModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(mode):
-            if #available(tvOS 16.0,iOS 16.0,watchOS 9.0,visionOS 1.0,macOS 13.0, *) {
+            if #available(iOS 16.0,tvOS 16.0,watchOS 9.0,macOS 13.0,visionOS 1.0, *) {
             let mode = mode as! SwiftUI.ScrollDismissesKeyboardMode
             
             __content
                 .scrollDismissesKeyboard(mode)
             
+                
             } else { __content }
         #endif
         }
@@ -9523,6 +9945,7 @@ struct _scrollIndicatorsModifier<R: RootRegistry>: ViewModifier {
 
     let value: Value
 
+    
     
     
 
@@ -9549,6 +9972,7 @@ struct _scrollIndicatorsModifier<R: RootRegistry>: ViewModifier {
             __content
                 .scrollIndicators(visibility, axes: axes)
             
+                
             
         
         }
@@ -9573,6 +9997,7 @@ struct _scrollIndicatorsFlashModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
@@ -9580,14 +10005,14 @@ struct _scrollIndicatorsFlashModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(tvOS 17.0,iOS 17.0,watchOS 10.0,visionOS 1.0,macOS 14.0, *)
+    @available(tvOS 17.0,visionOS 1.0,macOS 14.0,iOS 17.0,watchOS 10.0, *)
     init(trigger value: AttributeReference<String>) {
         self.value = ._0(value: value)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(tvOS 17.0,iOS 17.0,watchOS 10.0,visionOS 1.0,macOS 14.0, *)
+    @available(tvOS 17.0,visionOS 1.0,macOS 14.0,iOS 17.0,watchOS 10.0, *)
     init(onAppear: AttributeReference<Swift.Bool>) {
         self.value = ._1(onAppear: onAppear)
         
@@ -9600,22 +10025,24 @@ struct _scrollIndicatorsFlashModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(value):
-            if #available(tvOS 17.0,iOS 17.0,watchOS 10.0,visionOS 1.0,macOS 14.0, *) {
+            if #available(tvOS 17.0,visionOS 1.0,macOS 14.0,iOS 17.0,watchOS 10.0, *) {
             let value = value as! AttributeReference<String>
             
             __content
                 .scrollIndicatorsFlash(trigger: value.resolve(on: element, in: context))
             
+                
             } else { __content }
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(onAppear):
-            if #available(tvOS 17.0,iOS 17.0,watchOS 10.0,visionOS 1.0,macOS 14.0, *) {
+            if #available(tvOS 17.0,visionOS 1.0,macOS 14.0,iOS 17.0,watchOS 10.0, *) {
             let onAppear = onAppear as! AttributeReference<Swift.Bool>
             
             __content
                 .scrollIndicatorsFlash(onAppear: onAppear.resolve(on: element, in: context))
             
+                
             } else { __content }
         #endif
         }
@@ -9637,12 +10064,13 @@ struct _scrollPositionModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 @ChangeTracked private var _0_id: String?
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0,visionOS 1.0, *)
+    @available(tvOS 17.0,macOS 14.0,iOS 17.0,watchOS 10.0,visionOS 1.0, *)
     init(id: ChangeTracked<String?>,anchor: AttributeReference<SwiftUI.UnitPoint?>? = .init(storage: .constant(nil)) ) {
         self.value = ._0(anchor: anchor)
         self.__0_id = id
@@ -9655,12 +10083,13 @@ struct _scrollPositionModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(anchor):
-            if #available(macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0,visionOS 1.0, *) {
+            if #available(tvOS 17.0,macOS 14.0,iOS 17.0,watchOS 10.0,visionOS 1.0, *) {
             let anchor = anchor as? AttributeReference<SwiftUI.UnitPoint?>
             
             __content
                 .scrollPosition(id: __0_id.projectedValue, anchor: anchor?.resolve(on: element, in: context))
             
+                
             } else { __content }
         #endif
         }
@@ -9682,12 +10111,13 @@ struct _scrollTargetBehaviorModifier<R: RootRegistry>: ViewModifier {
 
     
     
+    
 
 
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(tvOS 17.0,watchOS 10.0,visionOS 1.0,iOS 17.0,macOS 14.0, *)
+    @available(tvOS 17.0,visionOS 1.0,watchOS 10.0,macOS 14.0,iOS 17.0, *)
     init(_ behavior: AnyScrollTargetBehavior) {
         self.value = ._0(behavior: behavior)
         
@@ -9700,12 +10130,13 @@ struct _scrollTargetBehaviorModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(behavior):
-            if #available(tvOS 17.0,watchOS 10.0,visionOS 1.0,iOS 17.0,macOS 14.0, *) {
+            if #available(tvOS 17.0,visionOS 1.0,watchOS 10.0,macOS 14.0,iOS 17.0, *) {
             let behavior = behavior as! AnyScrollTargetBehavior
             
             __content
                 .scrollTargetBehavior(behavior)
             
+                
             } else { __content }
         #endif
         }
@@ -9727,12 +10158,13 @@ struct _scrollTargetLayoutModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(tvOS 17.0,watchOS 10.0,visionOS 1.0,iOS 17.0,macOS 14.0, *)
+    @available(visionOS 1.0,watchOS 10.0,tvOS 17.0,iOS 17.0,macOS 14.0, *)
     init(isEnabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(isEnabled: isEnabled)
         
@@ -9745,12 +10177,13 @@ struct _scrollTargetLayoutModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(isEnabled):
-            if #available(tvOS 17.0,watchOS 10.0,visionOS 1.0,iOS 17.0,macOS 14.0, *) {
+            if #available(visionOS 1.0,watchOS 10.0,tvOS 17.0,iOS 17.0,macOS 14.0, *) {
             let isEnabled = isEnabled as! AttributeReference<Swift.Bool>
             
             __content
                 .scrollTargetLayout(isEnabled: isEnabled.resolve(on: element, in: context))
             
+                
             } else { __content }
         #endif
         }
@@ -9772,12 +10205,13 @@ struct _searchDictationBehaviorModifier<R: RootRegistry>: ViewModifier {
 
     
     
+    
 
 
 
 
     #if os(iOS) || os(visionOS) || os(xrOS)
-    @available(xrOS 1.0,iOS 17.0,visionOS 1.0, *)
+    @available(visionOS 1.0,iOS 17.0,xrOS 1.0, *)
     init(_ dictationBehavior: SwiftUI.TextInputDictationBehavior) {
         self.value = ._0(dictationBehavior: dictationBehavior)
         
@@ -9790,12 +10224,13 @@ struct _searchDictationBehaviorModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(visionOS) || os(xrOS)
         case let ._0(dictationBehavior):
-            if #available(xrOS 1.0,iOS 17.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,iOS 17.0,xrOS 1.0, *) {
             let dictationBehavior = dictationBehavior as! SwiftUI.TextInputDictationBehavior
             
             __content
                 .searchDictationBehavior(dictationBehavior)
             
+                
             } else { __content }
         #endif
         }
@@ -9817,12 +10252,13 @@ struct _searchPresentationToolbarBehaviorModifier<R: RootRegistry>: ViewModifier
 
     
     
+    
 
 
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 14.1,iOS 17.1,tvOS 17.1,watchOS 10.1,visionOS 1.0, *)
+    @available(iOS 17.1,tvOS 17.1,watchOS 10.1,macOS 14.1,visionOS 1.0, *)
     init(_ behavior: SwiftUI.SearchPresentationToolbarBehavior) {
         self.value = ._0(behavior: behavior)
         
@@ -9835,12 +10271,13 @@ struct _searchPresentationToolbarBehaviorModifier<R: RootRegistry>: ViewModifier
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(behavior):
-            if #available(macOS 14.1,iOS 17.1,tvOS 17.1,watchOS 10.1,visionOS 1.0, *) {
+            if #available(iOS 17.1,tvOS 17.1,watchOS 10.1,macOS 14.1,visionOS 1.0, *) {
             let behavior = behavior as! SwiftUI.SearchPresentationToolbarBehavior
             
             __content
                 .searchPresentationToolbarBehavior(behavior)
             
+                
             } else { __content }
         #endif
         }
@@ -9865,6 +10302,7 @@ struct _searchSuggestionsModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
@@ -9898,6 +10336,7 @@ struct _searchSuggestionsModifier<R: RootRegistry>: ViewModifier {
             __content
                 .searchSuggestions({ suggestions.resolve(on: element, in: context) })
             
+                
             
         
         
@@ -9908,6 +10347,7 @@ struct _searchSuggestionsModifier<R: RootRegistry>: ViewModifier {
             __content
                 .searchSuggestions(visibility.resolve(on: element, in: context), for: placements)
             
+                
             
         
         }
@@ -9944,6 +10384,7 @@ struct _searchableModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 @ChangeTracked private var _0_text: Swift.String
 
@@ -9983,7 +10424,7 @@ struct _searchableModifier<R: RootRegistry>: ViewModifier {
     }
     
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(iOS 17.0,visionOS 1.0,macOS 14.0, *)
+    @available(macOS 14.0,iOS 17.0,visionOS 1.0, *)
     init(text: ChangeTracked<Swift.String>,isPresented: ChangeTracked<Swift.Bool>,placement: SwiftUI.SearchFieldPlacement = .automatic, prompt: TextReference? = nil ) {
         self.value = ._3(placement: placement, prompt: prompt)
         self.__3_text = text
@@ -9999,7 +10440,7 @@ self.__4_isPresented = isPresented
     }
     #endif
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(iOS 17.0,macOS 14.0,visionOS 1.0, *)
+    @available(visionOS 1.0,iOS 17.0,macOS 14.0, *)
     init(text: ChangeTracked<Swift.String>,isPresented: ChangeTracked<Swift.Bool>,placement: SwiftUI.SearchFieldPlacement = .automatic, prompt: AttributeReference<String>) {
         self.value = ._5(placement: placement, prompt: prompt)
         self.__5_text = text
@@ -10019,6 +10460,7 @@ self.__5_isPresented = isPresented
             __content
                 .searchable(text: __0_text.projectedValue, placement: placement, prompt: prompt?.resolve(on: element, in: context))
             }
+                
             
         
         
@@ -10029,6 +10471,7 @@ self.__5_isPresented = isPresented
             __content
                 .searchable(text: __1_text.projectedValue, placement: placement, prompt: prompt)
             
+                
             
         
         
@@ -10039,17 +10482,19 @@ self.__5_isPresented = isPresented
             __content
                 .searchable(text: __2_text.projectedValue, placement: placement, prompt: prompt.resolve(on: element, in: context))
             
+                
             
         
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._3(placement, prompt):
-            if #available(iOS 17.0,visionOS 1.0,macOS 14.0, *) {
+            if #available(macOS 14.0,iOS 17.0,visionOS 1.0, *) {
             let placement = placement as! SwiftUI.SearchFieldPlacement 
 let prompt = prompt as? TextReference
             __content._observeTextReference(prompt, on: element, in: context) { __content in
             __content
                 .searchable(text: __3_text.projectedValue, isPresented: __3_isPresented.projectedValue, placement: placement, prompt: prompt?.resolve(on: element, in: context))
             }
+                
             } else { __content }
         #endif
         #if os(iOS) || os(macOS) || os(visionOS)
@@ -10061,17 +10506,19 @@ let prompt = prompt as! SwiftUI.LocalizedStringKey
             __content
                 .searchable(text: __4_text.projectedValue, isPresented: __4_isPresented.projectedValue, placement: placement, prompt: prompt)
             
+                
             } else { __content }
         #endif
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._5(placement, prompt):
-            if #available(iOS 17.0,macOS 14.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,iOS 17.0,macOS 14.0, *) {
             let placement = placement as! SwiftUI.SearchFieldPlacement 
 let prompt = prompt as! AttributeReference<String>
             
             __content
                 .searchable(text: __5_text.projectedValue, isPresented: __5_isPresented.projectedValue, placement: placement, prompt: prompt.resolve(on: element, in: context))
             
+                
             } else { __content }
         #endif
         }
@@ -10093,12 +10540,13 @@ struct _selectionDisabledModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 10.0,iOS 17.0,tvOS 17.0,visionOS 1.0,macOS 14.0, *)
+    @available(iOS 17.0,tvOS 17.0,watchOS 10.0,macOS 14.0,visionOS 1.0, *)
     init(_ isDisabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(isDisabled: isDisabled)
         
@@ -10111,12 +10559,13 @@ struct _selectionDisabledModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(isDisabled):
-            if #available(watchOS 10.0,iOS 17.0,tvOS 17.0,visionOS 1.0,macOS 14.0, *) {
+            if #available(iOS 17.0,tvOS 17.0,watchOS 10.0,macOS 14.0,visionOS 1.0, *) {
             let isDisabled = isDisabled as! AttributeReference<Swift.Bool>
             
             __content
                 .selectionDisabled(isDisabled.resolve(on: element, in: context))
             
+                
             } else { __content }
         #endif
         }
@@ -10138,6 +10587,7 @@ struct _shadowModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
@@ -10162,6 +10612,7 @@ struct _shadowModifier<R: RootRegistry>: ViewModifier {
             __content
                 .shadow(color: color.resolve(on: element, in: context), radius: radius.resolve(on: element, in: context), x: x.resolve(on: element, in: context), y: y.resolve(on: element, in: context))
             
+                
             
         
         }
@@ -10183,6 +10634,7 @@ struct _sheetModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 @ChangeTracked private var _0_isPresented: Swift.Bool
 @Event private var _0_onDismiss__0: Event.EventHandler
@@ -10208,6 +10660,7 @@ self.__0_onDismiss__0 = onDismiss__0
             __content
                 .sheet(isPresented: __0_isPresented.projectedValue, onDismiss: { __0_onDismiss__0.wrappedValue() }, content: { content.resolve(on: element, in: context) })
             
+                
             
         
         }
@@ -10221,21 +10674,22 @@ struct _simultaneousGestureModifier<R: RootRegistry>: ViewModifier {
     enum Value {
         case _never
         
-        indirect case _0(gesture: AnyGesture<Any>,mask: SwiftUI.GestureMask = .all )
+        indirect case _0(gesture: _AnyGesture,mask: SwiftUI.GestureMask = .all )
         
     }
 
     let value: Value
 
-    
-    
+    @ObservedElement private var element
+    @LiveContext<R> private var context
+    @GestureState private var gestureState = [String:Any]()
 
 
 
 
     
     
-    init(_ gesture: AnyGesture<Any>,including mask: SwiftUI.GestureMask = .all ) {
+    init(_ gesture: _AnyGesture,including mask: SwiftUI.GestureMask = .all ) {
         self.value = ._0(gesture: gesture, mask: mask)
         
     }
@@ -10251,8 +10705,9 @@ struct _simultaneousGestureModifier<R: RootRegistry>: ViewModifier {
             
             
             __content
-                .simultaneousGesture(gesture, including: mask)
+                .simultaneousGesture(gesture.resolve(on: element, in: context.withGestureState(_gestureState)), including: mask)
             
+                .environment(\.gestureState, _gestureState)
             
         
         }
@@ -10274,6 +10729,7 @@ struct _speechAdjustedPitchModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
@@ -10298,6 +10754,7 @@ struct _speechAdjustedPitchModifier<R: RootRegistry>: ViewModifier {
             __content
                 .speechAdjustedPitch(value.resolve(on: element, in: context))
             
+                
             
         
         }
@@ -10319,6 +10776,7 @@ struct _speechAlwaysIncludesPunctuationModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
@@ -10343,6 +10801,7 @@ struct _speechAlwaysIncludesPunctuationModifier<R: RootRegistry>: ViewModifier {
             __content
                 .speechAlwaysIncludesPunctuation(value.resolve(on: element, in: context))
             
+                
             
         
         }
@@ -10364,6 +10823,7 @@ struct _speechAnnouncementsQueuedModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
@@ -10388,6 +10848,7 @@ struct _speechAnnouncementsQueuedModifier<R: RootRegistry>: ViewModifier {
             __content
                 .speechAnnouncementsQueued(value.resolve(on: element, in: context))
             
+                
             
         
         }
@@ -10409,6 +10870,7 @@ struct _speechSpellsOutCharactersModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
@@ -10433,6 +10895,7 @@ struct _speechSpellsOutCharactersModifier<R: RootRegistry>: ViewModifier {
             __content
                 .speechSpellsOutCharacters(value.resolve(on: element, in: context))
             
+                
             
         
         }
@@ -10454,6 +10917,7 @@ struct _statusBarHiddenModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
@@ -10478,6 +10942,7 @@ struct _statusBarHiddenModifier<R: RootRegistry>: ViewModifier {
             __content
                 .statusBarHidden(hidden.resolve(on: element, in: context))
             
+                
             } else { __content }
         #endif
         }
@@ -10497,6 +10962,7 @@ struct _submitLabelModifier<R: RootRegistry>: ViewModifier {
 
     let value: Value
 
+    
     
     
 
@@ -10523,6 +10989,7 @@ struct _submitLabelModifier<R: RootRegistry>: ViewModifier {
             __content
                 .submitLabel(submitLabel)
             
+                
             
         
         }
@@ -10544,6 +11011,7 @@ struct _submitScopeModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
@@ -10568,6 +11036,7 @@ struct _submitScopeModifier<R: RootRegistry>: ViewModifier {
             __content
                 .submitScope(isBlocking.resolve(on: element, in: context))
             
+                
             
         
         }
@@ -10589,12 +11058,13 @@ struct _swipeActionsModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
 
     #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,macOS 12.0,iOS 15.0,watchOS 8.0, *)
+    @available(watchOS 8.0,macOS 12.0,iOS 15.0,visionOS 1.0, *)
     init(edge: SwiftUI.HorizontalEdge = .trailing, allowsFullSwipe: AttributeReference<Swift.Bool> = .init(storage: .constant(true)), content: ViewReference=ViewReference(value: [])) {
         self.value = ._0(edge: edge, allowsFullSwipe: allowsFullSwipe, content: content)
         
@@ -10607,7 +11077,7 @@ struct _swipeActionsModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
         case let ._0(edge, allowsFullSwipe, content):
-            if #available(visionOS 1.0,macOS 12.0,iOS 15.0,watchOS 8.0, *) {
+            if #available(watchOS 8.0,macOS 12.0,iOS 15.0,visionOS 1.0, *) {
             let edge = edge as! SwiftUI.HorizontalEdge 
 let allowsFullSwipe = allowsFullSwipe as! AttributeReference<Swift.Bool>
 let content = content as! ViewReference
@@ -10615,6 +11085,7 @@ let content = content as! ViewReference
             __content
                 .swipeActions(edge: edge, allowsFullSwipe: allowsFullSwipe.resolve(on: element, in: context), content: { content.resolve(on: element, in: context) })
             
+                
             } else { __content }
         #endif
         }
@@ -10639,6 +11110,7 @@ struct _symbolEffectModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
@@ -10646,14 +11118,14 @@ struct _symbolEffectModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(tvOS 17.0,watchOS 10.0,visionOS 1.0,macOS 14.0,iOS 17.0, *)
+    @available(iOS 17.0,tvOS 17.0,macOS 14.0,watchOS 10.0,visionOS 1.0, *)
     init(_ effect: AnyIndefiniteSymbolEffect,options: Symbols.SymbolEffectOptions = .default, isActive: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(effect: effect, options: options, isActive: isActive)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(tvOS 17.0,watchOS 10.0,visionOS 1.0,macOS 14.0,iOS 17.0, *)
+    @available(iOS 17.0,tvOS 17.0,macOS 14.0,watchOS 10.0,visionOS 1.0, *)
     init(_ effect: AnyDiscreteSymbolEffect,options: Symbols.SymbolEffectOptions = .default, value: AttributeReference<String>) {
         self.value = ._1(effect: effect, options: options, value: value)
         
@@ -10666,7 +11138,7 @@ struct _symbolEffectModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(effect, options, isActive):
-            if #available(tvOS 17.0,watchOS 10.0,visionOS 1.0,macOS 14.0,iOS 17.0, *) {
+            if #available(iOS 17.0,tvOS 17.0,macOS 14.0,watchOS 10.0,visionOS 1.0, *) {
             let effect = effect as! AnyIndefiniteSymbolEffect
 let options = options as! Symbols.SymbolEffectOptions 
 let isActive = isActive as! AttributeReference<Swift.Bool>
@@ -10674,11 +11146,12 @@ let isActive = isActive as! AttributeReference<Swift.Bool>
             __content
                 .symbolEffect(effect, options: options, isActive: isActive.resolve(on: element, in: context))
             
+                
             } else { __content }
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(effect, options, value):
-            if #available(tvOS 17.0,watchOS 10.0,visionOS 1.0,macOS 14.0,iOS 17.0, *) {
+            if #available(iOS 17.0,tvOS 17.0,macOS 14.0,watchOS 10.0,visionOS 1.0, *) {
             let effect = effect as! AnyDiscreteSymbolEffect
 let options = options as! Symbols.SymbolEffectOptions 
 let value = value as! AttributeReference<String>
@@ -10686,6 +11159,7 @@ let value = value as! AttributeReference<String>
             __content
                 .symbolEffect(effect, options: options, value: value.resolve(on: element, in: context))
             
+                
             } else { __content }
         #endif
         }
@@ -10707,12 +11181,13 @@ struct _symbolEffectsRemovedModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 10.0,iOS 17.0,tvOS 17.0,visionOS 1.0,macOS 14.0, *)
+    @available(iOS 17.0,tvOS 17.0,watchOS 10.0,macOS 14.0,visionOS 1.0, *)
     init(_ isEnabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(isEnabled: isEnabled)
         
@@ -10725,12 +11200,13 @@ struct _symbolEffectsRemovedModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(isEnabled):
-            if #available(watchOS 10.0,iOS 17.0,tvOS 17.0,visionOS 1.0,macOS 14.0, *) {
+            if #available(iOS 17.0,tvOS 17.0,watchOS 10.0,macOS 14.0,visionOS 1.0, *) {
             let isEnabled = isEnabled as! AttributeReference<Swift.Bool>
             
             __content
                 .symbolEffectsRemoved(isEnabled.resolve(on: element, in: context))
             
+                
             } else { __content }
         #endif
         }
@@ -10750,6 +11226,7 @@ struct _symbolRenderingModeModifier<R: RootRegistry>: ViewModifier {
 
     let value: Value
 
+    
     
     
 
@@ -10776,6 +11253,7 @@ struct _symbolRenderingModeModifier<R: RootRegistry>: ViewModifier {
             __content
                 .symbolRenderingMode(mode)
             
+                
             
         
         }
@@ -10795,6 +11273,7 @@ struct _symbolVariantModifier<R: RootRegistry>: ViewModifier {
 
     let value: Value
 
+    
     
     
 
@@ -10821,6 +11300,7 @@ struct _symbolVariantModifier<R: RootRegistry>: ViewModifier {
             __content
                 .symbolVariant(variant)
             
+                
             
         
         }
@@ -10842,6 +11322,7 @@ struct _tabItemModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
@@ -10866,6 +11347,7 @@ struct _tabItemModifier<R: RootRegistry>: ViewModifier {
             __content
                 .tabItem({ label.resolve(on: element, in: context) })
             
+                
             
         
         }
@@ -10885,6 +11367,7 @@ struct _tabViewStyleModifier<R: RootRegistry>: ViewModifier {
 
     let value: Value
 
+    
     
     
 
@@ -10911,6 +11394,7 @@ struct _tabViewStyleModifier<R: RootRegistry>: ViewModifier {
             __content
                 .tabViewStyle(style)
             
+                
             
         
         }
@@ -10932,12 +11416,13 @@ struct _tableStyleModifier<R: RootRegistry>: ViewModifier {
 
     
     
+    
 
 
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 12.0,iOS 16.0,visionOS 1.0, *)
+    @available(visionOS 1.0,iOS 16.0,macOS 12.0, *)
     init(_ style: AnyTableStyle) {
         self.value = ._0(style: style)
         
@@ -10950,12 +11435,13 @@ struct _tableStyleModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(style):
-            if #available(macOS 12.0,iOS 16.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,iOS 16.0,macOS 12.0, *) {
             let style = style as! AnyTableStyle
             
             __content
                 .tableStyle(style)
             
+                
             } else { __content }
         #endif
         }
@@ -10975,6 +11461,7 @@ struct _textCaseModifier<R: RootRegistry>: ViewModifier {
 
     let value: Value
 
+    
     
     
 
@@ -11001,6 +11488,7 @@ struct _textCaseModifier<R: RootRegistry>: ViewModifier {
             __content
                 .textCase(textCase)
             
+                
             
         
         }
@@ -11020,6 +11508,7 @@ struct _textContentTypeModifier<R: RootRegistry>: ViewModifier {
 
     let value: Value
 
+    
     
     
 
@@ -11046,6 +11535,7 @@ struct _textContentTypeModifier<R: RootRegistry>: ViewModifier {
             __content
                 .textContentType(textContentType)
             
+                
             } else { __content }
         #endif
         }
@@ -11067,12 +11557,13 @@ struct _textEditorStyleModifier<R: RootRegistry>: ViewModifier {
 
     
     
+    
 
 
 
 
     #if os(iOS) || os(macOS) || os(visionOS) || os(xrOS)
-    @available(xrOS 1.0,iOS 17.0,visionOS 1.0,macOS 14.0, *)
+    @available(iOS 17.0,xrOS 1.0,macOS 14.0,visionOS 1.0, *)
     init(_ style: AnyTextEditorStyle) {
         self.value = ._0(style: style)
         
@@ -11085,12 +11576,13 @@ struct _textEditorStyleModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS) || os(xrOS)
         case let ._0(style):
-            if #available(xrOS 1.0,iOS 17.0,visionOS 1.0,macOS 14.0, *) {
+            if #available(iOS 17.0,xrOS 1.0,macOS 14.0,visionOS 1.0, *) {
             let style = style as! AnyTextEditorStyle
             
             __content
                 .textEditorStyle(style)
             
+                
             } else { __content }
         #endif
         }
@@ -11110,6 +11602,7 @@ struct _textFieldStyleModifier<R: RootRegistry>: ViewModifier {
 
     let value: Value
 
+    
     
     
 
@@ -11136,6 +11629,7 @@ struct _textFieldStyleModifier<R: RootRegistry>: ViewModifier {
             __content
                 .textFieldStyle(style)
             
+                
             
         
         }
@@ -11155,6 +11649,7 @@ struct _textInputAutocapitalizationModifier<R: RootRegistry>: ViewModifier {
 
     let value: Value
 
+    
     
     
 
@@ -11181,6 +11676,7 @@ struct _textInputAutocapitalizationModifier<R: RootRegistry>: ViewModifier {
             __content
                 .textInputAutocapitalization(autocapitalization)
             
+                
             } else { __content }
         #endif
         }
@@ -11202,12 +11698,13 @@ struct _textSelectionModifier<R: RootRegistry>: ViewModifier {
 
     
     
+    
 
 
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 12.0,iOS 15.0,visionOS 1.0, *)
+    @available(visionOS 1.0,iOS 15.0,macOS 12.0, *)
     init(_ selectability: AnyTextSelectability) {
         self.value = ._0(selectability: selectability)
         
@@ -11220,12 +11717,13 @@ struct _textSelectionModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(selectability):
-            if #available(macOS 12.0,iOS 15.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,iOS 15.0,macOS 12.0, *) {
             let selectability = selectability as! AnyTextSelectability
             
             __content
                 .textSelection(selectability)
             
+                
             } else { __content }
         #endif
         }
@@ -11250,6 +11748,7 @@ struct _tintModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
@@ -11283,6 +11782,7 @@ struct _tintModifier<R: RootRegistry>: ViewModifier {
             __content
                 .tint(tint.resolve(on: element, in: context))
             
+                
             
         
         
@@ -11293,6 +11793,7 @@ struct _tintModifier<R: RootRegistry>: ViewModifier {
             __content
                 .tint(tint?.resolve(on: element, in: context))
             
+                
             
         
         }
@@ -11312,6 +11813,7 @@ struct _toggleStyleModifier<R: RootRegistry>: ViewModifier {
 
     let value: Value
 
+    
     
     
 
@@ -11338,6 +11840,7 @@ struct _toggleStyleModifier<R: RootRegistry>: ViewModifier {
             __content
                 .toggleStyle(style)
             
+                
             
         
         }
@@ -11368,6 +11871,7 @@ struct _toolbarModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
@@ -11386,7 +11890,7 @@ struct _toolbarModifier<R: RootRegistry>: ViewModifier {
     }
     
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0,visionOS 1.0, *)
+    @available(watchOS 10.0,macOS 14.0,tvOS 17.0,iOS 17.0,visionOS 1.0, *)
     init(removing defaultItemKind: SwiftUI.ToolbarDefaultItemKind?) {
         self.value = ._1(defaultItemKind: defaultItemKind)
         
@@ -11419,16 +11923,18 @@ struct _toolbarModifier<R: RootRegistry>: ViewModifier {
             __content
                 .toolbar(visibility.resolve(on: element, in: context), for: bars)
             
+                
             
         
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(defaultItemKind):
-            if #available(macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0,visionOS 1.0, *) {
+            if #available(watchOS 10.0,macOS 14.0,tvOS 17.0,iOS 17.0,visionOS 1.0, *) {
             let defaultItemKind = defaultItemKind as? SwiftUI.ToolbarDefaultItemKind
             
             __content
                 .toolbar(removing: defaultItemKind)
             
+                
             } else { __content }
         #endif
         
@@ -11439,6 +11945,7 @@ struct _toolbarModifier<R: RootRegistry>: ViewModifier {
             __content
                 .toolbar(content: { content.resolve(on: element, in: context) })
             
+                
             
         
         
@@ -11449,6 +11956,7 @@ struct _toolbarModifier<R: RootRegistry>: ViewModifier {
             __content
                 .toolbar(id: id.resolve(on: element, in: context), content: { content.resolve(on: element, in: context) })
             
+                
             
         
         }
@@ -11473,6 +11981,7 @@ struct _toolbarBackgroundModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
@@ -11506,6 +12015,7 @@ struct _toolbarBackgroundModifier<R: RootRegistry>: ViewModifier {
             __content
                 .toolbarBackground(style.resolve(on: element, in: context), for: bars)
             
+                
             
         
         
@@ -11516,6 +12026,7 @@ struct _toolbarBackgroundModifier<R: RootRegistry>: ViewModifier {
             __content
                 .toolbarBackground(visibility.resolve(on: element, in: context), for: bars)
             
+                
             
         
         }
@@ -11537,6 +12048,7 @@ struct _toolbarColorSchemeModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
@@ -11561,6 +12073,7 @@ struct _toolbarColorSchemeModifier<R: RootRegistry>: ViewModifier {
             __content
                 .toolbarColorScheme(colorScheme?.resolve(on: element, in: context), for: bars)
             
+                
             
         
         }
@@ -11580,6 +12093,7 @@ struct _toolbarRoleModifier<R: RootRegistry>: ViewModifier {
 
     let value: Value
 
+    
     
     
 
@@ -11606,6 +12120,7 @@ struct _toolbarRoleModifier<R: RootRegistry>: ViewModifier {
             __content
                 .toolbarRole(role)
             
+                
             
         
         }
@@ -11627,12 +12142,13 @@ struct _toolbarTitleDisplayModeModifier<R: RootRegistry>: ViewModifier {
 
     
     
+    
 
 
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,tvOS 17.0,macOS 14.0,iOS 17.0,watchOS 10.0, *)
+    @available(visionOS 1.0,tvOS 17.0,watchOS 10.0,iOS 17.0,macOS 14.0, *)
     init(_ mode: SwiftUI.ToolbarTitleDisplayMode) {
         self.value = ._0(mode: mode)
         
@@ -11645,12 +12161,13 @@ struct _toolbarTitleDisplayModeModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(mode):
-            if #available(visionOS 1.0,tvOS 17.0,macOS 14.0,iOS 17.0,watchOS 10.0, *) {
+            if #available(visionOS 1.0,tvOS 17.0,watchOS 10.0,iOS 17.0,macOS 14.0, *) {
             let mode = mode as! SwiftUI.ToolbarTitleDisplayMode
             
             __content
                 .toolbarTitleDisplayMode(mode)
             
+                
             } else { __content }
         #endif
         }
@@ -11672,6 +12189,7 @@ struct _toolbarTitleMenuModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
@@ -11696,6 +12214,7 @@ struct _toolbarTitleMenuModifier<R: RootRegistry>: ViewModifier {
             __content
                 .toolbarTitleMenu(content: { content.resolve(on: element, in: context) })
             
+                
             
         
         }
@@ -11717,12 +12236,13 @@ struct _touchBarCustomizationLabelModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
 
     #if os(macOS) || os(visionOS)
-    @available(macOS 10.15,visionOS 1.0, *)
+    @available(visionOS 1.0,macOS 10.15, *)
     init(_ label: TextReference) {
         self.value = ._0(label: label)
         
@@ -11735,12 +12255,13 @@ struct _touchBarCustomizationLabelModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(macOS) || os(visionOS)
         case let ._0(label):
-            if #available(macOS 10.15,visionOS 1.0, *) {
+            if #available(visionOS 1.0,macOS 10.15, *) {
             let label = label as! TextReference
             __content._observeTextReference(label, on: element, in: context) { __content in
             __content
                 .touchBarCustomizationLabel(label.resolve(on: element, in: context))
             }
+                
             } else { __content }
         #endif
         }
@@ -11762,12 +12283,13 @@ struct _touchBarItemPrincipalModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
 
     #if os(macOS) || os(visionOS)
-    @available(macOS 10.15,visionOS 1.0, *)
+    @available(visionOS 1.0,macOS 10.15, *)
     init(_ principal: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(principal: principal)
         
@@ -11780,12 +12302,13 @@ struct _touchBarItemPrincipalModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(macOS) || os(visionOS)
         case let ._0(principal):
-            if #available(macOS 10.15,visionOS 1.0, *) {
+            if #available(visionOS 1.0,macOS 10.15, *) {
             let principal = principal as! AttributeReference<Swift.Bool>
             
             __content
                 .touchBarItemPrincipal(principal.resolve(on: element, in: context))
             
+                
             } else { __content }
         #endif
         }
@@ -11807,12 +12330,13 @@ struct _transform3DEffectModifier<R: RootRegistry>: ViewModifier {
 
     
     
+    
 
 
 
 
     #if os(visionOS) || os(xrOS)
-    @available(xrOS 1.0,visionOS 1.0, *)
+    @available(visionOS 1.0,xrOS 1.0, *)
     init(_ transform: Spatial.AffineTransform3D) {
         self.value = ._0(transform: transform)
         
@@ -11825,12 +12349,13 @@ struct _transform3DEffectModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(visionOS) || os(xrOS)
         case let ._0(transform):
-            if #available(xrOS 1.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,xrOS 1.0, *) {
             let transform = transform as! Spatial.AffineTransform3D
             
             __content
                 .transform3DEffect(transform)
             
+                
             } else { __content }
         #endif
         }
@@ -11850,6 +12375,7 @@ struct _transformEffectModifier<R: RootRegistry>: ViewModifier {
 
     let value: Value
 
+    
     
     
 
@@ -11876,6 +12402,7 @@ struct _transformEffectModifier<R: RootRegistry>: ViewModifier {
             __content
                 .transformEffect(transform)
             
+                
             
         
         }
@@ -11895,6 +12422,7 @@ struct _transitionModifier<R: RootRegistry>: ViewModifier {
 
     let value: Value
 
+    
     
     
 
@@ -11921,6 +12449,7 @@ struct _transitionModifier<R: RootRegistry>: ViewModifier {
             __content
                 .transition(t)
             
+                
             
         
         }
@@ -11940,6 +12469,7 @@ struct _truncationModeModifier<R: RootRegistry>: ViewModifier {
 
     let value: Value
 
+    
     
     
 
@@ -11966,6 +12496,7 @@ struct _truncationModeModifier<R: RootRegistry>: ViewModifier {
             __content
                 .truncationMode(mode)
             
+                
             
         
         }
@@ -11985,6 +12516,7 @@ struct _unredactedModifier<R: RootRegistry>: ViewModifier {
 
     let value: Value
 
+    
     
     
 
@@ -12011,6 +12543,7 @@ struct _unredactedModifier<R: RootRegistry>: ViewModifier {
             __content
                 .unredacted()
             
+                
             
         
         }
@@ -12032,6 +12565,7 @@ struct _upperLimbVisibilityModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
@@ -12056,6 +12590,7 @@ struct _upperLimbVisibilityModifier<R: RootRegistry>: ViewModifier {
             __content
                 .upperLimbVisibility(preferredVisibility.resolve(on: element, in: context))
             
+                
             } else { __content }
         #endif
         }
@@ -12077,6 +12612,7 @@ struct _zIndexModifier<R: RootRegistry>: ViewModifier {
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+    
 
 
 
@@ -12101,6 +12637,7 @@ struct _zIndexModifier<R: RootRegistry>: ViewModifier {
             __content
                 .zIndex(value.resolve(on: element, in: context))
             
+                
             
         
         }
@@ -12932,16 +13469,16 @@ indirect case chunk12(_BuiltinModifierChunk12)
 indirect case chunk13(_BuiltinModifierChunk13)
 indirect case chunk14(_BuiltinModifierChunk14)
 indirect case chunk15(_BuiltinModifierChunk15)
-        indirect case _Rotation3DEffectModifier(LiveViewNative._Rotation3DEffectModifier<R>)
+        indirect case _SearchScopesModifier(LiveViewNative._SearchScopesModifier<R>)
 indirect case _FocusScopeModifier(LiveViewNative._FocusScopeModifier<R>)
-indirect case _PrefersDefaultFocusModifier(LiveViewNative._PrefersDefaultFocusModifier<R>)
-indirect case _PresentationDetentsModifier(LiveViewNative._PresentationDetentsModifier)
 indirect case _SearchCompletionModifier(LiveViewNative._SearchCompletionModifier<R>)
+indirect case _PrefersDefaultFocusModifier(LiveViewNative._PrefersDefaultFocusModifier<R>)
 indirect case _OnSubmitModifier(LiveViewNative._OnSubmitModifier)
 indirect case _MatchedGeometryEffectModifier(LiveViewNative._MatchedGeometryEffectModifier<R>)
 indirect case _PerspectiveRotationEffectModifier(LiveViewNative._PerspectiveRotationEffectModifier<R>)
 indirect case _MaskModifier(LiveViewNative._MaskModifier<R>)
-indirect case _SearchScopesModifier(LiveViewNative._SearchScopesModifier<R>)
+indirect case _PresentationDetentsModifier(LiveViewNative._PresentationDetentsModifier)
+indirect case _Rotation3DEffectModifier(LiveViewNative._Rotation3DEffectModifier<R>)
         indirect case _customRegistryModifier(R.CustomModifier)
         indirect case _anyTextModifier(_AnyTextModifier<R>)
         indirect case _anyImageModifier(_AnyImageModifier<R>)
@@ -12982,15 +13519,13 @@ case let .chunk14(chunk):
     content.modifier(chunk)
 case let .chunk15(chunk):
     content.modifier(chunk)
-            case let ._Rotation3DEffectModifier(modifier):
+            case let ._SearchScopesModifier(modifier):
     content.modifier(modifier)
 case let ._FocusScopeModifier(modifier):
     content.modifier(modifier)
-case let ._PrefersDefaultFocusModifier(modifier):
-    content.modifier(modifier)
-case let ._PresentationDetentsModifier(modifier):
-    content.modifier(modifier)
 case let ._SearchCompletionModifier(modifier):
+    content.modifier(modifier)
+case let ._PrefersDefaultFocusModifier(modifier):
     content.modifier(modifier)
 case let ._OnSubmitModifier(modifier):
     content.modifier(modifier)
@@ -13000,7 +13535,9 @@ case let ._PerspectiveRotationEffectModifier(modifier):
     content.modifier(modifier)
 case let ._MaskModifier(modifier):
     content.modifier(modifier)
-case let ._SearchScopesModifier(modifier):
+case let ._PresentationDetentsModifier(modifier):
+    content.modifier(modifier)
+case let ._Rotation3DEffectModifier(modifier):
     content.modifier(modifier)
             case let ._customRegistryModifier(modifier):
                 content.modifier(modifier)
@@ -13248,16 +13785,16 @@ _truncationModeModifier<R>.name: _truncationModeModifier<R>.parser(in: context).
 _unredactedModifier<R>.name: _unredactedModifier<R>.parser(in: context).map({ Output.chunk15(.unredacted($0)) }).eraseToAnyParser(),
 _upperLimbVisibilityModifier<R>.name: _upperLimbVisibilityModifier<R>.parser(in: context).map({ Output.chunk15(.upperLimbVisibility($0)) }).eraseToAnyParser(),
 _zIndexModifier<R>.name: _zIndexModifier<R>.parser(in: context).map({ Output.chunk15(.zIndex($0)) }).eraseToAnyParser(),
-                    LiveViewNative._Rotation3DEffectModifier<R>.name: LiveViewNative._Rotation3DEffectModifier<R>.parser(in: context).map(Output._Rotation3DEffectModifier).eraseToAnyParser(),
+                    LiveViewNative._SearchScopesModifier<R>.name: LiveViewNative._SearchScopesModifier<R>.parser(in: context).map(Output._SearchScopesModifier).eraseToAnyParser(),
 LiveViewNative._FocusScopeModifier<R>.name: LiveViewNative._FocusScopeModifier<R>.parser(in: context).map(Output._FocusScopeModifier).eraseToAnyParser(),
-LiveViewNative._PrefersDefaultFocusModifier<R>.name: LiveViewNative._PrefersDefaultFocusModifier<R>.parser(in: context).map(Output._PrefersDefaultFocusModifier).eraseToAnyParser(),
-LiveViewNative._PresentationDetentsModifier.name: LiveViewNative._PresentationDetentsModifier.parser(in: context).map(Output._PresentationDetentsModifier).eraseToAnyParser(),
 LiveViewNative._SearchCompletionModifier<R>.name: LiveViewNative._SearchCompletionModifier<R>.parser(in: context).map(Output._SearchCompletionModifier).eraseToAnyParser(),
+LiveViewNative._PrefersDefaultFocusModifier<R>.name: LiveViewNative._PrefersDefaultFocusModifier<R>.parser(in: context).map(Output._PrefersDefaultFocusModifier).eraseToAnyParser(),
 LiveViewNative._OnSubmitModifier.name: LiveViewNative._OnSubmitModifier.parser(in: context).map(Output._OnSubmitModifier).eraseToAnyParser(),
 LiveViewNative._MatchedGeometryEffectModifier<R>.name: LiveViewNative._MatchedGeometryEffectModifier<R>.parser(in: context).map(Output._MatchedGeometryEffectModifier).eraseToAnyParser(),
 LiveViewNative._PerspectiveRotationEffectModifier<R>.name: LiveViewNative._PerspectiveRotationEffectModifier<R>.parser(in: context).map(Output._PerspectiveRotationEffectModifier).eraseToAnyParser(),
 LiveViewNative._MaskModifier<R>.name: LiveViewNative._MaskModifier<R>.parser(in: context).map(Output._MaskModifier).eraseToAnyParser(),
-LiveViewNative._SearchScopesModifier<R>.name: LiveViewNative._SearchScopesModifier<R>.parser(in: context).map(Output._SearchScopesModifier).eraseToAnyParser(),
+LiveViewNative._PresentationDetentsModifier.name: LiveViewNative._PresentationDetentsModifier.parser(in: context).map(Output._PresentationDetentsModifier).eraseToAnyParser(),
+LiveViewNative._Rotation3DEffectModifier<R>.name: LiveViewNative._Rotation3DEffectModifier<R>.parser(in: context).map(Output._Rotation3DEffectModifier).eraseToAnyParser(),
                 ]
 
                 let deprecations = [
@@ -13454,7 +13991,7 @@ ConstantAtomLiteral("content").map({ () -> Self in
 /// * `.enabled`
 /// * `.disabled`
 @_documentation(visibility: public)
-@available(visionOS 1.0,macOS 14.0, *)
+@available(macOS 14.0,visionOS 1.0, *)
 extension AlternatingRowBackgroundBehavior: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -13534,7 +14071,7 @@ ConstantAtomLiteral("vertical").map({ () -> Self in
 /// * `.standard`
 /// * `.increased`
 @_documentation(visibility: public)
-@available(visionOS 1.0,iOS 17.0,macOS 14.0, *)
+@available(macOS 14.0,iOS 17.0,visionOS 1.0, *)
 extension BadgeProminence: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -13804,7 +14341,7 @@ ConstantAtomLiteral("plusLighter").map({ () -> Self in
 /// * `.enabled`
 /// * `.disabled`
 @_documentation(visibility: public)
-@available(visionOS 1.0,watchOS 10.0,tvOS 17.0,macOS 14.0,iOS 17.0, *)
+@available(iOS 17.0,watchOS 10.0,visionOS 1.0,macOS 14.0,tvOS 17.0, *)
 extension ButtonRepeatBehavior: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -13928,7 +14465,7 @@ ConstantAtomLiteral("dark").map({ () -> Self in
 /// * `.tabView`
 /// * `.navigation`
 @_documentation(visibility: public)
-@available(macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0,visionOS 1.0, *)
+@available(visionOS 1.0,watchOS 10.0,iOS 17.0,tvOS 17.0,macOS 14.0, *)
 extension ContainerBackgroundPlacement: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -13964,7 +14501,7 @@ fatalError("'navigation' is not available on this OS")
 /// * `.scrollContent`
 /// * `.scrollIndicators`
 @_documentation(visibility: public)
-@available(macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0,visionOS 1.0, *)
+@available(iOS 17.0,tvOS 17.0,watchOS 10.0,macOS 14.0,visionOS 1.0, *)
 extension ContentMarginPlacement: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -14028,7 +14565,7 @@ extension ContentShapeKinds: ParseableModifierValue {
 })
 ConstantAtomLiteral("dragPreview").map({ () -> Self in
 #if os(iOS) || os(macOS) || os(visionOS)
-if #available(macOS 12.0,iOS 15.0,tvOS 15.0,watchOS 8.0,visionOS 1.0, *) {
+if #available(watchOS 8.0,tvOS 15.0,macOS 12.0,iOS 15.0,visionOS 1.0, *) {
     return Self.dragPreview
 } else { fatalError("'dragPreview' is not available in this OS version") }
 #else
@@ -14037,7 +14574,7 @@ fatalError("'dragPreview' is not available on this OS")
 })
 ConstantAtomLiteral("contextMenuPreview").map({ () -> Self in
 #if os(iOS) || os(tvOS) || os(visionOS)
-if #available(macOS 12.0,iOS 15.0,tvOS 17.0,watchOS 8.0,visionOS 1.0, *) {
+if #available(watchOS 8.0,tvOS 17.0,macOS 12.0,iOS 15.0,visionOS 1.0, *) {
     return Self.contextMenuPreview
 } else { fatalError("'contextMenuPreview' is not available in this OS version") }
 #else
@@ -14046,7 +14583,7 @@ fatalError("'contextMenuPreview' is not available on this OS")
 })
 ConstantAtomLiteral("hoverEffect").map({ () -> Self in
 #if os(iOS) || os(visionOS)
-if #available(macOS 12.0,iOS 15.0,tvOS 15.0,watchOS 8.0,visionOS 1.0, *) {
+if #available(watchOS 8.0,tvOS 15.0,macOS 12.0,iOS 15.0,visionOS 1.0, *) {
     return Self.hoverEffect
 } else { fatalError("'hoverEffect' is not available in this OS version") }
 #else
@@ -14055,7 +14592,7 @@ fatalError("'hoverEffect' is not available on this OS")
 })
 ConstantAtomLiteral("focusEffect").map({ () -> Self in
 #if os(macOS) || os(visionOS) || os(watchOS)
-if #available(macOS 12.0,iOS 15.0,tvOS 15.0,watchOS 8.0,visionOS 1.0, *) {
+if #available(watchOS 8.0,tvOS 15.0,macOS 12.0,iOS 15.0,visionOS 1.0, *) {
     return Self.focusEffect
 } else { fatalError("'focusEffect' is not available in this OS version") }
 #else
@@ -14064,7 +14601,7 @@ fatalError("'focusEffect' is not available on this OS")
 })
 ConstantAtomLiteral("accessibility").map({ () -> Self in
 #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-if #available(tvOS 17.0,macOS 14.0,iOS 17.0,visionOS 1.0,watchOS 10.0, *) {
+if #available(macOS 14.0,visionOS 1.0,watchOS 10.0,tvOS 17.0,iOS 17.0, *) {
     return Self.accessibility
 } else { fatalError("'accessibility' is not available in this OS version") }
 #else
@@ -14086,7 +14623,7 @@ fatalError("'accessibility' is not available on this OS")
 /// * `.large`
 /// * `.extraLarge`
 @_documentation(visibility: public)
-@available(iOS 15.0,visionOS 1.0,macOS 10.15,watchOS 9.0, *)
+@available(iOS 15.0,watchOS 9.0,macOS 10.15,visionOS 1.0, *)
 extension ControlSize: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -14120,7 +14657,7 @@ fatalError("'regular' is not available on this OS")
 })
 ConstantAtomLiteral("large").map({ () -> Self in
 #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
-if #available(iOS 15.0,visionOS 1.0,macOS 11.0,watchOS 9.0, *) {
+if #available(iOS 15.0,watchOS 9.0,macOS 11.0,visionOS 1.0, *) {
     return Self.large
 } else { fatalError("'large' is not available in this OS version") }
 #else
@@ -14129,7 +14666,7 @@ fatalError("'large' is not available on this OS")
 })
 ConstantAtomLiteral("extraLarge").map({ () -> Self in
 #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS) || os(xrOS)
-if #available(iOS 17.0,visionOS 1.0,macOS 14.0,xrOS 1.0,watchOS 10.0, *) {
+if #available(iOS 17.0,watchOS 10.0,macOS 14.0,xrOS 1.0,visionOS 1.0, *) {
     return Self.extraLarge
 } else { fatalError("'extraLarge' is not available in this OS version") }
 #else
@@ -14184,7 +14721,7 @@ ConstantAtomLiteral("userInitiated").map({ () -> Self in
 /// * `.critical`
 /// * `.standard`
 @_documentation(visibility: public)
-@available(visionOS 1.0,iOS 17.0,tvOS 17.0,macOS 13.0,watchOS 10.0, *)
+@available(macOS 13.0,visionOS 1.0,watchOS 10.0,tvOS 17.0,iOS 17.0, *)
 extension DialogSeverity: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -14209,7 +14746,7 @@ fatalError("'critical' is not available on this OS")
 })
 ConstantAtomLiteral("standard").map({ () -> Self in
 #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-if #available(visionOS 1.0,iOS 17.0,tvOS 17.0,macOS 14.0,watchOS 10.0, *) {
+if #available(macOS 14.0,visionOS 1.0,watchOS 10.0,tvOS 17.0,iOS 17.0, *) {
     return Self.standard
 } else { fatalError("'standard' is not available in this OS version") }
 #else
@@ -14394,7 +14931,7 @@ ConstantAtomLiteral("all").map({ () -> Self in
 /// * `.includeHiddenFiles`
 /// * `.displayFileExtensions`
 @_documentation(visibility: public)
-@available(macOS 14.0,visionOS 1.0,iOS 17.0, *)
+@available(macOS 14.0,iOS 17.0,visionOS 1.0, *)
 extension FileDialogBrowserOptions: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -14539,7 +15076,7 @@ ConstantAtomLiteral("all").map({ () -> Self in
 /// * `.implicit`
 /// * `.never`
 @_documentation(visibility: public)
-@available(xrOS 1.0,visionOS 1.0, *)
+@available(visionOS 1.0,xrOS 1.0, *)
 extension GlassBackgroundDisplayMode: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -14620,7 +15157,7 @@ ConstantAtomLiteral("trailing").map({ () -> Self in
 })
 ConstantAtomLiteral("listRowSeparatorLeading").map({ () -> Self in
 #if os(iOS) || os(macOS) || os(visionOS)
-if #available(macOS 13.0,visionOS 1.0,iOS 16.0, *) {
+if #available(macOS 13.0,iOS 16.0,visionOS 1.0, *) {
     return Self.listRowSeparatorLeading
 } else { fatalError("'listRowSeparatorLeading' is not available in this OS version") }
 #else
@@ -14629,7 +15166,7 @@ fatalError("'listRowSeparatorLeading' is not available on this OS")
 })
 ConstantAtomLiteral("listRowSeparatorTrailing").map({ () -> Self in
 #if os(iOS) || os(macOS) || os(visionOS)
-if #available(macOS 13.0,visionOS 1.0,iOS 16.0, *) {
+if #available(macOS 13.0,iOS 16.0,visionOS 1.0, *) {
     return Self.listRowSeparatorTrailing
 } else { fatalError("'listRowSeparatorTrailing' is not available in this OS version") }
 #else
@@ -14684,7 +15221,7 @@ ConstantAtomLiteral("trailing").map({ () -> Self in
 /// * `.highlight`
 /// * `.lift`
 @_documentation(visibility: public)
-@available(tvOS 16.0,visionOS 1.0,iOS 13.4, *)
+@available(visionOS 1.0,iOS 13.4,tvOS 16.0, *)
 extension HoverEffect: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -14700,7 +15237,7 @@ fatalError("'automatic' is not available on this OS")
 })
 ConstantAtomLiteral("highlight").map({ () -> Self in
 #if os(iOS) || os(tvOS) || os(visionOS)
-if #available(tvOS 17.0,visionOS 1.0,iOS 13.4, *) {
+if #available(visionOS 1.0,iOS 13.4,tvOS 17.0, *) {
     return Self.highlight
 } else { fatalError("'highlight' is not available in this OS version") }
 #else
@@ -14728,7 +15265,7 @@ fatalError("'lift' is not available on this OS")
 /// * `.defaultAction`
 /// * `.cancelAction`
 @_documentation(visibility: public)
-@available(macOS 11.0,visionOS 1.0,iOS 14.0, *)
+@available(iOS 14.0,macOS 11.0,visionOS 1.0, *)
 extension KeyboardShortcut: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -14825,7 +15362,7 @@ extension MenuOrder: ParseableModifierValue {
 })
 ConstantAtomLiteral("priority").map({ () -> Self in
 #if os(iOS) || os(visionOS)
-if #available(iOS 16.0,watchOS 9.0,visionOS 1.0,macOS 13.0,tvOS 16.0, *) {
+if #available(tvOS 16.0,watchOS 9.0,iOS 16.0,macOS 13.0,visionOS 1.0, *) {
     return Self.priority
 } else { fatalError("'priority' is not available in this OS version") }
 #else
@@ -14856,7 +15393,7 @@ ConstantAtomLiteral("fixed").map({ () -> Self in
 /// * `.sheet`
 /// * `.fullScreenCover`
 @_documentation(visibility: public)
-@available(visionOS 1.0,iOS 16.4,tvOS 16.4,macOS 13.3,watchOS 9.4, *)
+@available(watchOS 9.4,tvOS 16.4,iOS 16.4,visionOS 1.0,macOS 13.3, *)
 extension PresentationAdaptation: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -14919,7 +15456,7 @@ fatalError("'fullScreenCover' is not available on this OS")
 /// * `.resizes`
 /// * `.scrolls`
 @_documentation(visibility: public)
-@available(visionOS 1.0,watchOS 9.4,tvOS 16.4,macOS 13.3,iOS 16.4, *)
+@available(iOS 16.4,watchOS 9.4,visionOS 1.0,macOS 13.3,tvOS 16.4, *)
 extension PresentationContentInteraction: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -15024,7 +15561,7 @@ ConstantAtomLiteral("privacy").map({ () -> Self in
 })
 ConstantAtomLiteral("invalidated").map({ () -> Self in
 #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-if #available(iOS 17.0,watchOS 10.0,visionOS 1.0,macOS 14.0,tvOS 17.0, *) {
+if #available(watchOS 10.0,tvOS 17.0,macOS 14.0,iOS 17.0,visionOS 1.0, *) {
     return Self.invalidated
 } else { fatalError("'invalidated' is not available in this OS version") }
 #else
@@ -15139,7 +15676,7 @@ extension ScenePadding: ParseableModifierValue {
 })
 ConstantAtomLiteral("navigationBar").map({ () -> Self in
 #if os(visionOS) || os(watchOS)
-if #available(macOS 13.0,tvOS 16.0,watchOS 9.0,visionOS 1.0,iOS 16.0, *) {
+if #available(iOS 16.0,tvOS 16.0,watchOS 9.0,macOS 13.0,visionOS 1.0, *) {
     return Self.navigationBar
 } else { fatalError("'navigationBar' is not available in this OS version") }
 #else
@@ -15159,7 +15696,7 @@ fatalError("'navigationBar' is not available on this OS")
 /// * `.always`
 /// * `.basedOnSize`
 @_documentation(visibility: public)
-@available(macOS 13.3,iOS 16.4,tvOS 16.4,watchOS 9.4,visionOS 1.0, *)
+@available(watchOS 9.4,tvOS 16.4,macOS 13.3,iOS 16.4,visionOS 1.0, *)
 extension ScrollBounceBehavior: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -15205,7 +15742,7 @@ fatalError("'basedOnSize' is not available on this OS")
 /// * `.interactively`
 /// * `.never`
 @_documentation(visibility: public)
-@available(macOS 13.0,iOS 16.0,tvOS 16.0,watchOS 9.0,visionOS 1.0, *)
+@available(watchOS 9.0,tvOS 16.0,macOS 13.0,iOS 16.0,visionOS 1.0, *)
 extension ScrollDismissesKeyboardMode: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -15314,7 +15851,7 @@ ConstantAtomLiteral("never").map({ () -> Self in
 /// * `.onTextEntry`
 /// * `.onSearchPresentation`
 @_documentation(visibility: public)
-@available(visionOS 1.0,watchOS 9.4,macOS 13.3,tvOS 16.4,iOS 16.4, *)
+@available(watchOS 9.4,tvOS 16.4,iOS 16.4,visionOS 1.0,macOS 13.3, *)
 extension SearchScopeActivation: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -15404,7 +15941,7 @@ ConstantAtomLiteral("content").map({ () -> Self in
 /// * `.enabled`
 /// * `.disabled`
 @_documentation(visibility: public)
-@available(iOS 17.0,watchOS 10.0,visionOS 1.0,macOS 14.0,tvOS 17.0, *)
+@available(tvOS 17.0,watchOS 10.0,iOS 17.0,macOS 14.0,visionOS 1.0, *)
 extension SpringLoadingBehavior: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -15587,7 +16124,7 @@ ConstantAtomLiteral("search").map({ () -> Self in
 /// Possible values:
 /// * `.sidebarToggle`
 @_documentation(visibility: public)
-@available(visionOS 1.0,iOS 17.0,tvOS 17.0,macOS 14.0,watchOS 10.0, *)
+@available(macOS 14.0,visionOS 1.0,watchOS 10.0,tvOS 17.0,iOS 17.0, *)
 extension ToolbarDefaultItemKind: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -15670,7 +16207,7 @@ fatalError("'editor' is not available on this OS")
 /// * `.inlineLarge`
 /// * `.inline`
 @_documentation(visibility: public)
-@available(watchOS 10.0,macOS 14.0,visionOS 1.0,tvOS 17.0,iOS 17.0, *)
+@available(tvOS 17.0,iOS 17.0,watchOS 10.0,macOS 14.0,visionOS 1.0, *)
 extension ToolbarTitleDisplayMode: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {

--- a/Sources/LiveViewNativeStylesheet/Parsing/External/ParseableModifier.swift
+++ b/Sources/LiveViewNativeStylesheet/Parsing/External/ParseableModifier.swift
@@ -52,6 +52,7 @@ public struct StandardExpressionParser<Output: ParseableExpressionProtocol>: Par
 
 public class ParseableModifierContext {
     public var metadata: Metadata = .init(file: "", line: 0, module: "unknown", source: "<unknown>")
+    public var gestureState = GestureState<[String:Any]>(initialValue: [:])
     
     public init() {}
 }
@@ -76,6 +77,13 @@ public struct EnumParser<T>: Parser {
         }
     }
 }
+
+public extension EnumParser where T: CaseIterable & RawRepresentable, T.RawValue == String {
+    init() {
+        self.allCases = Dictionary(uniqueKeysWithValues: T.allCases.map({ (key: $0.rawValue, value: $0) }))
+    }
+}
+
 extension ParseableModifierValue where Self: CaseIterable & RawRepresentable<String>, Self._ParserType == ImplicitStaticMember<Self, EnumParser<Self>> {
     public static func parser(in context: ParseableModifierContext) -> _ParserType {
         ImplicitStaticMember {

--- a/Sources/ModifierGenerator/Subcommands/DocumentationExtensions.swift
+++ b/Sources/ModifierGenerator/Subcommands/DocumentationExtensions.swift
@@ -37,7 +37,7 @@ extension ModifierGenerator {
             
             Self.typeVisitor.walk(sourceFile)
             
-            for (name, (signatures, _)) in modifiers {
+            for (name, (signatures, _, _)) in modifiers {
                 let firstSignatureDescription = signatureDescription(for: signatures.first!, on: name)
                 
                 let appleDocs = URL(string: "https://developer.apple.com/documentation/swiftui/view/")!

--- a/Sources/ModifierGenerator/Subcommands/Source.swift
+++ b/Sources/ModifierGenerator/Subcommands/Source.swift
@@ -53,6 +53,7 @@ extension ModifierGenerator {
 
                         \#(signatures.requiresContext ? "@ObservedElement private var element" : "")
                         \#(signatures.requiresContext ? "@LiveContext<R> private var context" : "")
+                        \#(signatures.requiresGestureState ? "@GestureState private var gestureState = [String:Any]()" : "")
                     
                     \#(signatures.0.compactMap(\.properties).joined(separator: "\n"))
 

--- a/Tests/LiveViewNativeTests/FormModelTests.swift
+++ b/Tests/LiveViewNativeTests/FormModelTests.swift
@@ -13,7 +13,7 @@ class FormModelTests: XCTestCase {
     func testFormChangeEvent() async throws {
         let expectation = XCTestExpectation(description: "Send a form change event.")
         
-        func pushEvent(type: String, event: String, value: Any, target: Int? = nil) async throws -> Void {
+        func pushEvent(type: String, event: String, value: Any, target: Int? = nil) async throws -> [String:Any]? {
             XCTAssertEqual(type, "form")
             XCTAssertEqual(event, "validate")
             
@@ -23,6 +23,8 @@ class FormModelTests: XCTestCase {
             XCTAssertNil(target)
 
             expectation.fulfill()
+            
+            return nil
         }
         
         let formModel = FormModel(elementID: "test-form")


### PR DESCRIPTION
Prototype of #1286 

The API is a bit different than the proposal. The property references were moved into the `gesture_state` helper, instead of on the `updating(...)` gesture modifier. You instead give the gesture an ID to update, and access the properties from that ID.

<table>
<tr>
<td>

```elixir
frame(width: 100, height: 100)
offset(
  x: gesture_state(:drag, .translation.width),
  y: gesture_state(:drag, .translation.height)
)
animation(.bouncy, value: gesture_state(:drag, .translation.width))
animation(.bouncy, value: gesture_state(:drag, .translation.height))
gesture(DragGesture().updating(:drag))
```

</td>

<td>

https://github.com/liveview-native/liveview-client-swiftui/assets/13581484/fcb31d22-216d-4f6c-a96a-e0026ab75828

</td>
</tr>
<tr>
<td>

```elixir
frame(width: 100, height: 100)
scaleEffect(
  gesture_state(:magnify, .magnification, defaultValue: 1),
  anchor: gesture_state(:magnify, .startAnchor, defaultValue: .center)
)
animation(.bouncy, value: gesture_state(:magnify, .magnification))
simultaneousGesture(MagnifyGesture().updating(:magnify))
```

</td>

<td>

https://github.com/liveview-native/liveview-client-swiftui/assets/13581484/b6b263ea-1b56-4f15-a4f9-70c97e35a4b0

</td>
</tr>
<tr>
<td>

```elixir
frame(width: 200, height: 200)
rotationEffect(
  gesture_state(:rotate, .rotation, defaultValue: .zero),
  anchor: gesture_state(:rotate, .startAnchor, defaultValue: .center)
)
animation(.bouncy, value: gesture_state(:rotate, .rotation.radians))
simultaneousGesture(RotateGesture().updating(:rotate))
```

</td>

<td>


https://github.com/liveview-native/liveview-client-swiftui/assets/13581484/9008f99d-7d56-407f-8bb3-ceb88b1796dc

</td>
</tr>
<tr>
<td>

```heex
<Rectangle class="rotation-demo magnify-demo" />
```

</td>

<td>

https://github.com/liveview-native/liveview-client-swiftui/assets/13581484/990cb6cf-6d15-4fe9-ae5b-b4bf777097ab

</td>
</tr>
</table>