### PR TITLE
Rename DatePicker's `components` to `displayedComponents`

### DIFF
--- a/Sources/LiveViewNative/Views/Controls and Indicators/Pickers/DatePicker.swift
+++ b/Sources/LiveViewNative/Views/Controls and Indicators/Pickers/DatePicker.swift
@@ -48,11 +48,11 @@ struct DatePicker<Root: RootRegistry>: View {
     ///- `hourAndMinute`
     ///- `date`
     @_documentation(visibility: public)
-    private var components: String?
+    private var displayedComponents: String?
     
     #if os(iOS) || os(macOS)
     private var datePickerComponents: DatePickerComponents {
-        components.flatMap({ DatePickerComponents.init(from: $0) }) ?? [.hourAndMinute, .date]
+        displayedComponents.flatMap({ DatePickerComponents.init(from: $0) }) ?? [.hourAndMinute, .date]
     }
     #endif
     


### PR DESCRIPTION
Closes #1348 