### PR TITLE
Add reconnect menu to `LiveErrorView`

### DIFF
--- a/Sources/LiveViewNative/Live/LiveErrorView.swift
+++ b/Sources/LiveViewNative/Live/LiveErrorView.swift
@@ -29,6 +29,16 @@ public struct LiveErrorView<Fallback: View>: View {
         {
             SwiftUI.VStack {
                 WebErrorView(html: trace)
+                #if os(watchOS)
+                SwiftUI.Button {
+                    Task {
+                        await reconnectLiveView(.restart)
+                    }
+                } label: {
+                    SwiftUI.Label("Restart", systemImage: "arrow.circlepath")
+                }
+                .padding()
+                #else
                 SwiftUI.Menu {
                     SwiftUI.Button {
                         Task {
@@ -48,6 +58,7 @@ public struct LiveErrorView<Fallback: View>: View {
                     SwiftUI.Label("Reconnect", systemImage: "arrow.2.circlepath")
                 }
                 .padding()
+                #endif
             }
         } else {
             fallback

--- a/Sources/LiveViewNative/Live/LiveErrorView.swift
+++ b/Sources/LiveViewNative/Live/LiveErrorView.swift
@@ -15,6 +15,8 @@ public struct LiveErrorView<Fallback: View>: View {
     let error: Error
     let fallback: Fallback
     
+    @Environment(\.reconnectLiveView) private var reconnectLiveView
+    
     public init(error: Error, @ViewBuilder fallback: () -> Fallback) {
         self.error = error
         self.fallback = fallback()
@@ -25,7 +27,28 @@ public struct LiveErrorView<Fallback: View>: View {
         if let error = error as? LiveConnectionError,
            case let .initialFetchUnexpectedResponse(_, trace?) = error
         {
-            WebErrorView(html: trace)
+            SwiftUI.VStack {
+                WebErrorView(html: trace)
+                SwiftUI.Menu {
+                    SwiftUI.Button {
+                        Task {
+                            await reconnectLiveView(.automatic)
+                        }
+                    } label: {
+                        SwiftUI.Label("Reconnect this page", systemImage: "arrow.2.circlepath")
+                    }
+                    SwiftUI.Button {
+                        Task {
+                            await reconnectLiveView(.restart)
+                        }
+                    } label: {
+                        SwiftUI.Label("Restart from root", systemImage: "arrow.circlepath")
+                    }
+                } label: {
+                    SwiftUI.Label("Reconnect", systemImage: "arrow.2.circlepath")
+                }
+                .padding()
+            }
         } else {
             fallback
         }

--- a/Sources/LiveViewNative/Live/LiveView.swift
+++ b/Sources/LiveViewNative/Live/LiveView.swift
@@ -191,6 +191,7 @@ public struct LiveView<
             }
         }
         .environment(\.stylesheet, session.stylesheet ?? .init(content: [], classes: [:]))
+        .environment(\.reconnectLiveView, .init(baseURL: session.url, action: session.reconnect))
         .environmentObject(session)
         .environmentObject(liveViewModel)
         .task {

--- a/Sources/LiveViewNative/Live/ReconnectLiveViewAction.swift
+++ b/Sources/LiveViewNative/Live/ReconnectLiveViewAction.swift
@@ -1,0 +1,42 @@
+//
+//  ReconnectLiveViewAction.swift
+//
+//
+//  Created by Carson.Katri on 4/16/24.
+//
+
+import SwiftUI
+
+/// Calls ``LiveSessionCoordinator/reconnect(url:httpMethod:httpBody:)`` in the current context.
+public struct ReconnectLiveViewAction {
+    let baseURL: URL?
+    let action: (_ url: URL?, _ httpMethod: String?, _ httpBody: Data?) async -> ()
+    
+    public func callAsFunction(_ style: ReconnectionStyle = .automatic) async {
+        switch style {
+        case .automatic:
+            await action(nil, nil, nil)
+        case .restart:
+            await action(baseURL, nil, nil)
+        }
+    }
+    
+    public enum ReconnectionStyle {
+        /// Preserve navigation state and reconnect on the current route
+        case automatic
+        /// Clear the navigation state and reconnect from the base path
+        case restart
+    }
+}
+
+extension EnvironmentValues {
+    private enum ReconnectLiveViewActionKey: EnvironmentKey {
+        static let defaultValue: ReconnectLiveViewAction = .init(baseURL: nil, action: { _, _, _ in })
+    }
+    
+    /// An action that calls ``LiveSessionCoordinator/reconnect(url:httpMethod:httpBody:)`` in the current context.
+    public var reconnectLiveView: ReconnectLiveViewAction {
+        get { self[ReconnectLiveViewActionKey.self] }
+        set { self[ReconnectLiveViewActionKey.self] = newValue }
+    }
+}

--- a/priv/templates/lvn.swiftui.gen/xcodegen/TemplateApp/ErrorView.swift
+++ b/priv/templates/lvn.swiftui.gen/xcodegen/TemplateApp/ErrorView.swift
@@ -57,6 +57,16 @@ struct ErrorView: View {
         } label: {
             Label("Copy Error", systemImage: "doc.on.doc")
         }
+        #if os(watchOS)
+        SwiftUI.Button {
+            Task {
+                await reconnectLiveView(.restart)
+            }
+        } label: {
+            SwiftUI.Label("Restart", systemImage: "arrow.circlepath")
+        }
+        .padding()
+        #else
         Menu {
             Button {
                 Task {
@@ -76,6 +86,7 @@ struct ErrorView: View {
             Label("Reconnect", systemImage: "arrow.2.circlepath")
         }
         .padding()
+        #endif
     }
 }
 

--- a/priv/templates/lvn.swiftui.gen/xcodegen/TemplateApp/ErrorView.swift
+++ b/priv/templates/lvn.swiftui.gen/xcodegen/TemplateApp/ErrorView.swift
@@ -8,6 +8,8 @@ import LiveViewNative
 
 struct ErrorView: View {
     let error: Error
+    
+    @Environment(\.reconnectLiveView) private var reconnectLiveView
 
     var body: some View {
         LiveErrorView(error: error) {
@@ -17,15 +19,7 @@ struct ErrorView: View {
                 } description: {
                     description
                 } actions: {
-                    Button {
-                        #if os(iOS)
-                        UIPasteboard.general.string = error.localizedDescription
-                        #elseif os(macOS)
-                        NSPasteboard.general.setString(error.localizedDescription, forType: .string)
-                        #endif
-                    } label: {
-                        Label("Copy Error", systemImage: "doc.on.doc")
-                    }
+                    actions
                 }
             } else {
                 VStack {
@@ -33,6 +27,7 @@ struct ErrorView: View {
                         .font(.headline)
                     description
                         .foregroundStyle(.secondary)
+                    actions
                 }
             }
         }
@@ -49,6 +44,38 @@ struct ErrorView: View {
         #else
         Text("The app will reconnect when network connection is regained.")
         #endif
+    }
+    
+    @ViewBuilder
+    var actions: some View {
+        Button {
+            #if os(iOS)
+            UIPasteboard.general.string = error.localizedDescription
+            #elseif os(macOS)
+            NSPasteboard.general.setString(error.localizedDescription, forType: .string)
+            #endif
+        } label: {
+            Label("Copy Error", systemImage: "doc.on.doc")
+        }
+        Menu {
+            Button {
+                Task {
+                    await reconnectLiveView(.automatic)
+                }
+            } label: {
+                Label("Reconnect this page", systemImage: "arrow.2.circlepath")
+            }
+            Button {
+                Task {
+                    await reconnectLiveView(.restart)
+                }
+            } label: {
+                Label("Restart from root", systemImage: "arrow.circlepath")
+            }
+        } label: {
+            Label("Reconnect", systemImage: "arrow.2.circlepath")
+        }
+        .padding()
     }
 }
 


### PR DESCRIPTION
Closes #1310

This adds a reconnect button to the `LiveErrorView`. It provides options to reconnect on the current route or from the root.

A new API was also added so users can trigger a reconnect without needing access to the session.
This follows the design of actions like [`openWindow`](https://developer.apple.com/documentation/swiftui/environmentvalues/openwindow) and [`dismiss`](https://developer.apple.com/documentation/swiftui/environmentvalues/dismiss) in SwiftUI.

```swift
struct MyCustomView: View {
  @Environment(\.reconnectLiveView) private var reconnectLiveView

  var body: some View {
    Button("Reconnect") {
      Task {
        await reconnectLiveView()
        await reconnectLiveView(.restart) // use the `restart` style to reconnect from the base URL.
      }
    }
  }
}
```

https://github.com/liveview-native/liveview-client-swiftui/assets/13581484/c8f93d37-433e-4cbc-910d-99e725c02cc2

Automatic reconnect is now enabled by default. It can also be customized with the `ReconnectBehavior` type:

```swift
#LiveView(
    .localhost,
    configuration: .init(reconnectBehavior: .exponential(upTo: 10, jitter: 0...1))
)
```