### PR TITLE
Update SwiftPhoenixClient to 5.3.2

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,7 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         .package(url: "https://github.com/scinfu/SwiftSoup.git", from: "2.3.2"),
-        .package(url: "https://github.com/davidstump/SwiftPhoenixClient.git", .upToNextMinor(from: "5.0.0")),
+        .package(url: "https://github.com/davidstump/SwiftPhoenixClient.git", .upToNextMinor(from: "5.3.2")),
         .package(url: "https://github.com/apple/swift-async-algorithms", from: "0.1.0"),
         .package(url: "https://github.com/liveview-native/liveview-native-core-swift.git", exact: "0.2.1"),
         

--- a/Sources/LiveViewNative/Coordinators/LiveSessionCoordinator.swift
+++ b/Sources/LiveViewNative/Coordinators/LiveSessionCoordinator.swift
@@ -418,7 +418,7 @@ public class LiveSessionCoordinator<R: RootRegistry>: ObservableObject {
                 socket.off(refs)
                 continuation.resume(returning: socket)
             })
-            refs.append(socket.onError { [weak self, weak socket] (error) in
+            refs.append(socket.onError { [weak self, weak socket] (error, response) in
                 guard let socket else { return }
                 guard self != nil else {
                     socket.disconnect()


### PR DESCRIPTION
This version fixes a few memory leaks that were impacting LiveView Native.