### PR TITLE
Treat boolean attributes as true if present and != "false"

### DIFF
--- a/Sources/LiveViewNative/Utils/DOM.swift
+++ b/Sources/LiveViewNative/Utils/DOM.swift
@@ -80,9 +80,9 @@ public struct ElementNode {
     /// > The strings `"true"`/`"false"` are ignored, and only the presence of the attribute is considered.
     /// > A value of `"false"` would still return `true`.
     public func attributeBoolean(for name: AttributeName) -> Bool {
-        guard let attribute = attribute(named: name)?.value
+        guard let attribute = attribute(named: name)
         else { return false }
-        return attribute != "false"
+        return attribute.value != "false"
     }
     
     /// The text of this element.


### PR DESCRIPTION
This updates the check for boolean attributes so the following cases work:

```heex
<!-- true -->
<Element isOn />
<Element isOn="true" />
<Element isOn={true} />
<Element isOn="123" />
<Element isOn="any value" />

<!-- false -->
<Element />
<Element isOn="false" />
<Element isOn={false} />
```