### PR TITLE
Support `phx-debounce="blur"`

### DIFF
--- a/Sources/LiveViewNative/Property Wrappers/ChangeTracked.swift
+++ b/Sources/LiveViewNative/Property Wrappers/ChangeTracked.swift
@@ -175,18 +175,13 @@ extension ChangeTracked where Value: FormValue {
                 .sink(receiveValue: { [weak self] localValue in
                     self?.objectWillChange.send()
                     self?.value = localValue
-                    Task { [weak self] in
-                        guard let self,
-                              self.sendChangeEvent
-                        else { return }
-                        // LiveView expects all values to be strings.
-                        let encodedValue: String
-                        if let localValue = localValue as? String {
-                            encodedValue = localValue
-                        } else {
-                            encodedValue = try String(data: JSONEncoder().encode(localValue), encoding: .utf8) ?? ""
+                    if changeTracked._event.debounceAttribute != .blur { // the input element should call `pushChangeEvent` when it loses focus.
+                        Task { [weak self] in
+                            guard let self,
+                                  self.sendChangeEvent
+                            else { return }
+                            try await pushChangeEvent(to: changeTracked)
                         }
-                        try await changeTracked.event(value: JSONSerialization.jsonObject(with: JSONEncoder().encode([self.attribute.rawValue: encodedValue]), options: .fragmentsAllowed))
                     }
                 })
             
@@ -201,6 +196,24 @@ extension ChangeTracked where Value: FormValue {
                     self.objectWillChange.send()
                 }
         }
+        
+        func pushChangeEvent(
+            to changeTracked: ChangeTracked<Value>
+        ) async throws {
+            guard let localValue = self.value else { return }
+            // LiveView expects all values to be strings.
+            let encodedValue: String
+            if let localValue = localValue as? String {
+                encodedValue = localValue
+            } else {
+                encodedValue = try String(data: JSONEncoder().encode(localValue), encoding: .utf8) ?? ""
+            }
+            try await changeTracked.event(value: JSONSerialization.jsonObject(with: JSONEncoder().encode([self.attribute.rawValue: encodedValue]), options: .fragmentsAllowed))
+        }
+    }
+    
+    func pushChangeEvent() async throws {
+        try await (self.localValue as? FormLocalValue)?.pushChangeEvent(to: self)
     }
 }
 

--- a/Sources/LiveViewNative/ViewModel.swift
+++ b/Sources/LiveViewNative/ViewModel.swift
@@ -39,7 +39,7 @@ public class FormModel: ObservableObject, CustomDebugStringConvertible {
     let elementID: String
     @_spi(LiveForm) public var pushEventImpl: ((String, String, Any, Int?) async throws -> Void)!
     
-    var changeEvent: String?
+    var changeEvent: ((Any) -> ())?
     var submitEvent: String?
     /// An action called when no `phx-submit` event is present.
     ///
@@ -55,7 +55,11 @@ public class FormModel: ObservableObject, CustomDebugStringConvertible {
     }
     
     @_spi(LiveForm) public func updateFromElement(_ element: ElementNode, submitAction: @escaping () -> ()) {
-        self.changeEvent = element.attributeValue(for: .init(name: "phx-change"))
+        self.changeEvent = element.attributeValue(for: .init(name: "phx-change")).flatMap({ event in
+            { value in
+                Task { [weak self] in try await self?.pushEventImpl("form", event, value, nil) }
+            }
+        })
         self.submitEvent = element.attributeValue(for: .init(name: "phx-submit"))
         self.submitAction = submitAction
     }
@@ -66,10 +70,23 @@ public class FormModel: ObservableObject, CustomDebugStringConvertible {
     ///
     /// See ``LiveViewCoordinator/pushEvent(type:event:value:target:)`` for more information.
     @MainActor
-    public func sendChangeEvent() async throws {
-        if let changeEvent = changeEvent {
-            try await pushFormEvent(changeEvent)
+    public func sendChangeEvent(_ value: any FormValue, for name: String, event: Event?) async throws {
+        guard let event = event?.wrappedValue.callAsFunction ?? changeEvent else { return }
+        
+        // LiveView expects all values to be strings.
+        let encodedValue: String = if let value = value as? String {
+            value
+        } else {
+            try value.formQueryEncoded()
         }
+        
+        var components = URLComponents()
+        components.queryItems = [
+            .init(name: name, value: encodedValue),
+            .init(name: "_target", value: name)
+        ]
+        
+        try await event(components.query!)
     }
     
     /// Sends a phx-submit event (if configured) to the server with the current form data.
@@ -125,7 +142,7 @@ public class FormModel: ObservableObject, CustomDebugStringConvertible {
         }
     }
     
-    public func setValue(_ value: (some FormValue)?, forName name: String, changeEvent: String?) {
+    public func setValue(_ value: (some FormValue)?, forName name: String, changeEvent: Event?) {
         let existing = data[name]
         if let existing,
            let value,
@@ -140,19 +157,11 @@ public class FormModel: ObservableObject, CustomDebugStringConvertible {
             return
         }
         data[name] = value
-        if let changeEvent = changeEvent ?? self.changeEvent {
+        if changeEvent?.debounceAttribute != .blur,
+           let value
+        {
             Task {
-                let data = if let value = value as? String {
-                    value
-                } else {
-                    try value.formQueryEncoded()
-                }
-                var components = URLComponents()
-                components.queryItems = [
-                    .init(name: name, value: data),
-                    .init(name: "_target", value: name)
-                ]
-                try await pushEventImpl("form", changeEvent, components.query!, nil)
+                try await sendChangeEvent(value, for: name, event: changeEvent)
             }
         }
     }

--- a/Sources/LiveViewNative/Views/Text Input and Output/SecureField.swift
+++ b/Sources/LiveViewNative/Views/Text Input and Output/SecureField.swift
@@ -30,7 +30,7 @@ import SwiftUI
 @_documentation(visibility: public)
 @LiveElement
 struct SecureField<Root: RootRegistry>: TextFieldProtocol {
-    @FormState("text") var text: String?
+    @FormState("text", default: "") var text: String?
     @LiveElementIgnored
     @FocusState private var isFocused: Bool
     
@@ -68,6 +68,7 @@ struct SecureField<Root: RootRegistry>: TextFieldProtocol {
                 $liveElement.element.buildPhxValuePayload()
                     .merging(["value": textBinding.wrappedValue], uniquingKeysWith: { a, _ in a })
             )
+            Task { try await _text.handleBlur() }
         }
     }
 }

--- a/Sources/LiveViewNative/Views/Text Input and Output/TextEditor.swift
+++ b/Sources/LiveViewNative/Views/Text Input and Output/TextEditor.swift
@@ -20,7 +20,7 @@ import SwiftUI
 @available(iOS 16.0, macOS 13.0, *)
 @LiveElement
 struct TextEditor<Root: RootRegistry>: TextFieldProtocol {
-    @FormState("text") var text: String?
+    @FormState("text", default: "") var text: String?
     @LiveElementIgnored
     @FocusState private var isFocused: Bool
     
@@ -55,6 +55,7 @@ struct TextEditor<Root: RootRegistry>: TextFieldProtocol {
                 $liveElement.element.buildPhxValuePayload()
                     .merging(["value": textBinding.wrappedValue], uniquingKeysWith: { a, _ in a })
             )
+            Task { try await _text.handleBlur() }
         }
     }
 }

--- a/Sources/LiveViewNative/Views/Text Input and Output/TextField.swift
+++ b/Sources/LiveViewNative/Views/Text Input and Output/TextField.swift
@@ -156,6 +156,7 @@ struct TextField<Root: RootRegistry>: TextFieldProtocol {
                 $liveElement.element.buildPhxValuePayload()
                     .merging(["value": textBinding.wrappedValue], uniquingKeysWith: { a, _ in a })
             )
+            Task { try await _text.handleBlur() }
         }
     }
     


### PR DESCRIPTION
Closes #1322 

`phx-debounce="blur"` only works on `<TextField>`, `<SecureField>`, and `<TextEditor>`. Other controls (like `<Slider>` or `<Toggle>`) don't seem capable of receiving focus. However, it could easily be expanded to other form controls as needed.

https://github.com/liveview-native/liveview-client-swiftui/assets/13581484/b6415b76-88c9-46ab-9bd4-66ff35ef615e

