### PR TITLE
`@Addon` macro API

### DIFF
--- a/Sources/LiveViewNative/Live/LiveView.swift
+++ b/Sources/LiveViewNative/Live/LiveView.swift
@@ -40,11 +40,39 @@ public macro LiveView<
 @freestanding(expression)
 public macro LiveView<
     Host: LiveViewHost,
+    ConnectingView: View,
+    DisconnectedView: View,
+    ReconnectingView: View,
+    ErrorView: View
+>(
+    _ host: Host,
+    configuration: LiveSessionConfiguration = .init(),
+    addons: [AddonRegistry],
+    @ViewBuilder connecting: @escaping () -> ConnectingView = { () -> Never in fatalError() },
+    @ViewBuilder disconnected: @escaping () -> DisconnectedView = { () -> Never in fatalError() },
+    @ViewBuilder reconnecting: @escaping (_ConnectedContent<EmptyRegistry>, Bool) -> ReconnectingView = { (_: _ConnectedContent<EmptyRegistry>, _: Bool) -> Never in fatalError() },
+    @ViewBuilder error: @escaping (Error) -> ErrorView = { (_: Error) -> Never in fatalError() }
+) -> AnyView = #externalMacro(module: "LiveViewNativeMacros", type: "LiveViewMacro")
+
+@freestanding(expression)
+public macro LiveView<
+    Host: LiveViewHost,
     PhaseView: View
 >(
     _ host: Host,
     configuration: LiveSessionConfiguration = .init(),
     addons: [any CustomRegistry<EmptyRegistry>.Type] = [],
+    @ViewBuilder content: @escaping (LiveViewPhase<EmptyRegistry>) -> PhaseView = { (_: LiveViewPhase<EmptyRegistry>) -> Never in fatalError() }
+) -> AnyView = #externalMacro(module: "LiveViewNativeMacros", type: "LiveViewMacro")
+
+@freestanding(expression)
+public macro LiveView<
+    Host: LiveViewHost,
+    PhaseView: View
+>(
+    _ host: Host,
+    configuration: LiveSessionConfiguration = .init(),
+    addons: [AddonRegistry],
     @ViewBuilder content: @escaping (LiveViewPhase<EmptyRegistry>) -> PhaseView = { (_: LiveViewPhase<EmptyRegistry>) -> Never in fatalError() }
 ) -> AnyView = #externalMacro(module: "LiveViewNativeMacros", type: "LiveViewMacro")
 

--- a/Sources/LiveViewNative/Live/LiveView.swift
+++ b/Sources/LiveViewNative/Live/LiveView.swift
@@ -47,7 +47,7 @@ public macro LiveView<
 >(
     _ host: Host,
     configuration: LiveSessionConfiguration = .init(),
-    addons: [AddonRegistry],
+    addons: [Addons],
     @ViewBuilder connecting: @escaping () -> ConnectingView = { () -> Never in fatalError() },
     @ViewBuilder disconnected: @escaping () -> DisconnectedView = { () -> Never in fatalError() },
     @ViewBuilder reconnecting: @escaping (_ConnectedContent<EmptyRegistry>, Bool) -> ReconnectingView = { (_: _ConnectedContent<EmptyRegistry>, _: Bool) -> Never in fatalError() },
@@ -72,7 +72,7 @@ public macro LiveView<
 >(
     _ host: Host,
     configuration: LiveSessionConfiguration = .init(),
-    addons: [AddonRegistry],
+    addons: [Addons],
     @ViewBuilder content: @escaping (LiveViewPhase<EmptyRegistry>) -> PhaseView = { (_: LiveViewPhase<EmptyRegistry>) -> Never in fatalError() }
 ) -> AnyView = #externalMacro(module: "LiveViewNativeMacros", type: "LiveViewMacro")
 

--- a/Sources/LiveViewNative/Registries/CustomRegistry.swift
+++ b/Sources/LiveViewNative/Registries/CustomRegistry.swift
@@ -9,6 +9,20 @@ import SwiftUI
 import LiveViewNativeCore
 import LiveViewNativeStylesheet
 
+@freestanding(declaration, names: arbitrary)
+public macro registerAddon(_ type: any CustomRegistry<EmptyRegistry>.Type) = #externalMacro(module: "LiveViewNativeMacros", type: "RegisterAddonMacro")
+
+/// A host for all `CustomRegistry` static members.
+///
+/// Register your addon in the registry by creating an extension and calling ``registerAddon(_:)``.
+///
+/// ```swift
+/// public extension AddonRegistry {
+///     #registerAddon(MyCustomRegistry<_>.self)
+/// }
+/// ```
+public enum AddonRegistry {}
+
 /// A custom registry allows clients to include custom view types in the LiveView DOM.
 ///
 /// To add a custom element or attribute, define an enum for the type alias for the tag/attribute name and implement the appropriate method.

--- a/Sources/LiveViewNative/Registries/CustomRegistry.swift
+++ b/Sources/LiveViewNative/Registries/CustomRegistry.swift
@@ -21,7 +21,11 @@ public macro registerAddon(_ type: any CustomRegistry<EmptyRegistry>.Type) = #ex
 ///     #registerAddon(MyCustomRegistry<_>.self)
 /// }
 /// ```
-public enum AddonRegistry {}
+public enum Addons {}
+
+@attached(peer, names: arbitrary)
+@attached(extension, conformances: CustomRegistry)
+public macro Addon() = #externalMacro(module: "LiveViewNativeMacros", type: "AddonMacro")
 
 /// A custom registry allows clients to include custom view types in the LiveView DOM.
 ///

--- a/Sources/LiveViewNativeMacros/AddonMacro.swift
+++ b/Sources/LiveViewNativeMacros/AddonMacro.swift
@@ -11,74 +11,6 @@ import SwiftSyntaxBuilder
 import SwiftSyntaxMacros
 import SwiftDiagnostics
 
-enum RegisterAddonMacro {
-    static let suffix = "Registry"
-}
-
-extension RegisterAddonMacro: DeclarationMacro {
-    static func expansion(
-        of node: some FreestandingMacroExpansionSyntax,
-        in context: some MacroExpansionContext
-    ) throws -> [DeclSyntax] {
-        guard let baseName = node.argumentList.first?
-            .expression.as(MemberAccessExprSyntax.self)?
-            .base?.as(GenericSpecializationExprSyntax.self)?
-            .expression.as(DeclReferenceExprSyntax.self)?
-            .baseName.text
-        else { throw DiagnosticsError(syntax: node, message: "Missing or invalid `CustomRegistry` type. Pass a registry in the form `MyCustomRegistry<_>.self`.", id: .missingRegistry) }
-        
-        guard baseName.hasSuffix(suffix),
-              baseName != suffix
-        else { throw DiagnosticsError(syntax: node, message: "Registry type name must have the 'Registry' suffix.", id: .invalidRegistryName) }
-        
-        guard baseName.first?.isUppercase == true
-        else { throw DiagnosticsError(syntax: node, message: "Registry type name must start with an uppercase letter.", id: .invalidRegistryName) }
-        
-        var name = baseName
-        
-        // Remove `*Registry` suffix.
-        name = String(name.prefix(upTo: name.index(name.endIndex, offsetBy: -suffix.count)))
-
-        // Lowercase the first character for camelCase.
-        name = name.prefix(1).lowercased() + name.dropFirst()
-        
-        return [
-            DeclSyntax(#"static var \#(raw: name): LiveViewNative.AddonRegistry { fatalError("Registered addons cannot be accessed outside of the #LiveView macro.") }"#)
-        ]
-    }
-}
-
-struct RegisterAddonDiagnostic: DiagnosticMessage {
-    enum ID: String {
-        case missingRegistry = "missing registry argument"
-        case invalidRegistryName = "invalid registry name"
-    }
-    
-    var message: String
-    var diagnosticID: MessageID
-    var severity: DiagnosticSeverity
-    
-    init(message: String, diagnosticID: SwiftDiagnostics.MessageID, severity: SwiftDiagnostics.DiagnosticSeverity = .error) {
-        self.message = message
-        self.diagnosticID = diagnosticID
-        self.severity = severity
-    }
-    
-    init(message: String, domain: String, id: ID, severity: SwiftDiagnostics.DiagnosticSeverity = .error) {
-        self.message = message
-        self.diagnosticID = MessageID(domain: domain, id: id.rawValue)
-        self.severity = severity
-    }
-}
-
-extension DiagnosticsError {
-    init<S: SyntaxProtocol>(syntax: S, message: String, domain: String = "RegisterAddon", id: RegisterAddonDiagnostic.ID, severity: SwiftDiagnostics.DiagnosticSeverity = .error) {
-        self.init(diagnostics: [
-            Diagnostic(node: Syntax(syntax), message: RegisterAddonDiagnostic(message: message, domain: domain, id: id, severity: severity))
-        ])
-    }
-}
-
 enum AddonMacro {}
 
 extension AddonMacro: PeerMacro {
@@ -115,5 +47,36 @@ extension AddonMacro: ExtensionMacro {
         [
             try ExtensionDeclSyntax(#"extension \#(type): LiveViewNative.CustomRegistry"#) {}
         ]
+    }
+}
+
+struct AddonDiagnostic: DiagnosticMessage {
+    enum ID: String {
+        case missingRegistry = "missing registry argument"
+        case invalidRegistryName = "invalid registry name"
+    }
+    
+    var message: String
+    var diagnosticID: MessageID
+    var severity: DiagnosticSeverity
+    
+    init(message: String, diagnosticID: SwiftDiagnostics.MessageID, severity: SwiftDiagnostics.DiagnosticSeverity = .error) {
+        self.message = message
+        self.diagnosticID = diagnosticID
+        self.severity = severity
+    }
+    
+    init(message: String, domain: String, id: ID, severity: SwiftDiagnostics.DiagnosticSeverity = .error) {
+        self.message = message
+        self.diagnosticID = MessageID(domain: domain, id: id.rawValue)
+        self.severity = severity
+    }
+}
+
+extension DiagnosticsError {
+    init<S: SyntaxProtocol>(syntax: S, message: String, domain: String = "Addon", id: AddonDiagnostic.ID, severity: SwiftDiagnostics.DiagnosticSeverity = .error) {
+        self.init(diagnostics: [
+            Diagnostic(node: Syntax(syntax), message: AddonDiagnostic(message: message, domain: domain, id: id, severity: severity))
+        ])
     }
 }

--- a/Sources/LiveViewNativeMacros/AddonMacro.swift
+++ b/Sources/LiveViewNativeMacros/AddonMacro.swift
@@ -1,0 +1,81 @@
+//
+//  AddonMacro.swift
+//
+//
+//  Created by Carson Katri on 4/18/24.
+//
+
+import SwiftCompilerPlugin
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+import SwiftDiagnostics
+
+enum RegisterAddonMacro {
+    static let suffix = "Registry"
+}
+
+extension RegisterAddonMacro: DeclarationMacro {
+    static func expansion(
+        of node: some FreestandingMacroExpansionSyntax,
+        in context: some MacroExpansionContext
+    ) throws -> [DeclSyntax] {
+        guard let baseName = node.argumentList.first?
+            .expression.as(MemberAccessExprSyntax.self)?
+            .base?.as(GenericSpecializationExprSyntax.self)?
+            .expression.as(DeclReferenceExprSyntax.self)?
+            .baseName.text
+        else { throw DiagnosticsError(syntax: node, message: "Missing or invalid `CustomRegistry` type. Pass a registry in the form `MyCustomRegistry<_>.self`.", id: .missingRegistry) }
+        
+        guard baseName.hasSuffix(suffix)
+        else { throw DiagnosticsError(syntax: node, message: "Registry type name must have the 'Registry' suffix.", id: .invalidRegistryName) }
+        
+        guard baseName.first?.isUppercase == true
+        else { throw DiagnosticsError(syntax: node, message: "Registry type name must start with an uppercase letter.", id: .invalidRegistryName) }
+        
+        var name = baseName
+        
+        // Remove `*Registry` suffix.
+        if name != suffix {
+          name = String(name.prefix(upTo: name.index(name.endIndex, offsetBy: -suffix.count)))
+        }
+
+        // Lowercase the first character for camelCase.
+        name = name.prefix(1).lowercased() + name.dropFirst()
+        
+        return [
+            DeclSyntax(#"static var \#(raw: name): LiveViewNative.AddonRegistry { fatalError("Registered addons cannot be accessed outside of the #LiveView macro.") }"#)
+        ]
+    }
+}
+
+struct RegisterAddonDiagnostic: DiagnosticMessage {
+    enum ID: String {
+        case missingRegistry = "missing registry argument"
+        case invalidRegistryName = "invalid registry name"
+    }
+    
+    var message: String
+    var diagnosticID: MessageID
+    var severity: DiagnosticSeverity
+    
+    init(message: String, diagnosticID: SwiftDiagnostics.MessageID, severity: SwiftDiagnostics.DiagnosticSeverity = .error) {
+        self.message = message
+        self.diagnosticID = diagnosticID
+        self.severity = severity
+    }
+    
+    init(message: String, domain: String, id: ID, severity: SwiftDiagnostics.DiagnosticSeverity = .error) {
+        self.message = message
+        self.diagnosticID = MessageID(domain: domain, id: id.rawValue)
+        self.severity = severity
+    }
+}
+
+extension DiagnosticsError {
+    init<S: SyntaxProtocol>(syntax: S, message: String, domain: String = "RegisterAddon", id: RegisterAddonDiagnostic.ID, severity: SwiftDiagnostics.DiagnosticSeverity = .error) {
+        self.init(diagnostics: [
+            Diagnostic(node: Syntax(syntax), message: RegisterAddonDiagnostic(message: message, domain: domain, id: id, severity: severity))
+        ])
+    }
+}

--- a/Sources/LiveViewNativeMacros/LiveViewMacro.swift
+++ b/Sources/LiveViewNativeMacros/LiveViewMacro.swift
@@ -89,7 +89,7 @@ extension LiveViewMacro: ExpressionMacro {
             let name = member.declName.baseName.text
             return TypeSyntax(MemberTypeSyntax(
                 baseType: MemberTypeSyntax(baseType: IdentifierTypeSyntax(name: .identifier("LiveViewNative")), name: .identifier("Addons")),
-                // transform camelCase name back to registry type name. See ``RegisterAddonMacro`` for the inverse transformation.
+                // transform camelCase name back to registry type name. See ``AddonMacro`` for the inverse transformation.
                 name: .identifier(name.prefix(1).uppercased() + name.dropFirst()),
                 genericArgumentClause: genericArgumentClause
             ))

--- a/Sources/LiveViewNativeMacros/LiveViewNativeMacros.swift
+++ b/Sources/LiveViewNativeMacros/LiveViewNativeMacros.swift
@@ -18,7 +18,6 @@ struct LiveViewNativeMacrosPlugin: CompilerPlugin {
         LiveAttributeMacro.self,
         LiveElementIgnoredMacro.self,
         
-        RegisterAddonMacro.self,
         AddonMacro.self
     ]
 }

--- a/Sources/LiveViewNativeMacros/LiveViewNativeMacros.swift
+++ b/Sources/LiveViewNativeMacros/LiveViewNativeMacros.swift
@@ -18,6 +18,7 @@ struct LiveViewNativeMacrosPlugin: CompilerPlugin {
         LiveAttributeMacro.self,
         LiveElementIgnoredMacro.self,
         
-        RegisterAddonMacro.self
+        RegisterAddonMacro.self,
+        AddonMacro.self
     ]
 }

--- a/Sources/LiveViewNativeMacros/LiveViewNativeMacros.swift
+++ b/Sources/LiveViewNativeMacros/LiveViewNativeMacros.swift
@@ -16,6 +16,8 @@ struct LiveViewNativeMacrosPlugin: CompilerPlugin {
         
         LiveElementMacro.self,
         LiveAttributeMacro.self,
-        LiveElementIgnoredMacro.self
+        LiveElementIgnoredMacro.self,
+        
+        RegisterAddonMacro.self
     ]
 }


### PR DESCRIPTION
Closes #1296 

Previously, addons were passed by type:

```swift
#LiveView(
  .localhost,
  addons: [ChartsRegistry<_>.self, LiveFormRegistry<_>.self]
)
```

This adds a new format for passing addons using static members on an `Addons` type:

```swift
#LiveView(
  .localhost,
  addons: [.charts, .liveForm]
)
```

This is simpler to read and write, and also allows for some helpful auto completion:
<img width="449" alt="Screenshot 2024-04-18 at 11 39 06 AM" src="https://github.com/liveview-native/liveview-client-swiftui/assets/13581484/879c6706-881d-493f-a848-44992cdddb66">

To make this work, the API for addon libraries has changed a bit.
Now, they should be declared as extensions on the `Addons` type. Add the `@Addon` macro on the struct.

```swift
public extension Addons {
  @Addon
  struct Charts<Root: RootRegistry> {
    // ...
  }
}
```

The `@Addon` macro will synthesize a static member by converting the type name to `camelCase`:

```swift
addons: [.charts]
```

The previous method of passing addons by type name is still available, and they can be declared outside the `Addons` type and without the `@Addon` macro if you don't want to support the static member method. This could be used for more custom cases (for example, a registry that is generic over some other type).