### PR TITLE
Only pass `$selection` binding if attributes are present

### DIFF
--- a/Sources/LiveViewNative/Views/Layout Containers/Presentation Containers/TabView.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Presentation Containers/TabView.swift
@@ -32,8 +32,13 @@ struct TabView<Root: RootRegistry>: View {
     @_documentation(visibility: public)
     @ChangeTracked(attribute: "selection") private var selection: String? = nil
     
+    @LiveAttribute(.init(name: "selection")) var selectionAttribute: String?
+    @LiveAttribute(.init(name: "phx-change")) var changeAttribute: String?
+    
     var body: some View {
-        SwiftUI.TabView(selection: $selection) {
+        SwiftUI.TabView(
+            selection: (selectionAttribute != nil || changeAttribute != nil) ? $selection : nil
+        ) {
             $liveElement.children()
         }
     }


### PR DESCRIPTION
Closes #1305 

This will allow `TabView` to be used without specifying a `tag` on each child element, or handling the page changes with `phx-change` and `selection`.