### PR TITLE
Properly handle default arguments to `@ParseableExpression`s

### DIFF
--- a/Sources/LiveViewNativeStylesheetMacros/ParseableExpressionMacro.swift
+++ b/Sources/LiveViewNativeStylesheetMacros/ParseableExpressionMacro.swift
@@ -180,8 +180,8 @@ public enum ParseableExpressionMacro: ExtensionMacro {
             // comma separate from wildcard if present
             if !wildcardArguments.isEmpty {
                 "try Whitespace().parse(&input)"
-                #"if input.first == ",".utf8.first {"# // labelled arguments if open
-                #"try ",".utf8.parse(&input)"#
+                #"if input.first == ",".utf8.first || input.first == "[".utf8.first {"# // labelled arguments if open
+                #"if input.first == ",".utf8.first { try ",".utf8.parse(&input) }"#
                 "try Whitespace().parse(&input)"
             } else {
                 #"if input.first == "[".utf8.first {"# // labelled arguments if open

--- a/Tests/LiveViewNativeStylesheetTests/ShapeStyleTests.swift
+++ b/Tests/LiveViewNativeStylesheetTests/ShapeStyleTests.swift
@@ -70,6 +70,10 @@ final class ShapeStyleTests: XCTestCase {
             #"{:Color, [], [[hue: 1, saturation: 0.5, brightness: 0.25, opacity: 0.75]]}"#,
             Color(hue: 1, saturation: 0.5, brightness: 0.25, opacity: 0.75)
         )
+        testParserShapeStyle(
+            #"{:Color, [], [[red: 0.852, green: 0.646, blue: 0.847]]}"#,
+            Color(red: 0.852, green: 0.646, blue: 0.847)
+        )
         // modifiers
         testParserShapeStyle(
             #"{:., [], [nil, {:., [], [:pink, {:opacity, [], [0.5]}]}]}"#,


### PR DESCRIPTION
Closes #1304 

Previously, it expected a comma to start the keyword arguments.

```ex
[:sRGB, [red: 1, green: 1, blue: 1]]
#     ^ comma starts keyword args
```

However, if the unlabeled argument `:sRGB` is not provided and the default value is used, the comma would not be present and parsing would fail.

Now, it looks for a comma *or* an open bracket `[`. This properly handles the case where all default values are used for the unlabeled arguments.

```ex
[[red: 1, green: 1, blue: 1]]
#^ bracket starts keyword args
```