### PR TITLE
Add missing `HorizontalAlignment`, `VerticalAlignment`, and `ToolbarItemPlacement` cases

### DIFF
--- a/Sources/LiveViewNative/Utils/Alignment.swift
+++ b/Sources/LiveViewNative/Utils/Alignment.swift
@@ -75,6 +75,8 @@ extension Alignment: Decodable, AttributeDecodable {
 /// - `leading`
 /// - `center`
 /// - `trailing`
+/// - `listRowSeparatorLeading`
+/// - `listRowSeparatorTrailing`
 extension HorizontalAlignment: Decodable, AttributeDecodable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
@@ -94,6 +96,12 @@ extension HorizontalAlignment: Decodable, AttributeDecodable {
             self = .leading
         case "trailing":
             self = .trailing
+        #if os(iOS) || os(macOS)
+        case "listRowSeparatorLeading":
+            self = .listRowSeparatorLeading
+        case "listRowSeparatorTrailing":
+            self = .listRowSeparatorTrailing
+        #endif
         default:
             return nil
         }
@@ -112,6 +120,8 @@ extension HorizontalAlignment: Decodable, AttributeDecodable {
 /// - `top`
 /// - `center`
 /// - `bottom`
+/// - `firstTextBaseline`
+/// - `lastTextBaseline`
 extension VerticalAlignment: Decodable, AttributeDecodable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
@@ -131,6 +141,10 @@ extension VerticalAlignment: Decodable, AttributeDecodable {
             self = .top
         case "bottom":
             self = .bottom
+        case "firstTextBaseline":
+            self = .firstTextBaseline
+        case "lastTextBaseline":
+            self = .lastTextBaseline
         default:
             return nil
         }

--- a/Sources/LiveViewNative/Views/Toolbars/ToolbarItem.swift
+++ b/Sources/LiveViewNative/Views/Toolbars/ToolbarItem.swift
@@ -158,25 +158,26 @@ enum ToolbarItemPlacement: String, AttributeDecodable {
     case principal
     @_documentation(visibility: public)
     case navigation
-    /// `primary-action`
     @_documentation(visibility: public)
     case primaryAction
-    /// `secondary-action`
     @_documentation(visibility: public)
     case secondaryAction
     @_documentation(visibility: public)
     case status
-    /// `confirmation-action`
     @_documentation(visibility: public)
     case confirmationAction
-    /// `cancellation-action`
     @_documentation(visibility: public)
     case cancellationAction
-    /// `destructive-action`
     @_documentation(visibility: public)
     case destructiveAction
     @_documentation(visibility: public)
     case keyboard
+    @_documentation(visibility: public)
+    case topBarLeading
+    @_documentation(visibility: public)
+    case topBarTrailing
+    @_documentation(visibility: public)
+    case bottomBar
     
     var placement: SwiftUI.ToolbarItemPlacement {
         switch self {
@@ -214,6 +215,24 @@ enum ToolbarItemPlacement: String, AttributeDecodable {
             return .automatic
             #else
             return .keyboard
+            #endif
+        case .topBarLeading:
+            #if os(macOS)
+            return .automatic
+            #else
+            return .topBarLeading
+            #endif
+        case .topBarTrailing:
+            #if os(macOS)
+            return .automatic
+            #else
+            return .topBarTrailing
+            #endif
+        case .bottomBar:
+            #if os(macOS) || os(tvOS)
+            return .automatic
+            #else
+            return .bottomBar
             #endif
         }
     }

--- a/Sources/LiveViewNative/Views/Toolbars/ToolbarItem.swift
+++ b/Sources/LiveViewNative/Views/Toolbars/ToolbarItem.swift
@@ -220,19 +220,31 @@ enum ToolbarItemPlacement: String, AttributeDecodable {
             #if os(macOS)
             return .automatic
             #else
-            return .topBarLeading
+            if #available(watchOS 10, *) {
+                return .topBarLeading
+            } else {
+                return .automatic
+            }
             #endif
         case .topBarTrailing:
             #if os(macOS)
             return .automatic
             #else
-            return .topBarTrailing
+            if #available(watchOS 10, *) {
+                return .topBarTrailing
+            } else {
+                return .automatic
+            }
             #endif
         case .bottomBar:
             #if os(macOS) || os(tvOS)
             return .automatic
             #else
-            return .bottomBar
+            if #available(watchOS 10, *) {
+                return .bottomBar
+            } else {
+                return .automatic
+            }
             #endif
         }
     }


### PR DESCRIPTION
Closes #1290 
Closes #1291 

Here's an example of the `bottomBar` placement being used:

```heex
<ToolbarItem template="toolbar" placement="bottomBar">
    <HStack>
        <Button><Image systemName="line.3.horizontal.decrease.circle" /></Button>
        <Spacer />
        <Button><Image systemName="square.and.pencil" /></Button>
    </HStack>
</ToolbarItem>
```

<img src="https://github.com/liveview-native/liveview-client-swiftui/assets/13581484/00789ce8-7852-4d58-acc1-52ee1d312e94" width=300 />
