### PR TITLE
Updates for LiveForm and web parity

### DIFF
--- a/Sources/LiveViewNative/Coordinators/LiveSessionConfiguration.swift
+++ b/Sources/LiveViewNative/Coordinators/LiveSessionConfiguration.swift
@@ -17,7 +17,7 @@ public struct LiveSessionConfiguration {
     public var connectParams: ((URL) -> [String: Any])? = nil
     
     /// The URL session the coordinator will use for performing HTTP and socket requests. By default, this is the shared session.
-    public var urlSession: URLSession = .shared
+    public var urlSessionConfiguration: URLSessionConfiguration = .default
     
     /// The transition used when the live view changes connects.
     public var transition: AnyTransition?
@@ -28,11 +28,11 @@ public struct LiveSessionConfiguration {
     
     public init(
         connectParams: ((URL) -> [String: Any])? = nil,
-        urlSession: URLSession = .shared,
+        urlSessionConfiguration: URLSessionConfiguration = .default,
         transition: AnyTransition? = nil
     ) {
         self.connectParams = connectParams
-        self.urlSession = urlSession
+        self.urlSessionConfiguration = urlSessionConfiguration
         self.transition = transition
     }
 }

--- a/Sources/LiveViewNative/Coordinators/LiveSessionConfiguration.swift
+++ b/Sources/LiveViewNative/Coordinators/LiveSessionConfiguration.swift
@@ -16,7 +16,11 @@ public struct LiveSessionConfiguration {
     /// By default, no connection params are provided.
     public var connectParams: ((URL) -> [String: Any])? = nil
     
-    /// The URL session the coordinator will use for performing HTTP and socket requests. By default, this is the shared session.
+    /// The URL session configuration the coordinator will use for performing HTTP and socket requests.
+    /// 
+    /// By default, this is the `default` configuration.
+    /// 
+    /// Some properties of the configuration (such as the `httpCookieStorage`) will be overridden by the session coordinator.
     public var urlSessionConfiguration: URLSessionConfiguration = .default
     
     /// The transition used when the live view changes connects.

--- a/Sources/LiveViewNative/Coordinators/LiveViewCoordinator.swift
+++ b/Sources/LiveViewNative/Coordinators/LiveViewCoordinator.swift
@@ -32,7 +32,7 @@ public class LiveViewCoordinator<R: RootRegistry>: ObservableObject {
         internalState
     }
     
-    let session: LiveSessionCoordinator<R>
+    @_spi(LiveForm) public let session: LiveSessionCoordinator<R>
     var url: URL
     
     private var channel: Channel?
@@ -230,6 +230,7 @@ public class LiveViewCoordinator<R: RootRegistry>: ObservableObject {
         connectParams["_csrf_token"] = domValues.phxCSRFToken
         connectParams["_lvn"] = session.platformParams
 
+        print("CONNECT LV:", self.url)
         let params: Payload = [
             "session": domValues.phxSession,
             "static": domValues.phxStatic,

--- a/Sources/LiveViewNative/NavStackEntryView.swift
+++ b/Sources/LiveViewNative/NavStackEntryView.swift
@@ -22,12 +22,6 @@ struct NavStackEntryView<R: RootRegistry>: View {
     var body: some View {
         elementTree
             .environmentObject(liveViewModel)
-            .onReceive(coordinator.$document) { newDocument in
-                if let doc = newDocument {
-                    // todo: doing this every time the DOM changes is probably not efficient
-                    liveViewModel.updateForms(nodes: doc[doc.root()].depthFirstChildren())
-                }
-            }
     }
     
     private func buildPhaseView(_ phase: LiveViewPhase<R>) -> some View {

--- a/Sources/LiveViewNative/Property Wrappers/Attribute.swift
+++ b/Sources/LiveViewNative/Property Wrappers/Attribute.swift
@@ -208,7 +208,7 @@ extension String: AttributeDecodable {
 /// The value is `true` if the attribute is present (regardless of value) and `false` otherwise.
 extension Bool: AttributeDecodable {
     public init(from attribute: LiveViewNativeCore.Attribute?, on element: ElementNode) throws {
-        self = attribute != nil
+        self = attribute != nil && attribute?.value != "false"
     }
 }
 

--- a/Sources/LiveViewNative/Property Wrappers/FormState.swift
+++ b/Sources/LiveViewNative/Property Wrappers/FormState.swift
@@ -181,7 +181,7 @@ public struct FormState<Value: FormValue> {
                     formModel.setInitialValue(initialValue, forName: elementName)
                     data.mode = .form(formModel)
                 } else {
-                    print("Warning: @FormState used on a name-less element inside of a <live-form>. This may not behave as expected.")
+                    print("Warning: @FormState used on a name-less element inside of a <LiveForm>. This may not behave as expected.")
                     data.mode = .local
                 }
             } else {

--- a/Sources/LiveViewNative/Utils/DOM.swift
+++ b/Sources/LiveViewNative/Utils/DOM.swift
@@ -80,7 +80,9 @@ public struct ElementNode {
     /// > The strings `"true"`/`"false"` are ignored, and only the presence of the attribute is considered.
     /// > A value of `"false"` would still return `true`.
     public func attributeBoolean(for name: AttributeName) -> Bool {
-        attribute(named: name) != nil
+        guard let attribute = attribute(named: name)
+        else { return false }
+        return attribute.value != "false"
     }
     
     /// The text of this element.

--- a/Sources/LiveViewNative/Utils/DOM.swift
+++ b/Sources/LiveViewNative/Utils/DOM.swift
@@ -80,9 +80,9 @@ public struct ElementNode {
     /// > The strings `"true"`/`"false"` are ignored, and only the presence of the attribute is considered.
     /// > A value of `"false"` would still return `true`.
     public func attributeBoolean(for name: AttributeName) -> Bool {
-        guard let attribute = attribute(named: name)
+        guard let attribute = attribute(named: name)?.value
         else { return false }
-        return attribute.value != "false"
+        return attribute != "false"
     }
     
     /// The text of this element.

--- a/Sources/LiveViewNative/ViewModel.swift
+++ b/Sources/LiveViewNative/ViewModel.swift
@@ -41,6 +41,9 @@ public class FormModel: ObservableObject, CustomDebugStringConvertible {
     
     var changeEvent: String?
     var submitEvent: String?
+    /// An action called when no `phx-submit` event is present.
+    ///
+    /// This typically performs a HTTP request and reconnects the LiveView.
     var submitAction: (() -> ())?
     
     /// The form data for this form.
@@ -83,6 +86,7 @@ public class FormModel: ObservableObject, CustomDebugStringConvertible {
         }
     }
     
+    /// Create a URL encoded body from the data in the form.
     public func buildFormQuery() throws -> String {
         let encoder = JSONEncoder()
         let data = try data.mapValues { value in
@@ -103,7 +107,7 @@ public class FormModel: ObservableObject, CustomDebugStringConvertible {
     
     @MainActor
     private func pushFormEvent(_ event: String) async throws {
-        // the `form` event type signals to LiveView on the backend that the payload is url encoded (e.g., `a=b&c=d`), so we use a different type
+        // the `form` event type expects a URL encoded payload (e.g., `a=b&c=d`)
         try await pushEventImpl("form", event, try buildFormQuery(), nil)
     }
     

--- a/Sources/LiveViewNative/Views/Images/AsyncImage.swift
+++ b/Sources/LiveViewNative/Views/Images/AsyncImage.swift
@@ -38,7 +38,7 @@ struct AsyncImage<R: RootRegistry>: View {
     /// How the image should be displayed if its native aspect ratio does not match that of the view.
     ///
     /// Possible values:
-    /// - `fill`: The image fills the view (meaning the edges may be croppped).
+    /// - `fill`: The image fills the view (meaning the edges may be cropped).
     /// - `fit` (deafult): The image is displayed at its native aspect ratio centered in the view.
     @_documentation(visibility: public)
     @Attribute("contentMode", transform: { $0?.value == "fill" ? .fill : .fit }) private var contentMode: ContentMode


### PR DESCRIPTION
Related to https://github.com/liveview-native/liveview-native-live-form/pull/9

* Support code for sending a request to `action` attribute of a `LiveForm`
* Reconnects can be performed with a `POST`, or any other http method
* *Breaking change*: `urlSession` configuration option was changed to a `urlSessionConfiguration` option. This allows the `LiveSessionCoordinator` to manage the session.
* `LiveSessionCoordinator` automatically adds `_format=swiftui` to any redirects.