### PR TITLE
Add support for visionOS and missing modifiers/types

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/liveview-native/liveview-native-core-swift.git",
       "state" : {
-        "revision" : "b6a24652b35acd534fa437cb4cf4654fcb33828f",
-        "version" : "0.1.0-7500ce9"
+        "revision" : "339594b395938e38f1fb2216a31c8791030ec9ba",
+        "version" : "0.2.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -27,7 +27,7 @@ let package = Package(
         .package(url: "https://github.com/scinfu/SwiftSoup.git", from: "2.3.2"),
         .package(url: "https://github.com/davidstump/SwiftPhoenixClient.git", .upToNextMinor(from: "5.0.0")),
         .package(url: "https://github.com/apple/swift-async-algorithms", from: "0.1.0"),
-        .package(url: "https://github.com/liveview-native/liveview-native-core-swift.git", exact: "0.1.0-7500ce9"),
+        .package(url: "https://github.com/liveview-native/liveview-native-core-swift.git", exact: "0.2.1"),
         
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.2.2"),
         .package(url: "https://github.com/apple/swift-markdown.git", from: "0.2.0"),

--- a/Sources/LiveViewNative/Live/LiveErrorView.swift
+++ b/Sources/LiveViewNative/Live/LiveErrorView.swift
@@ -29,7 +29,7 @@ public struct LiveErrorView<Fallback: View>: View {
         {
             SwiftUI.VStack {
                 WebErrorView(html: trace)
-                #if os(watchOS)
+                #if os(watchOS) || os(tvOS)
                 SwiftUI.Button {
                     Task {
                         await reconnectLiveView(.restart)

--- a/Sources/LiveViewNative/Stylesheets/Modifiers/Overrides/PerspectiveRotationEffectModifier.swift
+++ b/Sources/LiveViewNative/Stylesheets/Modifiers/Overrides/PerspectiveRotationEffectModifier.swift
@@ -1,8 +1,8 @@
 //
-//  Rotation3DEffectModifier.swift
+//  PerspectiveRotationEffectModifier.swift
 //
 //
-//  Created by Carson Katri on 11/22/23.
+//  Created by Carson Katri on 4/30/24.
 //
 
 import SwiftUI
@@ -10,34 +10,9 @@ import LiveViewNativeStylesheet
 
 // manual implementation
 // `axis` is a tuple type, which cannot conform to `ParseableModifierValue`.
-/// See [`SwiftUI.View/rotation3DEffect(_:axis:anchor:anchorZ:perspective:)`](https://developer.apple.com/documentation/swiftui/view/rotation3DEffect(_:axis:anchor:anchorZ:perspective:)) for more details on this ViewModifier.
-///
-/// ### rotation3DEffect(_:axis:anchor:anchorZ:perspective:)
-/// - `angle`: ``SwiftUI/Angle`` (required)
-/// - `axis`: Tuple with structure `(x: CGFloat, y: CGFloat, z: CGFloat)` (required)
-/// - `anchor`: ``SwiftUI/UnitPoint``
-/// - `anchorZ`: `attr("...")` or ``CoreFoundation/CGFloat``
-/// - `perspective`: `attr("...")` or ``CoreFoundation/CGFloat``
-///
-/// See [`SwiftUI.View/rotation3DEffect(_:axis:anchor:anchorZ:perspective:)`](https://developer.apple.com/documentation/swiftui/view/rotation3DEffect(_:axis:anchor:anchorZ:perspective:)) for more details on this ViewModifier.
-///
-/// Example:
-///
-/// ```elixir
-/// # stylesheet
-/// "example" do
-///   rotation3DEffect(.zero, axis: (x: 1, y: 0, z: 0), anchor: .center, anchorZ: attr("anchorZ"), perspective: attr("perspective"))
-/// end
-/// ```
-///
-/// ```heex
-/// <%!-- template --%>
-/// <Element class="example" anchorZ={@anchorZ} perspective={@perspective} />
-/// ```
-@_documentation(visibility: public)
 @ParseableExpression
-struct _Rotation3DEffectModifier<R: RootRegistry>: ViewModifier {
-    static var name: String { "rotation3DEffect" }
+struct _PerspectiveRotationEffectModifier<R: RootRegistry>: ViewModifier {
+    static var name: String { "perspectiveRotationEffect" }
     
     let angle: AttributeReference<Angle>
     let axis: _3DAxis
@@ -48,6 +23,7 @@ struct _Rotation3DEffectModifier<R: RootRegistry>: ViewModifier {
     @ObservedElement private var element
     @LiveContext<R> private var context
     
+    #if os(visionOS)
     init(
         _ angle: AttributeReference<Angle>,
         axis: _3DAxis,
@@ -61,16 +37,12 @@ struct _Rotation3DEffectModifier<R: RootRegistry>: ViewModifier {
         self.anchorZ = anchorZ
         self.perspective = perspective
     }
+    #endif
     
     func body(content: Content) -> some View {
+        content
         #if os(visionOS)
-        content.rotation3DEffect(
-            angle.resolve(on: element, in: context),
-            axis: (x: axis.x, y: axis.y, z: axis.z),
-            anchor: anchor
-        )
-        #else
-        content.rotation3DEffect(
+        .perspectiveRotationEffect(
             angle.resolve(on: element, in: context),
             axis: (x: axis.x, y: axis.y, z: axis.z),
             anchor: anchor,

--- a/Sources/LiveViewNative/Stylesheets/Modifiers/Overrides/PerspectiveRotationEffectModifier.swift
+++ b/Sources/LiveViewNative/Stylesheets/Modifiers/Overrides/PerspectiveRotationEffectModifier.swift
@@ -15,7 +15,7 @@ struct _PerspectiveRotationEffectModifier<R: RootRegistry>: ViewModifier {
     static var name: String { "perspectiveRotationEffect" }
     
     let angle: AttributeReference<Angle>
-    let axis: _3DAxis
+    let axis: _Rotation3DEffectModifier<R>._3DAxis
     let anchor: UnitPoint
     let anchorZ: AttributeReference<CGFloat>
     let perspective: AttributeReference<CGFloat>
@@ -26,7 +26,7 @@ struct _PerspectiveRotationEffectModifier<R: RootRegistry>: ViewModifier {
     #if os(visionOS)
     init(
         _ angle: AttributeReference<Angle>,
-        axis: _3DAxis,
+        axis: _Rotation3DEffectModifier<R>._3DAxis,
         anchor: UnitPoint = .center,
         anchorZ: AttributeReference<CGFloat> = .init(storage: .constant(0)),
         perspective: AttributeReference<CGFloat> = .init(storage: .constant(1))
@@ -50,34 +50,5 @@ struct _PerspectiveRotationEffectModifier<R: RootRegistry>: ViewModifier {
             perspective: perspective.resolve(on: element, in: context)
         )
         #endif
-    }
-    
-    struct _3DAxis: ParseableModifierValue {
-        let x: CGFloat
-        let y: CGFloat
-        let z: CGFloat
-        
-        static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
-            Parse {
-                "(".utf8
-                Whitespace()
-                "x:".utf8
-                Whitespace()
-                CGFloat.parser(in: context)
-                Whitespace()
-                "y:".utf8
-                Whitespace()
-                CGFloat.parser(in: context)
-                Whitespace()
-                "z:".utf8
-                Whitespace()
-                CGFloat.parser(in: context)
-                Whitespace()
-                ")".utf8
-            }
-            .map { x, y, z in
-                return .init(x: x, y: y, z: z)
-            }
-        }
     }
 }

--- a/Sources/LiveViewNative/Stylesheets/Modifiers/Text/FontDesignModifier.swift
+++ b/Sources/LiveViewNative/Stylesheets/Modifiers/Text/FontDesignModifier.swift
@@ -30,30 +30,24 @@ struct _FontDesignModifier<R: RootRegistry>: TextModifier {
     
     let design: Any?
 
-    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-    @available(watchOS 9.1,tvOS 16.1,iOS 16.1,macOS 13.0, *)
+    @available(watchOS 9.1,tvOS 16.1,iOS 16.1,macOS 13.0, visionOS 1, *)
     init(_ design: SwiftUI.Font.Design?) {
         self.design = design
     }
-    #endif
 
     func body(content: Content) -> some View {
-        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-        if #available(watchOS 9.1,tvOS 16.1,iOS 16.1,macOS 13.0, *) {
+        if #available(watchOS 9.1,tvOS 16.1,iOS 16.1,macOS 13.0, visionOS 1, *) {
             content.fontDesign(design as? SwiftUI.Font.Design)
         } else {
             content
         }
-        #endif
     }
     
     func apply(to text: SwiftUI.Text, on element: ElementNode) -> SwiftUI.Text {
-        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-        if #available(watchOS 9.1,tvOS 16.1,iOS 16.1,macOS 13.0, *) {
+        if #available(watchOS 9.1,tvOS 16.1,iOS 16.1,macOS 13.0, visionOS 1, *) {
             return text.fontDesign(design as? SwiftUI.Font.Design)
         } else {
             return text
         }
-        #endif
     }
 }

--- a/Sources/LiveViewNative/Stylesheets/Modifiers/Text/TextScaleModifier.swift
+++ b/Sources/LiveViewNative/Stylesheets/Modifiers/Text/TextScaleModifier.swift
@@ -40,33 +40,27 @@ struct _TextScaleModifier<R: RootRegistry>: TextModifier {
     @ObservedElement private var element
     @LiveContext<R> private var context
 
-    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-    @available(tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0, *)
+    @available(tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0, visionOS 1, *)
     init(_ scale: SwiftUI.Text.Scale, isEnabled: AttributeReference<Bool> = .init(storage: .constant(true))) {
         self.scale = scale
         self.isEnabled = isEnabled
     }
-    #endif
 
     func body(content: Content) -> some View {
-        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-        if #available(tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0, *) {
+        if #available(tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0, visionOS 1, *) {
             content
                 .textScale(scale as! SwiftUI.Text.Scale, isEnabled: isEnabled.resolve(on: element, in: context))
         } else {
             content
         }
-        #endif
     }
     
     func apply(to text: SwiftUI.Text, on element: ElementNode) -> SwiftUI.Text {
-        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-        if #available(tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0, *) {
+        if #available(tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0, visionOS 1, *) {
             return text
                 .textScale(scale as! SwiftUI.Text.Scale, isEnabled: isEnabled.resolve(on: element))
         } else {
             return text
         }
-        #endif
     }
 }

--- a/Sources/LiveViewNative/Stylesheets/ParseableTypes/AffineTransform3D+ParseableModifierValue.swift
+++ b/Sources/LiveViewNative/Stylesheets/ParseableTypes/AffineTransform3D+ParseableModifierValue.swift
@@ -1,0 +1,322 @@
+//
+//  AffineTransform3D+ParseableModifierValue.swift
+//
+//
+//  Created by Carson.Katri on 4/30/24.
+//
+
+#if os(visionOS)
+import SwiftUI
+import LiveViewNativeStylesheet
+
+extension AffineTransform3D: ParseableModifierValue {
+    public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
+        ParseableAffineTransform3D.parser(in: context).map(\.value)
+    }
+    
+    @ParseableExpression
+    struct ParseableAffineTransform3D {
+        static let name = "AffineTransform3D"
+        
+        let value: AffineTransform3D
+        
+        init() {
+            self.value = .init()
+        }
+        
+        init(
+            scale: Size3D = Size3D(width: 1.0, height: 1, depth: 1),
+            rotation: Rotation3D = .identity,
+            translation: Vector3D = .zero
+        ) {
+            self.value = .init(
+                scale: scale,
+                rotation: rotation,
+                translation: translation
+            )
+        }
+        
+        init(scale: Size3D) {
+            self.value = .init(scale: scale)
+        }
+        
+        init(rotation: Rotation3D) {
+            self.value = .init(rotation: rotation)
+        }
+        
+        init(translation: Vector3D) {
+            self.value = .init(translation: translation)
+        }
+        
+        init(pose: Pose3D) {
+            self.value = .init(pose: pose)
+        }
+        
+        init(shear: AxisWithFactors) {
+            self.value = .init(shear: shear)
+        }
+    }
+}
+
+extension Size3D: ParseableModifierValue {
+    public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
+        ParseableSize3D.parser(in: context).map(\.value)
+    }
+    
+    @ParseableExpression
+    struct ParseableSize3D {
+        static let name = "Size3D"
+        
+        let value: Size3D
+        
+        init(
+            width: Double = 0,
+            height: Double = 0,
+            depth: Double = 0
+        ) {
+            self.value = .init(
+                width: width,
+                height: height,
+                depth: depth
+            )
+        }
+    }
+}
+
+extension Rotation3D: ParseableModifierValue {
+    public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
+        ParseableRotation3D.parser(in: context).map(\.value)
+    }
+    
+    @ParseableExpression
+    struct ParseableRotation3D {
+        static let name = "Rotation3D"
+        
+        let value: Rotation3D
+        
+        init(angle: Angle2D, axis: RotationAxis3D) {
+            self.value = .init(angle: angle, axis: axis)
+        }
+        
+        init(position: Point3D, target: Point3D, up: Vector3D) {
+            self.value = .init(position: position, target: target, up: up)
+        }
+        
+        init(forward: Vector3D, up: Vector3D) {
+            self.value = .init(forward: forward, up: up)
+        }
+    }
+}
+
+extension Point3D: ParseableModifierValue {
+    public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
+        ParseablePoint3D.parser(in: context).map(\.value)
+    }
+    
+    @ParseableExpression
+    struct ParseablePoint3D {
+        static let name = "Point3D"
+        
+        let value: Point3D
+        
+        init() {
+            self.value = .init()
+        }
+        
+        init(
+            x: Double = 0,
+            y: Double = 0,
+            z: Double = 0
+        ) {
+            self.value = .init(x: x, y: y, z: z)
+        }
+        
+        init(_ xyz: Vector3D) {
+            self.value = .init(xyz)
+        }
+        
+        init(_ size: Size3D) {
+            self.value = .init(size)
+        }
+    }
+}
+
+extension Vector3D: ParseableModifierValue {
+    public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
+        ParseableVector3D.parser(in: context).map(\.value)
+    }
+    
+    @ParseableExpression
+    struct ParseableVector3D {
+        static let name = "Vector3D"
+        
+        let value: Vector3D
+        
+        init() {
+            self.value = .init()
+        }
+        
+        init(
+            x: Double = 0,
+            y: Double = 0,
+            z: Double = 0
+        ) {
+            self.value = .init(x: x, y: y, z: z)
+        }
+        
+        init(_ axis: RotationAxis3D) {
+            self.value = .init(axis)
+        }
+        
+        init(_ point: Point3D) {
+            self.value = .init(point)
+        }
+        
+        init(_ size: Size3D) {
+            self.value = .init(size)
+        }
+    }
+}
+
+extension Angle2D: ParseableModifierValue {
+    public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
+        OneOf {
+            ParseableAngle2D.parser(in: context).map(\.value)
+            ImplicitStaticMember {
+                OneOf {
+                    SwiftUI.Angle.Radians.parser(in: context).map({ Self.radians($0.radians) })
+                    SwiftUI.Angle.Degrees.parser(in: context).map({ Self.degrees($0.degrees) })
+                }
+            }
+        }
+    }
+    
+    @ParseableExpression
+    struct ParseableAngle2D {
+        static let name = "Angle2D"
+        
+        let value: Angle2D
+        
+        init() {
+            self.value = .init()
+        }
+        
+        init(radians: Double) {
+            self.value = .init(radians: radians)
+        }
+        
+        init(degrees: Double) {
+            self.value = .init(degrees: degrees)
+        }
+        
+        init(_ angle: Angle) {
+            self.value = .init(angle)
+        }
+    }
+}
+
+extension RotationAxis3D: ParseableModifierValue {
+    public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
+        ParseableRotationAxis3D.parser(in: context).map(\.value)
+    }
+    
+    @ParseableExpression
+    struct ParseableRotationAxis3D {
+        static let name = "RotationAxis3D"
+        
+        let value: RotationAxis3D
+        
+        init(x: Double, y: Double, z: Double) {
+            self.value = .init(x: x, y: y, z: z)
+        }
+        
+        init(_ xyz: Vector3D) {
+            self.value = .init(xyz)
+        }
+    }
+}
+
+extension Pose3D: ParseableModifierValue {
+    public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
+        ParseablePose3D.parser(in: context).map(\.value)
+    }
+    
+    @ParseableExpression
+    struct ParseablePose3D {
+        static let name = "Pose3D"
+        
+        let value: Pose3D
+        
+        init() {
+            self.value = .init()
+        }
+        
+        init(
+            forward: Vector3D,
+            up: Vector3D = Vector3D(x: 0, y: 1, z: 0)
+        ) {
+            self.value = .init(forward: forward, up: up)
+        }
+        
+        init(
+            position: Point3D,
+            rotation: Rotation3D
+        ) {
+            self.value = .init(position: position, rotation: rotation)
+        }
+        
+        init(
+            position: Point3D = .zero,
+            target: Point3D,
+            up: Vector3D = Vector3D(x: 0, y: 1, z: 0)
+        ) {
+            self.value = .init(position: position, target: target, up: up)
+        }
+    }
+}
+
+extension AxisWithFactors: ParseableModifierValue {
+    public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
+        ImplicitStaticMember {
+            OneOf {
+                XAxis.parser(in: context).map(\.value)
+                YAxis.parser(in: context).map(\.value)
+                ZAxis.parser(in: context).map(\.value)
+            }
+        }
+    }
+    
+    @ParseableExpression
+    struct XAxis: ParseableModifierValue {
+        static let name = "xAxis"
+        
+        let value: AxisWithFactors
+        
+        init(yShearFactor: Double, zShearFactor: Double) {
+            self.value = .xAxis(yShearFactor: yShearFactor, zShearFactor: zShearFactor)
+        }
+    }
+    
+    @ParseableExpression
+    struct YAxis: ParseableModifierValue {
+        static let name = "yAxis"
+        
+        let value: AxisWithFactors
+        
+        init(xShearFactor: Double, zShearFactor: Double) {
+            self.value = .yAxis(xShearFactor: xShearFactor, zShearFactor: zShearFactor)
+        }
+    }
+    
+    @ParseableExpression
+    struct ZAxis: ParseableModifierValue {
+        static let name = "zAxis"
+        
+        let value: AxisWithFactors
+        
+        init(xShearFactor: Double, yShearFactor: Double) {
+            self.value = .zAxis(xShearFactor: xShearFactor, yShearFactor: yShearFactor)
+        }
+    }
+}
+#endif

--- a/Sources/LiveViewNative/Stylesheets/ParseableTypes/AffineTransform3D+ParseableModifierValue.swift
+++ b/Sources/LiveViewNative/Stylesheets/ParseableTypes/AffineTransform3D+ParseableModifierValue.swift
@@ -7,8 +7,21 @@
 
 #if os(visionOS)
 import SwiftUI
+import Spatial
 import LiveViewNativeStylesheet
 
+/// See [`Spatial.AffineTransform3D`](https://developer.apple.com/documentation/spatial/AffineTransform3D) for more details.
+///
+/// Use ``Spatial/Size3D``, ``Spatial/Rotation3D``, ``Spatial/Vector3D``, ``Spatial/Pose3D``, and ``Spatial/AxisWithFactors`` to build a transformation matrix.
+///
+/// ```swift
+/// AffineTransform3D()
+/// AffineTransform3D(scale: Size3D(width: 5, height: 1, depth: 2))
+/// AffineTransform3D(rotation: .degrees(45), translation: Vector3D(x: 10, z: 5))
+/// AffineTransform3D(pose: Pose3D(forward: Vector3D(x: 1))
+/// AffineTransform3D(shear: .xAxis(yShearFactor: 1, zShearFactor: 1))
+/// ```
+@_documentation(visibility: public)
 extension AffineTransform3D: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ParseableAffineTransform3D.parser(in: context).map(\.value)
@@ -58,6 +71,21 @@ extension AffineTransform3D: ParseableModifierValue {
     }
 }
 
+/// See [`Spatial.Size3D`](https://developer.apple.com/documentation/spatial/Size3D) for more details.
+///
+/// Parameters:
+/// - `width`: ``Swift/Double``
+/// - `height`: ``Swift/Double``
+/// - `depth`: ``Swift/Double``
+///
+/// Example:
+///
+/// ```swift
+/// Size3D()
+/// Size3D(width: 10, depth: 5)
+/// Size3D(width: 1, height: 2, depth: 3)
+/// ```
+@_documentation(visibility: public)
 extension Size3D: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ParseableSize3D.parser(in: context).map(\.value)
@@ -83,6 +111,26 @@ extension Size3D: ParseableModifierValue {
     }
 }
 
+/// See [`Spatial.Rotation3D`](https://developer.apple.com/documentation/spatial/Rotation3D) for more details.
+///
+/// Use ``Spatial/Angle2D`` and ``Spatial/RotationAxis3D`` to construct a 3D rotation from an angle and axis.
+///
+/// ```swift
+/// Rotation3D(angle: .degrees(45), axis: RotationAxis3D(x: 1, y: 0, z: 0))
+/// ```
+///
+/// Use a ``Spatial/Point3D`` `position` and `target`, and ``Spatial/Vector3D`` `up` to construct a look rotation.
+///
+/// ```swift
+/// Rotation3D(position: Point3D(), target: Point3D(x: 5), up: Vector3D(z: 1))
+/// ```
+///
+/// Use a ``Spatial/Vector3D`` `forward` and `up` to construct a rotation.
+///
+/// ```swift
+/// Rotation3D(forward: Vector3D(x: 1), up: Vector3D(z: 1))
+/// ```
+@_documentation(visibility: public)
 extension Rotation3D: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ParseableRotation3D.parser(in: context).map(\.value)
@@ -108,6 +156,23 @@ extension Rotation3D: ParseableModifierValue {
     }
 }
 
+/// See [`Spatial.Point3D`](https://developer.apple.com/documentation/spatial/Point3D) for more details.
+///
+/// Provide an `x`, `y`, and `z` double to construct a point.
+///
+/// ```swift
+/// Point3D()
+/// Point3D(y: 1)
+/// Point3D(x: 1, y: 2, z: 3)
+/// ```
+///
+/// You can also convert a ``Spatial/Vector3D`` or ``Spatial/Size3D`` into a point.
+///
+/// ```swift
+/// Point3D(Vector3D(z: 1))
+/// Point3D(Size3D(x: 2, y: 2, z: 2))
+/// ```
+@_documentation(visibility: public)
 extension Point3D: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ParseablePoint3D.parser(in: context).map(\.value)
@@ -141,6 +206,24 @@ extension Point3D: ParseableModifierValue {
     }
 }
 
+/// See [`Spatial.Vector3D`](https://developer.apple.com/documentation/spatial/Vector3D) for more details.
+///
+/// Provide an `x`, `y`, and `z` double to construct a vector.
+///
+/// ```swift
+/// Vector3D()
+/// Vector3D(y: 1)
+/// Vector3D(x: 1, y: 2, z: 3)
+/// ```
+///
+/// You can also convert a ``Spatial/RotationAxis3D``, ``Spatial/Point3D`` or ``Spatial/Size3D`` into a vector.
+///
+/// ```swift
+/// Vector3D(RotationAxis3D(x: 1, y: 0, z: 1))
+/// Vector3D(Point3D(z: 1))
+/// Vector3D(Size3D(x: 2, y: 2, z: 2))
+/// ```
+@_documentation(visibility: public)
 extension Vector3D: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ParseableVector3D.parser(in: context).map(\.value)
@@ -178,6 +261,24 @@ extension Vector3D: ParseableModifierValue {
     }
 }
 
+/// See [`Spatial.Angle2D`](https://developer.apple.com/documentation/spatial/Angle2D) for more details.
+///
+/// Provide an angle in `radians` or `degrees` to construct a angle.
+///
+/// ```swift
+/// Angle2D(radians: 3.14)
+/// Angle2D(degrees: 180)
+/// .radians(3.14)
+/// .degrees(180)
+/// ```
+///
+/// You can also convert a ``SwiftUI/Angle`` into a angle.
+///
+/// ```swift
+/// Angle2D(.radians(3.14))
+/// Angle2D(.degrees(180))
+/// ```
+@_documentation(visibility: public)
 extension Angle2D: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         OneOf {
@@ -215,6 +316,20 @@ extension Angle2D: ParseableModifierValue {
     }
 }
 
+/// See [`Spatial.RotationAxis3D`](https://developer.apple.com/documentation/spatial/RotationAxis3D) for more details.
+///
+/// Provide an `x`, `y`, and `z` value to specify the axes.
+///
+/// ```swift
+/// RotationAxis3D(x: 1, y: 0, z: 0)
+/// ```
+///
+/// You can also convert a ``SwiftUI/Vector3D`` into a rotation axis.
+///
+/// ```swift
+/// RotationAxis3D(Vector3D(z: 1))
+/// ```
+@_documentation(visibility: public)
 extension RotationAxis3D: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ParseableRotationAxis3D.parser(in: context).map(\.value)
@@ -236,6 +351,27 @@ extension RotationAxis3D: ParseableModifierValue {
     }
 }
 
+/// See [`Spatial.Pose3D`](https://developer.apple.com/documentation/spatial/Pose3D) for more details.
+///
+/// Provide an ``Spatial/Vector3D`` `forward` and `up` to construct a pose.
+///
+/// ```swift
+/// Pose3D(forward: Vector3D(x: 1), up: Vector3D(z: 1))
+/// ```
+///
+/// Provide an ``Spatial/Point3D`` `position` and ``Spatial/Rotation3D`` `rotation` to construct a pose.
+///
+/// ```swift
+/// Pose3D(position: Point3D(), up: Rotation3D(angle: .radians(3.14), axis: RotationAxis3D(x: 1, y: 0, z: 0)))
+/// ```
+///
+/// Provide an ``Spatial/Point3D`` `position` and `target`, and a ``Spatial/Vector3D`` `up` to construct a pose.
+///
+/// ```swift
+/// Pose3D(position: Point3D(), target: Point3D(x: 1))
+/// Pose3D(position: Point3D(y: 1), target: Point3D(z: 1), up: Vector3D(z: 1))
+/// ```
+@_documentation(visibility: public)
 extension Pose3D: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ParseablePose3D.parser(in: context).map(\.value)
@@ -275,6 +411,16 @@ extension Pose3D: ParseableModifierValue {
     }
 }
 
+/// See [`Spatial.AxisWithFactors`](https://developer.apple.com/documentation/spatial/AxisWithFactors) for more details.
+///
+/// Create an `x`, `y`, or `z` axis with shear factors
+///
+/// ```swift
+/// .xAxis(yShearFactor: 1, zShearFactor: 0.5)
+/// .yAxis(xShearFactor: 0, zShearFactor: 1)
+/// .zAxis(xShearFactor: 2, yShearFactor: 0.5)
+/// ```
+@_documentation(visibility: public)
 extension AxisWithFactors: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {

--- a/Sources/LiveViewNative/Stylesheets/ParseableTypes/DepthAlignment+ParseableModifierValue.swift
+++ b/Sources/LiveViewNative/Stylesheets/ParseableTypes/DepthAlignment+ParseableModifierValue.swift
@@ -1,0 +1,21 @@
+//
+//  DepthAlignment+ParseableModifierValue.swift
+//
+//
+//  Created by Carson Katri on 4/30/24.
+//
+
+#if os(visionOS)
+import SwiftUI
+import LiveViewNativeStylesheet
+
+extension DepthAlignment: ParseableModifierValue {
+    public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
+        ImplicitStaticMember([
+            "back": .back,
+            "center": .center,
+            "front": .front,
+        ])
+    }
+}
+#endif

--- a/Sources/LiveViewNative/Stylesheets/ParseableTypes/EdgeInsets3D+ParseableModifierValue.swift
+++ b/Sources/LiveViewNative/Stylesheets/ParseableTypes/EdgeInsets3D+ParseableModifierValue.swift
@@ -9,6 +9,23 @@
 import SwiftUI
 import LiveViewNativeStylesheet
 
+/// See [`SwiftUI.EdgeInsets3D`](https://developer.apple.com/documentation/swiftui/EdgeInsets3D) for more details.
+///
+/// Provide a `horizontal`, `vertical`, and/or `depth` value to construct 3D edge insets.
+///
+/// ```swift
+/// EdgeInsets3D(vertical: 5, depth: 1)
+/// EdgeInsets3D(horizontal: 2)
+/// EdgeInsets3D(horizontal: 1, vertical: 2, depth: 3)
+/// ```
+///
+/// Provide `top`, `leading`, `bottom`, `trailing`, `front`, and `back` values to construct 3D edge insets.
+///
+/// ```swift
+/// EdgeInsets3D(top: 1, front: 5)
+/// EdgeInsets3D(leading: 8, trailing: 8, front: 6, back: 6)
+/// ```
+@_documentation(visibility: public)
 extension EdgeInsets3D: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ParseableEdgeInsets3D.parser(in: context).map(\.value)
@@ -16,7 +33,7 @@ extension EdgeInsets3D: ParseableModifierValue {
     
     @ParseableExpression
     struct ParseableEdgeInsets3D {
-        static let name = "EdgeInsets"
+        static let name = "EdgeInsets3D"
         
         let value: EdgeInsets3D
         
@@ -52,6 +69,16 @@ extension EdgeInsets3D: ParseableModifierValue {
     }
 }
 
+/// See [`SwiftUI.Edge3D.Set`](https://developer.apple.com/documentation/swiftui/Edge3D/Set) for more details.
+///
+/// Possible values:
+/// - `.all`
+/// - `.horizontal`
+/// - `.vertical`
+/// - `.depth`
+/// - An ``SwiftUI/Edge3D`` value
+/// - An array of ``SwiftUI/Edge3D`` values
+@_documentation(visibility: public)
 extension Edge3D.Set: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         OneOf {

--- a/Sources/LiveViewNative/Stylesheets/ParseableTypes/EdgeInsets3D+ParseableModifierValue.swift
+++ b/Sources/LiveViewNative/Stylesheets/ParseableTypes/EdgeInsets3D+ParseableModifierValue.swift
@@ -1,0 +1,71 @@
+//
+//  EdgeInsets3D+ParseableModifierValue.swift
+//
+//
+//  Created by Carson Katri on 4/30/24.
+//
+
+#if os(visionOS)
+import SwiftUI
+import LiveViewNativeStylesheet
+
+extension EdgeInsets3D: ParseableModifierValue {
+    public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
+        ParseableEdgeInsets3D.parser(in: context).map(\.value)
+    }
+    
+    @ParseableExpression
+    struct ParseableEdgeInsets3D {
+        static let name = "EdgeInsets"
+        
+        let value: EdgeInsets3D
+        
+        init(
+            horizontal: CGFloat = 0,
+            vertical: CGFloat = 0,
+            depth: CGFloat = 0
+        ) {
+            self.value = .init(
+                horizontal: horizontal,
+                vertical: vertical,
+                depth: depth
+            )
+        }
+        
+        init(
+            top: CGFloat = 0,
+            leading: CGFloat = 0,
+            bottom: CGFloat = 0,
+            trailing: CGFloat = 0,
+            front: CGFloat = 0,
+            back: CGFloat = 0
+        ) {
+            self.value = .init(
+                top: top,
+                leading: leading,
+                bottom: bottom,
+                trailing: trailing,
+                front: front,
+                back: back
+            )
+        }
+    }
+}
+
+extension Edge3D.Set: ParseableModifierValue {
+    public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
+        OneOf {
+            Edge3D.parser(in: context).map({ Self.init($0) })
+            Array<Edge3D>.parser(in: context).map({
+                $0.reduce(into: Self()) { $0.insert(.init($1)) }
+            })
+            ImplicitStaticMember([
+                "all": .all,
+                "horizontal": .horizontal,
+                "vertical": .vertical,
+                "depth": .depth,
+            ])
+        }
+    }
+}
+#endif

--- a/Sources/LiveViewNative/Stylesheets/ParseableTypes/ListSectionSpacing+ParseableModifierValue.swift
+++ b/Sources/LiveViewNative/Stylesheets/ParseableTypes/ListSectionSpacing+ParseableModifierValue.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 import LiveViewNativeStylesheet
 
-#if os(iOS) || os(watchOS)
+#if os(iOS) || os(watchOS) || os(visionOS)
 /// See [`SwiftUI.ListSectionSpacing`](https://developer.apple.com/documentation/swiftui/ListSectionSpacing) for more details.
 ///
 /// Possible values:
@@ -22,7 +22,7 @@ import LiveViewNativeStylesheet
 /// .custom(8)
 /// ```
 @_documentation(visibility: public)
-@available(iOS 17.0, watchOS 10.0, *)
+@available(iOS 17.0, watchOS 10.0, visionOS 1, *)
 extension ListSectionSpacing: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {

--- a/Sources/LiveViewNative/Stylesheets/ParseableTypes/OrnamentAttachmentAnchor+ParseableModifierValue.swift
+++ b/Sources/LiveViewNative/Stylesheets/ParseableTypes/OrnamentAttachmentAnchor+ParseableModifierValue.swift
@@ -1,0 +1,38 @@
+//
+//  OrnamentAttachmentAnchor+ParseableModifierValue.swift
+//
+//
+//  Created by Carson Katri on 5/1/24.
+//
+
+import SwiftUI
+import LiveViewNativeStylesheet
+
+/// See [`SwiftUI.OrnamentAttachmentAnchor`](https://developer.apple.com/documentation/swiftui/OrnamentAttachmentAnchor) for more details.
+///
+/// Use `.scene(_:)` with a ``SwiftUI/UnitPoint`` to create an attachment anchor.
+///
+/// ```swift
+/// .scene(.leading)
+/// .scene(.bottomTrailing)
+/// ```
+@_documentation(visibility: public)
+@_documentation(visibility: public)
+extension OrnamentAttachmentAnchor: ParseableModifierValue {
+    public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
+        ImplicitStaticMember {
+            _Scene.parser(in: context).map(\.value)
+        }
+    }
+    
+    @ParseableExpression
+    struct _Scene {
+        static let name = "scene"
+        
+        let value: OrnamentAttachmentAnchor
+        
+        init(_ anchor: UnitPoint) {
+            self.value = .scene(anchor)
+        }
+    }
+}

--- a/Sources/LiveViewNative/Stylesheets/ParseableTypes/OrnamentAttachmentAnchor+ParseableModifierValue.swift
+++ b/Sources/LiveViewNative/Stylesheets/ParseableTypes/OrnamentAttachmentAnchor+ParseableModifierValue.swift
@@ -17,7 +17,6 @@ import LiveViewNativeStylesheet
 /// .scene(.bottomTrailing)
 /// ```
 @_documentation(visibility: public)
-@_documentation(visibility: public)
 extension OrnamentAttachmentAnchor: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {

--- a/Sources/LiveViewNative/Stylesheets/ParseableTypes/OrnamentAttachmentAnchor+ParseableModifierValue.swift
+++ b/Sources/LiveViewNative/Stylesheets/ParseableTypes/OrnamentAttachmentAnchor+ParseableModifierValue.swift
@@ -5,6 +5,7 @@
 //  Created by Carson Katri on 5/1/24.
 //
 
+#if os(visionOS)
 import SwiftUI
 import LiveViewNativeStylesheet
 
@@ -35,3 +36,4 @@ extension OrnamentAttachmentAnchor: ParseableModifierValue {
         }
     }
 }
+#endif

--- a/Sources/LiveViewNative/Stylesheets/ParseableTypes/ShapeStyles/AnyShapeStyle+ParseableModifierValue.swift
+++ b/Sources/LiveViewNative/Stylesheets/ParseableTypes/ShapeStyles/AnyShapeStyle+ParseableModifierValue.swift
@@ -183,9 +183,11 @@ extension AnyShapeStyle: ParseableModifierValue {
                 ConstantAtomLiteral("link").map({ LinkShapeStyle() as any ShapeStyle })
                 ConstantAtomLiteral("fill").map({ FillShapeStyle() as any ShapeStyle })
             }
+            #if !os(visionOS)
             if #available(iOS 17, macOS 14, tvOS 17, watchOS 10, *) {
                 ConstantAtomLiteral("windowBackground").map({ WindowBackgroundShapeStyle() as any ShapeStyle })
             }
+            #endif
             
             ImagePaint.parser(in: context).map({ $0 as any ShapeStyle })
             _image.parser(in: context).map(\.value)

--- a/Sources/LiveViewNative/Stylesheets/ParseableTypes/SurroundingsEffect+ParseableModifierValue.swift
+++ b/Sources/LiveViewNative/Stylesheets/ParseableTypes/SurroundingsEffect+ParseableModifierValue.swift
@@ -9,6 +9,11 @@
 import SwiftUI
 import LiveViewNativeStylesheet
 
+/// See [`SwiftUI.SurroundingsEffect`](https://developer.apple.com/documentation/swiftui/SurroundingsEffect) for more details.
+///
+/// Possible values:
+/// - `.systemDark`
+@_documentation(visibility: public)
 extension SurroundingsEffect: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember([

--- a/Sources/LiveViewNative/Stylesheets/ParseableTypes/SurroundingsEffect+ParseableModifierValue.swift
+++ b/Sources/LiveViewNative/Stylesheets/ParseableTypes/SurroundingsEffect+ParseableModifierValue.swift
@@ -1,0 +1,19 @@
+//
+//  SurroundingsEffect+ParseableModifierValue.swift
+//
+//
+//  Created by Carson Katri on 4/30/24.
+//
+
+#if os(visionOS)
+import SwiftUI
+import LiveViewNativeStylesheet
+
+extension SurroundingsEffect: ParseableModifierValue {
+    public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
+        ImplicitStaticMember([
+            "systemDark": .systemDark
+        ])
+    }
+}
+#endif

--- a/Sources/LiveViewNative/Stylesheets/ParseableTypes/UITextContentType+ParseableModifierValue.swift
+++ b/Sources/LiveViewNative/Stylesheets/ParseableTypes/UITextContentType+ParseableModifierValue.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 import LiveViewNativeStylesheet
 
-#if os(iOS) || os(tvOS)
+#if os(iOS) || os(tvOS) || os(visionOS)
 /// See [`UIKit.UITextContentType`](https://developer.apple.com/documentation/uikit/UITextContentType) for more details.
 ///
 /// Possible values:
@@ -40,7 +40,7 @@ import LiveViewNativeStylesheet
 /// - `newPassword`
 /// - `oneTimeCode`
 @_documentation(visibility: public)
-@available(iOS 13.0, tvOS 13.0, *)
+@available(iOS 13.0, tvOS 13.0, visionOS 1, *)
 extension UITextContentType: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember([

--- a/Sources/LiveViewNative/Stylesheets/ParseableTypes/UnitPoint3D.swift
+++ b/Sources/LiveViewNative/Stylesheets/ParseableTypes/UnitPoint3D.swift
@@ -9,6 +9,45 @@
 import SwiftUI
 import LiveViewNativeStylesheet
 
+/// See [`SwiftUI.UnitPoint3D`](https://developer.apple.com/documentation/swiftui/UnitPoint3D) for more details.
+///
+/// Possible values:
+/// - `.origin`
+/// - `.zero`
+/// - `.topLeadingBack`
+/// - `.topLeading`
+/// - `.topLeadingFront`
+/// - `.topBack`
+/// - `.top`
+/// - `.topFront`
+/// - `.topTrailingBack`
+/// - `.topTrailing`
+/// - `.topTrailingFront`
+/// - `.leadingBack`
+/// - `.leading`
+/// - `.leadingFront`
+/// - `.back`
+/// - `.center`
+/// - `.front`
+/// - `.trailingBack`
+/// - `.trailing`
+/// - `.trailingFront`
+/// - `.bottomLeadingBack`
+/// - `.bottomLeading`
+/// - `.bottomLeadingFront`
+/// - `.bottomBack`
+/// - `.bottom`
+/// - `.bottomFront`
+/// - `.bottomTrailingBack`
+/// - `.bottomTrailing`
+/// - `.bottomTrailingFront`
+///
+/// Provide an `x`, `y`, and `z` value to construct a custom 3D unit point:
+///
+/// ```swift
+/// UnitPoint3D(x: 0, y: 0.5, z: 1)
+/// ```
+@_documentation(visibility: public)
 extension UnitPoint3D: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         OneOf {

--- a/Sources/LiveViewNative/Stylesheets/ParseableTypes/UnitPoint3D.swift
+++ b/Sources/LiveViewNative/Stylesheets/ParseableTypes/UnitPoint3D.swift
@@ -1,0 +1,69 @@
+//
+//  File.swift
+//  
+//
+//  Created by Carson.Katri on 4/30/24.
+//
+
+#if os(visionOS)
+import SwiftUI
+import LiveViewNativeStylesheet
+
+extension UnitPoint3D: ParseableModifierValue {
+    public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
+        OneOf {
+            ParseableUnitPoint3D.parser(in: context).map({ Self.init(x: $0.x, y: $0.y, z: $0.z) })
+            
+            ImplicitStaticMember([
+                "origin": .origin,
+                "zero": .zero,
+                
+                "topLeadingBack": .topLeadingBack,
+                "topLeading": .topLeading,
+                "topLeadingFront": .topLeadingFront,
+                "topBack": .topBack,
+                "top": .top,
+                "topFront": .topFront,
+                "topTrailingBack": .topTrailingBack,
+                "topTrailing": .topTrailing,
+                "topTrailingFront": .topTrailingFront,
+                
+                "leadingBack": .leadingBack,
+                "leading": .leading,
+                "leadingFront": .leadingFront,
+                "back": .back,
+                "center": .center,
+                "front": .front,
+                "trailingBack": .trailingBack,
+                "trailing": .trailing,
+                "trailingFront": .trailingFront,
+                
+                "bottomLeadingBack": .bottomLeadingBack,
+                "bottomLeading": .bottomLeading,
+                "bottomLeadingFront": .bottomLeadingFront,
+                "bottomBack": .bottomBack,
+                "bottom": .bottom,
+                "bottomFront": .bottomFront,
+                "bottomTrailingBack": .bottomTrailingBack,
+                "bottomTrailing": .bottomTrailing,
+                "bottomTrailingFront": .bottomTrailingFront,
+            ])
+        }
+    }
+    
+    @ParseableExpression
+    struct ParseableUnitPoint3D {
+        static let name = "UnitPoint3D"
+        
+        let x: CGFloat
+        let y: CGFloat
+        let z: CGFloat
+        
+        init(x: CGFloat, y: CGFloat, z: CGFloat) {
+            self.x = x
+            self.y = y
+            self.z = z
+        }
+    }
+}
+#endif

--- a/Sources/LiveViewNative/Views/Controls and Indicators/Menus/Menu.swift
+++ b/Sources/LiveViewNative/Views/Controls and Indicators/Menus/Menu.swift
@@ -30,15 +30,16 @@ import SwiftUI
 /// * `label` - Describes the content of the menu.
 /// * `content` - Elements displayed when expanded.
 @_documentation(visibility: public)
-@available(iOS 16.0, macOS 13.0, tvOS 17.0, *)
 @LiveElement
 struct Menu<Root: RootRegistry>: View {
     public var body: some View {
-        #if !os(watchOS) && (!os(tvOS) || swift(>=5.9))
-        SwiftUI.Menu {
-            $liveElement.children(in: "content", default: true)
-        } label: {
-            $liveElement.children(in: "label")
+        #if !os(watchOS)
+        if #available(iOS 16.0, macOS 13.0, tvOS 17.0, *) {
+            SwiftUI.Menu {
+                $liveElement.children(in: "content", default: true)
+            } label: {
+                $liveElement.children(in: "label")
+            }
         }
         #endif
     }

--- a/Sources/LiveViewNative/Views/Drawing and Graphics/NamespaceContext.swift
+++ b/Sources/LiveViewNative/Views/Drawing and Graphics/NamespaceContext.swift
@@ -27,7 +27,7 @@ struct NamespaceContext<Root: RootRegistry>: View {
     @LiveElementIgnored
     @Environment(\.namespaces) private var namespaces
     
-    #if !os(iOS)
+    #if !os(iOS) && !os(visionOS)
     @LiveElementIgnored
     @Environment(\.resetFocus) private var resetFocus
     #endif
@@ -36,7 +36,7 @@ struct NamespaceContext<Root: RootRegistry>: View {
         if let id {
             $liveElement.children()
                 .environment(\.namespaces, namespaces.merging([id: namespace], uniquingKeysWith: { $1 }))
-                #if !os(iOS)
+                #if !os(iOS) && !os(visionOS)
                 .onReceive($liveElement.context.coordinator.receiveEvent("reset_focus")) { event in
                     guard let namespace = event["namespace"] as? String,
                           namespace == id

--- a/Sources/LiveViewNative/Views/Toolbars/ToolbarItem.swift
+++ b/Sources/LiveViewNative/Views/Toolbars/ToolbarItem.swift
@@ -158,6 +158,8 @@ enum ToolbarItemPlacement: String, AttributeDecodable {
     case topBarTrailing
     @_documentation(visibility: public)
     case bottomBar
+    @_documentation(visibility: public)
+    case bottomOrnament
     
     var placement: SwiftUI.ToolbarItemPlacement {
         switch self {
@@ -191,7 +193,7 @@ enum ToolbarItemPlacement: String, AttributeDecodable {
         case .cancellationAction: return .cancellationAction
         case .destructiveAction: return .destructiveAction
         case .keyboard:
-            #if os(watchOS) || os(tvOS)
+            #if os(watchOS) || os(tvOS) || os(visionOS)
             return .automatic
             #else
             return .keyboard
@@ -225,6 +227,12 @@ enum ToolbarItemPlacement: String, AttributeDecodable {
             } else {
                 return .automatic
             }
+            #endif
+        case .bottomOrnament:
+            #if os(visionOS)
+            return .bottomOrnament
+            #else
+            return .automatic
             #endif
         }
     }

--- a/Sources/LiveViewNative/_GeneratedModifiers.swift
+++ b/Sources/LiveViewNative/_GeneratedModifiers.swift
@@ -1,4 +1,4 @@
-// File generated with `swift run ModifierGenerator source "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/System/Library/Frameworks/SwiftUI.framework/Modules/SwiftUI.swiftmodule/arm64-apple-ios.swiftinterface" > Sources/LiveViewNative/_GeneratedModifiers.swift`
+// File generated with `swift run ModifierGenerator source "/Applications/Xcode.app/Contents/Developer/Platforms/XROS.platform/Developer/SDKs/XROS.sdk/System/Library/Frameworks/SwiftUI.framework/Modules/SwiftUI.swiftmodule/arm64-apple-xros.swiftinterface" > Sources/LiveViewNative/_GeneratedModifiers.swift`
 
 import SwiftUI
 import Symbols
@@ -893,16 +893,16 @@ struct _badgeModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(macOS)
+        #if os(iOS) || os(macOS) || os(visionOS)
         indirect case _0(count: Any)
         #endif
-        #if os(iOS) || os(macOS)
+        #if os(iOS) || os(macOS) || os(visionOS)
         indirect case _1(label: Any?)
         #endif
-        #if os(iOS) || os(macOS)
+        #if os(iOS) || os(macOS) || os(visionOS)
         indirect case _2(key: Any?)
         #endif
-        #if os(iOS) || os(macOS)
+        #if os(iOS) || os(macOS) || os(visionOS)
         indirect case _3(label: Any)
         #endif
     }
@@ -921,29 +921,29 @@ struct _badgeModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(macOS)
-    @available(macOS 12.0,iOS 15.0, *)
+    #if os(iOS) || os(macOS) || os(visionOS)
+    @available(macOS 12.0,visionOS 1.0,iOS 15.0, *)
     init(_ count: AttributeReference<Swift.Int>) {
         self.value = ._0(count: count)
         
     }
     #endif
-    #if os(iOS) || os(macOS)
-    @available(macOS 12.0,iOS 15.0, *)
+    #if os(iOS) || os(macOS) || os(visionOS)
+    @available(macOS 12.0,visionOS 1.0,iOS 15.0, *)
     init(_ label: TextReference?) {
         self.value = ._1(label: label)
         
     }
     #endif
-    #if os(iOS) || os(macOS)
-    @available(macOS 12.0,iOS 15.0, *)
+    #if os(iOS) || os(macOS) || os(visionOS)
+    @available(macOS 12.0,visionOS 1.0,iOS 15.0, *)
     init(_ key: SwiftUI.LocalizedStringKey?) {
         self.value = ._2(key: key)
         
     }
     #endif
-    #if os(iOS) || os(macOS)
-    @available(macOS 12.0,iOS 15.0, *)
+    #if os(iOS) || os(macOS) || os(visionOS)
+    @available(macOS 12.0,visionOS 1.0,iOS 15.0, *)
     init(_ label: AttributeReference<String>) {
         self.value = ._3(label: label)
         
@@ -954,33 +954,33 @@ struct _badgeModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(macOS)
+        #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(count):
-            if #available(macOS 12.0,iOS 15.0, *) {
+            if #available(macOS 12.0,visionOS 1.0,iOS 15.0, *) {
             let count = count as! AttributeReference<Swift.Int>
             __content
                 .badge(count.resolve(on: element, in: context))
             } else { __content }
         #endif
-        #if os(iOS) || os(macOS)
+        #if os(iOS) || os(macOS) || os(visionOS)
         case let ._1(label):
-            if #available(macOS 12.0,iOS 15.0, *) {
+            if #available(macOS 12.0,visionOS 1.0,iOS 15.0, *) {
             let label = label as? TextReference
             __content
                 .badge(label?.resolve(on: element, in: context))
             } else { __content }
         #endif
-        #if os(iOS) || os(macOS)
+        #if os(iOS) || os(macOS) || os(visionOS)
         case let ._2(key):
-            if #available(macOS 12.0,iOS 15.0, *) {
+            if #available(macOS 12.0,visionOS 1.0,iOS 15.0, *) {
             let key = key as? SwiftUI.LocalizedStringKey
             __content
                 .badge(key)
             } else { __content }
         #endif
-        #if os(iOS) || os(macOS)
+        #if os(iOS) || os(macOS) || os(visionOS)
         case let ._3(label):
-            if #available(macOS 12.0,iOS 15.0, *) {
+            if #available(macOS 12.0,visionOS 1.0,iOS 15.0, *) {
             let label = label as! AttributeReference<String>
             __content
                 .badge(label.resolve(on: element, in: context))
@@ -1632,10 +1632,10 @@ struct _containerRelativeFrameModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         indirect case _0(axes: Any,alignment: Any)
         #endif
-        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         indirect case _1(axes: Any,count: Any,span: Any, spacing: Any,alignment: Any)
         #endif
     }
@@ -1650,15 +1650,15 @@ struct _containerRelativeFrameModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-    @available(iOS 17.0,macOS 14.0,watchOS 10.0,tvOS 17.0, *)
+    #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+    @available(watchOS 10.0,visionOS 1.0,iOS 17.0,macOS 14.0,tvOS 17.0, *)
     init(_ axes: SwiftUI.Axis.Set,alignment: AttributeReference<SwiftUI.Alignment> = .init(storage: .constant(.center)) ) {
         self.value = ._0(axes: axes, alignment: alignment)
         
     }
     #endif
-    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-    @available(macOS 14.0,tvOS 17.0,iOS 17.0,watchOS 10.0, *)
+    #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+    @available(watchOS 10.0,visionOS 1.0,iOS 17.0,macOS 14.0,tvOS 17.0, *)
     init(_ axes: SwiftUI.Axis.Set,count: AttributeReference<Swift.Int>,span: AttributeReference<Swift.Int> = .init(storage: .constant(1)), spacing: AttributeReference<CoreFoundation.CGFloat>,alignment: AttributeReference<SwiftUI.Alignment> = .init(storage: .constant(.center)) ) {
         self.value = ._1(axes: axes, count: count, span: span, spacing: spacing, alignment: alignment)
         
@@ -1669,18 +1669,18 @@ struct _containerRelativeFrameModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(axes, alignment):
-            if #available(iOS 17.0,macOS 14.0,watchOS 10.0,tvOS 17.0, *) {
+            if #available(watchOS 10.0,visionOS 1.0,iOS 17.0,macOS 14.0,tvOS 17.0, *) {
             let axes = axes as! SwiftUI.Axis.Set
 let alignment = alignment as! AttributeReference<SwiftUI.Alignment>
             __content
                 .containerRelativeFrame(axes, alignment: alignment.resolve(on: element, in: context))
             } else { __content }
         #endif
-        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(axes, count, span, spacing, alignment):
-            if #available(macOS 14.0,tvOS 17.0,iOS 17.0,watchOS 10.0, *) {
+            if #available(watchOS 10.0,visionOS 1.0,iOS 17.0,macOS 14.0,tvOS 17.0, *) {
             let axes = axes as! SwiftUI.Axis.Set
 let count = count as! AttributeReference<Swift.Int>
 let span = span as! AttributeReference<Swift.Int>
@@ -1849,10 +1849,10 @@ struct _contextMenuModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(macOS) || os(tvOS)
-        indirect case _0(menuItems: Any)
-        #endif
-        #if os(iOS) || os(macOS) || os(tvOS)
+        
+        indirect case _0(menuItems: ViewReference=ViewReference(value: []))
+        
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS)
         indirect case _1(menuItems: Any,preview: Any)
         #endif
     }
@@ -1867,15 +1867,15 @@ struct _contextMenuModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(macOS) || os(tvOS)
-    @available(macOS 10.15,iOS 13.0,tvOS 14.0, *)
+    
+    
     init(menuItems: ViewReference=ViewReference(value: [])) {
         self.value = ._0(menuItems: menuItems)
         
     }
-    #endif
-    #if os(iOS) || os(macOS) || os(tvOS)
-    @available(macOS 13.0,tvOS 16.0,iOS 16.0, *)
+    
+    #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS)
+    @available(iOS 16.0,tvOS 16.0,visionOS 1.0,macOS 13.0, *)
     init(menuItems: ViewReference=ViewReference(value: []),preview: ViewReference=ViewReference(value: [])) {
         self.value = ._1(menuItems: menuItems, preview: preview)
         
@@ -1886,17 +1886,17 @@ struct _contextMenuModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(macOS) || os(tvOS)
+        
         case let ._0(menuItems):
-            if #available(macOS 10.15,iOS 13.0,tvOS 14.0, *) {
-            let menuItems = menuItems as! ViewReference
+            
+            
             __content
                 .contextMenu(menuItems: { menuItems.resolve(on: element, in: context) })
-            } else { __content }
-        #endif
-        #if os(iOS) || os(macOS) || os(tvOS)
+            
+        
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS)
         case let ._1(menuItems, preview):
-            if #available(macOS 13.0,tvOS 16.0,iOS 16.0, *) {
+            if #available(iOS 16.0,tvOS 16.0,visionOS 1.0,macOS 13.0, *) {
             let menuItems = menuItems as! ViewReference
 let preview = preview as! ViewReference
             __content
@@ -1956,7 +1956,7 @@ struct _controlGroupStyleModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(macOS) || os(tvOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS)
         indirect case _0(style: Any)
         #endif
     }
@@ -1969,8 +1969,8 @@ struct _controlGroupStyleModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(macOS) || os(tvOS)
-    @available(macOS 12.0,tvOS 17.0,iOS 15.0, *)
+    #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS)
+    @available(iOS 15.0,macOS 12.0,tvOS 17.0,visionOS 1.0, *)
     init(_ style: AnyControlGroupStyle) {
         self.value = ._0(style: style)
         
@@ -1981,9 +1981,9 @@ struct _controlGroupStyleModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(macOS) || os(tvOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS)
         case let ._0(style):
-            if #available(macOS 12.0,tvOS 17.0,iOS 15.0, *) {
+            if #available(iOS 15.0,macOS 12.0,tvOS 17.0,visionOS 1.0, *) {
             let style = style as! AnyControlGroupStyle
             __content
                 .controlGroupStyle(style)
@@ -1999,7 +1999,7 @@ struct _controlSizeModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(macOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
         indirect case _0(controlSize: Any)
         #endif
     }
@@ -2012,8 +2012,8 @@ struct _controlSizeModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(macOS) || os(watchOS)
-    @available(macOS 10.15,watchOS 9.0,iOS 15.0, *)
+    #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
+    @available(iOS 15.0,macOS 10.15,visionOS 1.0,watchOS 9.0, *)
     init(_ controlSize: SwiftUI.ControlSize) {
         self.value = ._0(controlSize: controlSize)
         
@@ -2024,9 +2024,9 @@ struct _controlSizeModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(macOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
         case let ._0(controlSize):
-            if #available(macOS 10.15,watchOS 9.0,iOS 15.0, *) {
+            if #available(iOS 15.0,macOS 10.15,visionOS 1.0,watchOS 9.0, *) {
             let controlSize = controlSize as! SwiftUI.ControlSize
             __content
                 .controlSize(controlSize)
@@ -2042,7 +2042,7 @@ struct _coordinateSpaceModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         indirect case _0(name: Any)
         #endif
     }
@@ -2055,8 +2055,8 @@ struct _coordinateSpaceModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-    @available(tvOS 17.0,macOS 14.0,watchOS 10.0,iOS 17.0, *)
+    #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+    @available(visionOS 1.0,tvOS 17.0,macOS 14.0,watchOS 10.0,iOS 17.0, *)
     init(_ name: SwiftUI.NamedCoordinateSpace) {
         self.value = ._0(name: name)
         
@@ -2067,9 +2067,9 @@ struct _coordinateSpaceModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(name):
-            if #available(tvOS 17.0,macOS 14.0,watchOS 10.0,iOS 17.0, *) {
+            if #available(visionOS 1.0,tvOS 17.0,macOS 14.0,watchOS 10.0,iOS 17.0, *) {
             let name = name as! SwiftUI.NamedCoordinateSpace
             __content
                 .coordinateSpace(name)
@@ -2085,7 +2085,7 @@ struct _datePickerStyleModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(macOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
         indirect case _0(style: Any)
         #endif
     }
@@ -2098,8 +2098,8 @@ struct _datePickerStyleModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(macOS) || os(watchOS)
-    @available(macOS 10.15,iOS 13.0,watchOS 10.0, *)
+    #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
+    @available(iOS 13.0,macOS 10.15,watchOS 10.0,visionOS 1.0, *)
     init(_ style: AnyDatePickerStyle) {
         self.value = ._0(style: style)
         
@@ -2110,9 +2110,9 @@ struct _datePickerStyleModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(macOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
         case let ._0(style):
-            if #available(macOS 10.15,iOS 13.0,watchOS 10.0, *) {
+            if #available(iOS 13.0,macOS 10.15,watchOS 10.0,visionOS 1.0, *) {
             let style = style as! AnyDatePickerStyle
             __content
                 .datePickerStyle(style)
@@ -2128,7 +2128,7 @@ struct _defaultScrollAnchorModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         indirect case _0(anchor: Any?)
         #endif
     }
@@ -2141,8 +2141,8 @@ struct _defaultScrollAnchorModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-    @available(watchOS 10.0,iOS 17.0,macOS 14.0,tvOS 17.0, *)
+    #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+    @available(macOS 14.0,watchOS 10.0,tvOS 17.0,visionOS 1.0,iOS 17.0, *)
     init(_ anchor: AttributeReference<SwiftUI.UnitPoint?>?) {
         self.value = ._0(anchor: anchor)
         
@@ -2153,9 +2153,9 @@ struct _defaultScrollAnchorModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(anchor):
-            if #available(watchOS 10.0,iOS 17.0,macOS 14.0,tvOS 17.0, *) {
+            if #available(macOS 14.0,watchOS 10.0,tvOS 17.0,visionOS 1.0,iOS 17.0, *) {
             let anchor = anchor as? AttributeReference<SwiftUI.UnitPoint?>
             __content
                 .defaultScrollAnchor(anchor?.resolve(on: element, in: context))
@@ -2171,7 +2171,7 @@ struct _defaultWheelPickerItemHeightModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(watchOS)
+        #if os(visionOS) || os(watchOS)
         indirect case _0(height: Any)
         #endif
     }
@@ -2184,8 +2184,8 @@ struct _defaultWheelPickerItemHeightModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(watchOS)
-    @available(watchOS 6.0, *)
+    #if os(visionOS) || os(watchOS)
+    @available(visionOS 1.0,watchOS 6.0, *)
     init(_ height: AttributeReference<CoreFoundation.CGFloat>) {
         self.value = ._0(height: height)
         
@@ -2196,9 +2196,9 @@ struct _defaultWheelPickerItemHeightModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(watchOS)
+        #if os(visionOS) || os(watchOS)
         case let ._0(height):
-            if #available(watchOS 6.0, *) {
+            if #available(visionOS 1.0,watchOS 6.0, *) {
             let height = height as! AttributeReference<CoreFoundation.CGFloat>
             __content
                 .defaultWheelPickerItemHeight(height.resolve(on: element, in: context))
@@ -2300,16 +2300,16 @@ struct _dialogSuppressionToggleModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         indirect case _0(titleKey: Any)
         #endif
-        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         indirect case _1(title: Any)
         #endif
-        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         indirect case _2(label: Any)
         #endif
-        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
          case _3
         #endif
     }
@@ -2328,29 +2328,29 @@ struct _dialogSuppressionToggleModifier<R: RootRegistry>: ViewModifier {
 @ChangeTracked private var _3_isSuppressed: Swift.Bool
 
 
-    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-    @available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0, *)
+    #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+    @available(watchOS 10.0,visionOS 1.0,tvOS 17.0,iOS 17.0,macOS 14.0, *)
     init(_ titleKey: SwiftUI.LocalizedStringKey,isSuppressed: ChangeTracked<Swift.Bool>) {
         self.value = ._0(titleKey: titleKey)
         self.__0_isSuppressed = isSuppressed
     }
     #endif
-    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-    @available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0, *)
+    #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+    @available(watchOS 10.0,visionOS 1.0,tvOS 17.0,iOS 17.0,macOS 14.0, *)
     init(_ title: AttributeReference<String>,isSuppressed: ChangeTracked<Swift.Bool>) {
         self.value = ._1(title: title)
         self.__1_isSuppressed = isSuppressed
     }
     #endif
-    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-    @available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0, *)
+    #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+    @available(watchOS 10.0,visionOS 1.0,tvOS 17.0,iOS 17.0,macOS 14.0, *)
     init(_ label: TextReference,isSuppressed: ChangeTracked<Swift.Bool>) {
         self.value = ._2(label: label)
         self.__2_isSuppressed = isSuppressed
     }
     #endif
-    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-    @available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0, *)
+    #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+    @available(watchOS 10.0,visionOS 1.0,tvOS 17.0,iOS 17.0,macOS 14.0, *)
     init(isSuppressed: ChangeTracked<Swift.Bool>) {
         self.value = ._3
         self.__3_isSuppressed = isSuppressed
@@ -2361,33 +2361,33 @@ struct _dialogSuppressionToggleModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(titleKey):
-            if #available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0, *) {
+            if #available(watchOS 10.0,visionOS 1.0,tvOS 17.0,iOS 17.0,macOS 14.0, *) {
             let titleKey = titleKey as! SwiftUI.LocalizedStringKey
             __content
                 .dialogSuppressionToggle(titleKey, isSuppressed: __0_isSuppressed.projectedValue)
             } else { __content }
         #endif
-        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(title):
-            if #available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0, *) {
+            if #available(watchOS 10.0,visionOS 1.0,tvOS 17.0,iOS 17.0,macOS 14.0, *) {
             let title = title as! AttributeReference<String>
             __content
                 .dialogSuppressionToggle(title.resolve(on: element, in: context), isSuppressed: __1_isSuppressed.projectedValue)
             } else { __content }
         #endif
-        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._2(label):
-            if #available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0, *) {
+            if #available(watchOS 10.0,visionOS 1.0,tvOS 17.0,iOS 17.0,macOS 14.0, *) {
             let label = label as! TextReference
             __content
                 .dialogSuppressionToggle(label.resolve(on: element, in: context), isSuppressed: __2_isSuppressed.projectedValue)
             } else { __content }
         #endif
-        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case ._3:
-            if #available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0, *) {
+            if #available(watchOS 10.0,visionOS 1.0,tvOS 17.0,iOS 17.0,macOS 14.0, *) {
             
             __content
                 .dialogSuppressionToggle(isSuppressed: __3_isSuppressed.projectedValue)
@@ -2615,7 +2615,7 @@ struct _fileDialogCustomizationIDModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(macOS)
+        #if os(iOS) || os(macOS) || os(visionOS)
         indirect case _0(id: Any)
         #endif
     }
@@ -2628,8 +2628,8 @@ struct _fileDialogCustomizationIDModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(macOS)
-    @available(macOS 14.0,iOS 17.0, *)
+    #if os(iOS) || os(macOS) || os(visionOS)
+    @available(visionOS 1.0,iOS 17.0,macOS 14.0, *)
     init(_ id: AttributeReference<Swift.String>) {
         self.value = ._0(id: id)
         
@@ -2640,9 +2640,9 @@ struct _fileDialogCustomizationIDModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(macOS)
+        #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(id):
-            if #available(macOS 14.0,iOS 17.0, *) {
+            if #available(visionOS 1.0,iOS 17.0,macOS 14.0, *) {
             let id = id as! AttributeReference<Swift.String>
             __content
                 .fileDialogCustomizationID(id.resolve(on: element, in: context))
@@ -2658,7 +2658,7 @@ struct _fileDialogImportsUnresolvedAliasesModifier<R: RootRegistry>: ViewModifie
 
     enum Value {
         case _never
-        #if os(iOS) || os(macOS)
+        #if os(iOS) || os(macOS) || os(visionOS)
         indirect case _0(imports: Any)
         #endif
     }
@@ -2671,8 +2671,8 @@ struct _fileDialogImportsUnresolvedAliasesModifier<R: RootRegistry>: ViewModifie
 
 
 
-    #if os(iOS) || os(macOS)
-    @available(macOS 14.0,iOS 17.0, *)
+    #if os(iOS) || os(macOS) || os(visionOS)
+    @available(visionOS 1.0,iOS 17.0,macOS 14.0, *)
     init(_ imports: AttributeReference<Swift.Bool>) {
         self.value = ._0(imports: imports)
         
@@ -2683,9 +2683,9 @@ struct _fileDialogImportsUnresolvedAliasesModifier<R: RootRegistry>: ViewModifie
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(macOS)
+        #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(imports):
-            if #available(macOS 14.0,iOS 17.0, *) {
+            if #available(visionOS 1.0,iOS 17.0,macOS 14.0, *) {
             let imports = imports as! AttributeReference<Swift.Bool>
             __content
                 .fileDialogImportsUnresolvedAliases(imports.resolve(on: element, in: context))
@@ -2701,7 +2701,7 @@ struct _findDisabledModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS)
+        #if os(iOS) || os(visionOS)
         indirect case _0(isDisabled: Any)
         #endif
     }
@@ -2714,8 +2714,8 @@ struct _findDisabledModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS)
-    @available(iOS 16.0, *)
+    #if os(iOS) || os(visionOS)
+    @available(visionOS 1.0,iOS 16.0, *)
     init(_ isDisabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(isDisabled: isDisabled)
         
@@ -2726,9 +2726,9 @@ struct _findDisabledModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS)
+        #if os(iOS) || os(visionOS)
         case let ._0(isDisabled):
-            if #available(iOS 16.0, *) {
+            if #available(visionOS 1.0,iOS 16.0, *) {
             let isDisabled = isDisabled as! AttributeReference<Swift.Bool>
             __content
                 .findDisabled(isDisabled.resolve(on: element, in: context))
@@ -2744,7 +2744,7 @@ struct _findNavigatorModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS)
+        #if os(iOS) || os(visionOS)
          case _0
         #endif
     }
@@ -2757,8 +2757,8 @@ struct _findNavigatorModifier<R: RootRegistry>: ViewModifier {
 @ChangeTracked private var _0_isPresented: Swift.Bool
 
 
-    #if os(iOS)
-    @available(iOS 16.0, *)
+    #if os(iOS) || os(visionOS)
+    @available(visionOS 1.0,iOS 16.0, *)
     init(isPresented: ChangeTracked<Swift.Bool>) {
         self.value = ._0
         self.__0_isPresented = isPresented
@@ -2769,9 +2769,9 @@ struct _findNavigatorModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS)
+        #if os(iOS) || os(visionOS)
         case ._0:
-            if #available(iOS 16.0, *) {
+            if #available(visionOS 1.0,iOS 16.0, *) {
             
             __content
                 .findNavigator(isPresented: __0_isPresented.projectedValue)
@@ -2893,7 +2893,7 @@ struct _focusEffectDisabledModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         indirect case _0(disabled: Any)
         #endif
     }
@@ -2906,8 +2906,8 @@ struct _focusEffectDisabledModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-    @available(tvOS 17.0,iOS 17.0,watchOS 10.0,macOS 14.0, *)
+    #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+    @available(iOS 17.0,macOS 14.0,tvOS 17.0,watchOS 10.0,visionOS 1.0, *)
     init(_ disabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(disabled: disabled)
         
@@ -2918,9 +2918,9 @@ struct _focusEffectDisabledModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(disabled):
-            if #available(tvOS 17.0,iOS 17.0,watchOS 10.0,macOS 14.0, *) {
+            if #available(iOS 17.0,macOS 14.0,tvOS 17.0,watchOS 10.0,visionOS 1.0, *) {
             let disabled = disabled as! AttributeReference<Swift.Bool>
             __content
                 .focusEffectDisabled(disabled.resolve(on: element, in: context))
@@ -2950,7 +2950,7 @@ struct _focusSectionModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(macOS) || os(tvOS)
-    @available(macOS 13.0,tvOS 15.0, *)
+    @available(tvOS 15.0,macOS 13.0, *)
     init() {
         self.value = ._0
         
@@ -2963,7 +2963,7 @@ struct _focusSectionModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(macOS) || os(tvOS)
         case ._0:
-            if #available(macOS 13.0,tvOS 15.0, *) {
+            if #available(tvOS 15.0,macOS 13.0, *) {
             
             __content
                 .focusSection()
@@ -2979,10 +2979,10 @@ struct _focusableModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         indirect case _0(isFocusable: Any)
         #endif
-        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         indirect case _1(isFocusable: Any, interactions: Any)
         #endif
     }
@@ -2997,15 +2997,15 @@ struct _focusableModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-    @available(iOS 17.0,watchOS 8.0,macOS 12.0,tvOS 15.0, *)
+    #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+    @available(iOS 17.0,macOS 12.0,tvOS 15.0,watchOS 8.0,visionOS 1.0, *)
     init(_ isFocusable: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(isFocusable: isFocusable)
         
     }
     #endif
-    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-    @available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0, *)
+    #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+    @available(iOS 17.0,macOS 14.0,tvOS 17.0,watchOS 10.0,visionOS 1.0, *)
     init(_ isFocusable: AttributeReference<Swift.Bool> = .init(storage: .constant(true)), interactions: SwiftUI.FocusInteractions) {
         self.value = ._1(isFocusable: isFocusable, interactions: interactions)
         
@@ -3016,17 +3016,17 @@ struct _focusableModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(isFocusable):
-            if #available(iOS 17.0,watchOS 8.0,macOS 12.0,tvOS 15.0, *) {
+            if #available(iOS 17.0,macOS 12.0,tvOS 15.0,watchOS 8.0,visionOS 1.0, *) {
             let isFocusable = isFocusable as! AttributeReference<Swift.Bool>
             __content
                 .focusable(isFocusable.resolve(on: element, in: context))
             } else { __content }
         #endif
-        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(isFocusable, interactions):
-            if #available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0, *) {
+            if #available(iOS 17.0,macOS 14.0,tvOS 17.0,watchOS 10.0,visionOS 1.0, *) {
             let isFocusable = isFocusable as! AttributeReference<Swift.Bool>
 let interactions = interactions as! SwiftUI.FocusInteractions
             __content
@@ -3086,14 +3086,20 @@ struct _frameModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
+        #if os(visionOS)
+        indirect case _0(depth: Any?,alignment: Any)
+        #endif
+        #if os(visionOS)
+        indirect case _1(minDepth: Any?, idealDepth: Any?, maxDepth: Any?, alignment: Any)
+        #endif
         
-        indirect case _0(width: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), height: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), alignment: AttributeReference<SwiftUI.Alignment> = .init(storage: .constant(.center)) )
+        indirect case _2(width: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), height: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), alignment: AttributeReference<SwiftUI.Alignment> = .init(storage: .constant(.center)) )
         
         
-         case _1
+         case _3
         
         
-        indirect case _2(minWidth: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), idealWidth: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), maxWidth: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), minHeight: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), idealHeight: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), maxHeight: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), alignment: AttributeReference<SwiftUI.Alignment> = .init(storage: .constant(.center)) )
+        indirect case _4(minWidth: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), idealWidth: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), maxWidth: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), minHeight: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), idealHeight: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), maxHeight: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), alignment: AttributeReference<SwiftUI.Alignment> = .init(storage: .constant(.center)) )
         
     }
 
@@ -3109,24 +3115,42 @@ struct _frameModifier<R: RootRegistry>: ViewModifier {
 
 
 
+
+
+
+
+    #if os(visionOS)
+    @available(visionOS 1.0, *)
+    init(depth: AttributeReference<CoreFoundation.CGFloat?>?,alignment: SwiftUI.DepthAlignment = .center ) {
+        self.value = ._0(depth: depth, alignment: alignment)
+        
+    }
+    #endif
+    #if os(visionOS)
+    @available(visionOS 1.0, *)
+    init(minDepth: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), idealDepth: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), maxDepth: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), alignment: SwiftUI.DepthAlignment = .center ) {
+        self.value = ._1(minDepth: minDepth, idealDepth: idealDepth, maxDepth: maxDepth, alignment: alignment)
+        
+    }
+    #endif
     
     
     init(width: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), height: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), alignment: AttributeReference<SwiftUI.Alignment> = .init(storage: .constant(.center)) ) {
-        self.value = ._0(width: width, height: height, alignment: alignment)
+        self.value = ._2(width: width, height: height, alignment: alignment)
         
     }
     
     
     
     init() {
-        self.value = ._1
+        self.value = ._3
         
     }
     
     
     
     init(minWidth: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), idealWidth: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), maxWidth: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), minHeight: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), idealHeight: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), maxHeight: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), alignment: AttributeReference<SwiftUI.Alignment> = .init(storage: .constant(.center)) ) {
-        self.value = ._2(minWidth: minWidth, idealWidth: idealWidth, maxWidth: maxWidth, minHeight: minHeight, idealHeight: idealHeight, maxHeight: maxHeight, alignment: alignment)
+        self.value = ._4(minWidth: minWidth, idealWidth: idealWidth, maxWidth: maxWidth, minHeight: minHeight, idealHeight: idealHeight, maxHeight: maxHeight, alignment: alignment)
         
     }
     
@@ -3135,8 +3159,28 @@ struct _frameModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
+        #if os(visionOS)
+        case let ._0(depth, alignment):
+            if #available(visionOS 1.0, *) {
+            let depth = depth as? AttributeReference<CoreFoundation.CGFloat?>
+let alignment = alignment as! SwiftUI.DepthAlignment 
+            __content
+                .frame(depth: depth?.resolve(on: element, in: context), alignment: alignment)
+            } else { __content }
+        #endif
+        #if os(visionOS)
+        case let ._1(minDepth, idealDepth, maxDepth, alignment):
+            if #available(visionOS 1.0, *) {
+            let minDepth = minDepth as? AttributeReference<CoreFoundation.CGFloat?>
+let idealDepth = idealDepth as? AttributeReference<CoreFoundation.CGFloat?>
+let maxDepth = maxDepth as? AttributeReference<CoreFoundation.CGFloat?>
+let alignment = alignment as! SwiftUI.DepthAlignment 
+            __content
+                .frame(minDepth: minDepth?.resolve(on: element, in: context), idealDepth: idealDepth?.resolve(on: element, in: context), maxDepth: maxDepth?.resolve(on: element, in: context), alignment: alignment)
+            } else { __content }
+        #endif
         
-        case let ._0(width, height, alignment):
+        case let ._2(width, height, alignment):
             
             
             __content
@@ -3144,7 +3188,7 @@ struct _frameModifier<R: RootRegistry>: ViewModifier {
             
         
         
-        case ._1:
+        case ._3:
             
             
             __content
@@ -3152,7 +3196,7 @@ struct _frameModifier<R: RootRegistry>: ViewModifier {
             
         
         
-        case let ._2(minWidth, idealWidth, maxWidth, minHeight, idealHeight, maxHeight, alignment):
+        case let ._4(minWidth, idealWidth, maxWidth, minHeight, idealHeight, maxHeight, alignment):
             
             
             __content
@@ -3169,7 +3213,7 @@ struct _fullScreenCoverModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
         indirect case _0(content: Any)
         #endif
     }
@@ -3182,8 +3226,8 @@ struct _fullScreenCoverModifier<R: RootRegistry>: ViewModifier {
 @ChangeTracked private var _0_isPresented: Swift.Bool
 @Event private var _0_onDismiss__0: Event.EventHandler
 
-    #if os(iOS) || os(tvOS) || os(watchOS)
-    @available(iOS 14.0,watchOS 7.0,tvOS 14.0, *)
+    #if os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
+    @available(iOS 14.0,watchOS 7.0,tvOS 14.0,visionOS 1.0, *)
     init(isPresented: ChangeTracked<Swift.Bool>,onDismiss onDismiss__0: Event=Event(), content: ViewReference=ViewReference(value: [])) {
         self.value = ._0(content: content)
         self.__0_isPresented = isPresented
@@ -3195,9 +3239,9 @@ self.__0_onDismiss__0 = onDismiss__0
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(content):
-            if #available(iOS 14.0,watchOS 7.0,tvOS 14.0, *) {
+            if #available(iOS 14.0,watchOS 7.0,tvOS 14.0,visionOS 1.0, *) {
             let content = content as! ViewReference
             __content
                 .fullScreenCover(isPresented: __0_isPresented.projectedValue, onDismiss: { __0_onDismiss__0.wrappedValue() }, content: { content.resolve(on: element, in: context) })
@@ -3213,7 +3257,7 @@ struct _gaugeStyleModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(macOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
         indirect case _0(style: Any)
         #endif
     }
@@ -3226,8 +3270,8 @@ struct _gaugeStyleModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(macOS) || os(watchOS)
-    @available(macOS 13.0,iOS 16.0,watchOS 7.0, *)
+    #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
+    @available(iOS 16.0,macOS 13.0,visionOS 1.0,watchOS 7.0, *)
     init(_ style: AnyGaugeStyle) {
         self.value = ._0(style: style)
         
@@ -3238,9 +3282,9 @@ struct _gaugeStyleModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(macOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
         case let ._0(style):
-            if #available(macOS 13.0,iOS 16.0,watchOS 7.0, *) {
+            if #available(iOS 16.0,macOS 13.0,visionOS 1.0,watchOS 7.0, *) {
             let style = style as! AnyGaugeStyle
             __content
                 .gaugeStyle(style)
@@ -3256,7 +3300,7 @@ struct _geometryGroupModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
          case _0
         #endif
     }
@@ -3269,8 +3313,8 @@ struct _geometryGroupModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-    @available(iOS 17.0,macOS 14.0,tvOS 17.0,watchOS 10.0, *)
+    #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+    @available(iOS 17.0,tvOS 17.0,watchOS 10.0,visionOS 1.0,macOS 14.0, *)
     init() {
         self.value = ._0
         
@@ -3281,9 +3325,9 @@ struct _geometryGroupModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case ._0:
-            if #available(iOS 17.0,macOS 14.0,tvOS 17.0,watchOS 10.0, *) {
+            if #available(iOS 17.0,tvOS 17.0,watchOS 10.0,visionOS 1.0,macOS 14.0, *) {
             
             __content
                 .geometryGroup()
@@ -3332,6 +3376,70 @@ struct _gestureModifier<R: RootRegistry>: ViewModifier {
                 .gesture(gesture, including: mask)
             
         
+        }
+    }
+}
+@_documentation(visibility: public)
+@ParseableExpression
+struct _glassBackgroundEffectModifier<R: RootRegistry>: ViewModifier {
+    static var name: String { "glassBackgroundEffect" }
+
+    enum Value {
+        case _never
+        #if os(visionOS)
+        indirect case _0(displayMode: Any)
+        #endif
+        #if os(visionOS)
+        indirect case _1(shape: Any,displayMode: Any)
+        #endif
+    }
+
+    let value: Value
+
+    
+    
+
+
+
+
+
+
+    #if os(visionOS)
+    @available(visionOS 1.0, *)
+    init(displayMode: SwiftUI.GlassBackgroundDisplayMode = .always ) {
+        self.value = ._0(displayMode: displayMode)
+        
+    }
+    #endif
+    #if os(visionOS)
+    @available(visionOS 1.0, *)
+    init(in shape: AnyInsettableShape,displayMode: SwiftUI.GlassBackgroundDisplayMode = .always ) {
+        self.value = ._1(shape: shape, displayMode: displayMode)
+        
+    }
+    #endif
+
+    func body(content __content: Content) -> some View {
+        switch value {
+        case ._never:
+            fatalError("unreachable")
+        #if os(visionOS)
+        case let ._0(displayMode):
+            if #available(visionOS 1.0, *) {
+            let displayMode = displayMode as! SwiftUI.GlassBackgroundDisplayMode 
+            __content
+                .glassBackgroundEffect(displayMode: displayMode)
+            } else { __content }
+        #endif
+        #if os(visionOS)
+        case let ._1(shape, displayMode):
+            if #available(visionOS 1.0, *) {
+            let shape = shape as! AnyInsettableShape
+let displayMode = displayMode as! SwiftUI.GlassBackgroundDisplayMode 
+            __content
+                .glassBackgroundEffect(in: shape, displayMode: displayMode)
+            } else { __content }
+        #endif
         }
     }
 }
@@ -3557,7 +3665,7 @@ struct _groupBoxStyleModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(macOS)
+        #if os(iOS) || os(macOS) || os(visionOS)
         indirect case _0(style: Any)
         #endif
     }
@@ -3570,8 +3678,8 @@ struct _groupBoxStyleModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(macOS)
-    @available(macOS 11.0,iOS 14.0, *)
+    #if os(iOS) || os(macOS) || os(visionOS)
+    @available(macOS 11.0,visionOS 1.0,iOS 14.0, *)
     init(_ style: AnyGroupBoxStyle) {
         self.value = ._0(style: style)
         
@@ -3582,9 +3690,9 @@ struct _groupBoxStyleModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(macOS)
+        #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(style):
-            if #available(macOS 11.0,iOS 14.0, *) {
+            if #available(macOS 11.0,visionOS 1.0,iOS 14.0, *) {
             let style = style as! AnyGroupBoxStyle
             __content
                 .groupBoxStyle(style)
@@ -3874,14 +3982,14 @@ struct _hoverEffectModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(tvOS) || os(visionOS)
-    @available(visionOS 1.0,tvOS 16.0,iOS 13.4, *)
+    @available(visionOS 1.0,iOS 13.4,tvOS 16.0, *)
     init(_ effect: SwiftUI.HoverEffect = .automatic ) {
         self.value = ._0(effect: effect)
         
     }
     #endif
     #if os(iOS) || os(tvOS) || os(visionOS)
-    @available(tvOS 17.0,visionOS 1.0,iOS 17.0, *)
+    @available(visionOS 1.0,iOS 17.0,tvOS 17.0, *)
     init(_ effect: SwiftUI.HoverEffect = .automatic, isEnabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._1(effect: effect, isEnabled: isEnabled)
         
@@ -3894,7 +4002,7 @@ struct _hoverEffectModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(tvOS) || os(visionOS)
         case let ._0(effect):
-            if #available(visionOS 1.0,tvOS 16.0,iOS 13.4, *) {
+            if #available(visionOS 1.0,iOS 13.4,tvOS 16.0, *) {
             let effect = effect as! SwiftUI.HoverEffect 
             __content
                 .hoverEffect(effect)
@@ -3902,7 +4010,7 @@ struct _hoverEffectModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(tvOS) || os(visionOS)
         case let ._1(effect, isEnabled):
-            if #available(tvOS 17.0,visionOS 1.0,iOS 17.0, *) {
+            if #available(visionOS 1.0,iOS 17.0,tvOS 17.0, *) {
             let effect = effect as! SwiftUI.HoverEffect 
 let isEnabled = isEnabled as! AttributeReference<Swift.Bool>
             __content
@@ -3933,7 +4041,7 @@ struct _hoverEffectDisabledModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(tvOS) || os(visionOS)
-    @available(visionOS 1.0,tvOS 17.0,iOS 17.0, *)
+    @available(visionOS 1.0,iOS 17.0,tvOS 17.0, *)
     init(_ disabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(disabled: disabled)
         
@@ -3946,7 +4054,7 @@ struct _hoverEffectDisabledModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(tvOS) || os(visionOS)
         case let ._0(disabled):
-            if #available(visionOS 1.0,tvOS 17.0,iOS 17.0, *) {
+            if #available(visionOS 1.0,iOS 17.0,tvOS 17.0, *) {
             let disabled = disabled as! AttributeReference<Swift.Bool>
             __content
                 .hoverEffectDisabled(disabled.resolve(on: element, in: context))
@@ -4091,7 +4199,7 @@ struct _indexViewStyleModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
         indirect case _0(style: Any)
         #endif
     }
@@ -4104,8 +4212,8 @@ struct _indexViewStyleModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(tvOS) || os(watchOS)
-    @available(watchOS 8.0,tvOS 14.0,iOS 14.0, *)
+    #if os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
+    @available(watchOS 8.0,visionOS 1.0,iOS 14.0,tvOS 14.0, *)
     init(_ style: AnyIndexViewStyle) {
         self.value = ._0(style: style)
         
@@ -4116,9 +4224,9 @@ struct _indexViewStyleModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(style):
-            if #available(watchOS 8.0,tvOS 14.0,iOS 14.0, *) {
+            if #available(watchOS 8.0,visionOS 1.0,iOS 14.0,tvOS 14.0, *) {
             let style = style as! AnyIndexViewStyle
             __content
                 .indexViewStyle(style)
@@ -4148,7 +4256,7 @@ struct _inspectorModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS)
-    @available(macOS 14.0,iOS 17.0, *)
+    @available(iOS 17.0,macOS 14.0, *)
     init(isPresented: ChangeTracked<Swift.Bool>,content: ViewReference=ViewReference(value: [])) {
         self.value = ._0(content: content)
         self.__0_isPresented = isPresented
@@ -4161,7 +4269,7 @@ struct _inspectorModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS)
         case let ._0(content):
-            if #available(macOS 14.0,iOS 17.0, *) {
+            if #available(iOS 17.0,macOS 14.0, *) {
             let content = content as! ViewReference
             __content
                 .inspector(isPresented: __0_isPresented.projectedValue, content: { content.resolve(on: element, in: context) })
@@ -4196,14 +4304,14 @@ struct _inspectorColumnWidthModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS)
-    @available(macOS 14.0,iOS 17.0, *)
+    @available(iOS 17.0,macOS 14.0, *)
     init(min: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), ideal: AttributeReference<CoreFoundation.CGFloat>,max: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)) ) {
         self.value = ._0(min: min, ideal: ideal, max: max)
         
     }
     #endif
     #if os(iOS) || os(macOS)
-    @available(macOS 14.0,iOS 17.0, *)
+    @available(iOS 17.0,macOS 14.0, *)
     init(_ width: AttributeReference<CoreFoundation.CGFloat>) {
         self.value = ._1(width: width)
         
@@ -4216,7 +4324,7 @@ struct _inspectorColumnWidthModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS)
         case let ._0(min, ideal, max):
-            if #available(macOS 14.0,iOS 17.0, *) {
+            if #available(iOS 17.0,macOS 14.0, *) {
             let min = min as? AttributeReference<CoreFoundation.CGFloat?>
 let ideal = ideal as! AttributeReference<CoreFoundation.CGFloat>
 let max = max as? AttributeReference<CoreFoundation.CGFloat?>
@@ -4226,7 +4334,7 @@ let max = max as? AttributeReference<CoreFoundation.CGFloat?>
         #endif
         #if os(iOS) || os(macOS)
         case let ._1(width):
-            if #available(macOS 14.0,iOS 17.0, *) {
+            if #available(iOS 17.0,macOS 14.0, *) {
             let width = width as! AttributeReference<CoreFoundation.CGFloat>
             __content
                 .inspectorColumnWidth(width.resolve(on: element, in: context))
@@ -4328,7 +4436,7 @@ struct _invalidatableContentModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         indirect case _0(invalidatable: Any)
         #endif
     }
@@ -4341,8 +4449,8 @@ struct _invalidatableContentModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-    @available(tvOS 17.0,iOS 17.0,watchOS 10.0,macOS 14.0, *)
+    #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+    @available(macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0,visionOS 1.0, *)
     init(_ invalidatable: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(invalidatable: invalidatable)
         
@@ -4353,9 +4461,9 @@ struct _invalidatableContentModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(invalidatable):
-            if #available(tvOS 17.0,iOS 17.0,watchOS 10.0,macOS 14.0, *) {
+            if #available(macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0,visionOS 1.0, *) {
             let invalidatable = invalidatable as! AttributeReference<Swift.Bool>
             __content
                 .invalidatableContent(invalidatable.resolve(on: element, in: context))
@@ -4371,16 +4479,16 @@ struct _keyboardShortcutModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(macOS)
+        #if os(iOS) || os(macOS) || os(visionOS)
         indirect case _0(key: Any,modifiers: Any)
         #endif
-        #if os(iOS) || os(macOS)
+        #if os(iOS) || os(macOS) || os(visionOS)
         indirect case _1(shortcut: Any)
         #endif
-        #if os(iOS) || os(macOS)
+        #if os(iOS) || os(macOS) || os(visionOS)
         indirect case _2(shortcut: Any?)
         #endif
-        #if os(iOS) || os(macOS)
+        #if os(iOS) || os(macOS) || os(visionOS)
         indirect case _3(key: Any,modifiers: Any, localization: Any)
         #endif
     }
@@ -4399,29 +4507,29 @@ struct _keyboardShortcutModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(macOS)
-    @available(macOS 11.0,iOS 14.0, *)
+    #if os(iOS) || os(macOS) || os(visionOS)
+    @available(macOS 11.0,visionOS 1.0,iOS 14.0, *)
     init(_ key: SwiftUI.KeyEquivalent,modifiers: SwiftUI.EventModifiers = .command ) {
         self.value = ._0(key: key, modifiers: modifiers)
         
     }
     #endif
-    #if os(iOS) || os(macOS)
-    @available(macOS 11.0,iOS 14.0, *)
+    #if os(iOS) || os(macOS) || os(visionOS)
+    @available(macOS 11.0,visionOS 1.0,iOS 14.0, *)
     init(_ shortcut: SwiftUI.KeyboardShortcut) {
         self.value = ._1(shortcut: shortcut)
         
     }
     #endif
-    #if os(iOS) || os(macOS)
-    @available(macOS 12.3,iOS 15.4, *)
+    #if os(iOS) || os(macOS) || os(visionOS)
+    @available(macOS 12.3,visionOS 1.0,iOS 15.4, *)
     init(_ shortcut: SwiftUI.KeyboardShortcut?) {
         self.value = ._2(shortcut: shortcut)
         
     }
     #endif
-    #if os(iOS) || os(macOS)
-    @available(macOS 12.0,iOS 15.0, *)
+    #if os(iOS) || os(macOS) || os(visionOS)
+    @available(macOS 12.0,visionOS 1.0,iOS 15.0, *)
     init(_ key: SwiftUI.KeyEquivalent,modifiers: SwiftUI.EventModifiers = .command, localization: SwiftUI.KeyboardShortcut.Localization) {
         self.value = ._3(key: key, modifiers: modifiers, localization: localization)
         
@@ -4432,34 +4540,34 @@ struct _keyboardShortcutModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(macOS)
+        #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(key, modifiers):
-            if #available(macOS 11.0,iOS 14.0, *) {
+            if #available(macOS 11.0,visionOS 1.0,iOS 14.0, *) {
             let key = key as! SwiftUI.KeyEquivalent
 let modifiers = modifiers as! SwiftUI.EventModifiers 
             __content
                 .keyboardShortcut(key, modifiers: modifiers)
             } else { __content }
         #endif
-        #if os(iOS) || os(macOS)
+        #if os(iOS) || os(macOS) || os(visionOS)
         case let ._1(shortcut):
-            if #available(macOS 11.0,iOS 14.0, *) {
+            if #available(macOS 11.0,visionOS 1.0,iOS 14.0, *) {
             let shortcut = shortcut as! SwiftUI.KeyboardShortcut
             __content
                 .keyboardShortcut(shortcut)
             } else { __content }
         #endif
-        #if os(iOS) || os(macOS)
+        #if os(iOS) || os(macOS) || os(visionOS)
         case let ._2(shortcut):
-            if #available(macOS 12.3,iOS 15.4, *) {
+            if #available(macOS 12.3,visionOS 1.0,iOS 15.4, *) {
             let shortcut = shortcut as? SwiftUI.KeyboardShortcut
             __content
                 .keyboardShortcut(shortcut)
             } else { __content }
         #endif
-        #if os(iOS) || os(macOS)
+        #if os(iOS) || os(macOS) || os(visionOS)
         case let ._3(key, modifiers, localization):
-            if #available(macOS 12.0,iOS 15.0, *) {
+            if #available(macOS 12.0,visionOS 1.0,iOS 15.0, *) {
             let key = key as! SwiftUI.KeyEquivalent
 let modifiers = modifiers as! SwiftUI.EventModifiers 
 let localization = localization as! SwiftUI.KeyboardShortcut.Localization
@@ -4477,7 +4585,7 @@ struct _keyboardTypeModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(tvOS)
+        #if os(iOS) || os(tvOS) || os(visionOS)
         indirect case _0(type: Any)
         #endif
     }
@@ -4490,8 +4598,8 @@ struct _keyboardTypeModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(tvOS)
-    @available(tvOS 13.0,iOS 13.0, *)
+    #if os(iOS) || os(tvOS) || os(visionOS)
+    @available(visionOS 1.0,iOS 13.0,tvOS 13.0, *)
     init(_ type: UIKit.UIKeyboardType) {
         self.value = ._0(type: type)
         
@@ -4502,9 +4610,9 @@ struct _keyboardTypeModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(tvOS)
+        #if os(iOS) || os(tvOS) || os(visionOS)
         case let ._0(type):
-            if #available(tvOS 13.0,iOS 13.0, *) {
+            if #available(visionOS 1.0,iOS 13.0,tvOS 13.0, *) {
             let type = type as! UIKit.UIKeyboardType
             __content
                 .keyboardType(type)
@@ -5093,7 +5201,7 @@ struct _listRowSeparatorModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(macOS)
+        #if os(iOS) || os(macOS) || os(visionOS)
         indirect case _0(visibility: Any,edges: Any)
         #endif
     }
@@ -5106,8 +5214,8 @@ struct _listRowSeparatorModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(macOS)
-    @available(macOS 13.0,iOS 15.0, *)
+    #if os(iOS) || os(macOS) || os(visionOS)
+    @available(visionOS 1.0,iOS 15.0,macOS 13.0, *)
     init(_ visibility: AttributeReference<SwiftUI.Visibility>,edges: SwiftUI.VerticalEdge.Set = .all ) {
         self.value = ._0(visibility: visibility, edges: edges)
         
@@ -5118,9 +5226,9 @@ struct _listRowSeparatorModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(macOS)
+        #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(visibility, edges):
-            if #available(macOS 13.0,iOS 15.0, *) {
+            if #available(visionOS 1.0,iOS 15.0,macOS 13.0, *) {
             let visibility = visibility as! AttributeReference<SwiftUI.Visibility>
 let edges = edges as! SwiftUI.VerticalEdge.Set 
             __content
@@ -5137,7 +5245,7 @@ struct _listRowSeparatorTintModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(macOS)
+        #if os(iOS) || os(macOS) || os(visionOS)
         indirect case _0(color: Any?,edges: Any)
         #endif
     }
@@ -5150,8 +5258,8 @@ struct _listRowSeparatorTintModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(macOS)
-    @available(macOS 13.0,iOS 15.0, *)
+    #if os(iOS) || os(macOS) || os(visionOS)
+    @available(visionOS 1.0,iOS 15.0,macOS 13.0, *)
     init(_ color: AttributeReference<SwiftUI.Color?>?,edges: SwiftUI.VerticalEdge.Set = .all ) {
         self.value = ._0(color: color, edges: edges)
         
@@ -5162,9 +5270,9 @@ struct _listRowSeparatorTintModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(macOS)
+        #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(color, edges):
-            if #available(macOS 13.0,iOS 15.0, *) {
+            if #available(visionOS 1.0,iOS 15.0,macOS 13.0, *) {
             let color = color as? AttributeReference<SwiftUI.Color?>
 let edges = edges as! SwiftUI.VerticalEdge.Set 
             __content
@@ -5181,7 +5289,7 @@ struct _listRowSpacingModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS)
+        #if os(iOS) || os(visionOS)
         indirect case _0(spacing: Any?)
         #endif
     }
@@ -5194,8 +5302,8 @@ struct _listRowSpacingModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS)
-    @available(iOS 15.0, *)
+    #if os(iOS) || os(visionOS)
+    @available(iOS 15.0,visionOS 1.0, *)
     init(_ spacing: AttributeReference<CoreFoundation.CGFloat?>?) {
         self.value = ._0(spacing: spacing)
         
@@ -5206,9 +5314,9 @@ struct _listRowSpacingModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS)
+        #if os(iOS) || os(visionOS)
         case let ._0(spacing):
-            if #available(iOS 15.0, *) {
+            if #available(iOS 15.0,visionOS 1.0, *) {
             let spacing = spacing as? AttributeReference<CoreFoundation.CGFloat?>
             __content
                 .listRowSpacing(spacing?.resolve(on: element, in: context))
@@ -5224,7 +5332,7 @@ struct _listSectionSeparatorModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(macOS)
+        #if os(iOS) || os(macOS) || os(visionOS)
         indirect case _0(visibility: Any,edges: Any)
         #endif
     }
@@ -5237,8 +5345,8 @@ struct _listSectionSeparatorModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(macOS)
-    @available(macOS 13.0,iOS 15.0, *)
+    #if os(iOS) || os(macOS) || os(visionOS)
+    @available(visionOS 1.0,iOS 15.0,macOS 13.0, *)
     init(_ visibility: AttributeReference<SwiftUI.Visibility>,edges: SwiftUI.VerticalEdge.Set = .all ) {
         self.value = ._0(visibility: visibility, edges: edges)
         
@@ -5249,9 +5357,9 @@ struct _listSectionSeparatorModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(macOS)
+        #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(visibility, edges):
-            if #available(macOS 13.0,iOS 15.0, *) {
+            if #available(visionOS 1.0,iOS 15.0,macOS 13.0, *) {
             let visibility = visibility as! AttributeReference<SwiftUI.Visibility>
 let edges = edges as! SwiftUI.VerticalEdge.Set 
             __content
@@ -5268,7 +5376,7 @@ struct _listSectionSeparatorTintModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(macOS)
+        #if os(iOS) || os(macOS) || os(visionOS)
         indirect case _0(color: Any?,edges: Any)
         #endif
     }
@@ -5281,8 +5389,8 @@ struct _listSectionSeparatorTintModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(macOS)
-    @available(macOS 13.0,iOS 15.0, *)
+    #if os(iOS) || os(macOS) || os(visionOS)
+    @available(visionOS 1.0,iOS 15.0,macOS 13.0, *)
     init(_ color: AttributeReference<SwiftUI.Color?>?,edges: SwiftUI.VerticalEdge.Set = .all ) {
         self.value = ._0(color: color, edges: edges)
         
@@ -5293,9 +5401,9 @@ struct _listSectionSeparatorTintModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(macOS)
+        #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(color, edges):
-            if #available(macOS 13.0,iOS 15.0, *) {
+            if #available(visionOS 1.0,iOS 15.0,macOS 13.0, *) {
             let color = color as? AttributeReference<SwiftUI.Color?>
 let edges = edges as! SwiftUI.VerticalEdge.Set 
             __content
@@ -5312,10 +5420,10 @@ struct _listSectionSpacingModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(watchOS)
+        #if os(iOS) || os(visionOS) || os(watchOS)
         indirect case _0(spacing: Any)
         #endif
-        #if os(iOS) || os(watchOS)
+        #if os(iOS) || os(visionOS) || os(watchOS)
         indirect case _1(spacing: Any)
         #endif
     }
@@ -5330,15 +5438,15 @@ struct _listSectionSpacingModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(watchOS)
-    @available(watchOS 10.0,iOS 17.0, *)
+    #if os(iOS) || os(visionOS) || os(watchOS)
+    @available(iOS 17.0,visionOS 1.0,watchOS 10.0, *)
     init(_ spacing: SwiftUI.ListSectionSpacing) {
         self.value = ._0(spacing: spacing)
         
     }
     #endif
-    #if os(iOS) || os(watchOS)
-    @available(iOS 17.0,watchOS 10.0, *)
+    #if os(iOS) || os(visionOS) || os(watchOS)
+    @available(iOS 17.0,visionOS 1.0,watchOS 10.0, *)
     init(_ spacing: AttributeReference<CoreFoundation.CGFloat>) {
         self.value = ._1(spacing: spacing)
         
@@ -5349,17 +5457,17 @@ struct _listSectionSpacingModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(watchOS)
+        #if os(iOS) || os(visionOS) || os(watchOS)
         case let ._0(spacing):
-            if #available(watchOS 10.0,iOS 17.0, *) {
+            if #available(iOS 17.0,visionOS 1.0,watchOS 10.0, *) {
             let spacing = spacing as! SwiftUI.ListSectionSpacing
             __content
                 .listSectionSpacing(spacing)
             } else { __content }
         #endif
-        #if os(iOS) || os(watchOS)
+        #if os(iOS) || os(visionOS) || os(watchOS)
         case let ._1(spacing):
-            if #available(iOS 17.0,watchOS 10.0, *) {
+            if #available(iOS 17.0,visionOS 1.0,watchOS 10.0, *) {
             let spacing = spacing as! AttributeReference<CoreFoundation.CGFloat>
             __content
                 .listSectionSpacing(spacing.resolve(on: element, in: context))
@@ -5461,7 +5569,7 @@ struct _menuIndicatorModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(macOS) || os(tvOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS)
         indirect case _0(visibility: Any)
         #endif
     }
@@ -5474,8 +5582,8 @@ struct _menuIndicatorModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(macOS) || os(tvOS)
-    @available(macOS 12.0,iOS 15.0,tvOS 17.0, *)
+    #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS)
+    @available(iOS 15.0,macOS 12.0,tvOS 17.0,visionOS 1.0, *)
     init(_ visibility: AttributeReference<SwiftUI.Visibility>) {
         self.value = ._0(visibility: visibility)
         
@@ -5486,9 +5594,9 @@ struct _menuIndicatorModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(macOS) || os(tvOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS)
         case let ._0(visibility):
-            if #available(macOS 12.0,iOS 15.0,tvOS 17.0, *) {
+            if #available(iOS 15.0,macOS 12.0,tvOS 17.0,visionOS 1.0, *) {
             let visibility = visibility as! AttributeReference<SwiftUI.Visibility>
             __content
                 .menuIndicator(visibility.resolve(on: element, in: context))
@@ -5547,7 +5655,7 @@ struct _menuStyleModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(macOS) || os(tvOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS)
         indirect case _0(style: Any)
         #endif
     }
@@ -5560,8 +5668,8 @@ struct _menuStyleModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(macOS) || os(tvOS)
-    @available(macOS 11.0,iOS 14.0,tvOS 17.0, *)
+    #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS)
+    @available(macOS 11.0,iOS 14.0,tvOS 17.0,visionOS 1.0, *)
     init(_ style: AnyMenuStyle) {
         self.value = ._0(style: style)
         
@@ -5572,9 +5680,9 @@ struct _menuStyleModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(macOS) || os(tvOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS)
         case let ._0(style):
-            if #available(macOS 11.0,iOS 14.0,tvOS 17.0, *) {
+            if #available(macOS 11.0,iOS 14.0,tvOS 17.0,visionOS 1.0, *) {
             let style = style as! AnyMenuStyle
             __content
                 .menuStyle(style)
@@ -5762,7 +5870,7 @@ struct _navigationBarTitleDisplayModeModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(watchOS)
+        #if os(iOS) || os(visionOS) || os(watchOS)
         indirect case _0(displayMode: Any)
         #endif
     }
@@ -5775,8 +5883,8 @@ struct _navigationBarTitleDisplayModeModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(watchOS)
-    @available(watchOS 8.0,iOS 14.0, *)
+    #if os(iOS) || os(visionOS) || os(watchOS)
+    @available(iOS 14.0,visionOS 1.0,watchOS 8.0, *)
     init(_ displayMode: SwiftUI.NavigationBarItem.TitleDisplayMode) {
         self.value = ._0(displayMode: displayMode)
         
@@ -5787,9 +5895,9 @@ struct _navigationBarTitleDisplayModeModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(watchOS)
+        #if os(iOS) || os(visionOS) || os(watchOS)
         case let ._0(displayMode):
-            if #available(watchOS 8.0,iOS 14.0, *) {
+            if #available(iOS 14.0,visionOS 1.0,watchOS 8.0, *) {
             let displayMode = displayMode as! SwiftUI.NavigationBarItem.TitleDisplayMode
             __content
                 .navigationBarTitleDisplayMode(displayMode)
@@ -6092,7 +6200,7 @@ struct _navigationTitleModifier<R: RootRegistry>: ViewModifier {
     }
     
     #if os(watchOS)
-    @available(tvOS 14.0,macOS 11.0,watchOS 7.0,iOS 14.0, *)
+    @available(macOS 11.0,watchOS 7.0,tvOS 14.0,iOS 14.0, *)
     init(_ title: ViewReference=ViewReference(value: [])) {
         self.value = ._3(title: title)
         
@@ -6136,7 +6244,7 @@ struct _navigationTitleModifier<R: RootRegistry>: ViewModifier {
         
         #if os(watchOS)
         case let ._3(title):
-            if #available(tvOS 14.0,macOS 11.0,watchOS 7.0,iOS 14.0, *) {
+            if #available(macOS 11.0,watchOS 7.0,tvOS 14.0,iOS 14.0, *) {
             let title = title as! ViewReference
             __content
                 .navigationTitle({ title.resolve(on: element, in: context) })
@@ -6166,12 +6274,17 @@ struct _offsetModifier<R: RootRegistry>: ViewModifier {
         
         indirect case _1(x: AttributeReference<CoreFoundation.CGFloat> = .init(storage: .constant(0)), y: AttributeReference<CoreFoundation.CGFloat> = .init(storage: .constant(0)) )
         
+        #if os(visionOS)
+        indirect case _2(z: Any)
+        #endif
     }
 
     let value: Value
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+
+
 
 
 
@@ -6192,6 +6305,13 @@ struct _offsetModifier<R: RootRegistry>: ViewModifier {
         
     }
     
+    #if os(visionOS)
+    @available(visionOS 1.0, *)
+    init(z: AttributeReference<CoreFoundation.CGFloat>) {
+        self.value = ._2(z: z)
+        
+    }
+    #endif
 
     func body(content __content: Content) -> some View {
         switch value {
@@ -6213,6 +6333,14 @@ struct _offsetModifier<R: RootRegistry>: ViewModifier {
                 .offset(x: x.resolve(on: element, in: context), y: y.resolve(on: element, in: context))
             
         
+        #if os(visionOS)
+        case let ._2(z):
+            if #available(visionOS 1.0, *) {
+            let z = z as! AttributeReference<CoreFoundation.CGFloat>
+            __content
+                .offset(z: z.resolve(on: element, in: context))
+            } else { __content }
+        #endif
         }
     }
 }
@@ -6280,7 +6408,7 @@ struct _onDeleteCommandModifier<R: RootRegistry>: ViewModifier {
 @Event private var _0_action__0: Event.EventHandler
 
     #if os(macOS)
-    @available(macOS 10.15,tvOS 13.0, *)
+    @available(tvOS 13.0,macOS 10.15, *)
     init(perform action__0: Event=Event()) {
         self.value = ._0
         self.__0_action__0 = action__0
@@ -6293,7 +6421,7 @@ struct _onDeleteCommandModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(macOS)
         case ._0:
-            if #available(macOS 10.15,tvOS 13.0, *) {
+            if #available(tvOS 13.0,macOS 10.15, *) {
             
             __content
                 .onDeleteCommand(perform: { __0_action__0.wrappedValue() })
@@ -6366,7 +6494,7 @@ struct _onExitCommandModifier<R: RootRegistry>: ViewModifier {
 @Event private var _0_action__0: Event.EventHandler
 
     #if os(macOS) || os(tvOS)
-    @available(macOS 10.15,tvOS 13.0, *)
+    @available(tvOS 13.0,macOS 10.15, *)
     init(perform action__0: Event=Event()) {
         self.value = ._0
         self.__0_action__0 = action__0
@@ -6379,7 +6507,7 @@ struct _onExitCommandModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(macOS) || os(tvOS)
         case ._0:
-            if #available(macOS 10.15,tvOS 13.0, *) {
+            if #available(tvOS 13.0,macOS 10.15, *) {
             
             __content
                 .onExitCommand(perform: { __0_action__0.wrappedValue() })
@@ -6395,7 +6523,7 @@ struct _onHoverModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(macOS)
+        #if os(iOS) || os(macOS) || os(visionOS)
          case _0
         #endif
     }
@@ -6408,8 +6536,8 @@ struct _onHoverModifier<R: RootRegistry>: ViewModifier {
 
 @Event private var _0_action__1: Event.EventHandler
 
-    #if os(iOS) || os(macOS)
-    @available(macOS 10.15,iOS 13.4, *)
+    #if os(iOS) || os(macOS) || os(visionOS)
+    @available(visionOS 1.0,iOS 13.4,macOS 10.15, *)
     init(perform action__1: Event) {
         self.value = ._0
         self.__0_action__1 = action__1
@@ -6420,9 +6548,9 @@ struct _onHoverModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(macOS)
+        #if os(iOS) || os(macOS) || os(visionOS)
         case ._0:
-            if #available(macOS 10.15,iOS 13.4, *) {
+            if #available(visionOS 1.0,iOS 13.4,macOS 10.15, *) {
             
             __content
                 .onHover(perform: { __0_action__1.wrappedValue(value: $0) })
@@ -6438,7 +6566,7 @@ struct _onLongPressGestureModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(macOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
         indirect case _0(minimumDuration: Any, maximumDistance: Any)
         #endif
         #if os(tvOS)
@@ -6458,8 +6586,8 @@ struct _onLongPressGestureModifier<R: RootRegistry>: ViewModifier {
 @Event private var _1_action__0: Event.EventHandler
 @Event private var _1_onPressingChanged__1: Event.EventHandler
 
-    #if os(iOS) || os(macOS) || os(watchOS)
-    @available(tvOS 14.0,iOS 13.0,watchOS 6.0,macOS 10.15, *)
+    #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
+    @available(visionOS 1.0,iOS 13.0,watchOS 6.0,macOS 10.15,tvOS 14.0, *)
     init(minimumDuration: AttributeReference<Swift.Double> = .init(storage: .constant(0.5)), maximumDistance: AttributeReference<CoreFoundation.CGFloat> = .init(storage: .constant(10)), perform action__0: Event,onPressingChanged onPressingChanged__1: Event=Event() ) {
         self.value = ._0(minimumDuration: minimumDuration, maximumDistance: maximumDistance)
         self.__0_action__0 = action__0
@@ -6467,7 +6595,7 @@ self.__0_onPressingChanged__1 = onPressingChanged__1
     }
     #endif
     #if os(tvOS)
-    @available(tvOS 14.0,iOS 13.0,watchOS 6.0,macOS 10.15, *)
+    @available(iOS 13.0,watchOS 6.0,macOS 10.15,tvOS 14.0, *)
     init(minimumDuration: AttributeReference<Swift.Double> = .init(storage: .constant(0.5)), perform action__0: Event,onPressingChanged onPressingChanged__1: Event=Event() ) {
         self.value = ._1(minimumDuration: minimumDuration)
         self.__1_action__0 = action__0
@@ -6479,9 +6607,9 @@ self.__1_onPressingChanged__1 = onPressingChanged__1
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(macOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
         case let ._0(minimumDuration, maximumDistance):
-            if #available(tvOS 14.0,iOS 13.0,watchOS 6.0,macOS 10.15, *) {
+            if #available(visionOS 1.0,iOS 13.0,watchOS 6.0,macOS 10.15,tvOS 14.0, *) {
             let minimumDuration = minimumDuration as! AttributeReference<Swift.Double>
 let maximumDistance = maximumDistance as! AttributeReference<CoreFoundation.CGFloat>
             __content
@@ -6490,7 +6618,7 @@ let maximumDistance = maximumDistance as! AttributeReference<CoreFoundation.CGFl
         #endif
         #if os(tvOS)
         case let ._1(minimumDuration):
-            if #available(tvOS 14.0,iOS 13.0,watchOS 6.0,macOS 10.15, *) {
+            if #available(iOS 13.0,watchOS 6.0,macOS 10.15,tvOS 14.0, *) {
             let minimumDuration = minimumDuration as! AttributeReference<Swift.Double>
             __content
                 .onLongPressGesture(minimumDuration: minimumDuration.resolve(on: element, in: context), perform: { __1_action__0.wrappedValue() }, onPressingChanged: { __1_onPressingChanged__1.wrappedValue(value: $0) })
@@ -6565,7 +6693,7 @@ struct _onMoveCommandModifier<R: RootRegistry>: ViewModifier {
 @Event private var _0_action__1: Event.EventHandler
 
     #if os(macOS) || os(tvOS)
-    @available(macOS 10.15,tvOS 13.0, *)
+    @available(tvOS 13.0,macOS 10.15, *)
     init(perform action__1: Event=Event()) {
         self.value = ._0
         self.__0_action__1 = action__1
@@ -6578,7 +6706,7 @@ struct _onMoveCommandModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(macOS) || os(tvOS)
         case ._0:
-            if #available(macOS 10.15,tvOS 13.0, *) {
+            if #available(tvOS 13.0,macOS 10.15, *) {
             
             __content
                 .onMoveCommand(perform: { __0_action__1.wrappedValue(value: $0) })
@@ -6640,7 +6768,7 @@ struct _onTapGestureModifier<R: RootRegistry>: ViewModifier {
         
         indirect case _0(count: AttributeReference<Swift.Int> = .init(storage: .constant(1)))
         
-        #if os(iOS) || os(macOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
         indirect case _1(count: Any, coordinateSpace: Any)
         #endif
     }
@@ -6662,8 +6790,8 @@ struct _onTapGestureModifier<R: RootRegistry>: ViewModifier {
         self.__0_action__0 = action__0
     }
     
-    #if os(iOS) || os(macOS) || os(watchOS)
-    @available(macOS 14.0,iOS 17.0,watchOS 10.0, *)
+    #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
+    @available(iOS 17.0,macOS 14.0,watchOS 10.0,visionOS 1.0, *)
     init(count: AttributeReference<Swift.Int> = .init(storage: .constant(1)), coordinateSpace: AnyCoordinateSpaceProtocol = .local, perform action__1: Event) {
         self.value = ._1(count: count, coordinateSpace: coordinateSpace)
         self.__1_action__1 = action__1
@@ -6682,9 +6810,9 @@ struct _onTapGestureModifier<R: RootRegistry>: ViewModifier {
                 .onTapGesture(count: count.resolve(on: element, in: context), perform: { __0_action__0.wrappedValue() })
             
         
-        #if os(iOS) || os(macOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
         case let ._1(count, coordinateSpace):
-            if #available(macOS 14.0,iOS 17.0,watchOS 10.0, *) {
+            if #available(iOS 17.0,macOS 14.0,watchOS 10.0,visionOS 1.0, *) {
             let count = count as! AttributeReference<Swift.Int>
 let coordinateSpace = coordinateSpace as! AnyCoordinateSpaceProtocol 
             __content
@@ -6734,6 +6862,52 @@ struct _opacityModifier<R: RootRegistry>: ViewModifier {
                 .opacity(opacity.resolve(on: element, in: context))
             
         
+        }
+    }
+}
+@_documentation(visibility: public)
+@ParseableExpression
+struct _ornamentModifier<R: RootRegistry>: ViewModifier {
+    static var name: String { "ornament" }
+
+    enum Value {
+        case _never
+        #if os(visionOS)
+        indirect case _0(visibility: Any, attachmentAnchor: Any,contentAlignment: Any, ornament: Any)
+        #endif
+    }
+
+    let value: Value
+
+    @ObservedElement private var element
+    @LiveContext<R> private var context
+
+
+
+
+    #if os(visionOS)
+    @available(visionOS 1.0, *)
+    init(visibility: AttributeReference<SwiftUI.Visibility> = .init(storage: .constant(.automatic)), attachmentAnchor: SwiftUI.OrnamentAttachmentAnchor,contentAlignment: AttributeReference<SwiftUI.Alignment> = .init(storage: .constant(.center)), ornament: ViewReference=ViewReference(value: [])) {
+        self.value = ._0(visibility: visibility, attachmentAnchor: attachmentAnchor, contentAlignment: contentAlignment, ornament: ornament)
+        
+    }
+    #endif
+
+    func body(content __content: Content) -> some View {
+        switch value {
+        case ._never:
+            fatalError("unreachable")
+        #if os(visionOS)
+        case let ._0(visibility, attachmentAnchor, contentAlignment, ornament):
+            if #available(visionOS 1.0, *) {
+            let visibility = visibility as! AttributeReference<SwiftUI.Visibility>
+let attachmentAnchor = attachmentAnchor as! SwiftUI.OrnamentAttachmentAnchor
+let contentAlignment = contentAlignment as! AttributeReference<SwiftUI.Alignment>
+let ornament = ornament as! ViewReference
+            __content
+                .ornament(visibility: visibility.resolve(on: element, in: context), attachmentAnchor: attachmentAnchor, contentAlignment: contentAlignment.resolve(on: element, in: context), ornament: { ornament.resolve(on: element, in: context) })
+            } else { __content }
+        #endif
         }
     }
 }
@@ -6905,6 +7079,90 @@ struct _paddingModifier<R: RootRegistry>: ViewModifier {
 }
 @_documentation(visibility: public)
 @ParseableExpression
+struct _padding3DModifier<R: RootRegistry>: ViewModifier {
+    static var name: String { "padding3D" }
+
+    enum Value {
+        case _never
+        #if os(visionOS)
+        indirect case _0(insets: Any)
+        #endif
+        #if os(visionOS)
+        indirect case _1(edges: Any, length: Any?)
+        #endif
+        #if os(visionOS)
+        indirect case _2(length: Any)
+        #endif
+    }
+
+    let value: Value
+
+    @ObservedElement private var element
+    @LiveContext<R> private var context
+
+
+
+
+
+
+
+
+    #if os(visionOS)
+    @available(visionOS 1.0, *)
+    init(_ insets: SwiftUI.EdgeInsets3D) {
+        self.value = ._0(insets: insets)
+        
+    }
+    #endif
+    #if os(visionOS)
+    @available(visionOS 1.0, *)
+    init(_ edges: SwiftUI.Edge3D.Set = .all, _ length: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)) ) {
+        self.value = ._1(edges: edges, length: length)
+        
+    }
+    #endif
+    #if os(visionOS)
+    @available(visionOS 1.0, *)
+    init(_ length: AttributeReference<CoreFoundation.CGFloat>) {
+        self.value = ._2(length: length)
+        
+    }
+    #endif
+
+    func body(content __content: Content) -> some View {
+        switch value {
+        case ._never:
+            fatalError("unreachable")
+        #if os(visionOS)
+        case let ._0(insets):
+            if #available(visionOS 1.0, *) {
+            let insets = insets as! SwiftUI.EdgeInsets3D
+            __content
+                .padding3D(insets)
+            } else { __content }
+        #endif
+        #if os(visionOS)
+        case let ._1(edges, length):
+            if #available(visionOS 1.0, *) {
+            let edges = edges as! SwiftUI.Edge3D.Set 
+let length = length as? AttributeReference<CoreFoundation.CGFloat?>
+            __content
+                .padding3D(edges, length?.resolve(on: element, in: context))
+            } else { __content }
+        #endif
+        #if os(visionOS)
+        case let ._2(length):
+            if #available(visionOS 1.0, *) {
+            let length = length as! AttributeReference<CoreFoundation.CGFloat>
+            __content
+                .padding3D(length.resolve(on: element, in: context))
+            } else { __content }
+        #endif
+        }
+    }
+}
+@_documentation(visibility: public)
+@ParseableExpression
 struct _persistentSystemOverlaysModifier<R: RootRegistry>: ViewModifier {
     static var name: String { "persistentSystemOverlays" }
 
@@ -6996,7 +7254,7 @@ struct _popoverModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(macOS)
+        #if os(iOS) || os(macOS) || os(visionOS)
         indirect case _0(attachmentAnchor: Any, arrowEdge: Any, content: Any)
         #endif
     }
@@ -7009,8 +7267,8 @@ struct _popoverModifier<R: RootRegistry>: ViewModifier {
 @ChangeTracked private var _0_isPresented: Swift.Bool
 
 
-    #if os(iOS) || os(macOS)
-    @available(macOS 10.15,iOS 13.0, *)
+    #if os(iOS) || os(macOS) || os(visionOS)
+    @available(iOS 13.0,visionOS 1.0,macOS 10.15, *)
     init(isPresented: ChangeTracked<Swift.Bool>,attachmentAnchor: SwiftUI.PopoverAttachmentAnchor = .rect(.bounds), arrowEdge: SwiftUI.Edge = .top, content: ViewReference=ViewReference(value: [])) {
         self.value = ._0(attachmentAnchor: attachmentAnchor, arrowEdge: arrowEdge, content: content)
         self.__0_isPresented = isPresented
@@ -7021,9 +7279,9 @@ struct _popoverModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(macOS)
+        #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(attachmentAnchor, arrowEdge, content):
-            if #available(macOS 10.15,iOS 13.0, *) {
+            if #available(iOS 13.0,visionOS 1.0,macOS 10.15, *) {
             let attachmentAnchor = attachmentAnchor as! SwiftUI.PopoverAttachmentAnchor 
 let arrowEdge = arrowEdge as! SwiftUI.Edge 
 let content = content as! ViewReference
@@ -7142,15 +7400,58 @@ struct _preferredColorSchemeModifier<R: RootRegistry>: ViewModifier {
 }
 @_documentation(visibility: public)
 @ParseableExpression
+struct _preferredSurroundingsEffectModifier<R: RootRegistry>: ViewModifier {
+    static var name: String { "preferredSurroundingsEffect" }
+
+    enum Value {
+        case _never
+        #if os(visionOS)
+        indirect case _0(effect: Any?)
+        #endif
+    }
+
+    let value: Value
+
+    
+    
+
+
+
+
+    #if os(visionOS)
+    @available(visionOS 1.0, *)
+    init(_ effect: SwiftUI.SurroundingsEffect?) {
+        self.value = ._0(effect: effect)
+        
+    }
+    #endif
+
+    func body(content __content: Content) -> some View {
+        switch value {
+        case ._never:
+            fatalError("unreachable")
+        #if os(visionOS)
+        case let ._0(effect):
+            if #available(visionOS 1.0, *) {
+            let effect = effect as? SwiftUI.SurroundingsEffect
+            __content
+                .preferredSurroundingsEffect(effect)
+            } else { __content }
+        #endif
+        }
+    }
+}
+@_documentation(visibility: public)
+@ParseableExpression
 struct _presentationBackgroundModifier<R: RootRegistry>: ViewModifier {
     static var name: String { "presentationBackground" }
 
     enum Value {
         case _never
-        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         indirect case _0(style: Any)
         #endif
-        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         indirect case _1(alignment: Any, content: Any)
         #endif
     }
@@ -7165,15 +7466,15 @@ struct _presentationBackgroundModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-    @available(iOS 16.4,watchOS 9.4,macOS 13.3,tvOS 16.4, *)
+    #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+    @available(iOS 16.4,macOS 13.3,tvOS 16.4,watchOS 9.4,visionOS 1.0, *)
     init(_ style: AnyShapeStyle) {
         self.value = ._0(style: style)
         
     }
     #endif
-    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-    @available(iOS 16.4,watchOS 9.4,macOS 13.3,tvOS 16.4, *)
+    #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+    @available(iOS 16.4,macOS 13.3,tvOS 16.4,watchOS 9.4,visionOS 1.0, *)
     init(alignment: AttributeReference<SwiftUI.Alignment> = .init(storage: .constant(.center)), content: ViewReference=ViewReference(value: [])) {
         self.value = ._1(alignment: alignment, content: content)
         
@@ -7184,17 +7485,17 @@ struct _presentationBackgroundModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(style):
-            if #available(iOS 16.4,watchOS 9.4,macOS 13.3,tvOS 16.4, *) {
+            if #available(iOS 16.4,macOS 13.3,tvOS 16.4,watchOS 9.4,visionOS 1.0, *) {
             let style = style as! AnyShapeStyle
             __content
                 .presentationBackground(style)
             } else { __content }
         #endif
-        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(alignment, content):
-            if #available(iOS 16.4,watchOS 9.4,macOS 13.3,tvOS 16.4, *) {
+            if #available(iOS 16.4,macOS 13.3,tvOS 16.4,watchOS 9.4,visionOS 1.0, *) {
             let alignment = alignment as! AttributeReference<SwiftUI.Alignment>
 let content = content as! ViewReference
             __content
@@ -7211,7 +7512,7 @@ struct _presentationBackgroundInteractionModifier<R: RootRegistry>: ViewModifier
 
     enum Value {
         case _never
-        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         indirect case _0(interaction: Any)
         #endif
     }
@@ -7224,8 +7525,8 @@ struct _presentationBackgroundInteractionModifier<R: RootRegistry>: ViewModifier
 
 
 
-    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-    @available(iOS 16.4,watchOS 9.4,macOS 13.3,tvOS 16.4, *)
+    #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+    @available(iOS 16.4,macOS 13.3,tvOS 16.4,watchOS 9.4,visionOS 1.0, *)
     init(_ interaction: SwiftUI.PresentationBackgroundInteraction) {
         self.value = ._0(interaction: interaction)
         
@@ -7236,9 +7537,9 @@ struct _presentationBackgroundInteractionModifier<R: RootRegistry>: ViewModifier
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(interaction):
-            if #available(iOS 16.4,watchOS 9.4,macOS 13.3,tvOS 16.4, *) {
+            if #available(iOS 16.4,macOS 13.3,tvOS 16.4,watchOS 9.4,visionOS 1.0, *) {
             let interaction = interaction as! SwiftUI.PresentationBackgroundInteraction
             __content
                 .presentationBackgroundInteraction(interaction)
@@ -7254,10 +7555,10 @@ struct _presentationCompactAdaptationModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         indirect case _0(adaptation: Any)
         #endif
-        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         indirect case _1(horizontalAdaptation: Any,verticalAdaptation: Any)
         #endif
     }
@@ -7272,15 +7573,15 @@ struct _presentationCompactAdaptationModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-    @available(iOS 16.4,watchOS 9.4,macOS 13.3,tvOS 16.4, *)
+    #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+    @available(iOS 16.4,macOS 13.3,tvOS 16.4,watchOS 9.4,visionOS 1.0, *)
     init(_ adaptation: SwiftUI.PresentationAdaptation) {
         self.value = ._0(adaptation: adaptation)
         
     }
     #endif
-    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-    @available(tvOS 16.4,macOS 13.3,watchOS 9.4,iOS 16.4, *)
+    #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+    @available(iOS 16.4,macOS 13.3,tvOS 16.4,watchOS 9.4,visionOS 1.0, *)
     init(horizontal horizontalAdaptation: SwiftUI.PresentationAdaptation,vertical verticalAdaptation: SwiftUI.PresentationAdaptation) {
         self.value = ._1(horizontalAdaptation: horizontalAdaptation, verticalAdaptation: verticalAdaptation)
         
@@ -7291,17 +7592,17 @@ struct _presentationCompactAdaptationModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(adaptation):
-            if #available(iOS 16.4,watchOS 9.4,macOS 13.3,tvOS 16.4, *) {
+            if #available(iOS 16.4,macOS 13.3,tvOS 16.4,watchOS 9.4,visionOS 1.0, *) {
             let adaptation = adaptation as! SwiftUI.PresentationAdaptation
             __content
                 .presentationCompactAdaptation(adaptation)
             } else { __content }
         #endif
-        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(horizontalAdaptation, verticalAdaptation):
-            if #available(tvOS 16.4,macOS 13.3,watchOS 9.4,iOS 16.4, *) {
+            if #available(iOS 16.4,macOS 13.3,tvOS 16.4,watchOS 9.4,visionOS 1.0, *) {
             let horizontalAdaptation = horizontalAdaptation as! SwiftUI.PresentationAdaptation
 let verticalAdaptation = verticalAdaptation as! SwiftUI.PresentationAdaptation
             __content
@@ -7318,7 +7619,7 @@ struct _presentationContentInteractionModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         indirect case _0(behavior: Any)
         #endif
     }
@@ -7331,8 +7632,8 @@ struct _presentationContentInteractionModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-    @available(tvOS 16.4,macOS 13.3,watchOS 9.4,iOS 16.4, *)
+    #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+    @available(iOS 16.4,macOS 13.3,tvOS 16.4,watchOS 9.4,visionOS 1.0, *)
     init(_ behavior: SwiftUI.PresentationContentInteraction) {
         self.value = ._0(behavior: behavior)
         
@@ -7343,9 +7644,9 @@ struct _presentationContentInteractionModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(behavior):
-            if #available(tvOS 16.4,macOS 13.3,watchOS 9.4,iOS 16.4, *) {
+            if #available(iOS 16.4,macOS 13.3,tvOS 16.4,watchOS 9.4,visionOS 1.0, *) {
             let behavior = behavior as! SwiftUI.PresentationContentInteraction
             __content
                 .presentationContentInteraction(behavior)
@@ -7361,7 +7662,7 @@ struct _presentationCornerRadiusModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         indirect case _0(cornerRadius: Any?)
         #endif
     }
@@ -7374,8 +7675,8 @@ struct _presentationCornerRadiusModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-    @available(tvOS 16.4,macOS 13.3,watchOS 9.4,iOS 16.4, *)
+    #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+    @available(iOS 16.4,macOS 13.3,tvOS 16.4,watchOS 9.4,visionOS 1.0, *)
     init(_ cornerRadius: AttributeReference<CoreFoundation.CGFloat?>?) {
         self.value = ._0(cornerRadius: cornerRadius)
         
@@ -7386,9 +7687,9 @@ struct _presentationCornerRadiusModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(cornerRadius):
-            if #available(tvOS 16.4,macOS 13.3,watchOS 9.4,iOS 16.4, *) {
+            if #available(iOS 16.4,macOS 13.3,tvOS 16.4,watchOS 9.4,visionOS 1.0, *) {
             let cornerRadius = cornerRadius as? AttributeReference<CoreFoundation.CGFloat?>
             __content
                 .presentationCornerRadius(cornerRadius?.resolve(on: element, in: context))
@@ -7748,7 +8049,7 @@ struct _replaceDisabledModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS)
+        #if os(iOS) || os(visionOS)
         indirect case _0(isDisabled: Any)
         #endif
     }
@@ -7761,8 +8062,8 @@ struct _replaceDisabledModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS)
-    @available(iOS 16.0, *)
+    #if os(iOS) || os(visionOS)
+    @available(visionOS 1.0,iOS 16.0, *)
     init(_ isDisabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(isDisabled: isDisabled)
         
@@ -7773,9 +8074,9 @@ struct _replaceDisabledModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS)
+        #if os(iOS) || os(visionOS)
         case let ._0(isDisabled):
-            if #available(iOS 16.0, *) {
+            if #available(visionOS 1.0,iOS 16.0, *) {
             let isDisabled = isDisabled as! AttributeReference<Swift.Bool>
             __content
                 .replaceDisabled(isDisabled.resolve(on: element, in: context))
@@ -7949,12 +8250,27 @@ struct _scaleEffectModifier<R: RootRegistry>: ViewModifier {
         
         indirect case _2(x: AttributeReference<CoreFoundation.CGFloat> = .init(storage: .constant(1.0)), y: AttributeReference<CoreFoundation.CGFloat> = .init(storage: .constant(1.0)), anchor: AttributeReference<SwiftUI.UnitPoint> = .init(storage: .constant(.center)) )
         
+        #if os(visionOS)
+        indirect case _3(scale: Any,anchor: Any)
+        #endif
+        #if os(visionOS)
+        indirect case _4(s: Any,anchor: Any)
+        #endif
+        #if os(visionOS)
+        indirect case _5(x: Any, y: Any, z: Any, anchor: Any)
+        #endif
     }
 
     let value: Value
 
     @ObservedElement private var element
     @LiveContext<R> private var context
+
+
+
+
+
+
 
 
 
@@ -7984,6 +8300,27 @@ struct _scaleEffectModifier<R: RootRegistry>: ViewModifier {
         
     }
     
+    #if os(visionOS)
+    @available(visionOS 1.0, *)
+    init(_ scale: Spatial.Size3D,anchor: SwiftUI.UnitPoint3D = .center ) {
+        self.value = ._3(scale: scale, anchor: anchor)
+        
+    }
+    #endif
+    #if os(visionOS)
+    @available(visionOS 1.0, *)
+    init(_ s: AttributeReference<CoreFoundation.CGFloat>,anchor: SwiftUI.UnitPoint3D = .center ) {
+        self.value = ._4(s: s, anchor: anchor)
+        
+    }
+    #endif
+    #if os(visionOS)
+    @available(visionOS 1.0, *)
+    init(x: AttributeReference<CoreFoundation.CGFloat> = .init(storage: .constant(1.0)), y: AttributeReference<CoreFoundation.CGFloat> = .init(storage: .constant(1.0)), z: AttributeReference<CoreFoundation.CGFloat> = .init(storage: .constant(1.0)), anchor: SwiftUI.UnitPoint3D = .center ) {
+        self.value = ._5(x: x, y: y, z: z, anchor: anchor)
+        
+    }
+    #endif
 
     func body(content __content: Content) -> some View {
         switch value {
@@ -8013,6 +8350,35 @@ struct _scaleEffectModifier<R: RootRegistry>: ViewModifier {
                 .scaleEffect(x: x.resolve(on: element, in: context), y: y.resolve(on: element, in: context), anchor: anchor.resolve(on: element, in: context))
             
         
+        #if os(visionOS)
+        case let ._3(scale, anchor):
+            if #available(visionOS 1.0, *) {
+            let scale = scale as! Spatial.Size3D
+let anchor = anchor as! SwiftUI.UnitPoint3D 
+            __content
+                .scaleEffect(scale, anchor: anchor)
+            } else { __content }
+        #endif
+        #if os(visionOS)
+        case let ._4(s, anchor):
+            if #available(visionOS 1.0, *) {
+            let s = s as! AttributeReference<CoreFoundation.CGFloat>
+let anchor = anchor as! SwiftUI.UnitPoint3D 
+            __content
+                .scaleEffect(s.resolve(on: element, in: context), anchor: anchor)
+            } else { __content }
+        #endif
+        #if os(visionOS)
+        case let ._5(x, y, z, anchor):
+            if #available(visionOS 1.0, *) {
+            let x = x as! AttributeReference<CoreFoundation.CGFloat>
+let y = y as! AttributeReference<CoreFoundation.CGFloat>
+let z = z as! AttributeReference<CoreFoundation.CGFloat>
+let anchor = anchor as! SwiftUI.UnitPoint3D 
+            __content
+                .scaleEffect(x: x.resolve(on: element, in: context), y: y.resolve(on: element, in: context), z: z.resolve(on: element, in: context), anchor: anchor)
+            } else { __content }
+        #endif
         }
     }
 }
@@ -8172,7 +8538,7 @@ struct _scrollBounceBehaviorModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         indirect case _0(behavior: Any,axes: Any)
         #endif
     }
@@ -8185,8 +8551,8 @@ struct _scrollBounceBehaviorModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-    @available(watchOS 9.4,iOS 16.4,macOS 13.3,tvOS 16.4, *)
+    #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+    @available(macOS 13.3,visionOS 1.0,tvOS 16.4,watchOS 9.4,iOS 16.4, *)
     init(_ behavior: SwiftUI.ScrollBounceBehavior,axes: SwiftUI.Axis.Set = [.vertical] ) {
         self.value = ._0(behavior: behavior, axes: axes)
         
@@ -8197,9 +8563,9 @@ struct _scrollBounceBehaviorModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(behavior, axes):
-            if #available(watchOS 9.4,iOS 16.4,macOS 13.3,tvOS 16.4, *) {
+            if #available(macOS 13.3,visionOS 1.0,tvOS 16.4,watchOS 9.4,iOS 16.4, *) {
             let behavior = behavior as! SwiftUI.ScrollBounceBehavior
 let axes = axes as! SwiftUI.Axis.Set 
             __content
@@ -8216,7 +8582,7 @@ struct _scrollClipDisabledModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         indirect case _0(disabled: Any)
         #endif
     }
@@ -8229,8 +8595,8 @@ struct _scrollClipDisabledModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-    @available(watchOS 10.0,iOS 17.0,macOS 14.0,tvOS 17.0, *)
+    #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+    @available(macOS 14.0,watchOS 10.0,tvOS 17.0,visionOS 1.0,iOS 17.0, *)
     init(_ disabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(disabled: disabled)
         
@@ -8241,9 +8607,9 @@ struct _scrollClipDisabledModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(disabled):
-            if #available(watchOS 10.0,iOS 17.0,macOS 14.0,tvOS 17.0, *) {
+            if #available(macOS 14.0,watchOS 10.0,tvOS 17.0,visionOS 1.0,iOS 17.0, *) {
             let disabled = disabled as! AttributeReference<Swift.Bool>
             __content
                 .scrollClipDisabled(disabled.resolve(on: element, in: context))
@@ -8259,7 +8625,7 @@ struct _scrollContentBackgroundModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(macOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
         indirect case _0(visibility: Any)
         #endif
     }
@@ -8272,8 +8638,8 @@ struct _scrollContentBackgroundModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(macOS) || os(watchOS)
-    @available(macOS 13.0,iOS 16.0,watchOS 9.0, *)
+    #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
+    @available(visionOS 1.0,macOS 13.0,watchOS 9.0,iOS 16.0, *)
     init(_ visibility: AttributeReference<SwiftUI.Visibility>) {
         self.value = ._0(visibility: visibility)
         
@@ -8284,9 +8650,9 @@ struct _scrollContentBackgroundModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(macOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
         case let ._0(visibility):
-            if #available(macOS 13.0,iOS 16.0,watchOS 9.0, *) {
+            if #available(visionOS 1.0,macOS 13.0,watchOS 9.0,iOS 16.0, *) {
             let visibility = visibility as! AttributeReference<SwiftUI.Visibility>
             __content
                 .scrollContentBackground(visibility.resolve(on: element, in: context))
@@ -8359,7 +8725,7 @@ struct _scrollDismissesKeyboardModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-    @available(watchOS 9.0,iOS 16.0,macOS 13.0,tvOS 16.0, *)
+    @available(macOS 13.0,tvOS 16.0,watchOS 9.0,iOS 16.0, *)
     init(_ mode: SwiftUI.ScrollDismissesKeyboardMode) {
         self.value = ._0(mode: mode)
         
@@ -8372,7 +8738,7 @@ struct _scrollDismissesKeyboardModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
         case let ._0(mode):
-            if #available(watchOS 9.0,iOS 16.0,macOS 13.0,tvOS 16.0, *) {
+            if #available(macOS 13.0,tvOS 16.0,watchOS 9.0,iOS 16.0, *) {
             let mode = mode as! SwiftUI.ScrollDismissesKeyboardMode
             __content
                 .scrollDismissesKeyboard(mode)
@@ -8431,10 +8797,10 @@ struct _scrollIndicatorsFlashModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         indirect case _0(value: Any)
         #endif
-        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         indirect case _1(onAppear: Any)
         #endif
     }
@@ -8449,15 +8815,15 @@ struct _scrollIndicatorsFlashModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-    @available(watchOS 10.0,iOS 17.0,macOS 14.0,tvOS 17.0, *)
+    #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+    @available(macOS 14.0,visionOS 1.0,tvOS 17.0,watchOS 10.0,iOS 17.0, *)
     init(trigger value: AttributeReference<String>) {
         self.value = ._0(value: value)
         
     }
     #endif
-    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-    @available(watchOS 10.0,iOS 17.0,macOS 14.0,tvOS 17.0, *)
+    #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+    @available(macOS 14.0,visionOS 1.0,tvOS 17.0,watchOS 10.0,iOS 17.0, *)
     init(onAppear: AttributeReference<Swift.Bool>) {
         self.value = ._1(onAppear: onAppear)
         
@@ -8468,17 +8834,17 @@ struct _scrollIndicatorsFlashModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(value):
-            if #available(watchOS 10.0,iOS 17.0,macOS 14.0,tvOS 17.0, *) {
+            if #available(macOS 14.0,visionOS 1.0,tvOS 17.0,watchOS 10.0,iOS 17.0, *) {
             let value = value as! AttributeReference<String>
             __content
                 .scrollIndicatorsFlash(trigger: value.resolve(on: element, in: context))
             } else { __content }
         #endif
-        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(onAppear):
-            if #available(watchOS 10.0,iOS 17.0,macOS 14.0,tvOS 17.0, *) {
+            if #available(macOS 14.0,visionOS 1.0,tvOS 17.0,watchOS 10.0,iOS 17.0, *) {
             let onAppear = onAppear as! AttributeReference<Swift.Bool>
             __content
                 .scrollIndicatorsFlash(onAppear: onAppear.resolve(on: element, in: context))
@@ -8494,7 +8860,7 @@ struct _scrollPositionModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         indirect case _0(anchor: Any?)
         #endif
     }
@@ -8507,8 +8873,8 @@ struct _scrollPositionModifier<R: RootRegistry>: ViewModifier {
 @ChangeTracked private var _0_id: String?
 
 
-    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-    @available(tvOS 17.0,iOS 17.0,watchOS 10.0,macOS 14.0, *)
+    #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+    @available(macOS 14.0,iOS 17.0,tvOS 17.0,visionOS 1.0,watchOS 10.0, *)
     init(id: ChangeTracked<String?>,anchor: AttributeReference<SwiftUI.UnitPoint?>? = .init(storage: .constant(nil)) ) {
         self.value = ._0(anchor: anchor)
         self.__0_id = id
@@ -8519,9 +8885,9 @@ struct _scrollPositionModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(anchor):
-            if #available(tvOS 17.0,iOS 17.0,watchOS 10.0,macOS 14.0, *) {
+            if #available(macOS 14.0,iOS 17.0,tvOS 17.0,visionOS 1.0,watchOS 10.0, *) {
             let anchor = anchor as? AttributeReference<SwiftUI.UnitPoint?>
             __content
                 .scrollPosition(id: __0_id.projectedValue, anchor: anchor?.resolve(on: element, in: context))
@@ -8537,7 +8903,7 @@ struct _scrollTargetBehaviorModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         indirect case _0(behavior: Any)
         #endif
     }
@@ -8550,8 +8916,8 @@ struct _scrollTargetBehaviorModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-    @available(iOS 17.0,macOS 14.0,watchOS 10.0,tvOS 17.0, *)
+    #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+    @available(watchOS 10.0,visionOS 1.0,iOS 17.0,macOS 14.0,tvOS 17.0, *)
     init(_ behavior: AnyScrollTargetBehavior) {
         self.value = ._0(behavior: behavior)
         
@@ -8562,9 +8928,9 @@ struct _scrollTargetBehaviorModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(behavior):
-            if #available(iOS 17.0,macOS 14.0,watchOS 10.0,tvOS 17.0, *) {
+            if #available(watchOS 10.0,visionOS 1.0,iOS 17.0,macOS 14.0,tvOS 17.0, *) {
             let behavior = behavior as! AnyScrollTargetBehavior
             __content
                 .scrollTargetBehavior(behavior)
@@ -8580,7 +8946,7 @@ struct _scrollTargetLayoutModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         indirect case _0(isEnabled: Any)
         #endif
     }
@@ -8593,8 +8959,8 @@ struct _scrollTargetLayoutModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-    @available(macOS 14.0,tvOS 17.0,iOS 17.0,watchOS 10.0, *)
+    #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+    @available(watchOS 10.0,visionOS 1.0,iOS 17.0,macOS 14.0,tvOS 17.0, *)
     init(isEnabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(isEnabled: isEnabled)
         
@@ -8605,9 +8971,9 @@ struct _scrollTargetLayoutModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(isEnabled):
-            if #available(macOS 14.0,tvOS 17.0,iOS 17.0,watchOS 10.0, *) {
+            if #available(watchOS 10.0,visionOS 1.0,iOS 17.0,macOS 14.0,tvOS 17.0, *) {
             let isEnabled = isEnabled as! AttributeReference<Swift.Bool>
             __content
                 .scrollTargetLayout(isEnabled: isEnabled.resolve(on: element, in: context))
@@ -8666,7 +9032,7 @@ struct _searchPresentationToolbarBehaviorModifier<R: RootRegistry>: ViewModifier
 
     enum Value {
         case _never
-        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         indirect case _0(behavior: Any)
         #endif
     }
@@ -8679,8 +9045,8 @@ struct _searchPresentationToolbarBehaviorModifier<R: RootRegistry>: ViewModifier
 
 
 
-    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-    @available(tvOS 17.1,iOS 17.1,watchOS 10.1,macOS 14.1, *)
+    #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+    @available(macOS 14.1,watchOS 10.1,iOS 17.1,tvOS 17.1,visionOS 1.0, *)
     init(_ behavior: SwiftUI.SearchPresentationToolbarBehavior) {
         self.value = ._0(behavior: behavior)
         
@@ -8691,9 +9057,9 @@ struct _searchPresentationToolbarBehaviorModifier<R: RootRegistry>: ViewModifier
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(behavior):
-            if #available(tvOS 17.1,iOS 17.1,watchOS 10.1,macOS 14.1, *) {
+            if #available(macOS 14.1,watchOS 10.1,iOS 17.1,tvOS 17.1,visionOS 1.0, *) {
             let behavior = behavior as! SwiftUI.SearchPresentationToolbarBehavior
             __content
                 .searchPresentationToolbarBehavior(behavior)
@@ -8781,13 +9147,13 @@ struct _searchableModifier<R: RootRegistry>: ViewModifier {
         
         indirect case _2(placement: SwiftUI.SearchFieldPlacement = .automatic, prompt: AttributeReference<String>)
         
-        #if os(iOS) || os(macOS)
+        #if os(iOS) || os(macOS) || os(visionOS)
         indirect case _3(placement: Any, prompt: Any?)
         #endif
-        #if os(iOS) || os(macOS)
+        #if os(iOS) || os(macOS) || os(visionOS)
         indirect case _4(placement: Any, prompt: Any)
         #endif
-        #if os(iOS) || os(macOS)
+        #if os(iOS) || os(macOS) || os(visionOS)
         indirect case _5(placement: Any, prompt: Any)
         #endif
     }
@@ -8834,24 +9200,24 @@ struct _searchableModifier<R: RootRegistry>: ViewModifier {
         self.__2_text = text
     }
     
-    #if os(iOS) || os(macOS)
-    @available(macOS 14.0,iOS 17.0, *)
+    #if os(iOS) || os(macOS) || os(visionOS)
+    @available(iOS 17.0,visionOS 1.0,macOS 14.0, *)
     init(text: ChangeTracked<Swift.String>,isPresented: ChangeTracked<Swift.Bool>,placement: SwiftUI.SearchFieldPlacement = .automatic, prompt: TextReference? = nil ) {
         self.value = ._3(placement: placement, prompt: prompt)
         self.__3_text = text
 self.__3_isPresented = isPresented
     }
     #endif
-    #if os(iOS) || os(macOS)
-    @available(macOS 14.0,iOS 17.0, *)
+    #if os(iOS) || os(macOS) || os(visionOS)
+    @available(iOS 17.0,visionOS 1.0,macOS 14.0, *)
     init(text: ChangeTracked<Swift.String>,isPresented: ChangeTracked<Swift.Bool>,placement: SwiftUI.SearchFieldPlacement = .automatic, prompt: SwiftUI.LocalizedStringKey) {
         self.value = ._4(placement: placement, prompt: prompt)
         self.__4_text = text
 self.__4_isPresented = isPresented
     }
     #endif
-    #if os(iOS) || os(macOS)
-    @available(macOS 14.0,iOS 17.0, *)
+    #if os(iOS) || os(macOS) || os(visionOS)
+    @available(iOS 17.0,visionOS 1.0,macOS 14.0, *)
     init(text: ChangeTracked<Swift.String>,isPresented: ChangeTracked<Swift.Bool>,placement: SwiftUI.SearchFieldPlacement = .automatic, prompt: AttributeReference<String>) {
         self.value = ._5(placement: placement, prompt: prompt)
         self.__5_text = text
@@ -8887,27 +9253,27 @@ self.__5_isPresented = isPresented
                 .searchable(text: __2_text.projectedValue, placement: placement, prompt: prompt.resolve(on: element, in: context))
             
         
-        #if os(iOS) || os(macOS)
+        #if os(iOS) || os(macOS) || os(visionOS)
         case let ._3(placement, prompt):
-            if #available(macOS 14.0,iOS 17.0, *) {
+            if #available(iOS 17.0,visionOS 1.0,macOS 14.0, *) {
             let placement = placement as! SwiftUI.SearchFieldPlacement 
 let prompt = prompt as? TextReference
             __content
                 .searchable(text: __3_text.projectedValue, isPresented: __3_isPresented.projectedValue, placement: placement, prompt: prompt?.resolve(on: element, in: context))
             } else { __content }
         #endif
-        #if os(iOS) || os(macOS)
+        #if os(iOS) || os(macOS) || os(visionOS)
         case let ._4(placement, prompt):
-            if #available(macOS 14.0,iOS 17.0, *) {
+            if #available(iOS 17.0,visionOS 1.0,macOS 14.0, *) {
             let placement = placement as! SwiftUI.SearchFieldPlacement 
 let prompt = prompt as! SwiftUI.LocalizedStringKey
             __content
                 .searchable(text: __4_text.projectedValue, isPresented: __4_isPresented.projectedValue, placement: placement, prompt: prompt)
             } else { __content }
         #endif
-        #if os(iOS) || os(macOS)
+        #if os(iOS) || os(macOS) || os(visionOS)
         case let ._5(placement, prompt):
-            if #available(macOS 14.0,iOS 17.0, *) {
+            if #available(iOS 17.0,visionOS 1.0,macOS 14.0, *) {
             let placement = placement as! SwiftUI.SearchFieldPlacement 
 let prompt = prompt as! AttributeReference<String>
             __content
@@ -8924,7 +9290,7 @@ struct _selectionDisabledModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         indirect case _0(isDisabled: Any)
         #endif
     }
@@ -8937,8 +9303,8 @@ struct _selectionDisabledModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-    @available(tvOS 17.0,iOS 17.0,watchOS 10.0,macOS 14.0, *)
+    #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+    @available(macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0,visionOS 1.0, *)
     init(_ isDisabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(isDisabled: isDisabled)
         
@@ -8949,9 +9315,9 @@ struct _selectionDisabledModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(isDisabled):
-            if #available(tvOS 17.0,iOS 17.0,watchOS 10.0,macOS 14.0, *) {
+            if #available(macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0,visionOS 1.0, *) {
             let isDisabled = isDisabled as! AttributeReference<Swift.Bool>
             __content
                 .selectionDisabled(isDisabled.resolve(on: element, in: context))
@@ -9269,7 +9635,7 @@ struct _statusBarHiddenModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS)
+        #if os(iOS) || os(visionOS)
         indirect case _0(hidden: Any)
         #endif
     }
@@ -9282,8 +9648,8 @@ struct _statusBarHiddenModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS)
-    @available(iOS 13.0, *)
+    #if os(iOS) || os(visionOS)
+    @available(visionOS 1.0,iOS 13.0, *)
     init(_ hidden: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(hidden: hidden)
         
@@ -9294,9 +9660,9 @@ struct _statusBarHiddenModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS)
+        #if os(iOS) || os(visionOS)
         case let ._0(hidden):
-            if #available(iOS 13.0, *) {
+            if #available(visionOS 1.0,iOS 13.0, *) {
             let hidden = hidden as! AttributeReference<Swift.Bool>
             __content
                 .statusBarHidden(hidden.resolve(on: element, in: context))
@@ -9398,7 +9764,7 @@ struct _swipeActionsModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(macOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
         indirect case _0(edge: Any, allowsFullSwipe: Any, content: Any)
         #endif
     }
@@ -9411,8 +9777,8 @@ struct _swipeActionsModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(macOS) || os(watchOS)
-    @available(macOS 12.0,watchOS 8.0,iOS 15.0, *)
+    #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
+    @available(visionOS 1.0,macOS 12.0,watchOS 8.0,iOS 15.0, *)
     init(edge: SwiftUI.HorizontalEdge = .trailing, allowsFullSwipe: AttributeReference<Swift.Bool> = .init(storage: .constant(true)), content: ViewReference=ViewReference(value: [])) {
         self.value = ._0(edge: edge, allowsFullSwipe: allowsFullSwipe, content: content)
         
@@ -9423,9 +9789,9 @@ struct _swipeActionsModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(macOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
         case let ._0(edge, allowsFullSwipe, content):
-            if #available(macOS 12.0,watchOS 8.0,iOS 15.0, *) {
+            if #available(visionOS 1.0,macOS 12.0,watchOS 8.0,iOS 15.0, *) {
             let edge = edge as! SwiftUI.HorizontalEdge 
 let allowsFullSwipe = allowsFullSwipe as! AttributeReference<Swift.Bool>
 let content = content as! ViewReference
@@ -9443,10 +9809,10 @@ struct _symbolEffectModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         indirect case _0(effect: Any,options: Any, isActive: Any)
         #endif
-        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         indirect case _1(effect: Any,options: Any, value: Any)
         #endif
     }
@@ -9461,15 +9827,15 @@ struct _symbolEffectModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-    @available(tvOS 17.0,iOS 17.0,watchOS 10.0,macOS 14.0, *)
+    #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+    @available(watchOS 10.0,visionOS 1.0,tvOS 17.0,iOS 17.0,macOS 14.0, *)
     init(_ effect: AnyIndefiniteSymbolEffect,options: Symbols.SymbolEffectOptions = .default, isActive: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(effect: effect, options: options, isActive: isActive)
         
     }
     #endif
-    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-    @available(tvOS 17.0,iOS 17.0,watchOS 10.0,macOS 14.0, *)
+    #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+    @available(watchOS 10.0,visionOS 1.0,tvOS 17.0,iOS 17.0,macOS 14.0, *)
     init(_ effect: AnyDiscreteSymbolEffect,options: Symbols.SymbolEffectOptions = .default, value: AttributeReference<String>) {
         self.value = ._1(effect: effect, options: options, value: value)
         
@@ -9480,9 +9846,9 @@ struct _symbolEffectModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(effect, options, isActive):
-            if #available(tvOS 17.0,iOS 17.0,watchOS 10.0,macOS 14.0, *) {
+            if #available(watchOS 10.0,visionOS 1.0,tvOS 17.0,iOS 17.0,macOS 14.0, *) {
             let effect = effect as! AnyIndefiniteSymbolEffect
 let options = options as! Symbols.SymbolEffectOptions 
 let isActive = isActive as! AttributeReference<Swift.Bool>
@@ -9490,9 +9856,9 @@ let isActive = isActive as! AttributeReference<Swift.Bool>
                 .symbolEffect(effect, options: options, isActive: isActive.resolve(on: element, in: context))
             } else { __content }
         #endif
-        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(effect, options, value):
-            if #available(tvOS 17.0,iOS 17.0,watchOS 10.0,macOS 14.0, *) {
+            if #available(watchOS 10.0,visionOS 1.0,tvOS 17.0,iOS 17.0,macOS 14.0, *) {
             let effect = effect as! AnyDiscreteSymbolEffect
 let options = options as! Symbols.SymbolEffectOptions 
 let value = value as! AttributeReference<String>
@@ -9510,7 +9876,7 @@ struct _symbolEffectsRemovedModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         indirect case _0(isEnabled: Any)
         #endif
     }
@@ -9523,8 +9889,8 @@ struct _symbolEffectsRemovedModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-    @available(tvOS 17.0,iOS 17.0,watchOS 10.0,macOS 14.0, *)
+    #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+    @available(macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0,visionOS 1.0, *)
     init(_ isEnabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(isEnabled: isEnabled)
         
@@ -9535,9 +9901,9 @@ struct _symbolEffectsRemovedModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(isEnabled):
-            if #available(tvOS 17.0,iOS 17.0,watchOS 10.0,macOS 14.0, *) {
+            if #available(macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0,visionOS 1.0, *) {
             let isEnabled = isEnabled as! AttributeReference<Swift.Bool>
             __content
                 .symbolEffectsRemoved(isEnabled.resolve(on: element, in: context))
@@ -9725,7 +10091,7 @@ struct _tableStyleModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(macOS)
+        #if os(iOS) || os(macOS) || os(visionOS)
         indirect case _0(style: Any)
         #endif
     }
@@ -9738,8 +10104,8 @@ struct _tableStyleModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(macOS)
-    @available(macOS 12.0,iOS 16.0, *)
+    #if os(iOS) || os(macOS) || os(visionOS)
+    @available(macOS 12.0,visionOS 1.0,iOS 16.0, *)
     init(_ style: AnyTableStyle) {
         self.value = ._0(style: style)
         
@@ -9750,9 +10116,9 @@ struct _tableStyleModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(macOS)
+        #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(style):
-            if #available(macOS 12.0,iOS 16.0, *) {
+            if #available(macOS 12.0,visionOS 1.0,iOS 16.0, *) {
             let style = style as! AnyTableStyle
             __content
                 .tableStyle(style)
@@ -9811,7 +10177,7 @@ struct _textContentTypeModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(tvOS)
+        #if os(iOS) || os(tvOS) || os(visionOS)
         indirect case _0(textContentType: Any?)
         #endif
     }
@@ -9824,8 +10190,8 @@ struct _textContentTypeModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(tvOS)
-    @available(tvOS 13.0,iOS 13.0, *)
+    #if os(iOS) || os(tvOS) || os(visionOS)
+    @available(tvOS 13.0,visionOS 1.0,iOS 13.0, *)
     init(_ textContentType: UIKit.UITextContentType?) {
         self.value = ._0(textContentType: textContentType)
         
@@ -9836,9 +10202,9 @@ struct _textContentTypeModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(tvOS)
+        #if os(iOS) || os(tvOS) || os(visionOS)
         case let ._0(textContentType):
-            if #available(tvOS 13.0,iOS 13.0, *) {
+            if #available(tvOS 13.0,visionOS 1.0,iOS 13.0, *) {
             let textContentType = textContentType as? UIKit.UITextContentType
             __content
                 .textContentType(textContentType)
@@ -9868,7 +10234,7 @@ struct _textEditorStyleModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 14.0,visionOS 1.0,iOS 17.0, *)
+    @available(visionOS 1.0,iOS 17.0,macOS 14.0, *)
     init(_ style: AnyTextEditorStyle) {
         self.value = ._0(style: style)
         
@@ -9881,7 +10247,7 @@ struct _textEditorStyleModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(style):
-            if #available(macOS 14.0,visionOS 1.0,iOS 17.0, *) {
+            if #available(visionOS 1.0,iOS 17.0,macOS 14.0, *) {
             let style = style as! AnyTextEditorStyle
             __content
                 .textEditorStyle(style)
@@ -9940,7 +10306,7 @@ struct _textInputAutocapitalizationModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
         indirect case _0(autocapitalization: Any?)
         #endif
     }
@@ -9953,8 +10319,8 @@ struct _textInputAutocapitalizationModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(tvOS) || os(watchOS)
-    @available(tvOS 15.0,iOS 15.0,watchOS 8.0, *)
+    #if os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
+    @available(watchOS 8.0,visionOS 1.0,iOS 15.0,tvOS 15.0, *)
     init(_ autocapitalization: SwiftUI.TextInputAutocapitalization?) {
         self.value = ._0(autocapitalization: autocapitalization)
         
@@ -9965,9 +10331,9 @@ struct _textInputAutocapitalizationModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(autocapitalization):
-            if #available(tvOS 15.0,iOS 15.0,watchOS 8.0, *) {
+            if #available(watchOS 8.0,visionOS 1.0,iOS 15.0,tvOS 15.0, *) {
             let autocapitalization = autocapitalization as? SwiftUI.TextInputAutocapitalization
             __content
                 .textInputAutocapitalization(autocapitalization)
@@ -9983,7 +10349,7 @@ struct _textSelectionModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(macOS)
+        #if os(iOS) || os(macOS) || os(visionOS)
         indirect case _0(selectability: Any)
         #endif
     }
@@ -9996,8 +10362,8 @@ struct _textSelectionModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(macOS)
-    @available(macOS 12.0,iOS 15.0, *)
+    #if os(iOS) || os(macOS) || os(visionOS)
+    @available(macOS 12.0,visionOS 1.0,iOS 15.0, *)
     init(_ selectability: AnyTextSelectability) {
         self.value = ._0(selectability: selectability)
         
@@ -10008,9 +10374,9 @@ struct _textSelectionModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(macOS)
+        #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(selectability):
-            if #available(macOS 12.0,iOS 15.0, *) {
+            if #available(macOS 12.0,visionOS 1.0,iOS 15.0, *) {
             let selectability = selectability as! AnyTextSelectability
             __content
                 .textSelection(selectability)
@@ -10135,7 +10501,7 @@ struct _toolbarModifier<R: RootRegistry>: ViewModifier {
         
         indirect case _0(visibility: AttributeReference<SwiftUI.Visibility>,bars: SwiftUI.ToolbarPlacement)
         
-        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         indirect case _1(defaultItemKind: Any?)
         #endif
         
@@ -10167,8 +10533,8 @@ struct _toolbarModifier<R: RootRegistry>: ViewModifier {
         
     }
     
-    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-    @available(tvOS 17.0,macOS 14.0,watchOS 10.0,iOS 17.0, *)
+    #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+    @available(macOS 14.0,watchOS 10.0,tvOS 17.0,visionOS 1.0,iOS 17.0, *)
     init(removing defaultItemKind: SwiftUI.ToolbarDefaultItemKind?) {
         self.value = ._1(defaultItemKind: defaultItemKind)
         
@@ -10201,9 +10567,9 @@ struct _toolbarModifier<R: RootRegistry>: ViewModifier {
                 .toolbar(visibility.resolve(on: element, in: context), for: bars)
             
         
-        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(defaultItemKind):
-            if #available(tvOS 17.0,macOS 14.0,watchOS 10.0,iOS 17.0, *) {
+            if #available(macOS 14.0,watchOS 10.0,tvOS 17.0,visionOS 1.0,iOS 17.0, *) {
             let defaultItemKind = defaultItemKind as? SwiftUI.ToolbarDefaultItemKind
             __content
                 .toolbar(removing: defaultItemKind)
@@ -10384,7 +10750,7 @@ struct _toolbarTitleDisplayModeModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         indirect case _0(mode: Any)
         #endif
     }
@@ -10397,8 +10763,8 @@ struct _toolbarTitleDisplayModeModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-    @available(iOS 17.0,tvOS 17.0,macOS 14.0,watchOS 10.0, *)
+    #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+    @available(iOS 17.0,macOS 14.0,tvOS 17.0,visionOS 1.0,watchOS 10.0, *)
     init(_ mode: SwiftUI.ToolbarTitleDisplayMode) {
         self.value = ._0(mode: mode)
         
@@ -10409,9 +10775,9 @@ struct _toolbarTitleDisplayModeModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(mode):
-            if #available(iOS 17.0,tvOS 17.0,macOS 14.0,watchOS 10.0, *) {
+            if #available(iOS 17.0,macOS 14.0,tvOS 17.0,visionOS 1.0,watchOS 10.0, *) {
             let mode = mode as! SwiftUI.ToolbarTitleDisplayMode
             __content
                 .toolbarTitleDisplayMode(mode)
@@ -10544,6 +10910,49 @@ struct _touchBarItemPrincipalModifier<R: RootRegistry>: ViewModifier {
             let principal = principal as! AttributeReference<Swift.Bool>
             __content
                 .touchBarItemPrincipal(principal.resolve(on: element, in: context))
+            } else { __content }
+        #endif
+        }
+    }
+}
+@_documentation(visibility: public)
+@ParseableExpression
+struct _transform3DEffectModifier<R: RootRegistry>: ViewModifier {
+    static var name: String { "transform3DEffect" }
+
+    enum Value {
+        case _never
+        #if os(visionOS)
+        indirect case _0(transform: Any)
+        #endif
+    }
+
+    let value: Value
+
+    
+    
+
+
+
+
+    #if os(visionOS)
+    @available(visionOS 1.0, *)
+    init(_ transform: Spatial.AffineTransform3D) {
+        self.value = ._0(transform: transform)
+        
+    }
+    #endif
+
+    func body(content __content: Content) -> some View {
+        switch value {
+        case ._never:
+            fatalError("unreachable")
+        #if os(visionOS)
+        case let ._0(transform):
+            if #available(visionOS 1.0, *) {
+            let transform = transform as! Spatial.AffineTransform3D
+            __content
+                .transform3DEffect(transform)
             } else { __content }
         #endif
         }
@@ -10718,6 +11127,49 @@ struct _unredactedModifier<R: RootRegistry>: ViewModifier {
                 .unredacted()
             
         
+        }
+    }
+}
+@_documentation(visibility: public)
+@ParseableExpression
+struct _upperLimbVisibilityModifier<R: RootRegistry>: ViewModifier {
+    static var name: String { "upperLimbVisibility" }
+
+    enum Value {
+        case _never
+        #if os(visionOS)
+        indirect case _0(preferredVisibility: Any)
+        #endif
+    }
+
+    let value: Value
+
+    @ObservedElement private var element
+    @LiveContext<R> private var context
+
+
+
+
+    #if os(visionOS)
+    @available(visionOS 1.0, *)
+    init(_ preferredVisibility: AttributeReference<SwiftUI.Visibility>) {
+        self.value = ._0(preferredVisibility: preferredVisibility)
+        
+    }
+    #endif
+
+    func body(content __content: Content) -> some View {
+        switch value {
+        case ._never:
+            fatalError("unreachable")
+        #if os(visionOS)
+        case let ._0(preferredVisibility):
+            if #available(visionOS 1.0, *) {
+            let preferredVisibility = preferredVisibility as! AttributeReference<SwiftUI.Visibility>
+            __content
+                .upperLimbVisibility(preferredVisibility.resolve(on: element, in: context))
+            } else { __content }
+        #endif
         }
     }
 }
@@ -10976,6 +11428,7 @@ indirect case fullScreenCover(_fullScreenCoverModifier<R>)
 indirect case gaugeStyle(_gaugeStyleModifier<R>)
 indirect case geometryGroup(_geometryGroupModifier<R>)
 indirect case gesture(_gestureModifier<R>)
+indirect case glassBackgroundEffect(_glassBackgroundEffectModifier<R>)
 indirect case grayscale(_grayscaleModifier<R>)
 indirect case gridCellAnchor(_gridCellAnchorModifier<R>)
 indirect case gridCellColumns(_gridCellColumnsModifier<R>)
@@ -10984,7 +11437,6 @@ indirect case gridColumnAlignment(_gridColumnAlignmentModifier<R>)
 indirect case groupBoxStyle(_groupBoxStyleModifier<R>)
 indirect case headerProminence(_headerProminenceModifier<R>)
 indirect case help(_helpModifier<R>)
-indirect case hidden(_hiddenModifier<R>)
         
         func body(content: Content) -> some View {
             switch self {
@@ -10997,6 +11449,8 @@ case let .gaugeStyle(modifier):
 case let .geometryGroup(modifier):
     content.modifier(modifier)
 case let .gesture(modifier):
+    content.modifier(modifier)
+case let .glassBackgroundEffect(modifier):
     content.modifier(modifier)
 case let .grayscale(modifier):
     content.modifier(modifier)
@@ -11014,15 +11468,14 @@ case let .headerProminence(modifier):
     content.modifier(modifier)
 case let .help(modifier):
     content.modifier(modifier)
-case let .hidden(modifier):
-    content.modifier(modifier)
             }
         }
     }
 }
 extension BuiltinRegistry {
     enum _BuiltinModifierChunk5: ViewModifier {
-        indirect case highPriorityGesture(_highPriorityGestureModifier<R>)
+        indirect case hidden(_hiddenModifier<R>)
+indirect case highPriorityGesture(_highPriorityGestureModifier<R>)
 indirect case horizontalRadioGroupLayout(_horizontalRadioGroupLayoutModifier<R>)
 indirect case hoverEffect(_hoverEffectModifier<R>)
 indirect case hoverEffectDisabled(_hoverEffectDisabledModifier<R>)
@@ -11035,11 +11488,12 @@ indirect case inspectorColumnWidth(_inspectorColumnWidthModifier<R>)
 indirect case interactionActivityTrackingTag(_interactionActivityTrackingTagModifier<R>)
 indirect case interactiveDismissDisabled(_interactiveDismissDisabledModifier<R>)
 indirect case invalidatableContent(_invalidatableContentModifier<R>)
-indirect case keyboardShortcut(_keyboardShortcutModifier<R>)
         
         func body(content: Content) -> some View {
             switch self {
-            case let .highPriorityGesture(modifier):
+            case let .hidden(modifier):
+    content.modifier(modifier)
+case let .highPriorityGesture(modifier):
     content.modifier(modifier)
 case let .horizontalRadioGroupLayout(modifier):
     content.modifier(modifier)
@@ -11065,15 +11519,14 @@ case let .interactiveDismissDisabled(modifier):
     content.modifier(modifier)
 case let .invalidatableContent(modifier):
     content.modifier(modifier)
-case let .keyboardShortcut(modifier):
-    content.modifier(modifier)
             }
         }
     }
 }
 extension BuiltinRegistry {
     enum _BuiltinModifierChunk6: ViewModifier {
-        indirect case keyboardType(_keyboardTypeModifier<R>)
+        indirect case keyboardShortcut(_keyboardShortcutModifier<R>)
+indirect case keyboardType(_keyboardTypeModifier<R>)
 indirect case labelStyle(_labelStyleModifier<R>)
 indirect case labeledContentStyle(_labeledContentStyleModifier<R>)
 indirect case labelsHidden(_labelsHiddenModifier<R>)
@@ -11086,11 +11539,12 @@ indirect case listRowHoverEffect(_listRowHoverEffectModifier<R>)
 indirect case listRowHoverEffectDisabled(_listRowHoverEffectDisabledModifier<R>)
 indirect case listRowInsets(_listRowInsetsModifier<R>)
 indirect case listRowSeparator(_listRowSeparatorModifier<R>)
-indirect case listRowSeparatorTint(_listRowSeparatorTintModifier<R>)
         
         func body(content: Content) -> some View {
             switch self {
-            case let .keyboardType(modifier):
+            case let .keyboardShortcut(modifier):
+    content.modifier(modifier)
+case let .keyboardType(modifier):
     content.modifier(modifier)
 case let .labelStyle(modifier):
     content.modifier(modifier)
@@ -11116,15 +11570,14 @@ case let .listRowInsets(modifier):
     content.modifier(modifier)
 case let .listRowSeparator(modifier):
     content.modifier(modifier)
-case let .listRowSeparatorTint(modifier):
-    content.modifier(modifier)
             }
         }
     }
 }
 extension BuiltinRegistry {
     enum _BuiltinModifierChunk7: ViewModifier {
-        indirect case listRowSpacing(_listRowSpacingModifier<R>)
+        indirect case listRowSeparatorTint(_listRowSeparatorTintModifier<R>)
+indirect case listRowSpacing(_listRowSpacingModifier<R>)
 indirect case listSectionSeparator(_listSectionSeparatorModifier<R>)
 indirect case listSectionSeparatorTint(_listSectionSeparatorTintModifier<R>)
 indirect case listSectionSpacing(_listSectionSpacingModifier<R>)
@@ -11137,11 +11590,12 @@ indirect case minimumScaleFactor(_minimumScaleFactorModifier<R>)
 indirect case moveDisabled(_moveDisabledModifier<R>)
 indirect case multilineTextAlignment(_multilineTextAlignmentModifier<R>)
 indirect case navigationBarBackButtonHidden(_navigationBarBackButtonHiddenModifier<R>)
-indirect case navigationBarTitleDisplayMode(_navigationBarTitleDisplayModeModifier<R>)
         
         func body(content: Content) -> some View {
             switch self {
-            case let .listRowSpacing(modifier):
+            case let .listRowSeparatorTint(modifier):
+    content.modifier(modifier)
+case let .listRowSpacing(modifier):
     content.modifier(modifier)
 case let .listSectionSeparator(modifier):
     content.modifier(modifier)
@@ -11167,15 +11621,14 @@ case let .multilineTextAlignment(modifier):
     content.modifier(modifier)
 case let .navigationBarBackButtonHidden(modifier):
     content.modifier(modifier)
-case let .navigationBarTitleDisplayMode(modifier):
-    content.modifier(modifier)
             }
         }
     }
 }
 extension BuiltinRegistry {
     enum _BuiltinModifierChunk8: ViewModifier {
-        indirect case navigationDestination(_navigationDestinationModifier<R>)
+        indirect case navigationBarTitleDisplayMode(_navigationBarTitleDisplayModeModifier<R>)
+indirect case navigationDestination(_navigationDestinationModifier<R>)
 indirect case navigationSplitViewColumnWidth(_navigationSplitViewColumnWidthModifier<R>)
 indirect case navigationSplitViewStyle(_navigationSplitViewStyleModifier<R>)
 indirect case navigationSubtitle(_navigationSubtitleModifier<R>)
@@ -11188,11 +11641,12 @@ indirect case onExitCommand(_onExitCommandModifier<R>)
 indirect case onHover(_onHoverModifier<R>)
 indirect case onLongPressGesture(_onLongPressGestureModifier<R>)
 indirect case onLongTouchGesture(_onLongTouchGestureModifier<R>)
-indirect case onMoveCommand(_onMoveCommandModifier<R>)
         
         func body(content: Content) -> some View {
             switch self {
-            case let .navigationDestination(modifier):
+            case let .navigationBarTitleDisplayMode(modifier):
+    content.modifier(modifier)
+case let .navigationDestination(modifier):
     content.modifier(modifier)
 case let .navigationSplitViewColumnWidth(modifier):
     content.modifier(modifier)
@@ -11218,40 +11672,44 @@ case let .onLongPressGesture(modifier):
     content.modifier(modifier)
 case let .onLongTouchGesture(modifier):
     content.modifier(modifier)
-case let .onMoveCommand(modifier):
-    content.modifier(modifier)
             }
         }
     }
 }
 extension BuiltinRegistry {
     enum _BuiltinModifierChunk9: ViewModifier {
-        indirect case onPlayPauseCommand(_onPlayPauseCommandModifier<R>)
+        indirect case onMoveCommand(_onMoveCommandModifier<R>)
+indirect case onPlayPauseCommand(_onPlayPauseCommandModifier<R>)
 indirect case onTapGesture(_onTapGestureModifier<R>)
 indirect case opacity(_opacityModifier<R>)
+indirect case ornament(_ornamentModifier<R>)
 indirect case overlay(_overlayModifier<R>)
 indirect case padding(_paddingModifier<R>)
+indirect case padding3D(_padding3DModifier<R>)
 indirect case persistentSystemOverlays(_persistentSystemOverlaysModifier<R>)
 indirect case pickerStyle(_pickerStyleModifier<R>)
 indirect case popover(_popoverModifier<R>)
 indirect case position(_positionModifier<R>)
 indirect case preferredColorScheme(_preferredColorSchemeModifier<R>)
-indirect case presentationBackground(_presentationBackgroundModifier<R>)
-indirect case presentationBackgroundInteraction(_presentationBackgroundInteractionModifier<R>)
-indirect case presentationCompactAdaptation(_presentationCompactAdaptationModifier<R>)
-indirect case presentationContentInteraction(_presentationContentInteractionModifier<R>)
+indirect case preferredSurroundingsEffect(_preferredSurroundingsEffectModifier<R>)
         
         func body(content: Content) -> some View {
             switch self {
-            case let .onPlayPauseCommand(modifier):
+            case let .onMoveCommand(modifier):
+    content.modifier(modifier)
+case let .onPlayPauseCommand(modifier):
     content.modifier(modifier)
 case let .onTapGesture(modifier):
     content.modifier(modifier)
 case let .opacity(modifier):
     content.modifier(modifier)
+case let .ornament(modifier):
+    content.modifier(modifier)
 case let .overlay(modifier):
     content.modifier(modifier)
 case let .padding(modifier):
+    content.modifier(modifier)
+case let .padding3D(modifier):
     content.modifier(modifier)
 case let .persistentSystemOverlays(modifier):
     content.modifier(modifier)
@@ -11263,13 +11721,7 @@ case let .position(modifier):
     content.modifier(modifier)
 case let .preferredColorScheme(modifier):
     content.modifier(modifier)
-case let .presentationBackground(modifier):
-    content.modifier(modifier)
-case let .presentationBackgroundInteraction(modifier):
-    content.modifier(modifier)
-case let .presentationCompactAdaptation(modifier):
-    content.modifier(modifier)
-case let .presentationContentInteraction(modifier):
+case let .preferredSurroundingsEffect(modifier):
     content.modifier(modifier)
             }
         }
@@ -11277,7 +11729,11 @@ case let .presentationContentInteraction(modifier):
 }
 extension BuiltinRegistry {
     enum _BuiltinModifierChunk10: ViewModifier {
-        indirect case presentationCornerRadius(_presentationCornerRadiusModifier<R>)
+        indirect case presentationBackground(_presentationBackgroundModifier<R>)
+indirect case presentationBackgroundInteraction(_presentationBackgroundInteractionModifier<R>)
+indirect case presentationCompactAdaptation(_presentationCompactAdaptationModifier<R>)
+indirect case presentationContentInteraction(_presentationContentInteractionModifier<R>)
+indirect case presentationCornerRadius(_presentationCornerRadiusModifier<R>)
 indirect case presentationDragIndicator(_presentationDragIndicatorModifier<R>)
 indirect case previewDisplayName(_previewDisplayNameModifier<R>)
 indirect case privacySensitive(_privacySensitiveModifier<R>)
@@ -11287,14 +11743,18 @@ indirect case redacted(_redactedModifier<R>)
 indirect case refreshable(_refreshableModifier<R>)
 indirect case renameAction(_renameActionModifier<R>)
 indirect case replaceDisabled(_replaceDisabledModifier<R>)
-indirect case rotationEffect(_rotationEffectModifier<R>)
-indirect case safeAreaInset(_safeAreaInsetModifier<R>)
-indirect case saturation(_saturationModifier<R>)
-indirect case scaleEffect(_scaleEffectModifier<R>)
         
         func body(content: Content) -> some View {
             switch self {
-            case let .presentationCornerRadius(modifier):
+            case let .presentationBackground(modifier):
+    content.modifier(modifier)
+case let .presentationBackgroundInteraction(modifier):
+    content.modifier(modifier)
+case let .presentationCompactAdaptation(modifier):
+    content.modifier(modifier)
+case let .presentationContentInteraction(modifier):
+    content.modifier(modifier)
+case let .presentationCornerRadius(modifier):
     content.modifier(modifier)
 case let .presentationDragIndicator(modifier):
     content.modifier(modifier)
@@ -11314,21 +11774,17 @@ case let .renameAction(modifier):
     content.modifier(modifier)
 case let .replaceDisabled(modifier):
     content.modifier(modifier)
-case let .rotationEffect(modifier):
-    content.modifier(modifier)
-case let .safeAreaInset(modifier):
-    content.modifier(modifier)
-case let .saturation(modifier):
-    content.modifier(modifier)
-case let .scaleEffect(modifier):
-    content.modifier(modifier)
             }
         }
     }
 }
 extension BuiltinRegistry {
     enum _BuiltinModifierChunk11: ViewModifier {
-        indirect case scaledToFill(_scaledToFillModifier<R>)
+        indirect case rotationEffect(_rotationEffectModifier<R>)
+indirect case safeAreaInset(_safeAreaInsetModifier<R>)
+indirect case saturation(_saturationModifier<R>)
+indirect case scaleEffect(_scaleEffectModifier<R>)
+indirect case scaledToFill(_scaledToFillModifier<R>)
 indirect case scaledToFit(_scaledToFitModifier<R>)
 indirect case scenePadding(_scenePaddingModifier<R>)
 indirect case scrollBounceBehavior(_scrollBounceBehaviorModifier<R>)
@@ -11338,14 +11794,18 @@ indirect case scrollDisabled(_scrollDisabledModifier<R>)
 indirect case scrollDismissesKeyboard(_scrollDismissesKeyboardModifier<R>)
 indirect case scrollIndicators(_scrollIndicatorsModifier<R>)
 indirect case scrollIndicatorsFlash(_scrollIndicatorsFlashModifier<R>)
-indirect case scrollPosition(_scrollPositionModifier<R>)
-indirect case scrollTargetBehavior(_scrollTargetBehaviorModifier<R>)
-indirect case scrollTargetLayout(_scrollTargetLayoutModifier<R>)
-indirect case searchDictationBehavior(_searchDictationBehaviorModifier<R>)
         
         func body(content: Content) -> some View {
             switch self {
-            case let .scaledToFill(modifier):
+            case let .rotationEffect(modifier):
+    content.modifier(modifier)
+case let .safeAreaInset(modifier):
+    content.modifier(modifier)
+case let .saturation(modifier):
+    content.modifier(modifier)
+case let .scaleEffect(modifier):
+    content.modifier(modifier)
+case let .scaledToFill(modifier):
     content.modifier(modifier)
 case let .scaledToFit(modifier):
     content.modifier(modifier)
@@ -11365,21 +11825,17 @@ case let .scrollIndicators(modifier):
     content.modifier(modifier)
 case let .scrollIndicatorsFlash(modifier):
     content.modifier(modifier)
-case let .scrollPosition(modifier):
-    content.modifier(modifier)
-case let .scrollTargetBehavior(modifier):
-    content.modifier(modifier)
-case let .scrollTargetLayout(modifier):
-    content.modifier(modifier)
-case let .searchDictationBehavior(modifier):
-    content.modifier(modifier)
             }
         }
     }
 }
 extension BuiltinRegistry {
     enum _BuiltinModifierChunk12: ViewModifier {
-        indirect case searchPresentationToolbarBehavior(_searchPresentationToolbarBehaviorModifier<R>)
+        indirect case scrollPosition(_scrollPositionModifier<R>)
+indirect case scrollTargetBehavior(_scrollTargetBehaviorModifier<R>)
+indirect case scrollTargetLayout(_scrollTargetLayoutModifier<R>)
+indirect case searchDictationBehavior(_searchDictationBehaviorModifier<R>)
+indirect case searchPresentationToolbarBehavior(_searchPresentationToolbarBehaviorModifier<R>)
 indirect case searchSuggestions(_searchSuggestionsModifier<R>)
 indirect case searchable(_searchableModifier<R>)
 indirect case selectionDisabled(_selectionDisabledModifier<R>)
@@ -11389,14 +11845,18 @@ indirect case simultaneousGesture(_simultaneousGestureModifier<R>)
 indirect case speechAdjustedPitch(_speechAdjustedPitchModifier<R>)
 indirect case speechAlwaysIncludesPunctuation(_speechAlwaysIncludesPunctuationModifier<R>)
 indirect case speechAnnouncementsQueued(_speechAnnouncementsQueuedModifier<R>)
-indirect case speechSpellsOutCharacters(_speechSpellsOutCharactersModifier<R>)
-indirect case statusBarHidden(_statusBarHiddenModifier<R>)
-indirect case submitLabel(_submitLabelModifier<R>)
-indirect case submitScope(_submitScopeModifier<R>)
         
         func body(content: Content) -> some View {
             switch self {
-            case let .searchPresentationToolbarBehavior(modifier):
+            case let .scrollPosition(modifier):
+    content.modifier(modifier)
+case let .scrollTargetBehavior(modifier):
+    content.modifier(modifier)
+case let .scrollTargetLayout(modifier):
+    content.modifier(modifier)
+case let .searchDictationBehavior(modifier):
+    content.modifier(modifier)
+case let .searchPresentationToolbarBehavior(modifier):
     content.modifier(modifier)
 case let .searchSuggestions(modifier):
     content.modifier(modifier)
@@ -11416,21 +11876,17 @@ case let .speechAlwaysIncludesPunctuation(modifier):
     content.modifier(modifier)
 case let .speechAnnouncementsQueued(modifier):
     content.modifier(modifier)
-case let .speechSpellsOutCharacters(modifier):
-    content.modifier(modifier)
-case let .statusBarHidden(modifier):
-    content.modifier(modifier)
-case let .submitLabel(modifier):
-    content.modifier(modifier)
-case let .submitScope(modifier):
-    content.modifier(modifier)
             }
         }
     }
 }
 extension BuiltinRegistry {
     enum _BuiltinModifierChunk13: ViewModifier {
-        indirect case swipeActions(_swipeActionsModifier<R>)
+        indirect case speechSpellsOutCharacters(_speechSpellsOutCharactersModifier<R>)
+indirect case statusBarHidden(_statusBarHiddenModifier<R>)
+indirect case submitLabel(_submitLabelModifier<R>)
+indirect case submitScope(_submitScopeModifier<R>)
+indirect case swipeActions(_swipeActionsModifier<R>)
 indirect case symbolEffect(_symbolEffectModifier<R>)
 indirect case symbolEffectsRemoved(_symbolEffectsRemovedModifier<R>)
 indirect case symbolRenderingMode(_symbolRenderingModeModifier<R>)
@@ -11440,14 +11896,18 @@ indirect case tabViewStyle(_tabViewStyleModifier<R>)
 indirect case tableStyle(_tableStyleModifier<R>)
 indirect case textCase(_textCaseModifier<R>)
 indirect case textContentType(_textContentTypeModifier<R>)
-indirect case textEditorStyle(_textEditorStyleModifier<R>)
-indirect case textFieldStyle(_textFieldStyleModifier<R>)
-indirect case textInputAutocapitalization(_textInputAutocapitalizationModifier<R>)
-indirect case textSelection(_textSelectionModifier<R>)
         
         func body(content: Content) -> some View {
             switch self {
-            case let .swipeActions(modifier):
+            case let .speechSpellsOutCharacters(modifier):
+    content.modifier(modifier)
+case let .statusBarHidden(modifier):
+    content.modifier(modifier)
+case let .submitLabel(modifier):
+    content.modifier(modifier)
+case let .submitScope(modifier):
+    content.modifier(modifier)
+case let .swipeActions(modifier):
     content.modifier(modifier)
 case let .symbolEffect(modifier):
     content.modifier(modifier)
@@ -11467,21 +11927,17 @@ case let .textCase(modifier):
     content.modifier(modifier)
 case let .textContentType(modifier):
     content.modifier(modifier)
-case let .textEditorStyle(modifier):
-    content.modifier(modifier)
-case let .textFieldStyle(modifier):
-    content.modifier(modifier)
-case let .textInputAutocapitalization(modifier):
-    content.modifier(modifier)
-case let .textSelection(modifier):
-    content.modifier(modifier)
             }
         }
     }
 }
 extension BuiltinRegistry {
     enum _BuiltinModifierChunk14: ViewModifier {
-        indirect case tint(_tintModifier<R>)
+        indirect case textEditorStyle(_textEditorStyleModifier<R>)
+indirect case textFieldStyle(_textFieldStyleModifier<R>)
+indirect case textInputAutocapitalization(_textInputAutocapitalizationModifier<R>)
+indirect case textSelection(_textSelectionModifier<R>)
+indirect case tint(_tintModifier<R>)
 indirect case toggleStyle(_toggleStyleModifier<R>)
 indirect case toolbar(_toolbarModifier<R>)
 indirect case toolbarBackground(_toolbarBackgroundModifier<R>)
@@ -11491,14 +11947,18 @@ indirect case toolbarTitleDisplayMode(_toolbarTitleDisplayModeModifier<R>)
 indirect case toolbarTitleMenu(_toolbarTitleMenuModifier<R>)
 indirect case touchBarCustomizationLabel(_touchBarCustomizationLabelModifier<R>)
 indirect case touchBarItemPrincipal(_touchBarItemPrincipalModifier<R>)
-indirect case transformEffect(_transformEffectModifier<R>)
-indirect case transition(_transitionModifier<R>)
-indirect case truncationMode(_truncationModeModifier<R>)
-indirect case unredacted(_unredactedModifier<R>)
         
         func body(content: Content) -> some View {
             switch self {
-            case let .tint(modifier):
+            case let .textEditorStyle(modifier):
+    content.modifier(modifier)
+case let .textFieldStyle(modifier):
+    content.modifier(modifier)
+case let .textInputAutocapitalization(modifier):
+    content.modifier(modifier)
+case let .textSelection(modifier):
+    content.modifier(modifier)
+case let .tint(modifier):
     content.modifier(modifier)
 case let .toggleStyle(modifier):
     content.modifier(modifier)
@@ -11518,6 +11978,24 @@ case let .touchBarCustomizationLabel(modifier):
     content.modifier(modifier)
 case let .touchBarItemPrincipal(modifier):
     content.modifier(modifier)
+            }
+        }
+    }
+}
+extension BuiltinRegistry {
+    enum _BuiltinModifierChunk15: ViewModifier {
+        indirect case transform3DEffect(_transform3DEffectModifier<R>)
+indirect case transformEffect(_transformEffectModifier<R>)
+indirect case transition(_transitionModifier<R>)
+indirect case truncationMode(_truncationModeModifier<R>)
+indirect case unredacted(_unredactedModifier<R>)
+indirect case upperLimbVisibility(_upperLimbVisibilityModifier<R>)
+indirect case zIndex(_zIndexModifier<R>)
+        
+        func body(content: Content) -> some View {
+            switch self {
+            case let .transform3DEffect(modifier):
+    content.modifier(modifier)
 case let .transformEffect(modifier):
     content.modifier(modifier)
 case let .transition(modifier):
@@ -11526,17 +12004,9 @@ case let .truncationMode(modifier):
     content.modifier(modifier)
 case let .unredacted(modifier):
     content.modifier(modifier)
-            }
-        }
-    }
-}
-extension BuiltinRegistry {
-    enum _BuiltinModifierChunk15: ViewModifier {
-        indirect case zIndex(_zIndexModifier<R>)
-        
-        func body(content: Content) -> some View {
-            switch self {
-            case let .zIndex(modifier):
+case let .upperLimbVisibility(modifier):
+    content.modifier(modifier)
+case let .zIndex(modifier):
     content.modifier(modifier)
             }
         }
@@ -11560,15 +12030,16 @@ indirect case chunk12(_BuiltinModifierChunk12)
 indirect case chunk13(_BuiltinModifierChunk13)
 indirect case chunk14(_BuiltinModifierChunk14)
 indirect case chunk15(_BuiltinModifierChunk15)
-        indirect case _SearchScopesModifier(LiveViewNative._SearchScopesModifier<R>)
-indirect case _SearchCompletionModifier(LiveViewNative._SearchCompletionModifier<R>)
+        indirect case _PrefersDefaultFocusModifier(LiveViewNative._PrefersDefaultFocusModifier<R>)
 indirect case _MaskModifier(LiveViewNative._MaskModifier<R>)
-indirect case _Rotation3DEffectModifier(LiveViewNative._Rotation3DEffectModifier<R>)
 indirect case _OnSubmitModifier(LiveViewNative._OnSubmitModifier)
 indirect case _PresentationDetentsModifier(LiveViewNative._PresentationDetentsModifier)
-indirect case _FocusScopeModifier(LiveViewNative._FocusScopeModifier<R>)
+indirect case _SearchScopesModifier(LiveViewNative._SearchScopesModifier<R>)
+indirect case _PerspectiveRotationEffectModifier(LiveViewNative._PerspectiveRotationEffectModifier<R>)
+indirect case _Rotation3DEffectModifier(LiveViewNative._Rotation3DEffectModifier<R>)
+indirect case _SearchCompletionModifier(LiveViewNative._SearchCompletionModifier<R>)
 indirect case _MatchedGeometryEffectModifier(LiveViewNative._MatchedGeometryEffectModifier<R>)
-indirect case _PrefersDefaultFocusModifier(LiveViewNative._PrefersDefaultFocusModifier<R>)
+indirect case _FocusScopeModifier(LiveViewNative._FocusScopeModifier<R>)
         indirect case _customRegistryModifier(R.CustomModifier)
         indirect case _anyTextModifier(_AnyTextModifier<R>)
         indirect case _anyImageModifier(_AnyImageModifier<R>)
@@ -11609,23 +12080,25 @@ case let .chunk14(chunk):
     content.modifier(chunk)
 case let .chunk15(chunk):
     content.modifier(chunk)
-            case let ._SearchScopesModifier(modifier):
-    content.modifier(modifier)
-case let ._SearchCompletionModifier(modifier):
+            case let ._PrefersDefaultFocusModifier(modifier):
     content.modifier(modifier)
 case let ._MaskModifier(modifier):
-    content.modifier(modifier)
-case let ._Rotation3DEffectModifier(modifier):
     content.modifier(modifier)
 case let ._OnSubmitModifier(modifier):
     content.modifier(modifier)
 case let ._PresentationDetentsModifier(modifier):
     content.modifier(modifier)
-case let ._FocusScopeModifier(modifier):
+case let ._SearchScopesModifier(modifier):
+    content.modifier(modifier)
+case let ._PerspectiveRotationEffectModifier(modifier):
+    content.modifier(modifier)
+case let ._Rotation3DEffectModifier(modifier):
+    content.modifier(modifier)
+case let ._SearchCompletionModifier(modifier):
     content.modifier(modifier)
 case let ._MatchedGeometryEffectModifier(modifier):
     content.modifier(modifier)
-case let ._PrefersDefaultFocusModifier(modifier):
+case let ._FocusScopeModifier(modifier):
     content.modifier(modifier)
             case let ._customRegistryModifier(modifier):
                 content.modifier(modifier)
@@ -11713,6 +12186,7 @@ _fullScreenCoverModifier<R>.name: _fullScreenCoverModifier<R>.parser(in: context
 _gaugeStyleModifier<R>.name: _gaugeStyleModifier<R>.parser(in: context).map({ Output.chunk4(.gaugeStyle($0)) }).eraseToAnyParser(),
 _geometryGroupModifier<R>.name: _geometryGroupModifier<R>.parser(in: context).map({ Output.chunk4(.geometryGroup($0)) }).eraseToAnyParser(),
 _gestureModifier<R>.name: _gestureModifier<R>.parser(in: context).map({ Output.chunk4(.gesture($0)) }).eraseToAnyParser(),
+_glassBackgroundEffectModifier<R>.name: _glassBackgroundEffectModifier<R>.parser(in: context).map({ Output.chunk4(.glassBackgroundEffect($0)) }).eraseToAnyParser(),
 _grayscaleModifier<R>.name: _grayscaleModifier<R>.parser(in: context).map({ Output.chunk4(.grayscale($0)) }).eraseToAnyParser(),
 _gridCellAnchorModifier<R>.name: _gridCellAnchorModifier<R>.parser(in: context).map({ Output.chunk4(.gridCellAnchor($0)) }).eraseToAnyParser(),
 _gridCellColumnsModifier<R>.name: _gridCellColumnsModifier<R>.parser(in: context).map({ Output.chunk4(.gridCellColumns($0)) }).eraseToAnyParser(),
@@ -11721,7 +12195,7 @@ _gridColumnAlignmentModifier<R>.name: _gridColumnAlignmentModifier<R>.parser(in:
 _groupBoxStyleModifier<R>.name: _groupBoxStyleModifier<R>.parser(in: context).map({ Output.chunk4(.groupBoxStyle($0)) }).eraseToAnyParser(),
 _headerProminenceModifier<R>.name: _headerProminenceModifier<R>.parser(in: context).map({ Output.chunk4(.headerProminence($0)) }).eraseToAnyParser(),
 _helpModifier<R>.name: _helpModifier<R>.parser(in: context).map({ Output.chunk4(.help($0)) }).eraseToAnyParser(),
-_hiddenModifier<R>.name: _hiddenModifier<R>.parser(in: context).map({ Output.chunk4(.hidden($0)) }).eraseToAnyParser(),
+_hiddenModifier<R>.name: _hiddenModifier<R>.parser(in: context).map({ Output.chunk5(.hidden($0)) }).eraseToAnyParser(),
 _highPriorityGestureModifier<R>.name: _highPriorityGestureModifier<R>.parser(in: context).map({ Output.chunk5(.highPriorityGesture($0)) }).eraseToAnyParser(),
 _horizontalRadioGroupLayoutModifier<R>.name: _horizontalRadioGroupLayoutModifier<R>.parser(in: context).map({ Output.chunk5(.horizontalRadioGroupLayout($0)) }).eraseToAnyParser(),
 _hoverEffectModifier<R>.name: _hoverEffectModifier<R>.parser(in: context).map({ Output.chunk5(.hoverEffect($0)) }).eraseToAnyParser(),
@@ -11735,7 +12209,7 @@ _inspectorColumnWidthModifier<R>.name: _inspectorColumnWidthModifier<R>.parser(i
 _interactionActivityTrackingTagModifier<R>.name: _interactionActivityTrackingTagModifier<R>.parser(in: context).map({ Output.chunk5(.interactionActivityTrackingTag($0)) }).eraseToAnyParser(),
 _interactiveDismissDisabledModifier<R>.name: _interactiveDismissDisabledModifier<R>.parser(in: context).map({ Output.chunk5(.interactiveDismissDisabled($0)) }).eraseToAnyParser(),
 _invalidatableContentModifier<R>.name: _invalidatableContentModifier<R>.parser(in: context).map({ Output.chunk5(.invalidatableContent($0)) }).eraseToAnyParser(),
-_keyboardShortcutModifier<R>.name: _keyboardShortcutModifier<R>.parser(in: context).map({ Output.chunk5(.keyboardShortcut($0)) }).eraseToAnyParser(),
+_keyboardShortcutModifier<R>.name: _keyboardShortcutModifier<R>.parser(in: context).map({ Output.chunk6(.keyboardShortcut($0)) }).eraseToAnyParser(),
 _keyboardTypeModifier<R>.name: _keyboardTypeModifier<R>.parser(in: context).map({ Output.chunk6(.keyboardType($0)) }).eraseToAnyParser(),
 _labelStyleModifier<R>.name: _labelStyleModifier<R>.parser(in: context).map({ Output.chunk6(.labelStyle($0)) }).eraseToAnyParser(),
 _labeledContentStyleModifier<R>.name: _labeledContentStyleModifier<R>.parser(in: context).map({ Output.chunk6(.labeledContentStyle($0)) }).eraseToAnyParser(),
@@ -11749,7 +12223,7 @@ _listRowHoverEffectModifier<R>.name: _listRowHoverEffectModifier<R>.parser(in: c
 _listRowHoverEffectDisabledModifier<R>.name: _listRowHoverEffectDisabledModifier<R>.parser(in: context).map({ Output.chunk6(.listRowHoverEffectDisabled($0)) }).eraseToAnyParser(),
 _listRowInsetsModifier<R>.name: _listRowInsetsModifier<R>.parser(in: context).map({ Output.chunk6(.listRowInsets($0)) }).eraseToAnyParser(),
 _listRowSeparatorModifier<R>.name: _listRowSeparatorModifier<R>.parser(in: context).map({ Output.chunk6(.listRowSeparator($0)) }).eraseToAnyParser(),
-_listRowSeparatorTintModifier<R>.name: _listRowSeparatorTintModifier<R>.parser(in: context).map({ Output.chunk6(.listRowSeparatorTint($0)) }).eraseToAnyParser(),
+_listRowSeparatorTintModifier<R>.name: _listRowSeparatorTintModifier<R>.parser(in: context).map({ Output.chunk7(.listRowSeparatorTint($0)) }).eraseToAnyParser(),
 _listRowSpacingModifier<R>.name: _listRowSpacingModifier<R>.parser(in: context).map({ Output.chunk7(.listRowSpacing($0)) }).eraseToAnyParser(),
 _listSectionSeparatorModifier<R>.name: _listSectionSeparatorModifier<R>.parser(in: context).map({ Output.chunk7(.listSectionSeparator($0)) }).eraseToAnyParser(),
 _listSectionSeparatorTintModifier<R>.name: _listSectionSeparatorTintModifier<R>.parser(in: context).map({ Output.chunk7(.listSectionSeparatorTint($0)) }).eraseToAnyParser(),
@@ -11763,7 +12237,7 @@ _minimumScaleFactorModifier<R>.name: _minimumScaleFactorModifier<R>.parser(in: c
 _moveDisabledModifier<R>.name: _moveDisabledModifier<R>.parser(in: context).map({ Output.chunk7(.moveDisabled($0)) }).eraseToAnyParser(),
 _multilineTextAlignmentModifier<R>.name: _multilineTextAlignmentModifier<R>.parser(in: context).map({ Output.chunk7(.multilineTextAlignment($0)) }).eraseToAnyParser(),
 _navigationBarBackButtonHiddenModifier<R>.name: _navigationBarBackButtonHiddenModifier<R>.parser(in: context).map({ Output.chunk7(.navigationBarBackButtonHidden($0)) }).eraseToAnyParser(),
-_navigationBarTitleDisplayModeModifier<R>.name: _navigationBarTitleDisplayModeModifier<R>.parser(in: context).map({ Output.chunk7(.navigationBarTitleDisplayMode($0)) }).eraseToAnyParser(),
+_navigationBarTitleDisplayModeModifier<R>.name: _navigationBarTitleDisplayModeModifier<R>.parser(in: context).map({ Output.chunk8(.navigationBarTitleDisplayMode($0)) }).eraseToAnyParser(),
 _navigationDestinationModifier<R>.name: _navigationDestinationModifier<R>.parser(in: context).map({ Output.chunk8(.navigationDestination($0)) }).eraseToAnyParser(),
 _navigationSplitViewColumnWidthModifier<R>.name: _navigationSplitViewColumnWidthModifier<R>.parser(in: context).map({ Output.chunk8(.navigationSplitViewColumnWidth($0)) }).eraseToAnyParser(),
 _navigationSplitViewStyleModifier<R>.name: _navigationSplitViewStyleModifier<R>.parser(in: context).map({ Output.chunk8(.navigationSplitViewStyle($0)) }).eraseToAnyParser(),
@@ -11777,21 +12251,24 @@ _onExitCommandModifier<R>.name: _onExitCommandModifier<R>.parser(in: context).ma
 _onHoverModifier<R>.name: _onHoverModifier<R>.parser(in: context).map({ Output.chunk8(.onHover($0)) }).eraseToAnyParser(),
 _onLongPressGestureModifier<R>.name: _onLongPressGestureModifier<R>.parser(in: context).map({ Output.chunk8(.onLongPressGesture($0)) }).eraseToAnyParser(),
 _onLongTouchGestureModifier<R>.name: _onLongTouchGestureModifier<R>.parser(in: context).map({ Output.chunk8(.onLongTouchGesture($0)) }).eraseToAnyParser(),
-_onMoveCommandModifier<R>.name: _onMoveCommandModifier<R>.parser(in: context).map({ Output.chunk8(.onMoveCommand($0)) }).eraseToAnyParser(),
+_onMoveCommandModifier<R>.name: _onMoveCommandModifier<R>.parser(in: context).map({ Output.chunk9(.onMoveCommand($0)) }).eraseToAnyParser(),
 _onPlayPauseCommandModifier<R>.name: _onPlayPauseCommandModifier<R>.parser(in: context).map({ Output.chunk9(.onPlayPauseCommand($0)) }).eraseToAnyParser(),
 _onTapGestureModifier<R>.name: _onTapGestureModifier<R>.parser(in: context).map({ Output.chunk9(.onTapGesture($0)) }).eraseToAnyParser(),
 _opacityModifier<R>.name: _opacityModifier<R>.parser(in: context).map({ Output.chunk9(.opacity($0)) }).eraseToAnyParser(),
+_ornamentModifier<R>.name: _ornamentModifier<R>.parser(in: context).map({ Output.chunk9(.ornament($0)) }).eraseToAnyParser(),
 _overlayModifier<R>.name: _overlayModifier<R>.parser(in: context).map({ Output.chunk9(.overlay($0)) }).eraseToAnyParser(),
 _paddingModifier<R>.name: _paddingModifier<R>.parser(in: context).map({ Output.chunk9(.padding($0)) }).eraseToAnyParser(),
+_padding3DModifier<R>.name: _padding3DModifier<R>.parser(in: context).map({ Output.chunk9(.padding3D($0)) }).eraseToAnyParser(),
 _persistentSystemOverlaysModifier<R>.name: _persistentSystemOverlaysModifier<R>.parser(in: context).map({ Output.chunk9(.persistentSystemOverlays($0)) }).eraseToAnyParser(),
 _pickerStyleModifier<R>.name: _pickerStyleModifier<R>.parser(in: context).map({ Output.chunk9(.pickerStyle($0)) }).eraseToAnyParser(),
 _popoverModifier<R>.name: _popoverModifier<R>.parser(in: context).map({ Output.chunk9(.popover($0)) }).eraseToAnyParser(),
 _positionModifier<R>.name: _positionModifier<R>.parser(in: context).map({ Output.chunk9(.position($0)) }).eraseToAnyParser(),
 _preferredColorSchemeModifier<R>.name: _preferredColorSchemeModifier<R>.parser(in: context).map({ Output.chunk9(.preferredColorScheme($0)) }).eraseToAnyParser(),
-_presentationBackgroundModifier<R>.name: _presentationBackgroundModifier<R>.parser(in: context).map({ Output.chunk9(.presentationBackground($0)) }).eraseToAnyParser(),
-_presentationBackgroundInteractionModifier<R>.name: _presentationBackgroundInteractionModifier<R>.parser(in: context).map({ Output.chunk9(.presentationBackgroundInteraction($0)) }).eraseToAnyParser(),
-_presentationCompactAdaptationModifier<R>.name: _presentationCompactAdaptationModifier<R>.parser(in: context).map({ Output.chunk9(.presentationCompactAdaptation($0)) }).eraseToAnyParser(),
-_presentationContentInteractionModifier<R>.name: _presentationContentInteractionModifier<R>.parser(in: context).map({ Output.chunk9(.presentationContentInteraction($0)) }).eraseToAnyParser(),
+_preferredSurroundingsEffectModifier<R>.name: _preferredSurroundingsEffectModifier<R>.parser(in: context).map({ Output.chunk9(.preferredSurroundingsEffect($0)) }).eraseToAnyParser(),
+_presentationBackgroundModifier<R>.name: _presentationBackgroundModifier<R>.parser(in: context).map({ Output.chunk10(.presentationBackground($0)) }).eraseToAnyParser(),
+_presentationBackgroundInteractionModifier<R>.name: _presentationBackgroundInteractionModifier<R>.parser(in: context).map({ Output.chunk10(.presentationBackgroundInteraction($0)) }).eraseToAnyParser(),
+_presentationCompactAdaptationModifier<R>.name: _presentationCompactAdaptationModifier<R>.parser(in: context).map({ Output.chunk10(.presentationCompactAdaptation($0)) }).eraseToAnyParser(),
+_presentationContentInteractionModifier<R>.name: _presentationContentInteractionModifier<R>.parser(in: context).map({ Output.chunk10(.presentationContentInteraction($0)) }).eraseToAnyParser(),
 _presentationCornerRadiusModifier<R>.name: _presentationCornerRadiusModifier<R>.parser(in: context).map({ Output.chunk10(.presentationCornerRadius($0)) }).eraseToAnyParser(),
 _presentationDragIndicatorModifier<R>.name: _presentationDragIndicatorModifier<R>.parser(in: context).map({ Output.chunk10(.presentationDragIndicator($0)) }).eraseToAnyParser(),
 _previewDisplayNameModifier<R>.name: _previewDisplayNameModifier<R>.parser(in: context).map({ Output.chunk10(.previewDisplayName($0)) }).eraseToAnyParser(),
@@ -11802,10 +12279,10 @@ _redactedModifier<R>.name: _redactedModifier<R>.parser(in: context).map({ Output
 _refreshableModifier<R>.name: _refreshableModifier<R>.parser(in: context).map({ Output.chunk10(.refreshable($0)) }).eraseToAnyParser(),
 _renameActionModifier<R>.name: _renameActionModifier<R>.parser(in: context).map({ Output.chunk10(.renameAction($0)) }).eraseToAnyParser(),
 _replaceDisabledModifier<R>.name: _replaceDisabledModifier<R>.parser(in: context).map({ Output.chunk10(.replaceDisabled($0)) }).eraseToAnyParser(),
-_rotationEffectModifier<R>.name: _rotationEffectModifier<R>.parser(in: context).map({ Output.chunk10(.rotationEffect($0)) }).eraseToAnyParser(),
-_safeAreaInsetModifier<R>.name: _safeAreaInsetModifier<R>.parser(in: context).map({ Output.chunk10(.safeAreaInset($0)) }).eraseToAnyParser(),
-_saturationModifier<R>.name: _saturationModifier<R>.parser(in: context).map({ Output.chunk10(.saturation($0)) }).eraseToAnyParser(),
-_scaleEffectModifier<R>.name: _scaleEffectModifier<R>.parser(in: context).map({ Output.chunk10(.scaleEffect($0)) }).eraseToAnyParser(),
+_rotationEffectModifier<R>.name: _rotationEffectModifier<R>.parser(in: context).map({ Output.chunk11(.rotationEffect($0)) }).eraseToAnyParser(),
+_safeAreaInsetModifier<R>.name: _safeAreaInsetModifier<R>.parser(in: context).map({ Output.chunk11(.safeAreaInset($0)) }).eraseToAnyParser(),
+_saturationModifier<R>.name: _saturationModifier<R>.parser(in: context).map({ Output.chunk11(.saturation($0)) }).eraseToAnyParser(),
+_scaleEffectModifier<R>.name: _scaleEffectModifier<R>.parser(in: context).map({ Output.chunk11(.scaleEffect($0)) }).eraseToAnyParser(),
 _scaledToFillModifier<R>.name: _scaledToFillModifier<R>.parser(in: context).map({ Output.chunk11(.scaledToFill($0)) }).eraseToAnyParser(),
 _scaledToFitModifier<R>.name: _scaledToFitModifier<R>.parser(in: context).map({ Output.chunk11(.scaledToFit($0)) }).eraseToAnyParser(),
 _scenePaddingModifier<R>.name: _scenePaddingModifier<R>.parser(in: context).map({ Output.chunk11(.scenePadding($0)) }).eraseToAnyParser(),
@@ -11816,10 +12293,10 @@ _scrollDisabledModifier<R>.name: _scrollDisabledModifier<R>.parser(in: context).
 _scrollDismissesKeyboardModifier<R>.name: _scrollDismissesKeyboardModifier<R>.parser(in: context).map({ Output.chunk11(.scrollDismissesKeyboard($0)) }).eraseToAnyParser(),
 _scrollIndicatorsModifier<R>.name: _scrollIndicatorsModifier<R>.parser(in: context).map({ Output.chunk11(.scrollIndicators($0)) }).eraseToAnyParser(),
 _scrollIndicatorsFlashModifier<R>.name: _scrollIndicatorsFlashModifier<R>.parser(in: context).map({ Output.chunk11(.scrollIndicatorsFlash($0)) }).eraseToAnyParser(),
-_scrollPositionModifier<R>.name: _scrollPositionModifier<R>.parser(in: context).map({ Output.chunk11(.scrollPosition($0)) }).eraseToAnyParser(),
-_scrollTargetBehaviorModifier<R>.name: _scrollTargetBehaviorModifier<R>.parser(in: context).map({ Output.chunk11(.scrollTargetBehavior($0)) }).eraseToAnyParser(),
-_scrollTargetLayoutModifier<R>.name: _scrollTargetLayoutModifier<R>.parser(in: context).map({ Output.chunk11(.scrollTargetLayout($0)) }).eraseToAnyParser(),
-_searchDictationBehaviorModifier<R>.name: _searchDictationBehaviorModifier<R>.parser(in: context).map({ Output.chunk11(.searchDictationBehavior($0)) }).eraseToAnyParser(),
+_scrollPositionModifier<R>.name: _scrollPositionModifier<R>.parser(in: context).map({ Output.chunk12(.scrollPosition($0)) }).eraseToAnyParser(),
+_scrollTargetBehaviorModifier<R>.name: _scrollTargetBehaviorModifier<R>.parser(in: context).map({ Output.chunk12(.scrollTargetBehavior($0)) }).eraseToAnyParser(),
+_scrollTargetLayoutModifier<R>.name: _scrollTargetLayoutModifier<R>.parser(in: context).map({ Output.chunk12(.scrollTargetLayout($0)) }).eraseToAnyParser(),
+_searchDictationBehaviorModifier<R>.name: _searchDictationBehaviorModifier<R>.parser(in: context).map({ Output.chunk12(.searchDictationBehavior($0)) }).eraseToAnyParser(),
 _searchPresentationToolbarBehaviorModifier<R>.name: _searchPresentationToolbarBehaviorModifier<R>.parser(in: context).map({ Output.chunk12(.searchPresentationToolbarBehavior($0)) }).eraseToAnyParser(),
 _searchSuggestionsModifier<R>.name: _searchSuggestionsModifier<R>.parser(in: context).map({ Output.chunk12(.searchSuggestions($0)) }).eraseToAnyParser(),
 _searchableModifier<R>.name: _searchableModifier<R>.parser(in: context).map({ Output.chunk12(.searchable($0)) }).eraseToAnyParser(),
@@ -11830,10 +12307,10 @@ _simultaneousGestureModifier<R>.name: _simultaneousGestureModifier<R>.parser(in:
 _speechAdjustedPitchModifier<R>.name: _speechAdjustedPitchModifier<R>.parser(in: context).map({ Output.chunk12(.speechAdjustedPitch($0)) }).eraseToAnyParser(),
 _speechAlwaysIncludesPunctuationModifier<R>.name: _speechAlwaysIncludesPunctuationModifier<R>.parser(in: context).map({ Output.chunk12(.speechAlwaysIncludesPunctuation($0)) }).eraseToAnyParser(),
 _speechAnnouncementsQueuedModifier<R>.name: _speechAnnouncementsQueuedModifier<R>.parser(in: context).map({ Output.chunk12(.speechAnnouncementsQueued($0)) }).eraseToAnyParser(),
-_speechSpellsOutCharactersModifier<R>.name: _speechSpellsOutCharactersModifier<R>.parser(in: context).map({ Output.chunk12(.speechSpellsOutCharacters($0)) }).eraseToAnyParser(),
-_statusBarHiddenModifier<R>.name: _statusBarHiddenModifier<R>.parser(in: context).map({ Output.chunk12(.statusBarHidden($0)) }).eraseToAnyParser(),
-_submitLabelModifier<R>.name: _submitLabelModifier<R>.parser(in: context).map({ Output.chunk12(.submitLabel($0)) }).eraseToAnyParser(),
-_submitScopeModifier<R>.name: _submitScopeModifier<R>.parser(in: context).map({ Output.chunk12(.submitScope($0)) }).eraseToAnyParser(),
+_speechSpellsOutCharactersModifier<R>.name: _speechSpellsOutCharactersModifier<R>.parser(in: context).map({ Output.chunk13(.speechSpellsOutCharacters($0)) }).eraseToAnyParser(),
+_statusBarHiddenModifier<R>.name: _statusBarHiddenModifier<R>.parser(in: context).map({ Output.chunk13(.statusBarHidden($0)) }).eraseToAnyParser(),
+_submitLabelModifier<R>.name: _submitLabelModifier<R>.parser(in: context).map({ Output.chunk13(.submitLabel($0)) }).eraseToAnyParser(),
+_submitScopeModifier<R>.name: _submitScopeModifier<R>.parser(in: context).map({ Output.chunk13(.submitScope($0)) }).eraseToAnyParser(),
 _swipeActionsModifier<R>.name: _swipeActionsModifier<R>.parser(in: context).map({ Output.chunk13(.swipeActions($0)) }).eraseToAnyParser(),
 _symbolEffectModifier<R>.name: _symbolEffectModifier<R>.parser(in: context).map({ Output.chunk13(.symbolEffect($0)) }).eraseToAnyParser(),
 _symbolEffectsRemovedModifier<R>.name: _symbolEffectsRemovedModifier<R>.parser(in: context).map({ Output.chunk13(.symbolEffectsRemoved($0)) }).eraseToAnyParser(),
@@ -11844,10 +12321,10 @@ _tabViewStyleModifier<R>.name: _tabViewStyleModifier<R>.parser(in: context).map(
 _tableStyleModifier<R>.name: _tableStyleModifier<R>.parser(in: context).map({ Output.chunk13(.tableStyle($0)) }).eraseToAnyParser(),
 _textCaseModifier<R>.name: _textCaseModifier<R>.parser(in: context).map({ Output.chunk13(.textCase($0)) }).eraseToAnyParser(),
 _textContentTypeModifier<R>.name: _textContentTypeModifier<R>.parser(in: context).map({ Output.chunk13(.textContentType($0)) }).eraseToAnyParser(),
-_textEditorStyleModifier<R>.name: _textEditorStyleModifier<R>.parser(in: context).map({ Output.chunk13(.textEditorStyle($0)) }).eraseToAnyParser(),
-_textFieldStyleModifier<R>.name: _textFieldStyleModifier<R>.parser(in: context).map({ Output.chunk13(.textFieldStyle($0)) }).eraseToAnyParser(),
-_textInputAutocapitalizationModifier<R>.name: _textInputAutocapitalizationModifier<R>.parser(in: context).map({ Output.chunk13(.textInputAutocapitalization($0)) }).eraseToAnyParser(),
-_textSelectionModifier<R>.name: _textSelectionModifier<R>.parser(in: context).map({ Output.chunk13(.textSelection($0)) }).eraseToAnyParser(),
+_textEditorStyleModifier<R>.name: _textEditorStyleModifier<R>.parser(in: context).map({ Output.chunk14(.textEditorStyle($0)) }).eraseToAnyParser(),
+_textFieldStyleModifier<R>.name: _textFieldStyleModifier<R>.parser(in: context).map({ Output.chunk14(.textFieldStyle($0)) }).eraseToAnyParser(),
+_textInputAutocapitalizationModifier<R>.name: _textInputAutocapitalizationModifier<R>.parser(in: context).map({ Output.chunk14(.textInputAutocapitalization($0)) }).eraseToAnyParser(),
+_textSelectionModifier<R>.name: _textSelectionModifier<R>.parser(in: context).map({ Output.chunk14(.textSelection($0)) }).eraseToAnyParser(),
 _tintModifier<R>.name: _tintModifier<R>.parser(in: context).map({ Output.chunk14(.tint($0)) }).eraseToAnyParser(),
 _toggleStyleModifier<R>.name: _toggleStyleModifier<R>.parser(in: context).map({ Output.chunk14(.toggleStyle($0)) }).eraseToAnyParser(),
 _toolbarModifier<R>.name: _toolbarModifier<R>.parser(in: context).map({ Output.chunk14(.toolbar($0)) }).eraseToAnyParser(),
@@ -11858,20 +12335,23 @@ _toolbarTitleDisplayModeModifier<R>.name: _toolbarTitleDisplayModeModifier<R>.pa
 _toolbarTitleMenuModifier<R>.name: _toolbarTitleMenuModifier<R>.parser(in: context).map({ Output.chunk14(.toolbarTitleMenu($0)) }).eraseToAnyParser(),
 _touchBarCustomizationLabelModifier<R>.name: _touchBarCustomizationLabelModifier<R>.parser(in: context).map({ Output.chunk14(.touchBarCustomizationLabel($0)) }).eraseToAnyParser(),
 _touchBarItemPrincipalModifier<R>.name: _touchBarItemPrincipalModifier<R>.parser(in: context).map({ Output.chunk14(.touchBarItemPrincipal($0)) }).eraseToAnyParser(),
-_transformEffectModifier<R>.name: _transformEffectModifier<R>.parser(in: context).map({ Output.chunk14(.transformEffect($0)) }).eraseToAnyParser(),
-_transitionModifier<R>.name: _transitionModifier<R>.parser(in: context).map({ Output.chunk14(.transition($0)) }).eraseToAnyParser(),
-_truncationModeModifier<R>.name: _truncationModeModifier<R>.parser(in: context).map({ Output.chunk14(.truncationMode($0)) }).eraseToAnyParser(),
-_unredactedModifier<R>.name: _unredactedModifier<R>.parser(in: context).map({ Output.chunk14(.unredacted($0)) }).eraseToAnyParser(),
+_transform3DEffectModifier<R>.name: _transform3DEffectModifier<R>.parser(in: context).map({ Output.chunk15(.transform3DEffect($0)) }).eraseToAnyParser(),
+_transformEffectModifier<R>.name: _transformEffectModifier<R>.parser(in: context).map({ Output.chunk15(.transformEffect($0)) }).eraseToAnyParser(),
+_transitionModifier<R>.name: _transitionModifier<R>.parser(in: context).map({ Output.chunk15(.transition($0)) }).eraseToAnyParser(),
+_truncationModeModifier<R>.name: _truncationModeModifier<R>.parser(in: context).map({ Output.chunk15(.truncationMode($0)) }).eraseToAnyParser(),
+_unredactedModifier<R>.name: _unredactedModifier<R>.parser(in: context).map({ Output.chunk15(.unredacted($0)) }).eraseToAnyParser(),
+_upperLimbVisibilityModifier<R>.name: _upperLimbVisibilityModifier<R>.parser(in: context).map({ Output.chunk15(.upperLimbVisibility($0)) }).eraseToAnyParser(),
 _zIndexModifier<R>.name: _zIndexModifier<R>.parser(in: context).map({ Output.chunk15(.zIndex($0)) }).eraseToAnyParser(),
-                    LiveViewNative._SearchScopesModifier<R>.name: LiveViewNative._SearchScopesModifier<R>.parser(in: context).map(Output._SearchScopesModifier).eraseToAnyParser(),
-LiveViewNative._SearchCompletionModifier<R>.name: LiveViewNative._SearchCompletionModifier<R>.parser(in: context).map(Output._SearchCompletionModifier).eraseToAnyParser(),
+                    LiveViewNative._PrefersDefaultFocusModifier<R>.name: LiveViewNative._PrefersDefaultFocusModifier<R>.parser(in: context).map(Output._PrefersDefaultFocusModifier).eraseToAnyParser(),
 LiveViewNative._MaskModifier<R>.name: LiveViewNative._MaskModifier<R>.parser(in: context).map(Output._MaskModifier).eraseToAnyParser(),
-LiveViewNative._Rotation3DEffectModifier<R>.name: LiveViewNative._Rotation3DEffectModifier<R>.parser(in: context).map(Output._Rotation3DEffectModifier).eraseToAnyParser(),
 LiveViewNative._OnSubmitModifier.name: LiveViewNative._OnSubmitModifier.parser(in: context).map(Output._OnSubmitModifier).eraseToAnyParser(),
 LiveViewNative._PresentationDetentsModifier.name: LiveViewNative._PresentationDetentsModifier.parser(in: context).map(Output._PresentationDetentsModifier).eraseToAnyParser(),
-LiveViewNative._FocusScopeModifier<R>.name: LiveViewNative._FocusScopeModifier<R>.parser(in: context).map(Output._FocusScopeModifier).eraseToAnyParser(),
+LiveViewNative._SearchScopesModifier<R>.name: LiveViewNative._SearchScopesModifier<R>.parser(in: context).map(Output._SearchScopesModifier).eraseToAnyParser(),
+LiveViewNative._PerspectiveRotationEffectModifier<R>.name: LiveViewNative._PerspectiveRotationEffectModifier<R>.parser(in: context).map(Output._PerspectiveRotationEffectModifier).eraseToAnyParser(),
+LiveViewNative._Rotation3DEffectModifier<R>.name: LiveViewNative._Rotation3DEffectModifier<R>.parser(in: context).map(Output._Rotation3DEffectModifier).eraseToAnyParser(),
+LiveViewNative._SearchCompletionModifier<R>.name: LiveViewNative._SearchCompletionModifier<R>.parser(in: context).map(Output._SearchCompletionModifier).eraseToAnyParser(),
 LiveViewNative._MatchedGeometryEffectModifier<R>.name: LiveViewNative._MatchedGeometryEffectModifier<R>.parser(in: context).map(Output._MatchedGeometryEffectModifier).eraseToAnyParser(),
-LiveViewNative._PrefersDefaultFocusModifier<R>.name: LiveViewNative._PrefersDefaultFocusModifier<R>.parser(in: context).map(Output._PrefersDefaultFocusModifier).eraseToAnyParser(),
+LiveViewNative._FocusScopeModifier<R>.name: LiveViewNative._FocusScopeModifier<R>.parser(in: context).map(Output._FocusScopeModifier).eraseToAnyParser(),
                 ]
 
                 let deprecations = [
@@ -11981,7 +12461,7 @@ LiveViewNative._PrefersDefaultFocusModifier<R>.name: LiveViewNative._PrefersDefa
     }
 }
 
-/// See [`SwiftUI.AccessibilityChildBehavior`](https://developer.apple.com/documentation/swiftui/AccessibilityChildBehavior)
+/// See [`SwiftUI.AccessibilityChildBehavior`](https://developer.apple.com/documentation/swiftui/AccessibilityChildBehavior) for more details.
 ///
 /// Possible values:
 /// * `.ignore`
@@ -12026,7 +12506,7 @@ ConstantAtomLiteral("combine").map({ () -> Self in
 }
 
 
-/// See [`SwiftUI.AccessibilityLabeledPairRole`](https://developer.apple.com/documentation/swiftui/AccessibilityLabeledPairRole)
+/// See [`SwiftUI.AccessibilityLabeledPairRole`](https://developer.apple.com/documentation/swiftui/AccessibilityLabeledPairRole) for more details.
 ///
 /// Possible values:
 /// * `.label`
@@ -12061,7 +12541,7 @@ ConstantAtomLiteral("content").map({ () -> Self in
 }
 
 #if os(macOS)
-/// See [`SwiftUI.AlternatingRowBackgroundBehavior`](https://developer.apple.com/documentation/swiftui/AlternatingRowBackgroundBehavior)
+/// See [`SwiftUI.AlternatingRowBackgroundBehavior`](https://developer.apple.com/documentation/swiftui/AlternatingRowBackgroundBehavior) for more details.
 ///
 /// Possible values:
 /// * `.automatic`
@@ -12106,7 +12586,7 @@ fatalError("'disabled' is not available on this OS")
 }
 #endif
 
-/// See [`SwiftUI.Axis`](https://developer.apple.com/documentation/swiftui/Axis)
+/// See [`SwiftUI.Axis`](https://developer.apple.com/documentation/swiftui/Axis) for more details.
 ///
 /// Possible values:
 /// * `.horizontal`
@@ -12140,21 +12620,21 @@ ConstantAtomLiteral("vertical").map({ () -> Self in
     }
 }
 
-#if os(iOS) || os(macOS)
-/// See [`SwiftUI.BadgeProminence`](https://developer.apple.com/documentation/swiftui/BadgeProminence)
+#if os(iOS) || os(macOS) || os(visionOS)
+/// See [`SwiftUI.BadgeProminence`](https://developer.apple.com/documentation/swiftui/BadgeProminence) for more details.
 ///
 /// Possible values:
 /// * `.decreased`
 /// * `.standard`
 /// * `.increased`
 @_documentation(visibility: public)
-@available(macOS 14.0,iOS 17.0, *)
+@available(macOS 14.0,iOS 17.0,visionOS 1.0, *)
 extension BadgeProminence: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             ConstantAtomLiteral("decreased").map({ () -> Self in
-#if os(iOS) || os(macOS)
+#if os(iOS) || os(macOS) || os(visionOS)
 
     return Self.decreased
 
@@ -12163,7 +12643,7 @@ fatalError("'decreased' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("standard").map({ () -> Self in
-#if os(iOS) || os(macOS)
+#if os(iOS) || os(macOS) || os(visionOS)
 
     return Self.standard
 
@@ -12172,7 +12652,7 @@ fatalError("'standard' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("increased").map({ () -> Self in
-#if os(iOS) || os(macOS)
+#if os(iOS) || os(macOS) || os(visionOS)
 
     return Self.increased
 
@@ -12186,7 +12666,7 @@ fatalError("'increased' is not available on this OS")
 }
 #endif
 
-/// See [`SwiftUI.BlendMode`](https://developer.apple.com/documentation/swiftui/BlendMode)
+/// See [`SwiftUI.BlendMode`](https://developer.apple.com/documentation/swiftui/BlendMode) for more details.
 ///
 /// Possible values:
 /// * `.normal`
@@ -12410,21 +12890,21 @@ ConstantAtomLiteral("plusLighter").map({ () -> Self in
     }
 }
 
-#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-/// See [`SwiftUI.ButtonRepeatBehavior`](https://developer.apple.com/documentation/swiftui/ButtonRepeatBehavior)
+#if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+/// See [`SwiftUI.ButtonRepeatBehavior`](https://developer.apple.com/documentation/swiftui/ButtonRepeatBehavior) for more details.
 ///
 /// Possible values:
 /// * `.automatic`
 /// * `.enabled`
 /// * `.disabled`
 @_documentation(visibility: public)
-@available(macOS 14.0,tvOS 17.0,watchOS 10.0,iOS 17.0, *)
+@available(visionOS 1.0,watchOS 10.0,macOS 14.0,tvOS 17.0,iOS 17.0, *)
 extension ButtonRepeatBehavior: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             ConstantAtomLiteral("automatic").map({ () -> Self in
-#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+#if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
 
     return Self.automatic
 
@@ -12433,7 +12913,7 @@ fatalError("'automatic' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("enabled").map({ () -> Self in
-#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+#if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
 
     return Self.enabled
 
@@ -12442,7 +12922,7 @@ fatalError("'enabled' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("disabled").map({ () -> Self in
-#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+#if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
 
     return Self.disabled
 
@@ -12456,7 +12936,7 @@ fatalError("'disabled' is not available on this OS")
 }
 #endif
 
-/// See [`SwiftUI.ColorRenderingMode`](https://developer.apple.com/documentation/swiftui/ColorRenderingMode)
+/// See [`SwiftUI.ColorRenderingMode`](https://developer.apple.com/documentation/swiftui/ColorRenderingMode) for more details.
 ///
 /// Possible values:
 /// * `.nonLinear`
@@ -12501,7 +12981,7 @@ ConstantAtomLiteral("extendedLinear").map({ () -> Self in
 }
 
 
-/// See [`SwiftUI.ColorScheme`](https://developer.apple.com/documentation/swiftui/ColorScheme)
+/// See [`SwiftUI.ColorScheme`](https://developer.apple.com/documentation/swiftui/ColorScheme) for more details.
 ///
 /// Possible values:
 /// * `.light`
@@ -12535,32 +13015,32 @@ ConstantAtomLiteral("dark").map({ () -> Self in
     }
 }
 
-#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-/// See [`SwiftUI.ContainerBackgroundPlacement`](https://developer.apple.com/documentation/swiftui/ContainerBackgroundPlacement)
+#if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+/// See [`SwiftUI.ContainerBackgroundPlacement`](https://developer.apple.com/documentation/swiftui/ContainerBackgroundPlacement) for more details.
 ///
 /// Possible values:
 /// * `.tabView`
 /// * `.navigation`
 @_documentation(visibility: public)
-@available(iOS 17.0,watchOS 10.0,tvOS 17.0,macOS 14.0, *)
+@available(iOS 17.0,tvOS 17.0,macOS 14.0,watchOS 10.0,visionOS 1.0, *)
 extension ContainerBackgroundPlacement: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             ConstantAtomLiteral("tabView").map({ () -> Self in
 #if os(watchOS)
-
+if #available(iOS 17.0,tvOS 17.0,macOS 14.0,watchOS 10.0, *) {
     return Self.tabView
-
+} else { fatalError("'tabView' is not available in this OS version") }
 #else
 fatalError("'tabView' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("navigation").map({ () -> Self in
 #if os(watchOS)
-
+if #available(iOS 17.0,tvOS 17.0,macOS 14.0,watchOS 10.0, *) {
     return Self.navigation
-
+} else { fatalError("'navigation' is not available in this OS version") }
 #else
 fatalError("'navigation' is not available on this OS")
 #endif
@@ -12570,21 +13050,21 @@ fatalError("'navigation' is not available on this OS")
     }
 }
 #endif
-#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-/// See [`SwiftUI.ContentMarginPlacement`](https://developer.apple.com/documentation/swiftui/ContentMarginPlacement)
+#if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+/// See [`SwiftUI.ContentMarginPlacement`](https://developer.apple.com/documentation/swiftui/ContentMarginPlacement) for more details.
 ///
 /// Possible values:
 /// * `.automatic`
 /// * `.scrollContent`
 /// * `.scrollIndicators`
 @_documentation(visibility: public)
-@available(tvOS 17.0,watchOS 10.0,iOS 17.0,macOS 14.0, *)
+@available(iOS 17.0,tvOS 17.0,macOS 14.0,watchOS 10.0,visionOS 1.0, *)
 extension ContentMarginPlacement: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             ConstantAtomLiteral("automatic").map({ () -> Self in
-#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+#if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
 
     return Self.automatic
 
@@ -12593,7 +13073,7 @@ fatalError("'automatic' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("scrollContent").map({ () -> Self in
-#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+#if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
 
     return Self.scrollContent
 
@@ -12602,7 +13082,7 @@ fatalError("'scrollContent' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("scrollIndicators").map({ () -> Self in
-#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+#if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
 
     return Self.scrollIndicators
 
@@ -12616,7 +13096,7 @@ fatalError("'scrollIndicators' is not available on this OS")
 }
 #endif
 
-/// See [`SwiftUI.ContentShapeKinds`](https://developer.apple.com/documentation/swiftui/ContentShapeKinds)
+/// See [`SwiftUI.ContentShapeKinds`](https://developer.apple.com/documentation/swiftui/ContentShapeKinds) for more details.
 ///
 /// Possible values:
 /// * `.interaction`
@@ -12641,8 +13121,8 @@ extension ContentShapeKinds: ParseableModifierValue {
 
 })
 ConstantAtomLiteral("dragPreview").map({ () -> Self in
-#if os(iOS) || os(macOS)
-if #available(tvOS 15.0,iOS 15.0,watchOS 8.0,macOS 12.0, *) {
+#if os(iOS) || os(macOS) || os(visionOS)
+if #available(iOS 15.0,tvOS 15.0,macOS 12.0,watchOS 8.0,visionOS 1.0, *) {
     return Self.dragPreview
 } else { fatalError("'dragPreview' is not available in this OS version") }
 #else
@@ -12650,8 +13130,8 @@ fatalError("'dragPreview' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("contextMenuPreview").map({ () -> Self in
-#if os(iOS) || os(tvOS)
-if #available(tvOS 17.0,iOS 15.0,watchOS 8.0,macOS 12.0, *) {
+#if os(iOS) || os(tvOS) || os(visionOS)
+if #available(iOS 15.0,tvOS 17.0,macOS 12.0,watchOS 8.0,visionOS 1.0, *) {
     return Self.contextMenuPreview
 } else { fatalError("'contextMenuPreview' is not available in this OS version") }
 #else
@@ -12659,8 +13139,8 @@ fatalError("'contextMenuPreview' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("hoverEffect").map({ () -> Self in
-#if os(iOS)
-if #available(tvOS 15.0,iOS 15.0,watchOS 8.0,macOS 12.0, *) {
+#if os(iOS) || os(visionOS)
+if #available(iOS 15.0,tvOS 15.0,macOS 12.0,watchOS 8.0,visionOS 1.0, *) {
     return Self.hoverEffect
 } else { fatalError("'hoverEffect' is not available in this OS version") }
 #else
@@ -12669,7 +13149,7 @@ fatalError("'hoverEffect' is not available on this OS")
 })
 ConstantAtomLiteral("focusEffect").map({ () -> Self in
 #if os(macOS) || os(watchOS)
-if #available(tvOS 15.0,iOS 15.0,watchOS 8.0,macOS 12.0, *) {
+if #available(iOS 15.0,tvOS 15.0,macOS 12.0,watchOS 8.0, *) {
     return Self.focusEffect
 } else { fatalError("'focusEffect' is not available in this OS version") }
 #else
@@ -12677,8 +13157,8 @@ fatalError("'focusEffect' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("accessibility").map({ () -> Self in
-#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-if #available(watchOS 10.0,macOS 14.0,iOS 17.0,tvOS 17.0, *) {
+#if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+if #available(macOS 14.0,visionOS 1.0,iOS 17.0,watchOS 10.0,tvOS 17.0, *) {
     return Self.accessibility
 } else { fatalError("'accessibility' is not available in this OS version") }
 #else
@@ -12690,8 +13170,8 @@ fatalError("'accessibility' is not available on this OS")
     }
 }
 
-#if os(iOS) || os(macOS) || os(watchOS)
-/// See [`SwiftUI.ControlSize`](https://developer.apple.com/documentation/swiftui/ControlSize)
+#if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
+/// See [`SwiftUI.ControlSize`](https://developer.apple.com/documentation/swiftui/ControlSize) for more details.
 ///
 /// Possible values:
 /// * `.mini`
@@ -12700,13 +13180,13 @@ fatalError("'accessibility' is not available on this OS")
 /// * `.large`
 /// * `.extraLarge`
 @_documentation(visibility: public)
-@available(macOS 10.15,iOS 15.0,watchOS 9.0, *)
+@available(watchOS 9.0,macOS 10.15,visionOS 1.0,iOS 15.0, *)
 extension ControlSize: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             ConstantAtomLiteral("mini").map({ () -> Self in
-#if os(iOS) || os(macOS) || os(watchOS)
+#if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
 
     return Self.mini
 
@@ -12715,7 +13195,7 @@ fatalError("'mini' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("small").map({ () -> Self in
-#if os(iOS) || os(macOS) || os(watchOS)
+#if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
 
     return Self.small
 
@@ -12724,7 +13204,7 @@ fatalError("'small' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("regular").map({ () -> Self in
-#if os(iOS) || os(macOS) || os(watchOS)
+#if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
 
     return Self.regular
 
@@ -12733,8 +13213,8 @@ fatalError("'regular' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("large").map({ () -> Self in
-#if os(iOS) || os(macOS) || os(watchOS)
-if #available(macOS 11.0,iOS 15.0,watchOS 9.0, *) {
+#if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
+if #available(watchOS 9.0,macOS 11.0,visionOS 1.0,iOS 15.0, *) {
     return Self.large
 } else { fatalError("'large' is not available in this OS version") }
 #else
@@ -12743,7 +13223,7 @@ fatalError("'large' is not available on this OS")
 })
 ConstantAtomLiteral("extraLarge").map({ () -> Self in
 #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
-if #available(watchOS 10.0,macOS 14.0,iOS 17.0,visionOS 1.0, *) {
+if #available(watchOS 10.0,macOS 14.0,visionOS 1.0,iOS 17.0, *) {
     return Self.extraLarge
 } else { fatalError("'extraLarge' is not available in this OS version") }
 #else
@@ -12756,7 +13236,7 @@ fatalError("'extraLarge' is not available on this OS")
 }
 #endif
 
-/// See [`SwiftUI.DefaultFocusEvaluationPriority`](https://developer.apple.com/documentation/swiftui/DefaultFocusEvaluationPriority)
+/// See [`SwiftUI.DefaultFocusEvaluationPriority`](https://developer.apple.com/documentation/swiftui/DefaultFocusEvaluationPriority) for more details.
 ///
 /// Possible values:
 /// * `.automatic`
@@ -12790,21 +13270,21 @@ ConstantAtomLiteral("userInitiated").map({ () -> Self in
     }
 }
 
-#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-/// See [`SwiftUI.DialogSeverity`](https://developer.apple.com/documentation/swiftui/DialogSeverity)
+#if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+/// See [`SwiftUI.DialogSeverity`](https://developer.apple.com/documentation/swiftui/DialogSeverity) for more details.
 ///
 /// Possible values:
 /// * `.automatic`
 /// * `.critical`
 /// * `.standard`
 @_documentation(visibility: public)
-@available(watchOS 10.0,macOS 13.0,iOS 17.0,tvOS 17.0, *)
+@available(iOS 17.0,watchOS 10.0,tvOS 17.0,macOS 13.0,visionOS 1.0, *)
 extension DialogSeverity: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             ConstantAtomLiteral("automatic").map({ () -> Self in
-#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+#if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
 
     return Self.automatic
 
@@ -12813,7 +13293,7 @@ fatalError("'automatic' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("critical").map({ () -> Self in
-#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+#if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
 
     return Self.critical
 
@@ -12822,8 +13302,8 @@ fatalError("'critical' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("standard").map({ () -> Self in
-#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-if #available(watchOS 10.0,macOS 14.0,iOS 17.0,tvOS 17.0, *) {
+#if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+if #available(macOS 14.0,watchOS 10.0,visionOS 1.0,tvOS 17.0,iOS 17.0, *) {
     return Self.standard
 } else { fatalError("'standard' is not available in this OS version") }
 #else
@@ -12836,7 +13316,7 @@ fatalError("'standard' is not available on this OS")
 }
 #endif
 #if os(watchOS)
-/// See [`SwiftUI.DigitalCrownRotationalSensitivity`](https://developer.apple.com/documentation/swiftui/DigitalCrownRotationalSensitivity)
+/// See [`SwiftUI.DigitalCrownRotationalSensitivity`](https://developer.apple.com/documentation/swiftui/DigitalCrownRotationalSensitivity) for more details.
 ///
 /// Possible values:
 /// * `.low`
@@ -12880,8 +13360,33 @@ fatalError("'high' is not available on this OS")
     }
 }
 #endif
+#if os(visionOS)
+/// See [`SwiftUI.Edge3D`](https://developer.apple.com/documentation/swiftui/Edge3D) for more details.
+///
+/// Possible values:
+/// * `.top`
+@_documentation(visibility: public)
+@available(visionOS 1.0, *)
+extension Edge3D: ParseableModifierValue {
+    public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
+        ImplicitStaticMember {
+            OneOf {
+            ConstantAtomLiteral("top").map({ () -> Self in
+#if os(visionOS)
 
-/// See [`SwiftUI.EventModifiers`](https://developer.apple.com/documentation/swiftui/EventModifiers)
+    return Self.top
+
+#else
+fatalError("'top' is not available on this OS")
+#endif
+})
+            }
+        }
+    }
+}
+#endif
+
+/// See [`SwiftUI.EventModifiers`](https://developer.apple.com/documentation/swiftui/EventModifiers) for more details.
 ///
 /// Possible values:
 /// * `.capsLock`
@@ -12975,21 +13480,21 @@ ConstantAtomLiteral("all").map({ () -> Self in
     }
 }
 
-#if os(iOS) || os(macOS)
-/// See [`SwiftUI.FileDialogBrowserOptions`](https://developer.apple.com/documentation/swiftui/FileDialogBrowserOptions)
+#if os(iOS) || os(macOS) || os(visionOS)
+/// See [`SwiftUI.FileDialogBrowserOptions`](https://developer.apple.com/documentation/swiftui/FileDialogBrowserOptions) for more details.
 ///
 /// Possible values:
 /// * `.enumeratePackages`
 /// * `.includeHiddenFiles`
 /// * `.displayFileExtensions`
 @_documentation(visibility: public)
-@available(iOS 17.0,macOS 14.0, *)
+@available(macOS 14.0,iOS 17.0,visionOS 1.0, *)
 extension FileDialogBrowserOptions: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             ConstantAtomLiteral("enumeratePackages").map({ () -> Self in
-#if os(iOS) || os(macOS)
+#if os(iOS) || os(macOS) || os(visionOS)
 
     return Self.enumeratePackages
 
@@ -12998,7 +13503,7 @@ fatalError("'enumeratePackages' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("includeHiddenFiles").map({ () -> Self in
-#if os(iOS) || os(macOS)
+#if os(iOS) || os(macOS) || os(visionOS)
 
     return Self.includeHiddenFiles
 
@@ -13007,7 +13512,7 @@ fatalError("'includeHiddenFiles' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("displayFileExtensions").map({ () -> Self in
-#if os(iOS) || os(macOS)
+#if os(iOS) || os(macOS) || os(visionOS)
 
     return Self.displayFileExtensions
 
@@ -13020,21 +13525,21 @@ fatalError("'displayFileExtensions' is not available on this OS")
     }
 }
 #endif
-#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-/// See [`SwiftUI.FocusInteractions`](https://developer.apple.com/documentation/swiftui/FocusInteractions)
+#if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+/// See [`SwiftUI.FocusInteractions`](https://developer.apple.com/documentation/swiftui/FocusInteractions) for more details.
 ///
 /// Possible values:
 /// * `.activate`
 /// * `.edit`
 /// * `.automatic`
 @_documentation(visibility: public)
-@available(macOS 14.0,tvOS 17.0,watchOS 10.0,iOS 17.0, *)
+@available(iOS 17.0,watchOS 10.0,tvOS 17.0,visionOS 1.0,macOS 14.0, *)
 extension FocusInteractions: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             ConstantAtomLiteral("activate").map({ () -> Self in
-#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+#if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
 
     return Self.activate
 
@@ -13043,7 +13548,7 @@ fatalError("'activate' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("edit").map({ () -> Self in
-#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+#if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
 
     return Self.edit
 
@@ -13052,7 +13557,7 @@ fatalError("'edit' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("automatic").map({ () -> Self in
-#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+#if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
 
     return Self.automatic
 
@@ -13066,7 +13571,7 @@ fatalError("'automatic' is not available on this OS")
 }
 #endif
 
-/// See [`SwiftUI.GestureMask`](https://developer.apple.com/documentation/swiftui/GestureMask)
+/// See [`SwiftUI.GestureMask`](https://developer.apple.com/documentation/swiftui/GestureMask) for more details.
 ///
 /// Possible values:
 /// * `.none`
@@ -13120,8 +13625,53 @@ ConstantAtomLiteral("all").map({ () -> Self in
     }
 }
 
+#if os(visionOS)
+/// See [`SwiftUI.GlassBackgroundDisplayMode`](https://developer.apple.com/documentation/swiftui/GlassBackgroundDisplayMode) for more details.
+///
+/// Possible values:
+/// * `.always`
+/// * `.implicit`
+/// * `.never`
+@_documentation(visibility: public)
+@available(visionOS 1.0, *)
+extension GlassBackgroundDisplayMode: ParseableModifierValue {
+    public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
+        ImplicitStaticMember {
+            OneOf {
+            ConstantAtomLiteral("always").map({ () -> Self in
+#if os(visionOS)
 
-/// See [`SwiftUI.HorizontalAlignment`](https://developer.apple.com/documentation/swiftui/HorizontalAlignment)
+    return Self.always
+
+#else
+fatalError("'always' is not available on this OS")
+#endif
+})
+ConstantAtomLiteral("implicit").map({ () -> Self in
+#if os(visionOS)
+
+    return Self.implicit
+
+#else
+fatalError("'implicit' is not available on this OS")
+#endif
+})
+ConstantAtomLiteral("never").map({ () -> Self in
+#if os(visionOS)
+
+    return Self.never
+
+#else
+fatalError("'never' is not available on this OS")
+#endif
+})
+            }
+        }
+    }
+}
+#endif
+
+/// See [`SwiftUI.HorizontalAlignment`](https://developer.apple.com/documentation/swiftui/HorizontalAlignment) for more details.
 ///
 /// Possible values:
 /// * `.leading`
@@ -13163,8 +13713,8 @@ ConstantAtomLiteral("trailing").map({ () -> Self in
 
 })
 ConstantAtomLiteral("listRowSeparatorLeading").map({ () -> Self in
-#if os(iOS) || os(macOS)
-if #available(iOS 16.0,macOS 13.0, *) {
+#if os(iOS) || os(macOS) || os(visionOS)
+if #available(macOS 13.0,iOS 16.0,visionOS 1.0, *) {
     return Self.listRowSeparatorLeading
 } else { fatalError("'listRowSeparatorLeading' is not available in this OS version") }
 #else
@@ -13172,8 +13722,8 @@ fatalError("'listRowSeparatorLeading' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("listRowSeparatorTrailing").map({ () -> Self in
-#if os(iOS) || os(macOS)
-if #available(iOS 16.0,macOS 13.0, *) {
+#if os(iOS) || os(macOS) || os(visionOS)
+if #available(macOS 13.0,iOS 16.0,visionOS 1.0, *) {
     return Self.listRowSeparatorTrailing
 } else { fatalError("'listRowSeparatorTrailing' is not available in this OS version") }
 #else
@@ -13186,7 +13736,7 @@ fatalError("'listRowSeparatorTrailing' is not available on this OS")
 }
 
 
-/// See [`SwiftUI.HorizontalEdge`](https://developer.apple.com/documentation/swiftui/HorizontalEdge)
+/// See [`SwiftUI.HorizontalEdge`](https://developer.apple.com/documentation/swiftui/HorizontalEdge) for more details.
 ///
 /// Possible values:
 /// * `.leading`
@@ -13220,21 +13770,21 @@ ConstantAtomLiteral("trailing").map({ () -> Self in
     }
 }
 
-#if os(iOS) || os(tvOS)
-/// See [`SwiftUI.HoverEffect`](https://developer.apple.com/documentation/swiftui/HoverEffect)
+#if os(iOS) || os(tvOS) || os(visionOS)
+/// See [`SwiftUI.HoverEffect`](https://developer.apple.com/documentation/swiftui/HoverEffect) for more details.
 ///
 /// Possible values:
 /// * `.automatic`
 /// * `.highlight`
 /// * `.lift`
 @_documentation(visibility: public)
-@available(iOS 13.4,tvOS 16.0, *)
+@available(visionOS 1.0,iOS 13.4,tvOS 16.0, *)
 extension HoverEffect: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             ConstantAtomLiteral("automatic").map({ () -> Self in
-#if os(iOS) || os(tvOS)
+#if os(iOS) || os(tvOS) || os(visionOS)
 
     return Self.automatic
 
@@ -13243,8 +13793,8 @@ fatalError("'automatic' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("highlight").map({ () -> Self in
-#if os(iOS) || os(tvOS)
-if #available(iOS 13.4,tvOS 17.0, *) {
+#if os(iOS) || os(tvOS) || os(visionOS)
+if #available(visionOS 1.0,iOS 13.4,tvOS 17.0, *) {
     return Self.highlight
 } else { fatalError("'highlight' is not available in this OS version") }
 #else
@@ -13252,7 +13802,7 @@ fatalError("'highlight' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("lift").map({ () -> Self in
-#if os(iOS) || os(tvOS)
+#if os(iOS) || os(tvOS) || os(visionOS)
 
     return Self.lift
 
@@ -13265,20 +13815,20 @@ fatalError("'lift' is not available on this OS")
     }
 }
 #endif
-#if os(iOS) || os(macOS)
-/// See [`SwiftUI.KeyboardShortcut`](https://developer.apple.com/documentation/swiftui/KeyboardShortcut)
+#if os(iOS) || os(macOS) || os(visionOS)
+/// See [`SwiftUI.KeyboardShortcut`](https://developer.apple.com/documentation/swiftui/KeyboardShortcut) for more details.
 ///
 /// Possible values:
 /// * `.defaultAction`
 /// * `.cancelAction`
 @_documentation(visibility: public)
-@available(macOS 11.0,iOS 14.0, *)
+@available(macOS 11.0,iOS 14.0,visionOS 1.0, *)
 extension KeyboardShortcut: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             ConstantAtomLiteral("defaultAction").map({ () -> Self in
-#if os(iOS) || os(macOS)
+#if os(iOS) || os(macOS) || os(visionOS)
 
     return Self.defaultAction
 
@@ -13287,7 +13837,7 @@ fatalError("'defaultAction' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("cancelAction").map({ () -> Self in
-#if os(iOS) || os(macOS)
+#if os(iOS) || os(macOS) || os(visionOS)
 
     return Self.cancelAction
 
@@ -13301,7 +13851,7 @@ fatalError("'cancelAction' is not available on this OS")
 }
 #endif
 
-/// See [`SwiftUI.MatchedGeometryProperties`](https://developer.apple.com/documentation/swiftui/MatchedGeometryProperties)
+/// See [`SwiftUI.MatchedGeometryProperties`](https://developer.apple.com/documentation/swiftui/MatchedGeometryProperties) for more details.
 ///
 /// Possible values:
 /// * `.position`
@@ -13346,7 +13896,7 @@ ConstantAtomLiteral("frame").map({ () -> Self in
 }
 
 
-/// See [`SwiftUI.MenuOrder`](https://developer.apple.com/documentation/swiftui/MenuOrder)
+/// See [`SwiftUI.MenuOrder`](https://developer.apple.com/documentation/swiftui/MenuOrder) for more details.
 ///
 /// Possible values:
 /// * `.automatic`
@@ -13368,8 +13918,8 @@ extension MenuOrder: ParseableModifierValue {
 
 })
 ConstantAtomLiteral("priority").map({ () -> Self in
-#if os(iOS)
-if #available(macOS 13.0,watchOS 9.0,tvOS 16.0,iOS 16.0, *) {
+#if os(iOS) || os(visionOS)
+if #available(watchOS 9.0,visionOS 1.0,macOS 13.0,tvOS 16.0,iOS 16.0, *) {
     return Self.priority
 } else { fatalError("'priority' is not available in this OS version") }
 #else
@@ -13390,8 +13940,8 @@ ConstantAtomLiteral("fixed").map({ () -> Self in
     }
 }
 
-#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-/// See [`SwiftUI.PresentationAdaptation`](https://developer.apple.com/documentation/swiftui/PresentationAdaptation)
+#if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+/// See [`SwiftUI.PresentationAdaptation`](https://developer.apple.com/documentation/swiftui/PresentationAdaptation) for more details.
 ///
 /// Possible values:
 /// * `.automatic`
@@ -13400,13 +13950,13 @@ ConstantAtomLiteral("fixed").map({ () -> Self in
 /// * `.sheet`
 /// * `.fullScreenCover`
 @_documentation(visibility: public)
-@available(tvOS 16.4,macOS 13.3,iOS 16.4,watchOS 9.4, *)
+@available(iOS 16.4,watchOS 9.4,tvOS 16.4,macOS 13.3,visionOS 1.0, *)
 extension PresentationAdaptation: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             ConstantAtomLiteral("automatic").map({ () -> Self in
-#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+#if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
 
     return Self.automatic
 
@@ -13415,7 +13965,7 @@ fatalError("'automatic' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("none").map({ () -> Self in
-#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+#if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
 
     return Self.none
 
@@ -13424,7 +13974,7 @@ fatalError("'none' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("popover").map({ () -> Self in
-#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+#if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
 
     return Self.popover
 
@@ -13433,7 +13983,7 @@ fatalError("'popover' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("sheet").map({ () -> Self in
-#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+#if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
 
     return Self.sheet
 
@@ -13442,7 +13992,7 @@ fatalError("'sheet' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("fullScreenCover").map({ () -> Self in
-#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+#if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
 
     return Self.fullScreenCover
 
@@ -13455,21 +14005,21 @@ fatalError("'fullScreenCover' is not available on this OS")
     }
 }
 #endif
-#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-/// See [`SwiftUI.PresentationContentInteraction`](https://developer.apple.com/documentation/swiftui/PresentationContentInteraction)
+#if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+/// See [`SwiftUI.PresentationContentInteraction`](https://developer.apple.com/documentation/swiftui/PresentationContentInteraction) for more details.
 ///
 /// Possible values:
 /// * `.automatic`
 /// * `.resizes`
 /// * `.scrolls`
 @_documentation(visibility: public)
-@available(macOS 13.3,tvOS 16.4,watchOS 9.4,iOS 16.4, *)
+@available(visionOS 1.0,watchOS 9.4,macOS 13.3,tvOS 16.4,iOS 16.4, *)
 extension PresentationContentInteraction: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             ConstantAtomLiteral("automatic").map({ () -> Self in
-#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+#if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
 
     return Self.automatic
 
@@ -13478,7 +14028,7 @@ fatalError("'automatic' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("resizes").map({ () -> Self in
-#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+#if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
 
     return Self.resizes
 
@@ -13487,7 +14037,7 @@ fatalError("'resizes' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("scrolls").map({ () -> Self in
-#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+#if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
 
     return Self.scrolls
 
@@ -13501,7 +14051,7 @@ fatalError("'scrolls' is not available on this OS")
 }
 #endif
 
-/// See [`SwiftUI.Prominence`](https://developer.apple.com/documentation/swiftui/Prominence)
+/// See [`SwiftUI.Prominence`](https://developer.apple.com/documentation/swiftui/Prominence) for more details.
 ///
 /// Possible values:
 /// * `.standard`
@@ -13536,7 +14086,7 @@ ConstantAtomLiteral("increased").map({ () -> Self in
 }
 
 
-/// See [`SwiftUI.RedactionReasons`](https://developer.apple.com/documentation/swiftui/RedactionReasons)
+/// See [`SwiftUI.RedactionReasons`](https://developer.apple.com/documentation/swiftui/RedactionReasons) for more details.
 ///
 /// Possible values:
 /// * `.placeholder`
@@ -13567,8 +14117,8 @@ ConstantAtomLiteral("privacy").map({ () -> Self in
 
 })
 ConstantAtomLiteral("invalidated").map({ () -> Self in
-#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-if #available(macOS 14.0,watchOS 10.0,tvOS 17.0,iOS 17.0, *) {
+#if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+if #available(watchOS 10.0,visionOS 1.0,macOS 14.0,tvOS 17.0,iOS 17.0, *) {
     return Self.invalidated
 } else { fatalError("'invalidated' is not available in this OS version") }
 #else
@@ -13581,7 +14131,7 @@ fatalError("'invalidated' is not available on this OS")
 }
 
 
-/// See [`SwiftUI.RoundedCornerStyle`](https://developer.apple.com/documentation/swiftui/RoundedCornerStyle)
+/// See [`SwiftUI.RoundedCornerStyle`](https://developer.apple.com/documentation/swiftui/RoundedCornerStyle) for more details.
 ///
 /// Possible values:
 /// * `.circular`
@@ -13616,7 +14166,7 @@ ConstantAtomLiteral("continuous").map({ () -> Self in
 }
 
 
-/// See [`SwiftUI.SafeAreaRegions`](https://developer.apple.com/documentation/swiftui/SafeAreaRegions)
+/// See [`SwiftUI.SafeAreaRegions`](https://developer.apple.com/documentation/swiftui/SafeAreaRegions) for more details.
 ///
 /// Possible values:
 /// * `.container`
@@ -13661,7 +14211,7 @@ ConstantAtomLiteral("all").map({ () -> Self in
 }
 
 
-/// See [`SwiftUI.ScenePadding`](https://developer.apple.com/documentation/swiftui/ScenePadding)
+/// See [`SwiftUI.ScenePadding`](https://developer.apple.com/documentation/swiftui/ScenePadding) for more details.
 ///
 /// Possible values:
 /// * `.minimum`
@@ -13683,7 +14233,7 @@ extension ScenePadding: ParseableModifierValue {
 })
 ConstantAtomLiteral("navigationBar").map({ () -> Self in
 #if os(watchOS)
-if #available(iOS 16.0,watchOS 9.0,tvOS 16.0,macOS 13.0, *) {
+if #available(iOS 16.0,tvOS 16.0,macOS 13.0,watchOS 9.0, *) {
     return Self.navigationBar
 } else { fatalError("'navigationBar' is not available in this OS version") }
 #else
@@ -13695,21 +14245,21 @@ fatalError("'navigationBar' is not available on this OS")
     }
 }
 
-#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-/// See [`SwiftUI.ScrollBounceBehavior`](https://developer.apple.com/documentation/swiftui/ScrollBounceBehavior)
+#if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+/// See [`SwiftUI.ScrollBounceBehavior`](https://developer.apple.com/documentation/swiftui/ScrollBounceBehavior) for more details.
 ///
 /// Possible values:
 /// * `.automatic`
 /// * `.always`
 /// * `.basedOnSize`
 @_documentation(visibility: public)
-@available(tvOS 16.4,watchOS 9.4,iOS 16.4,macOS 13.3, *)
+@available(iOS 16.4,tvOS 16.4,macOS 13.3,watchOS 9.4,visionOS 1.0, *)
 extension ScrollBounceBehavior: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             ConstantAtomLiteral("automatic").map({ () -> Self in
-#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+#if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
 
     return Self.automatic
 
@@ -13718,7 +14268,7 @@ fatalError("'automatic' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("always").map({ () -> Self in
-#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+#if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
 
     return Self.always
 
@@ -13727,7 +14277,7 @@ fatalError("'always' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("basedOnSize").map({ () -> Self in
-#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+#if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
 
     return Self.basedOnSize
 
@@ -13741,7 +14291,7 @@ fatalError("'basedOnSize' is not available on this OS")
 }
 #endif
 #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-/// See [`SwiftUI.ScrollDismissesKeyboardMode`](https://developer.apple.com/documentation/swiftui/ScrollDismissesKeyboardMode)
+/// See [`SwiftUI.ScrollDismissesKeyboardMode`](https://developer.apple.com/documentation/swiftui/ScrollDismissesKeyboardMode) for more details.
 ///
 /// Possible values:
 /// * `.automatic`
@@ -13749,46 +14299,46 @@ fatalError("'basedOnSize' is not available on this OS")
 /// * `.interactively`
 /// * `.never`
 @_documentation(visibility: public)
-@available(tvOS 16.0,watchOS 9.0,iOS 16.0,macOS 13.0, *)
+@available(iOS 16.0,tvOS 16.0,macOS 13.0,watchOS 9.0, *)
 extension ScrollDismissesKeyboardMode: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             ConstantAtomLiteral("automatic").map({ () -> Self in
-
+#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
 
     return Self.automatic
 
-
-
-
+#else
+fatalError("'automatic' is not available on this OS")
+#endif
 })
 ConstantAtomLiteral("immediately").map({ () -> Self in
-
+#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
 
     return Self.immediately
 
-
-
-
+#else
+fatalError("'immediately' is not available on this OS")
+#endif
 })
 ConstantAtomLiteral("interactively").map({ () -> Self in
-
+#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
 
     return Self.interactively
 
-
-
-
+#else
+fatalError("'interactively' is not available on this OS")
+#endif
 })
 ConstantAtomLiteral("never").map({ () -> Self in
-
+#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
 
     return Self.never
 
-
-
-
+#else
+fatalError("'never' is not available on this OS")
+#endif
 })
             }
         }
@@ -13796,7 +14346,7 @@ ConstantAtomLiteral("never").map({ () -> Self in
 }
 #endif
 
-/// See [`SwiftUI.ScrollIndicatorVisibility`](https://developer.apple.com/documentation/swiftui/ScrollIndicatorVisibility)
+/// See [`SwiftUI.ScrollIndicatorVisibility`](https://developer.apple.com/documentation/swiftui/ScrollIndicatorVisibility) for more details.
 ///
 /// Possible values:
 /// * `.automatic`
@@ -13850,21 +14400,21 @@ ConstantAtomLiteral("never").map({ () -> Self in
     }
 }
 
-#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-/// See [`SwiftUI.SearchScopeActivation`](https://developer.apple.com/documentation/swiftui/SearchScopeActivation)
+#if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+/// See [`SwiftUI.SearchScopeActivation`](https://developer.apple.com/documentation/swiftui/SearchScopeActivation) for more details.
 ///
 /// Possible values:
 /// * `.automatic`
 /// * `.onTextEntry`
 /// * `.onSearchPresentation`
 @_documentation(visibility: public)
-@available(iOS 16.4,watchOS 9.4,tvOS 16.4,macOS 13.3, *)
+@available(macOS 13.3,tvOS 16.4,watchOS 9.4,visionOS 1.0,iOS 16.4, *)
 extension SearchScopeActivation: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             ConstantAtomLiteral("automatic").map({ () -> Self in
-#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+#if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
 
     return Self.automatic
 
@@ -13873,7 +14423,7 @@ fatalError("'automatic' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("onTextEntry").map({ () -> Self in
-#if os(iOS) || os(macOS) || os(watchOS)
+#if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
 
     return Self.onTextEntry
 
@@ -13882,7 +14432,7 @@ fatalError("'onTextEntry' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("onSearchPresentation").map({ () -> Self in
-#if os(iOS) || os(macOS) || os(watchOS)
+#if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
 
     return Self.onSearchPresentation
 
@@ -13896,7 +14446,7 @@ fatalError("'onSearchPresentation' is not available on this OS")
 }
 #endif
 
-/// See [`SwiftUI.SearchSuggestionsPlacement`](https://developer.apple.com/documentation/swiftui/SearchSuggestionsPlacement)
+/// See [`SwiftUI.SearchSuggestionsPlacement`](https://developer.apple.com/documentation/swiftui/SearchSuggestionsPlacement) for more details.
 ///
 /// Possible values:
 /// * `.automatic`
@@ -13940,21 +14490,21 @@ ConstantAtomLiteral("content").map({ () -> Self in
     }
 }
 
-#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-/// See [`SwiftUI.SpringLoadingBehavior`](https://developer.apple.com/documentation/swiftui/SpringLoadingBehavior)
+#if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+/// See [`SwiftUI.SpringLoadingBehavior`](https://developer.apple.com/documentation/swiftui/SpringLoadingBehavior) for more details.
 ///
 /// Possible values:
 /// * `.automatic`
 /// * `.enabled`
 /// * `.disabled`
 @_documentation(visibility: public)
-@available(macOS 14.0,watchOS 10.0,tvOS 17.0,iOS 17.0, *)
+@available(watchOS 10.0,visionOS 1.0,macOS 14.0,tvOS 17.0,iOS 17.0, *)
 extension SpringLoadingBehavior: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             ConstantAtomLiteral("automatic").map({ () -> Self in
-#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+#if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
 
     return Self.automatic
 
@@ -13963,7 +14513,7 @@ fatalError("'automatic' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("enabled").map({ () -> Self in
-#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+#if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
 
     return Self.enabled
 
@@ -13972,7 +14522,7 @@ fatalError("'enabled' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("disabled").map({ () -> Self in
-#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+#if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
 
     return Self.disabled
 
@@ -13986,7 +14536,7 @@ fatalError("'disabled' is not available on this OS")
 }
 #endif
 
-/// See [`SwiftUI.SubmitLabel`](https://developer.apple.com/documentation/swiftui/SubmitLabel)
+/// See [`SwiftUI.SubmitLabel`](https://developer.apple.com/documentation/swiftui/SubmitLabel) for more details.
 ///
 /// Possible values:
 /// * `.done`
@@ -14091,7 +14641,7 @@ ConstantAtomLiteral("`continue`").map({ () -> Self in
 }
 
 
-/// See [`SwiftUI.SubmitTriggers`](https://developer.apple.com/documentation/swiftui/SubmitTriggers)
+/// See [`SwiftUI.SubmitTriggers`](https://developer.apple.com/documentation/swiftui/SubmitTriggers) for more details.
 ///
 /// Possible values:
 /// * `.text`
@@ -14125,19 +14675,19 @@ ConstantAtomLiteral("search").map({ () -> Self in
     }
 }
 
-#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-/// See [`SwiftUI.ToolbarDefaultItemKind`](https://developer.apple.com/documentation/swiftui/ToolbarDefaultItemKind)
+#if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+/// See [`SwiftUI.ToolbarDefaultItemKind`](https://developer.apple.com/documentation/swiftui/ToolbarDefaultItemKind) for more details.
 ///
 /// Possible values:
 /// * `.sidebarToggle`
 @_documentation(visibility: public)
-@available(watchOS 10.0,macOS 14.0,iOS 17.0,tvOS 17.0, *)
+@available(macOS 14.0,watchOS 10.0,visionOS 1.0,tvOS 17.0,iOS 17.0, *)
 extension ToolbarDefaultItemKind: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             ConstantAtomLiteral("sidebarToggle").map({ () -> Self in
-#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+#if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
 
     return Self.sidebarToggle
 
@@ -14151,7 +14701,7 @@ fatalError("'sidebarToggle' is not available on this OS")
 }
 #endif
 
-/// See [`SwiftUI.ToolbarRole`](https://developer.apple.com/documentation/swiftui/ToolbarRole)
+/// See [`SwiftUI.ToolbarRole`](https://developer.apple.com/documentation/swiftui/ToolbarRole) for more details.
 ///
 /// Possible values:
 /// * `.automatic`
@@ -14174,8 +14724,8 @@ extension ToolbarRole: ParseableModifierValue {
 
 })
 ConstantAtomLiteral("navigationStack").map({ () -> Self in
-#if os(iOS) || os(tvOS) || os(watchOS)
-if #available(macOS 13.0,tvOS 16.0,watchOS 9.0,iOS 16.0, *) {
+#if os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
+if #available(iOS 16.0,watchOS 9.0,tvOS 16.0,visionOS 1.0,macOS 13.0, *) {
     return Self.navigationStack
 } else { fatalError("'navigationStack' is not available in this OS version") }
 #else
@@ -14183,8 +14733,8 @@ fatalError("'navigationStack' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("browser").map({ () -> Self in
-#if os(iOS)
-if #available(macOS 13.0,tvOS 16.0,watchOS 9.0,iOS 16.0, *) {
+#if os(iOS) || os(visionOS)
+if #available(iOS 16.0,watchOS 9.0,tvOS 16.0,visionOS 1.0,macOS 13.0, *) {
     return Self.browser
 } else { fatalError("'browser' is not available in this OS version") }
 #else
@@ -14192,8 +14742,8 @@ fatalError("'browser' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("editor").map({ () -> Self in
-#if os(iOS) || os(macOS)
-if #available(macOS 13.0,tvOS 16.0,watchOS 9.0,iOS 16.0, *) {
+#if os(iOS) || os(macOS) || os(visionOS)
+if #available(iOS 16.0,watchOS 9.0,tvOS 16.0,visionOS 1.0,macOS 13.0, *) {
     return Self.editor
 } else { fatalError("'editor' is not available in this OS version") }
 #else
@@ -14205,8 +14755,8 @@ fatalError("'editor' is not available on this OS")
     }
 }
 
-#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-/// See [`SwiftUI.ToolbarTitleDisplayMode`](https://developer.apple.com/documentation/swiftui/ToolbarTitleDisplayMode)
+#if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+/// See [`SwiftUI.ToolbarTitleDisplayMode`](https://developer.apple.com/documentation/swiftui/ToolbarTitleDisplayMode) for more details.
 ///
 /// Possible values:
 /// * `.automatic`
@@ -14214,13 +14764,13 @@ fatalError("'editor' is not available on this OS")
 /// * `.inlineLarge`
 /// * `.inline`
 @_documentation(visibility: public)
-@available(tvOS 17.0,macOS 14.0,iOS 17.0,watchOS 10.0, *)
+@available(iOS 17.0,watchOS 10.0,tvOS 17.0,macOS 14.0,visionOS 1.0, *)
 extension ToolbarTitleDisplayMode: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             ConstantAtomLiteral("automatic").map({ () -> Self in
-#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+#if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
 
     return Self.automatic
 
@@ -14229,7 +14779,7 @@ fatalError("'automatic' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("large").map({ () -> Self in
-#if os(iOS) || os(watchOS)
+#if os(iOS) || os(visionOS) || os(watchOS)
 
     return Self.large
 
@@ -14238,7 +14788,7 @@ fatalError("'large' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("inlineLarge").map({ () -> Self in
-#if os(iOS) || os(macOS)
+#if os(iOS) || os(macOS) || os(visionOS)
 
     return Self.inlineLarge
 
@@ -14247,7 +14797,7 @@ fatalError("'inlineLarge' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("inline").map({ () -> Self in
-#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+#if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
 
     return Self.inline
 
@@ -14261,7 +14811,7 @@ fatalError("'inline' is not available on this OS")
 }
 #endif
 
-/// See [`SwiftUI.VerticalAlignment`](https://developer.apple.com/documentation/swiftui/VerticalAlignment)
+/// See [`SwiftUI.VerticalAlignment`](https://developer.apple.com/documentation/swiftui/VerticalAlignment) for more details.
 ///
 /// Possible values:
 /// * `.top`
@@ -14326,7 +14876,7 @@ ConstantAtomLiteral("lastTextBaseline").map({ () -> Self in
 }
 
 
-/// See [`SwiftUI.VerticalEdge`](https://developer.apple.com/documentation/swiftui/VerticalEdge)
+/// See [`SwiftUI.VerticalEdge`](https://developer.apple.com/documentation/swiftui/VerticalEdge) for more details.
 ///
 /// Possible values:
 /// * `.top`
@@ -14361,7 +14911,7 @@ ConstantAtomLiteral("bottom").map({ () -> Self in
 }
 
 
-/// See [`SwiftUI.Visibility`](https://developer.apple.com/documentation/swiftui/Visibility)
+/// See [`SwiftUI.Visibility`](https://developer.apple.com/documentation/swiftui/Visibility) for more details.
 ///
 /// Possible values:
 /// * `.automatic`

--- a/Sources/LiveViewNative/visionOS+defaultWheelPickerItemHeight.swift
+++ b/Sources/LiveViewNative/visionOS+defaultWheelPickerItemHeight.swift
@@ -1,0 +1,16 @@
+//
+//  View+defaultWheelPickerItemHeight.swift
+//
+//
+//  Created by Carson Katri on 4/25/24.
+//
+
+#if os(visionOS)
+import SwiftUI
+
+extension View {
+    func defaultWheelPickerItemHeight(_ value: CGFloat) -> some View {
+        self
+    }
+}
+#endif

--- a/Sources/ModifierGenerator/ModifierGenerator.swift
+++ b/Sources/ModifierGenerator/ModifierGenerator.swift
@@ -23,6 +23,7 @@ struct ModifierGenerator: ParsableCommand {
         "_MaskModifier<R>",
         "_MatchedGeometryEffectModifier<R>",
         "_Rotation3DEffectModifier<R>",
+        "_PerspectiveRotationEffectModifier<R>",
         "_PresentationDetentsModifier",
         "_FocusScopeModifier<R>",
         "_PrefersDefaultFocusModifier<R>",
@@ -78,6 +79,8 @@ struct ModifierGenerator: ParsableCommand {
         "SearchScopeActivation",
         "SearchSuggestionsPlacement",
         "RoundedCornerStyle",
+        "GlassBackgroundDisplayMode",
+        "Edge3D",
     ]
 
     static let denylist: Set<String> = [
@@ -123,6 +126,7 @@ struct ModifierGenerator: ParsableCommand {
         "mask",
         "matchedGeometryEffect",
         "rotation3DEffect",
+        "perspectiveRotationEffect",
         "presentationDetents",
         "focusScope",
         "prefersDefaultFocus",
@@ -187,7 +191,6 @@ struct ModifierGenerator: ParsableCommand {
         "layerEffect",
         "layoutDirectionBehavior",
         "menuActionDismissBehavior",
-        "ornament",
         "paletteSelectionEffect",
         "springLoadingBehavior",
         "touchBar",

--- a/Sources/ModifierGenerator/Subcommands/Source.swift
+++ b/Sources/ModifierGenerator/Subcommands/Source.swift
@@ -9,7 +9,7 @@ extension ModifierGenerator {
         static let configuration = CommandConfiguration(abstract: "Generate Swift source code for modifiers and enums in a `swiftinterface` file.")
         
         @Argument(
-            help: "The `.swiftinterface` file from `/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/System/Library/Frameworks/SwiftUI.framework/Modules/SwiftUI.swiftmodule/arm64-apple-ios.swiftinterface`",
+            help: "The `.swiftinterface` file from `/Applications/Xcode.app/Contents/Developer/Platforms/XROS.platform/Developer/SDKs/XROS.sdk/System/Library/Frameworks/SwiftUI.framework/Modules/SwiftUI.swiftmodule/arm64-apple-xros.swiftinterface`",
             transform: { URL(filePath: $0) }
         )
         var interface: URL
@@ -25,7 +25,7 @@ extension ModifierGenerator {
             
             FileHandle.standardOutput.write(Data(
                 #"""
-                // File generated with `swift run ModifierGenerator source "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/System/Library/Frameworks/SwiftUI.framework/Modules/SwiftUI.swiftmodule/arm64-apple-ios.swiftinterface" > Sources/LiveViewNative/_GeneratedModifiers.swift`
+                // File generated with `swift run ModifierGenerator source "/Applications/Xcode.app/Contents/Developer/Platforms/XROS.platform/Developer/SDKs/XROS.sdk/System/Library/Frameworks/SwiftUI.framework/Modules/SwiftUI.swiftmodule/arm64-apple-xros.swiftinterface" > Sources/LiveViewNative/_GeneratedModifiers.swift`
                 
                 import SwiftUI
                 import Symbols


### PR DESCRIPTION
This updates the core dependency, with visionOS support included.

The `_GeneratedModifier.swift` was regenerated using Xcode 15.3, and uses the `arm64-apple-xros.swiftinterface` instead of the iOS file to include some missing modifiers. I also added missing types for these modifiers.