### PR TITLE
Remove <%!-- template --%> specifier

### DIFF
--- a/Sources/LiveViewNative/Stylesheets/Modifiers/Overrides/FocusScopeModifier.swift
+++ b/Sources/LiveViewNative/Stylesheets/Modifiers/Overrides/FocusScopeModifier.swift
@@ -17,16 +17,8 @@ import LiveViewNativeStylesheet
 ///
 /// Example:
 ///
-/// ```elixir
-/// # stylesheet
-/// "example" do
-///   focusScope(attr("namespace"))
-/// end
-/// ```
-///
 /// ```heex
-/// <%!-- template --%>
-/// <Element class="example" namespace={@namespace} />
+/// <Element style='focusScope(attr("namespace"))' namespace={@namespace} />
 /// ```
 @_documentation(visibility: public)
 @ParseableExpression

--- a/Sources/LiveViewNative/Stylesheets/Modifiers/Overrides/MaskModifier.swift
+++ b/Sources/LiveViewNative/Stylesheets/Modifiers/Overrides/MaskModifier.swift
@@ -20,16 +20,8 @@ import LiveViewNativeStylesheet
 ///
 /// Example:
 ///
-/// ```elixir
-/// # stylesheet
-/// "example" do
-///   mask(alignment: .center, mask: :mask)
-/// end
-/// ```
-///
 /// ```heex
-/// <%!-- template --%>
-/// <Element class="example">
+/// <Element style='mask(alignment: .center, mask: :mask)'>
 ///   <Child template="mask" />
 /// </Element>
 /// ```

--- a/Sources/LiveViewNative/Stylesheets/Modifiers/Overrides/MatchedGeometryEffectModifier.swift
+++ b/Sources/LiveViewNative/Stylesheets/Modifiers/Overrides/MatchedGeometryEffectModifier.swift
@@ -23,16 +23,8 @@ import LiveViewNativeStylesheet
 ///
 /// Example:
 ///
-/// ```elixir
-/// # stylesheet
-/// "example" do
-///   matchedGeometryEffect(id: attr("id"), in: attr("namespace"), properties: .frame, anchor: .center, isSource: attr("isSource"))
-/// end
-/// ```
-///
 /// ```heex
-/// <%!-- template --%>
-/// <Element class="example" id={@id} namespace={@namespace} isSource={@isSource} />
+/// <Element style='matchedGeometryEffect(id: attr("id"), in: attr("namespace"), properties: .frame, anchor: .center, isSource: attr("isSource"))' id={@id} namespace={@namespace} isSource={@isSource} />
 /// ```
 @_documentation(visibility: public)
 @ParseableExpression

--- a/Sources/LiveViewNative/Stylesheets/Modifiers/Overrides/PrefersDefaultFocusModifier.swift
+++ b/Sources/LiveViewNative/Stylesheets/Modifiers/Overrides/PrefersDefaultFocusModifier.swift
@@ -18,16 +18,8 @@ import LiveViewNativeStylesheet
 ///
 /// Example:
 ///
-/// ```elixir
-/// # stylesheet
-/// "example" do
-///   prefersDefaultFocus(attr("prefersDefaultFocus"), in: attr("namespace"))
-/// end
-/// ```
-///
 /// ```heex
-/// <%!-- template --%>
-/// <Element class="example" prefersDefaultFocus={@prefersDefaultFocus} namespace={@namespace} />
+/// <Element style='prefersDefaultFocus(attr("prefersDefaultFocus"), in: attr("namespace"))' prefersDefaultFocus={@prefersDefaultFocus} namespace={@namespace} />
 /// ```
 @_documentation(visibility: public)
 @ParseableExpression

--- a/Sources/LiveViewNative/Stylesheets/Modifiers/Overrides/Rotation3DEffectModifier.swift
+++ b/Sources/LiveViewNative/Stylesheets/Modifiers/Overrides/Rotation3DEffectModifier.swift
@@ -23,16 +23,8 @@ import LiveViewNativeStylesheet
 ///
 /// Example:
 ///
-/// ```elixir
-/// # stylesheet
-/// "example" do
-///   rotation3DEffect(.zero, axis: (x: 1, y: 0, z: 0), anchor: .center, anchorZ: attr("anchorZ"), perspective: attr("perspective"))
-/// end
-/// ```
-///
 /// ```heex
-/// <%!-- template --%>
-/// <Element class="example" anchorZ={@anchorZ} perspective={@perspective} />
+/// <Element style='rotation3DEffect(.zero, axis: (x: 1, y: 0, z: 0), anchor: .center, anchorZ: attr("anchorZ"), perspective: attr("perspective"))' anchorZ={@anchorZ} perspective={@perspective} />
 /// ```
 @_documentation(visibility: public)
 @ParseableExpression

--- a/Sources/LiveViewNative/Stylesheets/Modifiers/Overrides/SearchCompletionModifier.swift
+++ b/Sources/LiveViewNative/Stylesheets/Modifiers/Overrides/SearchCompletionModifier.swift
@@ -19,11 +19,8 @@ import LiveViewNativeStylesheet
 ///
 /// Example:
 ///
-/// ```elixir
-/// # stylesheet
-/// "example" do
-///   searchCompletion(:token)
-/// end
+/// ```html
+/// <Element style="searchCompletion(:token)" />
 /// ```
 ///
 /// ### searchCompletion(_:)
@@ -33,16 +30,8 @@ import LiveViewNativeStylesheet
 ///
 /// Example:
 ///
-/// ```elixir
-/// # stylesheet
-/// "example" do
-///   searchCompletion(attr("completion"))
-/// end
-/// ```
-///
 /// ```heex
-/// <%!-- template --%>
-/// <Element class="example" completion={@completion} />
+/// <Element style='searchCompletion(attr("completion"))' completion={@completion} />
 /// ```
 @_documentation(visibility: public)
 @ParseableExpression

--- a/Sources/LiveViewNative/Stylesheets/Modifiers/Overrides/SearchScopesModifier.swift
+++ b/Sources/LiveViewNative/Stylesheets/Modifiers/Overrides/SearchScopesModifier.swift
@@ -21,22 +21,13 @@ import LiveViewNativeStylesheet
 ///
 /// Example:
 ///
-/// ```elixir
-/// # stylesheet
-/// "example" do
-///   searchScopes(attr("scope"), activation: .automatic, scopes: :scopes)
-/// end
-/// ```
-///
 /// ```heex
-/// <%!-- template --%>
-/// <Element class="example" scope={@scope} phx-change="scope">
+/// <Element style='searchScopes(attr("scope"), activation: .automatic, scopes: :scopes)' scope={@scope} phx-change="scope">
 ///   <Child template="scopes" />
 /// </Element>
 /// ```
 ///
 /// ```elixir
-/// # LiveView
 /// def handle_event("scope", params, socket)
 /// ```
 ///
@@ -48,22 +39,13 @@ import LiveViewNativeStylesheet
 ///
 /// Example:
 ///
-/// ```elixir
-/// # stylesheet
-/// "example" do
-///   searchScopes(attr("scope"), scopes: :scopes)
-/// end
-/// ```
-///
 /// ```heex
-/// <%!-- template --%>
-/// <Element class="example" scope={@scope} phx-change="scope">
+/// <Element style='searchScopes(attr("scope"), scopes: :scopes)' scope={@scope} phx-change="scope">
 ///   <Child template="scopes" />
 /// </Element>
 /// ```
 ///
 /// ```elixir
-/// # LiveView
 /// def handle_event("scope", params, socket)
 /// ```
 @_documentation(visibility: public)

--- a/Sources/LiveViewNative/Stylesheets/Modifiers/Shapes/ScaleModifier.swift
+++ b/Sources/LiveViewNative/Stylesheets/Modifiers/Shapes/ScaleModifier.swift
@@ -19,16 +19,8 @@ import LiveViewNativeStylesheet
 ///
 /// Example:
 ///
-/// ```elixir
-/// # stylesheet
-/// "example" do
-///   scale(x: attr("x"), y: attr("y"), anchor: .center)
-/// end
-/// ```
-///
 /// ```heex
-/// <%!-- template --%>
-/// <Element class="example" x={@x} y={@y} />
+/// <Element class='scale(x: attr("x"), y: attr("y"), anchor: .center)' x={@x} y={@y} />
 /// ```
 @_documentation(visibility: public)
 @ParseableExpression

--- a/Sources/LiveViewNative/Stylesheets/Modifiers/Shapes/StrokeModifier.swift
+++ b/Sources/LiveViewNative/Stylesheets/Modifiers/Shapes/StrokeModifier.swift
@@ -19,16 +19,8 @@ import LiveViewNativeStylesheet
 ///
 /// Example:
 ///
-/// ```elixir
-/// # stylesheet
-/// "example" do
-///   stroke(AnyShapeStyle, style: StrokeStyle, antialiased: attr("antialiased"))
-/// end
-/// ```
-///
 /// ```heex
-/// <%!-- template --%>
-/// <Element class="example" antialiased={@antialiased} />
+/// <Element style='stroke(AnyShapeStyle, style: StrokeStyle, antialiased: attr("antialiased"))' antialiased={@antialiased} />
 /// ```
 ///
 /// ### stroke(_:lineWidth:antialiased:)
@@ -40,16 +32,8 @@ import LiveViewNativeStylesheet
 ///
 /// Example:
 ///
-/// ```elixir
-/// # stylesheet
-/// "example" do
-///   stroke(AnyShapeStyle, lineWidth: attr("lineWidth"), antialiased: attr("antialiased"))
-/// end
-/// ```
-///
 /// ```heex
-/// <%!-- template --%>
-/// <Element class="example" lineWidth={@lineWidth} antialiased={@antialiased} />
+/// <Element style='stroke(AnyShapeStyle, lineWidth: attr("lineWidth"), antialiased: attr("antialiased"))' lineWidth={@lineWidth} antialiased={@antialiased} />
 /// ```
 @_documentation(visibility: public)
 @ParseableExpression

--- a/Sources/LiveViewNative/Stylesheets/Modifiers/Text/BaselineOffsetModifier.swift
+++ b/Sources/LiveViewNative/Stylesheets/Modifiers/Text/BaselineOffsetModifier.swift
@@ -17,16 +17,8 @@ import LiveViewNativeStylesheet
 ///
 /// Example:
 ///
-/// ```elixir
-/// # stylesheet
-/// "example" do
-///   baselineOffset(attr("baselineOffset"))
-/// end
-/// ```
-///
 /// ```heex
-/// <%!-- template --%>
-/// <Element class="example" baselineOffset={@baselineOffset} />
+/// <Element style='baselineOffset(attr("baselineOffset"))' baselineOffset={@baselineOffset} />
 /// ```
 @_documentation(visibility: public)
 @ParseableExpression

--- a/Sources/LiveViewNative/Stylesheets/Modifiers/Text/BoldModifier.swift
+++ b/Sources/LiveViewNative/Stylesheets/Modifiers/Text/BoldModifier.swift
@@ -17,16 +17,8 @@ import LiveViewNativeStylesheet
 ///
 /// Example:
 ///
-/// ```elixir
-/// # stylesheet
-/// "example" do
-///   bold(attr("isActive"))
-/// end
-/// ```
-///
 /// ```heex
-/// <%!-- template --%>
-/// <Element class="example" isActive={@isActive} />
+/// <Element style='bold(attr("isActive"))' isActive={@isActive} />
 /// ```
 @_documentation(visibility: public)
 @ParseableExpression

--- a/Sources/LiveViewNative/Stylesheets/Modifiers/Text/ItalicModifier.swift
+++ b/Sources/LiveViewNative/Stylesheets/Modifiers/Text/ItalicModifier.swift
@@ -17,16 +17,8 @@ import LiveViewNativeStylesheet
 ///
 /// Example:
 ///
-/// ```elixir
-/// # stylesheet
-/// "example" do
-///   italic(attr("isActive"))
-/// end
-/// ```
-///
 /// ```heex
-/// <%!-- template --%>
-/// <Element class="example" isActive={@isActive} />
+/// <Element style='italic(attr("isActive"))' isActive={@isActive} />
 /// ```
 @_documentation(visibility: public)
 @ParseableExpression

--- a/Sources/LiveViewNative/Stylesheets/Modifiers/Text/KerningModifier.swift
+++ b/Sources/LiveViewNative/Stylesheets/Modifiers/Text/KerningModifier.swift
@@ -17,16 +17,8 @@ import LiveViewNativeStylesheet
 ///
 /// Example:
 ///
-/// ```elixir
-/// # stylesheet
-/// "example" do
-///   kerning(attr("kerning"))
-/// end
-/// ```
-///
 /// ```heex
-/// <%!-- template --%>
-/// <Element class="example" kerning={@kerning} />
+/// <Element style='kerning(attr("kerning"))' kerning={@kerning} />
 /// ```
 @_documentation(visibility: public)
 @ParseableExpression

--- a/Sources/LiveViewNative/Stylesheets/Modifiers/Text/MonospacedModifier.swift
+++ b/Sources/LiveViewNative/Stylesheets/Modifiers/Text/MonospacedModifier.swift
@@ -17,16 +17,8 @@ import LiveViewNativeStylesheet
 ///
 /// Example:
 ///
-/// ```elixir
-/// # stylesheet
-/// "example" do
-///   monospaced(attr("isActive"))
-/// end
-/// ```
-///
 /// ```heex
-/// <%!-- template --%>
-/// <Element class="example" isActive={@isActive} />
+/// <Element style='monospaced(attr("isActive"))' isActive={@isActive} />
 /// ```
 @_documentation(visibility: public)
 @ParseableExpression

--- a/Sources/LiveViewNative/Stylesheets/Modifiers/Text/StrikethroughModifier.swift
+++ b/Sources/LiveViewNative/Stylesheets/Modifiers/Text/StrikethroughModifier.swift
@@ -19,16 +19,8 @@ import LiveViewNativeStylesheet
 ///
 /// Example:
 ///
-/// ```elixir
-/// # stylesheet
-/// "example" do
-///   strikethrough(attr("isActive"), pattern: .solid, color: attr("color"))
-/// end
-/// ```
-///
 /// ```heex
-/// <%!-- template --%>
-/// <Element class="example" isActive={@isActive} color={@color} />
+/// <Element style='strikethrough(attr("isActive"), pattern: .solid, color: attr("color"))' isActive={@isActive} color={@color} />
 /// ```
 @_documentation(visibility: public)
 @ParseableExpression

--- a/Sources/LiveViewNative/Stylesheets/Modifiers/Text/TextScaleModifier.swift
+++ b/Sources/LiveViewNative/Stylesheets/Modifiers/Text/TextScaleModifier.swift
@@ -18,16 +18,8 @@ import LiveViewNativeStylesheet
 ///
 /// Example:
 ///
-/// ```elixir
-/// # stylesheet
-/// "example" do
-///   textScale(.default, isEnabled: attr("isEnabled"))
-/// end
-/// ```
-///
 /// ```heex
-/// <%!-- template --%>
-/// <Element class="example" isEnabled={@isEnabled} />
+/// <Element style='textScale(.default, isEnabled: attr("isEnabled"))' isEnabled={@isEnabled} />
 /// ```
 @_documentation(visibility: public)
 @ParseableExpression

--- a/Sources/LiveViewNative/Stylesheets/Modifiers/Text/TrackingModifier.swift
+++ b/Sources/LiveViewNative/Stylesheets/Modifiers/Text/TrackingModifier.swift
@@ -17,16 +17,8 @@ import LiveViewNativeStylesheet
 ///
 /// Example:
 ///
-/// ```elixir
-/// # stylesheet
-/// "example" do
-///   tracking(attr("tracking"))
-/// end
-/// ```
-///
 /// ```heex
-/// <%!-- template --%>
-/// <Element class="example" tracking={@tracking} />
+/// <Element style='tracking(attr("tracking"))' tracking={@tracking} />
 /// ```
 @_documentation(visibility: public)
 @ParseableExpression

--- a/Sources/LiveViewNative/Stylesheets/Modifiers/Text/UnderlineModifier.swift
+++ b/Sources/LiveViewNative/Stylesheets/Modifiers/Text/UnderlineModifier.swift
@@ -19,16 +19,8 @@ import LiveViewNativeStylesheet
 ///
 /// Example:
 ///
-/// ```elixir
-/// # stylesheet
-/// "example" do
-///   underline(attr("isActive"), pattern: .solid, color: attr("color"))
-/// end
-/// ```
-///
 /// ```heex
-/// <%!-- template --%>
-/// <Element class="example" isActive={@isActive} color={@color} />
+/// <Element style='underline(attr("isActive"), pattern: .solid, color: attr("color"))' isActive={@isActive} color={@color} />
 /// ```
 @_documentation(visibility: public)
 @ParseableExpression

--- a/Sources/ModifierGenerator/Subcommands/DocumentationExtensions.swift
+++ b/Sources/ModifierGenerator/Subcommands/DocumentationExtensions.swift
@@ -189,7 +189,6 @@ extension ModifierGenerator {
                     result.append(#"""
                     
                     ```html
-                    <%!-- template --%>
                     <Element style=\#(quotedStyle) \#(resolvedAttributes.joined(separator: " ")) />
                     ```
                     """#)
@@ -197,7 +196,6 @@ extension ModifierGenerator {
                     result.append(#"""
                     
                     ```html
-                    <%!-- template --%>
                     <Element style=\#(quotedStyle) \#(resolvedAttributes.joined(separator: " "))>
                     \#(templates.map({ "  \($0)" }).joined(separator: "\n"))
                     </Element>
@@ -208,7 +206,6 @@ extension ModifierGenerator {
                 result.append(#"""
                 
                 ```html
-                <%!-- template --%>
                 <Element style=\#(quotedStyle)>
                 \#(templates.map({ "  \($0)" }).joined(separator: "\n"))
                 </Element>
@@ -221,7 +218,6 @@ extension ModifierGenerator {
                 result.append(#"""
                 
                 ```elixir
-                # LiveView
                 \#(resolvedEvents.map({ #"def handle_event("\#($0)", params, socket)"# }).joined(separator: "\n"))
                 ```
                 """#)


### PR DESCRIPTION
Closes #1364 

Along with #1366, this PR switches the manually written documentation for modifiers to use the `style` attribute instead of a separate stylesheet.

It also removes the `<%!-- template --%>` and `# LiveView` comments from codeblocks as they are no longer needed for clarity.