### PR TITLE
Expose `node` and `data` on ElementNode

### DIFF
--- a/Sources/LiveViewNative/Protocols/ContentBuilder.swift
+++ b/Sources/LiveViewNative/Protocols/ContentBuilder.swift
@@ -340,6 +340,14 @@ public struct ContentBuilderContext<R: RootRegistry, Builder: ContentBuilder>: D
         
         let resolvedStylesheet: [String:[BuilderModifierContainer<Builder>]]
         
+        public var coordinator: LiveViewCoordinator<R> {
+            context.coordinator
+        }
+        
+        public var url: URL {
+            context.url
+        }
+        
         func value<OtherBuilder: ContentBuilder>(for _: OtherBuilder.Type = OtherBuilder.self) -> ContentBuilderContext<R, OtherBuilder>.Value {
             return .init(
                 coordinatorEnvironment: coordinatorEnvironment,

--- a/Sources/LiveViewNative/Utils/DOM.swift
+++ b/Sources/LiveViewNative/Utils/DOM.swift
@@ -23,14 +23,16 @@ import LiveViewNativeCore
 /// - ``depthFirstChildren()``
 /// - ``elementChildren()``
 /// - ``innerText()``
-public struct ElementNode {
-    let node: Node
-    let data: ElementData
+public struct ElementNode: Identifiable {
+    public let node: Node
+    public let data: ElementData
     
     init(node: Node, data: ElementData) {
         self.node = node
         self.data = data
     }
+    
+    public var id: NodeRef { node.id }
     
     /// A sequence representing this element's direct children.
     public func children() -> NodeChildrenSequence { node.children() }
@@ -112,7 +114,7 @@ public struct ElementNode {
 }
 
 extension Node {
-    func asElement() -> ElementNode? {
+    public func asElement() -> ElementNode? {
         if case .element(let data) = self.data {
             return ElementNode(node: self, data: data)
         } else {


### PR DESCRIPTION
This opens up the `ElementNode` API for addon libraries.

They can now access the `Node` from an `ElementNode` instance. I've also added an `Identifiable` conformance to `ElementNode`, where the ID of the element node is the `node.id`