### PR TITLE
Update addon documentation

### DIFF
--- a/Sources/LiveViewNative/Live/LiveElement.swift
+++ b/Sources/LiveViewNative/Live/LiveElement.swift
@@ -8,13 +8,67 @@
 import SwiftUI
 import LiveViewNativeCore
 
+/// Describes a View that is used as an element in a LiveView Native template.
+///
+/// Any properties of the ``SwiftUI/View`` will be decoded from element attributes.
+///
+/// - Precondition: A generic argument named `Root` conforming to ``RootRegistry`` must be included on the struct.
+/// - Precondition: All properties should have a default value, or be marked optional.
+///
+/// ```swift
+/// @LiveElement
+/// struct MyTag<Root: RootRegistry>: View {
+///     private var label: String?
+///     private var count: Int = 0
+///
+///     var body: some View {
+///         Text(label ?? "")
+///         Text("Value: \(count)")
+///     }
+/// }
+/// ```
+///
+/// ```html
+/// <MyTag label="Cookies" count="3" />
+/// ```
+///
+/// By default, the property name is used verbatim as the attribute name.
+/// Use the ``LiveAttribute(_:)`` macro to customize the name of an attribute.
+///
+/// Use the ``LiveElementIgnored()`` macro to disable decoding of a property.
+/// This is useful when interfacing with SwiftUI property wrappers, such as ``SwiftUI/State`` and ``SwiftUI/Environment``.
 @attached(member, names: named(liveElement), named(_TrackedContent))
 @attached(memberAttribute)
 public macro LiveElement() = #externalMacro(module: "LiveViewNativeMacros", type: "LiveElementMacro")
 
+/// Marks a property as an attribute on a ``LiveElement()``.
+///
+/// By default, the property name is used verbatim as the attribute name.
+/// Provide the `name` argument to customize the namespace/name of the attribute.
+///
+/// ```swift
+/// @LiveAttribute(.init(namespace: "item", name: "count"))
+/// private var count: Int = 0
+/// ```
+///
+/// ```html
+/// <MyTag item:count="3" />
+/// ```
 @attached(accessor, names: named(get))
 public macro LiveAttribute(_ name: AttributeName? = nil) = #externalMacro(module: "LiveViewNativeMacros", type: "LiveAttributeMacro")
 
+/// Disables attribute decoding for a property on a ``LiveElement()``.
+///
+/// By default, all properties are treated as attributes by ``LiveElement()``.
+/// This macro disables attribute decoding for a property.
+///
+/// This can used with SwiftUI property wrappers, such as ``SwiftUI/State`` and ``SwiftUI/Environment``,
+/// which should only be handled client-side.
+///
+/// ```swift
+/// @LiveElementIgnored
+/// @State private var isExpanded = false
+/// ```
 @attached(accessor, names: named(willSet))
 public macro LiveElementIgnored() = #externalMacro(module: "LiveViewNativeMacros", type: "LiveElementIgnoredMacro")
 
@@ -24,7 +78,9 @@ public protocol _LiveElementTrackedContent {
 }
 
 @propertyWrapper public struct _LiveElementTracked<R: RootRegistry, T: _LiveElementTrackedContent>: DynamicProperty {
+    /// The ``ElementNode`` used to build a live element.
     @ObservedElement public var element
+    /// The ``LiveContext`` for a live element.
     @LiveContext<R> public var context
     
     public var wrappedValue: T
@@ -52,12 +108,22 @@ public protocol _LiveElementTrackedContent {
 }
 
 public extension _LiveElementTracked {
+    /// Builds all child elements into a View hierarchy.
+    ///
+    /// By default, elements with a `template` are filtered out.
+    /// You can provide a custom `predicate` to filter different elements.
+    ///
+    /// - Parameter predicate: The filter used to select child nodes for render.
     func children(_ predicate: (Node) -> Bool = { node in
         !node.attributes.contains(where: { $0.name.namespace == nil && $0.name.name == "template" })
     }) -> some View {
         context.coordinator.builder.fromNodes(_element.children.filter(predicate), context: context.storage)
     }
     
+    /// Builds all children with a given `template` attribute.
+    ///
+    /// - Parameter template: The ``Template`` used to filter child elements. A String literal can be provided for simple template values.
+    /// - Parameter includeDefault: Whether elements without a `template` attribute should be included in the filter. Defaults to `false`.
     func children(in template: Template, default includeDefault: Bool = false) -> some View {
         children {
             $0.attributes.contains(where: {
@@ -66,6 +132,10 @@ public extension _LiveElementTracked {
         }
     }
     
+    /// Check whether one or more children have a matching `template` attribute.
+    ///
+    /// - Parameter template: The ``Template`` used to filter child elements. A String literal can be provided for simple template values.
+    /// - Parameter includeDefault: Whether elements without a `template` attribute should be included in the filter. Defaults to `false`.
     func hasTemplate(_ template: Template, default includeDefault: Bool = false) -> Bool {
         _element.children.contains(where: {
             for attribute in $0.attributes {
@@ -83,11 +153,33 @@ public extension _LiveElementTracked {
         hasTemplate(.init(name, value: value))
     }
     
+    /// Array containing children of the ``ElementNode``.
     var childNodes: [LiveViewNativeCore.Node] {
         _element.children
     }
 }
 
+/// A value passed to the `template` attribute, used for filtering children.
+///
+/// A string literal can be used to create a simple template.
+///
+/// ```swift
+/// $liveElement.children(in: "label")
+/// ```
+///
+/// ```html
+/// <Element template="label" />
+/// ```
+///
+/// When a `value` is passed, the `template` attribute should match the scheme `name.value`.
+///
+/// ```swift
+/// $liveElement.children(in: Template("phase", value: "success"))
+/// ```
+///
+/// ```html
+/// <Element template="phase.success" />
+/// ```
 public struct Template: RawRepresentable, ExpressibleByStringLiteral {
     let name: String
     let value: String?

--- a/Sources/LiveViewNative/LiveViewNative.docc/AddCustomElement.md
+++ b/Sources/LiveViewNative/LiveViewNative.docc/AddCustomElement.md
@@ -1,35 +1,49 @@
 # Adding Custom Elements
 
-Use the ``RootRegistry`` protocol to define how DOM elements are converted to SwiftUI views.
+Use the ``LiveElement()`` macro to declare custom elements.
 
 ## Overview
 
-If you don't already have one, create a type that conforms to the ``RootRegistry`` protocol and provide it as the generic type parameter to your ``LiveViewCoordinator``.
+If you don't already have one, create a type that uses the ``Addon()`` macro, and include it in the list of `addons` on your ``LiveView``.
 
 ```swift
-struct MyRegistry: RootRegistry {
-}
-```
-
-Then, add an enum type called `TagName` that has strings for raw values. This type is what the framework uses to check if your custom registry supports a given tag name. All of the string values should be lowercase, otherwise the framework will not support them. In the following example, `<my-tag>` elements in the DOM will be converted to the `.myTag` name.
-
-```swift
-struct MyRegistry: RootRegistry {
-    enum TagName: String {
-        case myTag = "my-tag"
+public extension Addons {
+    @Addon
+    struct MyAddon<Root: RootRegistry> {
+        // ...
     }
 }
 ```
 
-To provide views for these elements, implement the ``CustomRegistry/lookup(_:element:)-795ez`` method. Your implementation of this method is automatically treated as SwiftUI `ViewBuilder`, so simply construct the view you want to use rather than returning it.
+```swift
+#LiveView(
+    .localhost,
+    addons: [.myAddon]
+)
+```
 
-In the following example, the element `<my-tag />` in the DOM will be displayed as the text "My custom element!"
+Then, add an enum type called `TagName` that has strings for raw values. This type is what the framework uses to check if your custom registry supports a given tag name. In the following example, `<MyTag>` elements in the DOM will be converted to the `.myTag` name.
 
 ```swift
-struct MyRegistry: RootRegistry {
+@Addon
+struct MyAddon<Root: RootRegistry> {
     enum TagName: String {
-        case myTag = "my-tag"
+        case myTag = "MyTag"
     }
+}
+```
+
+To provide a ``SwiftUI/View`` for this element, implement the ``CustomRegistry/lookup(_:element:)-795ez`` method. Your implementation of this method is automatically treated as SwiftUI `ViewBuilder`, so simply construct the view you want to use rather than returning it.
+
+In the following example, the element `<MyTag />` in the DOM will be displayed as the text "My custom element!"
+
+```swift
+@Addon
+struct MyAddon<Root: RootRegistry> {
+    enum TagName: String {
+        case myTag = "MyTag"
+    }
+
     static func lookup(_ name: TagName, element: ElementNode) -> some View {
         switch name {
         case .myTag:
@@ -39,4 +53,207 @@ struct MyRegistry: RootRegistry {
 }
 ```
 
+```html
+<MyTag />
+```
+
 Because an enum is used for the tag name, do not include a `default` branch in your `switch` statement so that Swift will check it for exhaustiveness.
+
+## Live Elements
+
+Not every element renders a static SwiftUI View. Some need arguments, children, events, etc.
+
+To enable more functionality in a custom element, use the ``LiveElement()`` macro.
+Add this macro to a custom View with a `Root` generic argument.
+
+```swift
+@LiveElement
+struct MyTag<Root: RootRegistry>: View {
+    var body: some View {
+        Text("My custom element!")
+    }
+}
+```
+
+Add this View to your addon to make it available in templates.
+
+```swift
+@Addon
+struct MyAddon<Root: RootRegistry> {
+    enum TagName: String {
+        case myTag = "MyTag"
+    }
+
+    static func lookup(_ name: TagName, element: ElementNode) -> some View {
+        switch name {
+        case .myTag:
+            MyTag<Root>()
+        }
+    }
+}
+```
+
+### Attributes
+
+To add attributes to your element, simply add properties to the struct.
+Any ``AttributeDecodable`` type will automatically be decoded.
+
+All properties should have a default value or be optional.
+
+```swift
+@LiveElement
+struct MyTag<Root: RootRegistry>: View {
+    private var label: String?
+    private var itemCount: Int = 0
+
+    var body: some View {
+        Text(label ?? "")
+        Text("Value: \(itemCount)")
+    }
+}
+```
+
+```html
+<MyTag label="Cookies" itemCount="3" />
+```
+
+The name of the property is used verbatim as the attribute name.
+Add the ``LiveAttribute(_:)`` macro to customize the name of an attribute.
+
+By default, all properties will be treated as attributes on the element.
+If you don't want a property to be an attribute, add the ``LiveElementIgnored()`` macro.
+
+```swift
+@LiveElement
+struct MyTag<Root: RootRegistry>: View {
+    private var label: String?
+    @LiveAttribute(.init(namespace: "item", name: "count")) private var itemCount: Int = 0
+    
+    // this property will not be available as an attribute
+    @LiveElementIgnored
+    @Environment(\.colorScheme)
+    private var colorScheme: ColorScheme
+
+    var body: some View {
+        Text(label ?? "")
+        switch colorScheme {
+        case .dark:
+            Text("Value: \(itemCount)").foregroundStyle(.yellow)
+        default:
+            Text("Value: \(itemCount)").foregroundStyle(.orange)
+        }
+    }
+}
+```
+
+```html
+<MyTag label="Cookies" item:count="3" />
+```
+
+### Children
+Use the synthesized `$liveElement` value to access child elements.
+For example, we can replace the `label` attribute with the children of the element.
+
+```swift
+@LiveElement
+struct MyTag<Root: RootRegistry>: View {
+    private var count: Int = 0
+
+    var body: some View {
+        $liveElement.children()
+        Text("Value: \(count)")
+    }
+}
+```
+
+```html
+<MyTag count="3">
+    <Text>Cookies</Text>
+</MyTag>
+```
+
+Provide a predicate to include different children in different parts of your View.
+By default, the `template` attribute is used to filter children in LiveView Native.
+However, you can provide a custom filter predicate for more custom behavior.
+
+Use the ``Template`` struct to filter with more complex template values, or provide a string name.
+
+```swift
+$liveElement.children(in: "label", default: true)
+```
+
+The `default` argument determines whether elements without a `template` attribute are also included in the filter.
+It is `false` by default.
+
+```html
+<MyTag count="3">
+    <Text template="label">Cookies</Text>
+    <Text>Also part of the "label" filter because `default` is `true`.</Text>
+</MyTag>
+```
+
+### Events
+Event attributes can be added with the ``Event`` property wrapper.
+These attributes behave like `phx-click` and other built-in bindings, where the attribute value determines the event it sends.
+The framework automatically handles `phx-debounce`, `phx-throttle`, `phx-target`, and other built-in properties.
+
+Call the event as a function in your View's `body`.
+
+```swift
+@LiveElement
+struct MyTag<Root: RootRegistry>: View {
+    private var count: Int = 0
+
+    @Event("onIncrement", type: "click") private var onIncrement
+
+    var body: some View {
+        $liveElement.children()
+        Text("Value: \(count)")
+        Button("Increment") {
+            onIncrement(value: count + 1)
+        }
+    }
+}
+```
+
+```html
+<MyTag count={@count} onIncrement="handle-increment">
+    <Text>Cookies</Text>
+</MyTag>
+```
+
+```elixir
+def handle_event("handle-increment", new_count, socket) do
+    {:noreply, assign(socket, count: new_count)}
+end
+```
+
+### Live Context
+Access the ``LiveContext`` via the synthesized `$liveElement` property.
+This allows you to access the ``LiveViewCoordinator`` to send/receive events to/from the server.
+
+```swift
+@LiveElement
+struct MyTag<Root: RootRegistry>: View {
+    private var count: Int = 0
+
+    var body: some View {
+        $liveElement.children()
+        Text("Value: \(count)")
+        Button("Increment") {
+            Task {
+                try await $liveElement.context.coordinator.pushEvent(
+                    type: "click",
+                    event: "increment",
+                    value: count + 1,
+                    target: nil
+                )
+            }
+        }
+    }
+}
+```
+
+```elixir
+def handle_event("increment", new_count, socket), do: ...
+```

--- a/Sources/LiveViewNative/LiveViewNative.docc/AddCustomModifier.md
+++ b/Sources/LiveViewNative/LiveViewNative.docc/AddCustomModifier.md
@@ -4,53 +4,167 @@ Use the ``RootRegistry`` protocol to define how custom modifiers in the DOM are 
 
 ## Overview
 
-If you don't already have one, create a type that conforms to the ``RootRegistry`` protocol and provide it as the eneric type paramter to your ``LiveViewCoordinator``.
+If you don't already have one, create a type that uses the ``Addon()`` macro, and include it in the list of `addons` on your ``LiveView``.
 
 ```swift
-struct MyRegistry: RootRegistry {
-}
-```
-
-Then, add an enum called `AttributeName` that has strings for raw values and conforms to `Equatable`. The framework will use this type to check if your registry supports a particular attribute name. All of the string values should be lowercase, otherwise the framework will not use them.
-
-```swift
-struct MyRegistry: RootRegistry {
-    enum ModifierType: String {
-        case myFont = "my_font"
+public extension Addons {
+    @Addon
+    struct MyAddon<Root: RootRegistry> {
+        // ...
     }
 }
 ```
 
-To define the view modifier for this attributes, implement the ``CustomRegistry/decodeModifier(_:from:)-9gliz`` method. This method is automatically treated as a ``ViewModifierBuilder``, so simply construct your modifier rather than returning it.
+```swift
+#LiveView(
+    .localhost,
+    addons: [.myAddon]
+)
+```
 
-In the following example, a modifier like `{"type": "my_font", "size": 22}` could be used to apply the custom font named "My Font" with a fixed size of 22pt.
+Then, add an enum called `CustomModifier` that has cases for each modifier to include.
+The framework uses this type to parse modifiers in a stylesheet.
+
+Use the ``CustomModifierGroupParser`` to include multiple modifiers.
 
 ```swift
-struct MyRegistry: RootRegistry {
-    enum ModifierType: String {
-        case myFont = "my_font"
-    }
-
-    static func decodeModifier(_ type: ModifierType, from decoder: Decoder) throws -> some ViewModifier {
-        switch name {
-        case .myFont:
-            try MyFontModifier(from: decoder)
+@Addon
+struct MyAddon<Root: RootRegistry> {
+    enum CustomModifier: ViewModifier, ParseableModifierValue {
+        case myFirstModifier(MyFirstModifier<Root>)
+        case mySecondModifier(MySecondModifier<Root>)
+        
+        static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
+            CustomModifierGroupParser(output: Self.self) {
+                MyFirstModifier<Root>.parser(in: context).map(Self.myFirstModifier)
+                MySecondModifier<Root>.parser(in: context).map(Self.mySecondModifier)
+            }
+        }
+        
+        func body(content: Content) -> some View {
+            switch self {
+            case .myFirstModifier(let modifier):
+                content.modifier(modifier)
+            case .mySecondModifier(let modifier):
+                content.modifier(modifier)
+            }
         }
     }
 }
 ```
 
-Because an enum is used for the attribute name, do not include a `default` branch in your `switch` statement so that Swift will check if for exhaustiveness.
+## Parseable Modifiers
 
-Then, implement the `MyFontModifier` struct. By conforming to the `Decodable` protocol, the `init(from:)` initializer that handles decoding the modifier from JSON can be synthesized automatically. The `body(content:)` method modifies the `content` view it receives based on whatever values were decoded.
+Each modifier should conform to ``LiveViewNativeStylesheet/ParseableModifierValue``.
+You can use the ``LiveViewNativeStylesheet/ParseableExpression()`` macro to synthesize this conformance.
+
+The macro will synthesize a parser for each `init` clause.
+
+Any type conforming to ``LiveViewNativeStylesheet/ParseableModifierValue`` can be used as an argument in an `init` clause.
 
 ```swift
-struct MyFontModifier: ViewModifier, Decodable {
-    let size: Double?
+@ParseableExpression
+struct MyFirstModifier<Root: RootRegistry>: ViewModifier {
+    static var name: String { "myFirstModifier" }
 
+    let color: Color
+
+    init(_ color: Color) {
+        self.color = color
+    }
+
+    init(red: Double, green: Double, blue: Double) {
+        self.color = Color(.sRGB, red: red, green: green, blue: blue)
+    }
+    
     func body(content: Content) -> some View {
         content
-            .font(.custom("My Font", fixedSize: size ?? 13))
+            .bold()
+            .background(color)
     }
 }
+```
+
+In the stylesheet, you can use either clause:
+
+```swift
+// myFirstModifier(_:)
+myFirstModifier(.red)
+myFirstModifier(.blue)
+myFirstModifier(Color(white: 0.5))
+
+// myFirstModifier(red:green:blue:)
+myFirstModifier(red: 1, green: 0.5, blue: 0)
+```
+
+### Nested Content
+Use ``ObservedElement`` and ``LiveContext`` to access properties/children of the element the modifier is applied to.
+
+The ``ViewReference`` type can be used to refer to nested children with a `template` attribute.
+
+```swift
+@ParseableExpression
+struct MyBackgroundModifier<Root: RootRegistry>: ViewModifier {
+    static var name: String { "myBackground" }
+
+    @ObservedElement private var element
+    @LiveContext<Root> private var context
+
+    let content: ViewReference
+
+    init(_ content: ViewReference) {
+        self.content = content
+    }
+    
+    func body(content: Content) -> some View {
+        content.background(content.resolve(on: element, in: context))
+    }
+}
+```
+
+```elixir
+"my-background" do
+    myBackground(:my_content)
+end
+```
+
+```html
+<Element class="my-background">
+    <Text template="my_content">Nested Content</Text>
+</Element>
+```
+
+### Attribute References
+Any type that conforms to ``AttributeDecodable`` can be wrapped with ``AttributeReference``.
+
+This will make it usable with the `attr(<name>)` helper in a stylesheet.
+
+```swift
+@ParseableExpression
+struct MyTitleModifier<Root: RootRegistry>: ViewModifier {
+    static var name: String { "myTitle" }
+
+    @ObservedElement private var element
+    @LiveContext<Root> private var context
+
+    let title: AttributeReference<String>
+
+    init(_ title: AttributeReference<String>) {
+        self.title = title
+    }
+    
+    func body(content: Content) -> some View {
+        content.navigationTitle(title.resolve(on: element, in: context))
+    }
+}
+```
+
+```elixir
+"my-title" do
+    myTitle(attr("title"))
+end
+```
+
+```html
+<Element class="my-title" title="My Title" />
 ```


### PR DESCRIPTION
This updates the documentation pages on creating custom elements and modifiers for the latest API changes.

You can view this documentation from Xcode by pressing *Product -> Build Documentation*. This will build all LiveView Native documentation and open it in *Window -> Developer Documentation* once it completes. The pages are called "Adding Custom Elements" and "Adding Custom Modifiers".