### PR TITLE
Add separate `setup` and `disconnected` states

### DIFF
--- a/Sources/LiveViewNative/Coordinators/LiveSessionState.swift
+++ b/Sources/LiveViewNative/Coordinators/LiveSessionState.swift
@@ -10,21 +10,23 @@ import Foundation
 /// The live view connection state.
 public enum LiveSessionState {
     /// The coordinator has not yet connected to the live view.
-    case notConnected
+    case setup
     /// The coordinator is attempting to connect.
     case connecting
     /// The coordinator is attempting to reconnect.
     case reconnecting
     /// The coordinator has connected and the view tree can be rendered.
     case connected
-    // todo: disconnected state?
+    /// The coordinator is disconnected.
+    case disconnected
     /// The coordinator failed to connect and produced the given error.
     case connectionFailed(Error)
     
-    /// Either `notConnected` or `connecting`
+    /// Either `setup` or `connecting`
     var isPending: Bool {
         switch self {
-        case .notConnected,
+        case .setup,
+             .disconnected,
              .connecting,
              .reconnecting:
             return true

--- a/Sources/LiveViewNative/Coordinators/LiveViewCoordinator.swift
+++ b/Sources/LiveViewNative/Coordinators/LiveViewCoordinator.swift
@@ -26,7 +26,7 @@ private let logger = Logger(subsystem: "LiveViewNative", category: "LiveViewCoor
 /// - ``handleEvent(_:handler:)``
 @MainActor
 public class LiveViewCoordinator<R: RootRegistry>: ObservableObject {
-    @Published internal private(set) var internalState: LiveSessionState = .notConnected
+    @Published internal private(set) var internalState: LiveSessionState = .setup
     
     var state: LiveSessionState {
         internalState
@@ -283,7 +283,7 @@ public class LiveViewCoordinator<R: RootRegistry>: ObservableObject {
         channel.on("phx_close") { [weak self, weak channel] message in
             Task { @MainActor in
                 guard channel === self?.channel else { return }
-                self?.internalState = .notConnected
+                self?.internalState = .disconnected
             }
         }
         
@@ -320,7 +320,7 @@ public class LiveViewCoordinator<R: RootRegistry>: ObservableObject {
         }
         await MainActor.run { [weak self] in
             self?.channel = nil
-            self?.internalState = .notConnected
+            self?.internalState = .disconnected
         }
     }
     

--- a/Sources/LiveViewNative/Live/LiveView.swift
+++ b/Sources/LiveViewNative/Live/LiveView.swift
@@ -201,7 +201,9 @@ public struct LiveView<
             return .connecting
         case let .connectionFailed(error):
             return .error(error)
-        case .notConnected:
+        case .setup:
+            return .connecting
+        case .disconnected:
             return .disconnected
         case .reconnecting:
             return .reconnecting(_ConnectedContent<R>(session: session))

--- a/Sources/LiveViewNative/NavStackEntryView.swift
+++ b/Sources/LiveViewNative/NavStackEntryView.swift
@@ -30,12 +30,14 @@ struct NavStackEntryView<R: RootRegistry>: View {
     
     private var phase: LiveViewPhase<R> {
         switch coordinator.state {
-        case .notConnected:
-            return .connecting // `disconnected` phase only applies to the socket connection, not the channel.
+        case .setup:
+            return .connecting
         case .connecting:
             return .connecting
         case .connectionFailed(let error):
             return .error(error)
+        case .disconnected:
+            return .disconnected
         case .reconnecting, .connected: // these phases should always be handled internally
             fatalError()
         }

--- a/Sources/LiveViewNative/NavStackEntryView.swift
+++ b/Sources/LiveViewNative/NavStackEntryView.swift
@@ -31,7 +31,7 @@ struct NavStackEntryView<R: RootRegistry>: View {
     private var phase: LiveViewPhase<R> {
         switch coordinator.state {
         case .notConnected:
-            return .disconnected
+            return .connecting // `disconnected` phase only applies to the socket connection, not the channel.
         case .connecting:
             return .connecting
         case .connectionFailed(let error):


### PR DESCRIPTION
Closes #1355 

This replaces the `notConnected` state with 2 new states:
* `setup` - the initial state when a coordinator has not attempted to connect yet
* `disconnected` - any other disconnected state after a connection has been established/attempted

`setup` maps to `LiveViewPhase.connecting` in the public API.