### PR TITLE
Add additional core components and app layout

### DIFF
--- a/priv/templates/lvn.gen.layout/app.neex
+++ b/priv/templates/lvn.gen.layout/app.neex
@@ -1,0 +1,2 @@
+<.flash_group flash={@flash} />
+<%%= @inner_content %>


### PR DESCRIPTION
This adds the following core components:
* `modal`
* `flash`
* `flash_group`
* `list`

Updates were made to the following components:
* `button`
* `table`

A new `app.swiftui.neex` layout was added as well, which injects the `flash_group` component to support `put_flash` in all template projects.

## Components
<table>
<tr>
  <th>Component</th>
  <th>Demo</th>
</tr>
<tr>
<td>

```heex
<.flash_group flash={@flash} />
```
```ex
def handle_event("flash", _params, socket) do
  {:noreply, put_flash(socket, :info, "This is an info flash")}
end

def handle_event("flash-err", _params, socket) do
  {:noreply, put_flash(socket, :error, "This is an error flash")}
end
```

</td>
<td>

https://github.com/liveview-native/liveview-client-swiftui/assets/13581484/5e496735-97c1-4b34-afe6-b4981c168e11

</td>
</tr>
<tr>
<td>

```heex
<.modal show id="confirm-modal">
  This is a modal.
</.modal>
```

</td>
<td>

https://github.com/liveview-native/liveview-client-swiftui/assets/13581484/c1c20466-063a-4b8a-9e59-c27295eac13d

</td>
</tr>
<tr>
<td>

```heex
<.table id="users" rows={@users}>
  <:col :let={user} label="id"><%= user.id %></:col>
  <:col :let={user} label="username"><%= user.username %></:col>
  <:action>
    <Button>Save</Button>
  </:action>
  <:action>
    <Button role="destructive">Delete</Button>
  </:action>
</.table>
```

</td>
<td>

> [!NOTE]
> Table renders as a List on iPhones.

<img width="568" alt="Screenshot 2024-05-07 at 3 02 43 PM" src="https://github.com/liveview-native/liveview-client-swiftui/assets/13581484/6469bf9d-e07e-425b-a9de-6f5ae4f85aa5">

</td>
</tr>
<tr>
<td>

```heex
<.list>
  <:item title="Title"><%= @post.title %></:item>
  <:item title="Views"><%= @post.views %></:item>
</.list>
```

</td>
<td>

![Simulator Screenshot - iPhone 15 Pro - 2024-05-07 at 15 18 44](https://github.com/liveview-native/liveview-client-swiftui/assets/13581484/ac4194c2-860e-4d5f-b587-cfd24a6efa84)

</td>
</tr>
</table>


