### PR TITLE
Use `style` attribute for generated docs

### DIFF
--- a/Sources/ModifierGenerator/Subcommands/DocumentationExtensions.swift
+++ b/Sources/ModifierGenerator/Subcommands/DocumentationExtensions.swift
@@ -16,7 +16,7 @@ extension ModifierGenerator {
         static let configuration = CommandConfiguration(abstract: "Output a list of the names of all available modifiers.")
         
         @Option(
-            help: "The `.swiftinterface` file from `/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/System/Library/Frameworks/SwiftUI.framework/Modules/SwiftUI.swiftmodule/arm64-apple-ios.swiftinterface`",
+            help: "The `.swiftinterface` file from `/Applications/Xcode.app/Contents/Developer/Platforms/XROS.platform/Developer/SDKs/XROS.sdk/System/Library/Frameworks/SwiftUI.framework/Modules/SwiftUI.swiftmodule/arm64-apple-xros.swiftinterface`",
             transform: { URL(filePath: $0) }
         )
         var interface: URL
@@ -156,25 +156,19 @@ extension ModifierGenerator {
             }
             
             var result = ""
+            let style: String
             
             if parameters.isEmpty {
-                result.append(#"""
-                ```elixir
-                # stylesheet
-                "example" do
-                  \#(name)()
-                end
-                ```
-                """#)
+                style = #"\#(name)()"#
             } else {
-                result.append(#"""
-                ```elixir
-                # stylesheet
-                "example" do
-                  \#(name)(\#(parameters.joined(separator: ", ")))
-                end
-                ```
-                """#)
+                style = #"\#(name)(\#(parameters.joined(separator: ", ")))"#
+            }
+            
+            let quotedStyle: String
+            if style.contains(#"""# as Character) {
+                quotedStyle = #"'\#(style)'"#
+            } else {
+                quotedStyle = #""\#(style)""#
             }
             
             let changeEvent: String? = switch changeTracked.count {
@@ -196,7 +190,7 @@ extension ModifierGenerator {
                     
                     ```html
                     <%!-- template --%>
-                    <Element class="example" \#(resolvedAttributes.joined(separator: " ")) />
+                    <Element style=\#(quotedStyle) \#(resolvedAttributes.joined(separator: " ")) />
                     ```
                     """#)
                 } else {
@@ -204,7 +198,7 @@ extension ModifierGenerator {
                     
                     ```html
                     <%!-- template --%>
-                    <Element class="example" \#(resolvedAttributes.joined(separator: " "))>
+                    <Element style=\#(quotedStyle) \#(resolvedAttributes.joined(separator: " "))>
                     \#(templates.map({ "  \($0)" }).joined(separator: "\n"))
                     </Element>
                     ```
@@ -215,7 +209,7 @@ extension ModifierGenerator {
                 
                 ```html
                 <%!-- template --%>
-                <Element class="example">
+                <Element style=\#(quotedStyle)>
                 \#(templates.map({ "  \($0)" }).joined(separator: "\n"))
                 </Element>
                 ```

--- a/Sources/ModifierGenerator/Subcommands/List.swift
+++ b/Sources/ModifierGenerator/Subcommands/List.swift
@@ -9,7 +9,7 @@ extension ModifierGenerator {
         static let configuration = CommandConfiguration(abstract: "Output a list of the names of all available modifiers.")
         
         @Option(
-            help: "The `.swiftinterface` file from `/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/System/Library/Frameworks/SwiftUI.framework/Modules/SwiftUI.swiftmodule/arm64-apple-ios.swiftinterface`",
+            help: "The `.swiftinterface` file from `/Applications/Xcode.app/Contents/Developer/Platforms/XROS.platform/Developer/SDKs/XROS.sdk/System/Library/Frameworks/SwiftUI.framework/Modules/SwiftUI.swiftmodule/arm64-apple-xros.swiftinterface`",
             transform: { URL(filePath: $0) }
         )
         var interface: URL?

--- a/Sources/ModifierGenerator/Subcommands/Schema.swift
+++ b/Sources/ModifierGenerator/Subcommands/Schema.swift
@@ -9,7 +9,7 @@ extension ModifierGenerator {
         static let configuration = CommandConfiguration(abstract: "Generate a `stylesheet-language.json` file compatible with the VS Code extension.")
         
         @Option(
-            help: "The `.swiftinterface` file from `/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/System/Library/Frameworks/SwiftUI.framework/Modules/SwiftUI.swiftmodule/arm64-apple-ios.swiftinterface`",
+            help: "The `.swiftinterface` file from `/Applications/Xcode.app/Contents/Developer/Platforms/XROS.platform/Developer/SDKs/XROS.sdk/System/Library/Frameworks/SwiftUI.framework/Modules/SwiftUI.swiftmodule/arm64-apple-xros.swiftinterface`",
             transform: { URL(filePath: $0) }
         )
         var interface: URL?

--- a/lib/mix/tasks/lvn.swiftui.gen.docs.ex
+++ b/lib/mix/tasks/lvn.swiftui.gen.docs.ex
@@ -7,7 +7,7 @@ defmodule Mix.Tasks.Lvn.Swiftui.Gen.Docs do
   # Using a temporary folder outside of the project avoids ElixirLS file watching issues
   defp temp_doc_folder, do: Path.join(System.tmp_dir!(), "temp_swiftui_docs")
   defp generate_swift_lvn_docs_command, do: ~c"xcodebuild docbuild -scheme LiveViewNative -destination generic/platform=iOS -derivedDataPath #{temp_doc_folder()} -skipMacroValidation -skipPackagePluginValidation"
-  @swiftui_interface_path "Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/System/Library/Frameworks/SwiftUI.framework/Modules/SwiftUI.swiftmodule/arm64-apple-ios.swiftinterface"
+  @swiftui_interface_path "Platforms/XROS.platform/Developer/SDKs/XROS.sdk/System/Library/Frameworks/SwiftUI.framework/Modules/SwiftUI.swiftmodule/arm64-apple-xros.swiftinterface"
   defp generate_modifier_documentation_extensions(xcode_path), do: ~c(xcrun swift run ModifierGenerator documentation-extensions --interface "#{Path.join(xcode_path, @swiftui_interface_path)}" --output Sources/LiveViewNative/LiveViewNative.docc/DocumentationExtensions)
   @generate_documentation_extensions ~c(xcrun swift package plugin --allow-writing-to-package-directory generate-documentation-extensions)
   defp modifier_list(xcode_path), do: ~s(xcrun swift run ModifierGenerator list --interface "#{Path.join(xcode_path, @swiftui_interface_path)}" --modifier-search-path Sources/LiveViewNative/Stylesheets/Modifiers)


### PR DESCRIPTION
This will automatically switch between using double `"` and single `'` quotes depending on the contents of the modifier being documented.

I've also updated the generator to use the XROS swiftinterface file instead of the iPhoneOS one to include visionOS modifiers in the generated documentation.

<img width="854" alt="Screenshot 2024-05-22 at 4 10 26 PM" src="https://github.com/liveview-native/liveview-client-swiftui/assets/13581484/ce0de6c9-351c-45bf-91c9-7a9afa5618e8">
