### PR TITLE
Add support for AttributeReference in individual Color properties

### DIFF
--- a/Sources/LiveViewNative/Stylesheets/AttributeReference.swift
+++ b/Sources/LiveViewNative/Stylesheets/AttributeReference.swift
@@ -22,12 +22,20 @@ import LiveViewNativeCore
 ///
 /// The attribute will be automatically decoded to the correct type using the conformance to ``AttributeDecodable``.
 public struct AttributeReference<Value: ParseableModifierValue & AttributeDecodable>: ParseableModifierValue {
-    enum Storage {
+    public enum Storage {
         case constant(Value)
         case reference(AttributeName)
     }
     
     let storage: Storage
+    
+    public init(_ constant: Value) {
+        self.storage = .constant(constant)
+    }
+    
+    init(storage: Storage) {
+        self.storage = storage
+    }
     
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         OneOf {
@@ -47,6 +55,15 @@ public struct AttributeReference<Value: ParseableModifierValue & AttributeDecoda
             return value
         case .reference(let name):
             return try! element.attributeValue(Value.self, for: name)
+        }
+    }
+    
+    public func constant(default: Value) -> Value {
+        switch storage {
+        case .constant(let value):
+            return value
+        case .reference:
+            return `default`
         }
     }
 }

--- a/Sources/LiveViewNative/Stylesheets/Modifiers/Shapes/FillModifier.swift
+++ b/Sources/LiveViewNative/Stylesheets/Modifiers/Shapes/FillModifier.swift
@@ -29,16 +29,16 @@ import LiveViewNativeStylesheet
 struct _FillModifier: ShapeFinalizerModifier {
     static let name = "fill"
     
-    let content: AnyShapeStyle
+    let content: AnyShapeStyle.Resolvable
     let style: FillStyle
     
-    init(_ content: AnyShapeStyle = .init(.foreground), style: FillStyle = .init()) {
+    init(_ content: AnyShapeStyle.Resolvable = .init(.foreground), style: FillStyle = .init()) {
         self.content = content
         self.style = style
     }
     
     @ViewBuilder
     func apply(to shape: AnyShape, on element: ElementNode) -> some View {
-        shape.fill(content, style: style)
+        shape.fill(content.resolve(on: element), style: style)
     }
 }

--- a/Sources/LiveViewNative/Stylesheets/Modifiers/Shapes/StrokeModifier.swift
+++ b/Sources/LiveViewNative/Stylesheets/Modifiers/Shapes/StrokeModifier.swift
@@ -57,20 +57,17 @@ struct _StrokeModifier<R: RootRegistry>: ShapeFinalizerModifier {
     static var name: String { "stroke" }
     
     enum Storage {
-        case _0(content: AnyShapeStyle, style: StrokeStyle, antialiased: AttributeReference<Bool>)
-        case _1(content: AnyShapeStyle, lineWidth: AttributeReference<CGFloat>, antialiased: AttributeReference<Bool>)
+        case _0(content: AnyShapeStyle.Resolvable, style: StrokeStyle, antialiased: AttributeReference<Bool>)
+        case _1(content: AnyShapeStyle.Resolvable, lineWidth: AttributeReference<CGFloat>, antialiased: AttributeReference<Bool>)
     }
     
     let storage: Storage
     
-    @ObservedElement private var element
-    @LiveContext<R> private var context
-    
-    init(_ content: AnyShapeStyle, style: StrokeStyle, antialiased: AttributeReference<Bool> = .init(storage: .constant(true))) {
+    init(_ content: AnyShapeStyle.Resolvable, style: StrokeStyle, antialiased: AttributeReference<Bool> = .init(storage: .constant(true))) {
         self.storage = ._0(content: content, style: style, antialiased: antialiased)
     }
     
-    init(_ content: AnyShapeStyle, lineWidth: AttributeReference<CGFloat> = .init(storage: .constant(1)), antialiased: AttributeReference<Bool> = .init(storage: .constant(true))) {
+    init(_ content: AnyShapeStyle.Resolvable, lineWidth: AttributeReference<CGFloat> = .init(storage: .constant(1)), antialiased: AttributeReference<Bool> = .init(storage: .constant(true))) {
         self.storage = ._1(content: content, lineWidth: lineWidth, antialiased: antialiased)
     }
     
@@ -79,15 +76,15 @@ struct _StrokeModifier<R: RootRegistry>: ShapeFinalizerModifier {
         switch storage {
         case ._0(let content, let style, let antialiased):
             if #available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *) {
-                shape.stroke(content, style: style, antialiased: antialiased.resolve(on: element, in: context))
+                shape.stroke(content.resolve(on: element), style: style, antialiased: antialiased.resolve(on: element))
             } else {
-                shape.stroke(content, style: style)
+                shape.stroke(content.resolve(on: element), style: style)
             }
         case ._1(let content, let lineWidth, let antialiased):
             if #available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *) {
-                shape.stroke(content, lineWidth: lineWidth.resolve(on: element, in: context), antialiased: antialiased.resolve(on: element, in: context))
+                shape.stroke(content.resolve(on: element), lineWidth: lineWidth.resolve(on: element), antialiased: antialiased.resolve(on: element))
             } else {
-                shape.stroke(content, lineWidth: lineWidth.resolve(on: element, in: context))
+                shape.stroke(content.resolve(on: element), lineWidth: lineWidth.resolve(on: element))
             }
         }
     }

--- a/Sources/LiveViewNative/Stylesheets/Modifiers/Text/ForegroundStyleModifier.swift
+++ b/Sources/LiveViewNative/Stylesheets/Modifiers/Text/ForegroundStyleModifier.swift
@@ -58,33 +58,35 @@ struct _ForegroundStyleModifier<R: RootRegistry>: TextModifier {
     static var name: String { "foregroundStyle" }
 
     enum Value {
-        case _0(style: AnyShapeStyle)
-        case _1(primary: AnyShapeStyle, secondary: AnyShapeStyle)
-        case _2(primary: AnyShapeStyle, secondary: AnyShapeStyle, tertiary: AnyShapeStyle)
+        case _0(style: AnyShapeStyle.Resolvable)
+        case _1(primary: AnyShapeStyle.Resolvable, secondary: AnyShapeStyle.Resolvable)
+        case _2(primary: AnyShapeStyle.Resolvable, secondary: AnyShapeStyle.Resolvable, tertiary: AnyShapeStyle.Resolvable)
     }
 
     let value: Value
     
-    init(_ style: AnyShapeStyle) {
+    @ObservedElement private var element
+    
+    init(_ style: AnyShapeStyle.Resolvable) {
         self.value = ._0(style: style)
     }
     
-    init(_ primary: AnyShapeStyle, _ secondary: AnyShapeStyle) {
+    init(_ primary: AnyShapeStyle.Resolvable, _ secondary: AnyShapeStyle.Resolvable) {
         self.value = ._1(primary: primary, secondary: secondary)
     }
     
-    init(_ primary: AnyShapeStyle, _ secondary: AnyShapeStyle, _ tertiary: AnyShapeStyle) {
+    init(_ primary: AnyShapeStyle.Resolvable, _ secondary: AnyShapeStyle.Resolvable, _ tertiary: AnyShapeStyle.Resolvable) {
         self.value = ._2(primary: primary, secondary: secondary, tertiary: tertiary)
     }
 
     func body(content: Content) -> some View {
         switch value {
         case let ._0(style):
-            content.foregroundStyle(style)
+            content.foregroundStyle(style.resolve(on: element))
         case let ._1(primary, secondary):
-            content.foregroundStyle(primary, secondary)
+            content.foregroundStyle(primary.resolve(on: element), secondary.resolve(on: element))
         case let ._2(primary, secondary, tertiary):
-            content.foregroundStyle(primary, secondary, tertiary)
+            content.foregroundStyle(primary.resolve(on: element), secondary.resolve(on: element), tertiary.resolve(on: element))
         }
     }
     
@@ -92,7 +94,7 @@ struct _ForegroundStyleModifier<R: RootRegistry>: TextModifier {
         if #available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *),
            case let ._0(style) = value
         {
-            return text.foregroundStyle(style)
+            return text.foregroundStyle(style.resolve(on: element))
         } else {
             return text
         }

--- a/Sources/LiveViewNative/Stylesheets/Modifiers/Text/StrikethroughModifier.swift
+++ b/Sources/LiveViewNative/Stylesheets/Modifiers/Text/StrikethroughModifier.swift
@@ -37,7 +37,7 @@ struct _StrikethroughModifier<R: RootRegistry>: TextModifier {
 
     let isActive: AttributeReference<Bool>
     let pattern: SwiftUI.Text.LineStyle.Pattern
-    let color: AttributeReference<SwiftUI.Color?>?
+    let color: Color.Resolvable?
 
     @ObservedElement private var element
     @LiveContext<R> private var context
@@ -45,7 +45,7 @@ struct _StrikethroughModifier<R: RootRegistry>: TextModifier {
     init(
         _ isActive: AttributeReference<Bool> = .init(storage: .constant(true)),
         pattern: SwiftUI.Text.LineStyle.Pattern = .solid,
-        color: AttributeReference<SwiftUI.Color?>? = .init(storage: .constant(nil))
+        color: Color.Resolvable? = nil
     ) {
         self.isActive = isActive
         self.pattern = pattern

--- a/Sources/LiveViewNative/Stylesheets/Modifiers/Text/UnderlineModifier.swift
+++ b/Sources/LiveViewNative/Stylesheets/Modifiers/Text/UnderlineModifier.swift
@@ -37,7 +37,7 @@ struct _UnderlineModifier<R: RootRegistry>: ViewModifier {
 
     let isActive: AttributeReference<Bool>
     let pattern: SwiftUI.Text.LineStyle.Pattern
-    let color: AttributeReference<SwiftUI.Color?>?
+    let color: Color.Resolvable?
 
     @ObservedElement private var element
     @LiveContext<R> private var context
@@ -45,7 +45,7 @@ struct _UnderlineModifier<R: RootRegistry>: ViewModifier {
     init(
         _ isActive: AttributeReference<Bool> = .init(storage: .constant(true)),
         pattern: SwiftUI.Text.LineStyle.Pattern = .solid,
-        color: AttributeReference<SwiftUI.Color?>? = .init(storage: .constant(nil))
+        color: Color.Resolvable? = nil
     ) {
         self.isActive = isActive
         self.pattern = pattern

--- a/Sources/LiveViewNative/Stylesheets/ParseableTypes/ListItemTint+ParseableModifierValue.swift
+++ b/Sources/LiveViewNative/Stylesheets/ParseableTypes/ListItemTint+ParseableModifierValue.swift
@@ -15,36 +15,57 @@ import LiveViewNativeStylesheet
 /// - `.fixed(Color)`, with a ``SwiftUI/Color``
 /// - `.preferred(Color)`, with a ``SwiftUI/Color``
 @_documentation(visibility: public)
-extension ListItemTint: ParseableModifierValue {
-    public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
-        ImplicitStaticMember {
-            OneOf {
-                ConstantAtomLiteral("monochrome").map({ Self.monochrome })
-                Fixed.parser(in: context).map({ Self.fixed($0.tint) })
-                Preferred.parser(in: context).map({ Self.preferred($0.tint) })
+extension ListItemTint {
+    struct Resolvable: ParseableModifierValue {
+        public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
+            ImplicitStaticMember {
+                OneOf {
+                    ConstantAtomLiteral("monochrome").map({ Self(storage: .monochrome) })
+                    Fixed.parser(in: context).map({ Self(storage: .fixed($0.tint)) })
+                    Preferred.parser(in: context).map({ Self(storage: .preferred($0.tint)) })
+                }
             }
         }
-    }
-    
-    @ParseableExpression
-    struct Fixed {
-        static let name = "fixed"
         
-        let tint: Color
-        
-        init(_ tint: Color) {
-            self.tint = tint
+        enum Storage {
+            case monochrome
+            case fixed(Color.Resolvable)
+            case preferred(Color.Resolvable)
         }
-    }
-    
-    @ParseableExpression
-    struct Preferred {
-        static let name = "preferred"
         
-        let tint: Color
+        let storage: Storage
         
-        init(_ tint: Color) {
-            self.tint = tint
+        func resolve<R: RootRegistry>(on element: ElementNode, in context: LiveContext<R>) -> ListItemTint {
+            switch storage {
+            case .monochrome:
+                    .monochrome
+            case .fixed(let fixed):
+                    .fixed(fixed.resolve(on: element, in: context))
+            case .preferred(let preferred):
+                    .preferred(preferred.resolve(on: element, in: context))
+            }
+        }
+        
+        @ParseableExpression
+        struct Fixed {
+            static let name = "fixed"
+            
+            let tint: Color.Resolvable
+            
+            init(_ tint: Color.Resolvable) {
+                self.tint = tint
+            }
+        }
+        
+        @ParseableExpression
+        struct Preferred {
+            static let name = "preferred"
+            
+            let tint: Color.Resolvable
+            
+            init(_ tint: Color.Resolvable) {
+                self.tint = tint
+            }
         }
     }
 }

--- a/Sources/LiveViewNative/Stylesheets/ParseableTypes/ShapeStyles/AnyShapeStyle+ParseableModifierValue.swift
+++ b/Sources/LiveViewNative/Stylesheets/ParseableTypes/ShapeStyles/AnyShapeStyle+ParseableModifierValue.swift
@@ -138,316 +138,528 @@ import LiveViewNativeStylesheet
 /// .blue.shadow(.inner(radius: 8, y: 8))
 /// ```
 @_documentation(visibility: public)
-extension AnyShapeStyle: ParseableModifierValue {
-    public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
-        OneOf {
+public extension AnyShapeStyle {
+    struct Resolvable: ParseableModifierValue {
+        enum Storage {
+            case value(AnyShapeStyle)
+            case color(Color.Resolvable)
+            
+            case gradient(Gradient.Resolvable)
+            case anyGradient(AnyGradient.Resolvable)
+            
+            case angularGradient(_angularGradient)
+            case conicGradient(_conicGradient)
+            case ellipticalGradient(_ellipticalGradient)
+            case linearGradient(_linearGradient)
+            case radialGradient(_radialGradient)
+            
+            case modifier(StyleModifier)
+            
+            init(_ style: some ShapeStyle) {
+                self = .value(AnyShapeStyle(style))
+            }
+        }
+        
+        let storage: Storage
+        let modifiers: [StyleModifier]
+        
+        public func resolve(on element: ElementNode) -> AnyShapeStyle {
+            let base: any ShapeStyle = switch storage {
+            case .value(let value):
+                value
+            case .color(let color):
+                color.resolve(on: element)
+            case let .gradient(gradient):
+                gradient.resolve(on: element)
+            case let .anyGradient(gradient):
+                gradient.resolve(on: element)
+            case let .angularGradient(gradient):
+                gradient.resolve(on: element)
+            case let .conicGradient(gradient):
+                gradient.resolve(on: element)
+            case let .ellipticalGradient(gradient):
+                gradient.resolve(on: element)
+            case let .linearGradient(gradient):
+                gradient.resolve(on: element)
+            case let .radialGradient(gradient):
+                gradient.resolve(on: element)
+            case let .modifier(modifier):
+                modifier.resolve(on: element)
+            }
+            return modifiers.reduce(AnyShapeStyle(base)) {
+                AnyShapeStyle($1.apply(to: $0, on: element))
+            }
+        }
+        
+        public func resolve<R: RootRegistry>(on element: ElementNode, in context: LiveContext<R>) -> AnyShapeStyle {
+            resolve(on: element)
+        }
+        
+        public init(_ constant: AnyShapeStyle) {
+            self.storage = .value(constant)
+            self.modifiers = []
+        }
+        
+        public init(_ constant: some ShapeStyle) {
+            self.storage = .value(AnyShapeStyle(constant))
+            self.modifiers = []
+        }
+        
+        init(storage: Storage, modifiers: [StyleModifier]) {
+            self.storage = storage
+            self.modifiers = modifiers
+        }
+        
+        public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
             ChainedMemberExpression {
                 baseParser(in: context)
             } member: {
                 StyleModifier.parser(in: context)
             }
-            .map({ (base: any ShapeStyle, members: [StyleModifier]) in
-                (base: base, members: members)
-            })
-            _ColorParser(context: context) {
-                StyleModifier.parser(in: context)
-            }
-            .map({ (base: SwiftUI.Color, members: [StyleModifier]) in
-                (base: base as any ShapeStyle, members: members)
+            .map({ (base: Storage, members: [StyleModifier]) in
+                Self(storage: base, modifiers: members)
             })
         }
-        .map({ (base: any ShapeStyle, modifiers: [StyleModifier]) in
-            var result = base
-            for modifier in modifiers {
-                result = modifier.apply(to: result)
-            }
-            return AnyShapeStyle(result)
-        })
-    }
-    
-    static func baseParser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, any ShapeStyle> {
-        OneOf {
-            HierarchicalShapeStyle.parser(in: context).map({ $0 as any ShapeStyle })
+        
+        static func baseParser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Storage> {
+            BaseParser(context: context)
+        }
+        
+        private struct BaseParser: Parser {
+            let context: ParseableModifierContext
             
-            Material.parser(in: context).map({ $0 as any ShapeStyle })
-            
-            ConstantAtomLiteral("foreground").map({ ForegroundStyle() as any ShapeStyle })
-            ConstantAtomLiteral("background").map({ BackgroundStyle() as any ShapeStyle })
-            #if !os(watchOS) && !os(tvOS)
-            ConstantAtomLiteral("selection").map({ SelectionShapeStyle() as any ShapeStyle })
-            #endif
-            ConstantAtomLiteral("tint").map({ TintShapeStyle() as any ShapeStyle })
-            if #available(iOS 17, macOS 14, tvOS 17, watchOS 10, visionOS 1, *) {
-                ConstantAtomLiteral("separator").map({ SeparatorShapeStyle() as any ShapeStyle })
-                ConstantAtomLiteral("placeholder").map({ PlaceholderTextShapeStyle() as any ShapeStyle })
-                ConstantAtomLiteral("link").map({ LinkShapeStyle() as any ShapeStyle })
-                ConstantAtomLiteral("fill").map({ FillShapeStyle() as any ShapeStyle })
-            }
-            #if !os(visionOS)
-            if #available(iOS 17, macOS 14, tvOS 17, watchOS 10, *) {
-                ConstantAtomLiteral("windowBackground").map({ WindowBackgroundShapeStyle() as any ShapeStyle })
-            }
-            #endif
-            
-            ImagePaint.parser(in: context).map({ $0 as any ShapeStyle })
-            _image.parser(in: context).map(\.value)
-            
-            Gradient.parser(in: context).map({ $0 as any ShapeStyle })
-            AnyGradient.parser(in: context).map({ $0 as any ShapeStyle })
-            
-            AngularGradient.parser(in: context).map({ $0 as any ShapeStyle })
-            _angularGradient.parser(in: context).map(\.value)
-            _conicGradient.parser(in: context).map(\.value)
-            
-            EllipticalGradient.parser(in: context).map({ $0 as any ShapeStyle })
-            _ellipticalGradient.parser(in: context).map(\.value)
-            
-            LinearGradient.parser(in: context).map({ $0 as any ShapeStyle })
-            _linearGradient.parser(in: context).map(\.value)
-            
-            RadialGradient.parser(in: context).map({ $0 as any ShapeStyle })
-            _radialGradient.parser(in: context).map(\.value)
-            
-            StyleModifier.parser(in: context).map(\.value)
-        }
-    }
-    
-    @ParseableExpression
-    struct _angularGradient {
-        static let name = "angularGradient"
-        
-        let value: any ShapeStyle
-        
-        init(_ gradient: AnyGradient, center: UnitPoint = .center, startAngle: Angle, endAngle: Angle) {
-            self.value = AngularGradient.angularGradient(gradient, center: center, startAngle: startAngle, endAngle: endAngle)
-        }
-        
-        init(_ gradient: Gradient, center: UnitPoint = .center, startAngle: Angle, endAngle: Angle) {
-            self.value = AngularGradient.angularGradient(gradient, center: center, startAngle: startAngle, endAngle: endAngle)
-        }
-        
-        init(colors: [Color], center: UnitPoint, startAngle: Angle, endAngle: Angle) {
-            self.value = AngularGradient.angularGradient(colors: colors, center: center, startAngle: startAngle, endAngle: endAngle)
-        }
-        
-        init(stops: [Gradient.Stop], center: UnitPoint, startAngle: Angle, endAngle: Angle) {
-            self.value = AngularGradient.angularGradient(stops: stops, center: center, startAngle: startAngle, endAngle: endAngle)
-        }
-    }
-    
-    @ParseableExpression
-    struct _conicGradient {
-        static let name = "conicGradient"
-        
-        let value: any ShapeStyle
-        
-        init(_ gradient: AnyGradient, center: UnitPoint = .center, angle: Angle = .zero) {
-            self.value = AngularGradient.conicGradient(gradient, center: center, angle: angle)
-        }
-        
-        init(_ gradient: Gradient, center: UnitPoint, angle: Angle = .zero) {
-            self.value = AngularGradient.conicGradient(gradient, center: center, angle: angle)
-        }
-        
-        init(colors: [Color], center: UnitPoint, angle: Angle = .zero) {
-            self.value = AngularGradient.conicGradient(colors: colors, center: center, angle: angle)
-        }
-        
-        init(stops: [Gradient.Stop], center: UnitPoint, angle: Angle = .zero) {
-            self.value = AngularGradient.conicGradient(stops: stops, center: center, angle: angle)
-        }
-    }
-    
-    @ParseableExpression
-    struct _ellipticalGradient {
-        static let name = "ellipticalGradient"
-        
-        let value: any ShapeStyle
-        
-        init(_ gradient: Gradient, center: UnitPoint = .center, startRadiusFraction: CGFloat = 0, endRadiusFraction: CGFloat = 0.5) {
-            self.value = EllipticalGradient.ellipticalGradient(gradient, center: center, startRadiusFraction: startRadiusFraction, endRadiusFraction: endRadiusFraction)
-        }
-        
-        init(colors: [Color], center: UnitPoint = .center, startRadiusFraction: CGFloat = 0, endRadiusFraction: CGFloat = 0.5) {
-            self.value = EllipticalGradient.ellipticalGradient(colors: colors, center: center, startRadiusFraction: startRadiusFraction, endRadiusFraction: endRadiusFraction)
-        }
-        
-        init(stops: [Gradient.Stop], center: UnitPoint = .center, startRadiusFraction: CGFloat = 0, endRadiusFraction: CGFloat = 0.5) {
-            self.value = EllipticalGradient.ellipticalGradient(stops: stops, center: center, startRadiusFraction: startRadiusFraction, endRadiusFraction: endRadiusFraction)
-        }
-        
-        init(_ gradient: AnyGradient, center: UnitPoint = .center, startRadiusFraction: CGFloat = 0, endRadiusFraction: CGFloat = 0.5) {
-            self.value = EllipticalGradient.ellipticalGradient(gradient, center: center, startRadiusFraction: startRadiusFraction, endRadiusFraction: endRadiusFraction)
-        }
-    }
-    
-    @ParseableExpression
-    struct _linearGradient {
-        static let name = "linearGradient"
-        
-        let value: any ShapeStyle
-        
-        init(_ gradient: Gradient, startPoint: UnitPoint, endPoint: UnitPoint) {
-            self.value = LinearGradient.linearGradient(gradient, startPoint: startPoint, endPoint: endPoint)
-        }
-        
-        init(colors: [Color], startPoint: UnitPoint, endPoint: UnitPoint) {
-            self.value = LinearGradient.linearGradient(colors: colors, startPoint: startPoint, endPoint: endPoint)
-        }
-        
-        init(stops: [Gradient.Stop], startPoint: UnitPoint, endPoint: UnitPoint) {
-            self.value = LinearGradient.linearGradient(stops: stops, startPoint: startPoint, endPoint: endPoint)
-        }
-        
-        init(_ gradient: AnyGradient, startPoint: UnitPoint, endPoint: UnitPoint) {
-            self.value = LinearGradient.linearGradient(gradient, startPoint: startPoint, endPoint: endPoint)
-        }
-    }
-    
-    @ParseableExpression
-    struct _radialGradient {
-        static let name = "radialGradient"
-        
-        let value: any ShapeStyle
-        
-        init(_ gradient: Gradient, center: UnitPoint, startRadius: CGFloat, endRadius: CGFloat) {
-            self.value = RadialGradient.radialGradient(gradient, center: center, startRadius: startRadius, endRadius: endRadius)
-        }
-        
-        init(colors: [Color], center: UnitPoint, startRadius: CGFloat, endRadius: CGFloat) {
-            self.value = RadialGradient.radialGradient(colors: colors, center: center, startRadius: startRadius, endRadius: endRadius)
-        }
-        
-        init(stops: [Gradient.Stop], center: UnitPoint, startRadius: CGFloat, endRadius: CGFloat) {
-            self.value = RadialGradient.radialGradient(stops: stops, center: center, startRadius: startRadius, endRadius: endRadius)
-        }
-        
-        init(_ gradient: AnyGradient, center: UnitPoint = .center, startRadius: CGFloat = 0, endRadius: CGFloat) {
-            self.value = RadialGradient.radialGradient(gradient, center: center, startRadius: startRadius, endRadius: endRadius)
-        }
-    }
-    
-    @ParseableExpression
-    struct _image {
-        static let name = "image"
-        
-        let value: any ShapeStyle
-        
-        init(_ image: Image, sourceRect: CGRect = .init(x: 0, y: 0, width: 1, height: 1), scale: CGFloat = 1) {
-            self.value = ImagePaint.image(image, sourceRect: sourceRect, scale: scale)
-        }
-    }
-    
-    enum StyleModifier: ParseableModifierValue {
-        case blendMode(_blendMode)
-        case opacity(_opacity)
-        case shadow(_shadow)
-        case hierarchical(HierarchicalLevel)
-        
-        static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
-            OneOf {
-                _blendMode.parser(in: context).map(Self.blendMode)
-                _opacity.parser(in: context).map(Self.opacity)
-                _shadow.parser(in: context).map(Self.shadow)
-                HierarchicalLevel.parser(in: context).map(Self.hierarchical)
-            }
-        }
-        
-        @ParseableExpression
-        struct _blendMode {
-            static let name = "blendMode"
-            
-            let value: BlendMode
-            
-            init(_ value: BlendMode) {
-                self.value = value
-            }
-        }
-        
-        @ParseableExpression
-        struct _opacity {
-            static let name = "opacity"
-            
-            let value: Double
-            
-            init(_ value: Double) {
-                self.value = value
-            }
-        }
-        
-        @ParseableExpression
-        struct _shadow {
-            static let name = "shadow"
-            
-            let value: ShadowStyle
-            
-            init(_ value: ShadowStyle) {
-                self.value = value
-            }
-        }
-        
-        enum HierarchicalLevel: String, CaseIterable, ParseableModifierValue {
-            typealias _ParserType = EnumParser<Self>
-            
-            static func parser(in context: ParseableModifierContext) -> EnumParser<Self> {
-                .init(Dictionary(uniqueKeysWithValues: Self.allCases.map({ ($0.rawValue, $0) })))
-            }
-            
-            case secondary
-            case tertiary
-            case quaternary
-            case quinary
-        }
-        
-        /// Apply this modifier to an existing `ShapeStyle`.
-        func apply(to style: some ShapeStyle) -> any ShapeStyle {
-            switch self {
-            case let .blendMode(blendMode):
-                return style.blendMode(blendMode.value)
-            case let .opacity(opacity):
-                return style.opacity(opacity.value)
-            case let .shadow(shadow):
-                return style.shadow(shadow.value)
-            case let .hierarchical(level):
+            func parse(_ input: inout Substring.UTF8View) throws -> Storage {
+                var parsers: [AnyParser<Substring.UTF8View, Storage>] = [
+                    Color.Resolvable.parser(in: context).map(Storage.color).eraseToAnyParser(),
+                    HierarchicalShapeStyle.parser(in: context).map({ Storage($0) }).eraseToAnyParser(),
+                    
+                    Material.parser(in: context).map({ Storage($0) }).eraseToAnyParser(),
+                    
+                    ConstantAtomLiteral("foreground").map({ Storage(ForegroundStyle()) }).eraseToAnyParser(),
+                    ConstantAtomLiteral("background").map({ Storage(BackgroundStyle()) }).eraseToAnyParser(),
+                    
+                    ImagePaint.parser(in: context).map({ Storage($0) }).eraseToAnyParser(),
+                    _image.parser(in: context).map({ Storage($0.value) }).eraseToAnyParser(),
+                    
+                    Gradient.Resolvable.parser(in: context).map({ Storage.gradient($0) }).eraseToAnyParser(),
+                    AnyGradient.Resolvable.parser(in: context).map({ Storage.anyGradient($0) }).eraseToAnyParser(),
+                    
+                    _angularGradient.parser(in: context).map({ Storage.angularGradient($0) }).eraseToAnyParser(),
+                    _conicGradient.parser(in: context).map({ Storage.conicGradient($0) }).eraseToAnyParser(),
+                    
+                    _ellipticalGradient.parser(in: context).map({ Storage.ellipticalGradient($0) }).eraseToAnyParser(),
+                    
+                    _linearGradient.parser(in: context).map({ Storage.linearGradient($0) }).eraseToAnyParser(),
+                    
+                    _radialGradient.parser(in: context).map({ Storage.radialGradient($0) }).eraseToAnyParser(),
+                    
+                    StyleModifier.parser(in: context).map({ Storage.modifier($0) }).eraseToAnyParser(),
+                ]
+#if !os(watchOS) && !os(tvOS)
+                parsers.append(ConstantAtomLiteral("selection").map({ Storage(SelectionShapeStyle()) }).eraseToAnyParser())
+#endif
+                parsers.append(ConstantAtomLiteral("tint").map({ Storage(TintShapeStyle()) }).eraseToAnyParser())
                 if #available(iOS 17, macOS 14, tvOS 17, watchOS 10, visionOS 1, *) {
-                    switch level {
-                    case .secondary:
-                        return style.secondary
-                    case .tertiary:
-                        return style.tertiary
-                    case .quaternary:
-                        return style.quaternary
-                    case .quinary:
-                        return style.quinary
+                    parsers.append(ConstantAtomLiteral("separator").map({ Storage(SeparatorShapeStyle()) }).eraseToAnyParser())
+                    parsers.append(ConstantAtomLiteral("placeholder").map({ Storage(PlaceholderTextShapeStyle()) }).eraseToAnyParser())
+                    parsers.append(ConstantAtomLiteral("link").map({ Storage(LinkShapeStyle()) }).eraseToAnyParser())
+                    parsers.append(ConstantAtomLiteral("fill").map({ Storage(FillShapeStyle()) }).eraseToAnyParser())
+                }
+#if !os(visionOS)
+                if #available(iOS 17, macOS 14, tvOS 17, watchOS 10, *) {
+                    parsers.append(ConstantAtomLiteral("windowBackground").map({ Storage(WindowBackgroundShapeStyle()) }).eraseToAnyParser())
+                }
+#endif
+                
+                let copy = input
+                for parser in parsers {
+                    if let value = try? parser.parse(&input) {
+                        return value
+                    } else {
+                        input = copy
                     }
-                } else {
-                    return style
+                }
+                throw ArgumentParseError.unknownArgument("AnyShapeStyle")
+            }
+        }
+        
+        @ParseableExpression
+        enum _angularGradient {
+            static let name = "angularGradient"
+            
+            case anyGradient(gradient: AnyGradient.Resolvable, center: AttributeReference<UnitPoint>, startAngle: AttributeReference<Angle>, endAngle: AttributeReference<Angle>)
+            case gradient(gradient: Gradient.Resolvable, center: AttributeReference<UnitPoint>, startAngle: AttributeReference<Angle>, endAngle: AttributeReference<Angle>)
+            case colors(colors: [Color.Resolvable], center: AttributeReference<UnitPoint>, startAngle: AttributeReference<Angle>, endAngle: AttributeReference<Angle>)
+            case stops(stops: [Gradient.Stop.Resolvable], center: AttributeReference<UnitPoint>, startAngle: AttributeReference<Angle>, endAngle: AttributeReference<Angle>)
+            
+            init(
+                _ gradient: AnyGradient.Resolvable,
+                center: AttributeReference<UnitPoint> = .init(.center),
+                startAngle: AttributeReference<Angle>,
+                endAngle: AttributeReference<Angle>
+            ) {
+                self = .anyGradient(gradient: gradient, center: center, startAngle: startAngle, endAngle: endAngle)
+            }
+            
+            init(
+                _ gradient: Gradient.Resolvable,
+                center: AttributeReference<UnitPoint> = .init(.center),
+                startAngle: AttributeReference<Angle>,
+                endAngle: AttributeReference<Angle>
+            ) {
+                self = .gradient(gradient: gradient, center: center, startAngle: startAngle, endAngle: endAngle)
+            }
+            
+            init(
+                colors: [Color.Resolvable],
+                center: AttributeReference<UnitPoint>,
+                startAngle: AttributeReference<Angle>,
+                endAngle: AttributeReference<Angle>
+            ) {
+                self = .colors(colors: colors, center: center, startAngle: startAngle, endAngle: endAngle)
+            }
+            
+            init(
+                stops: [Gradient.Stop.Resolvable],
+                center: AttributeReference<UnitPoint> = .init(.center),
+                startAngle: AttributeReference<Angle>,
+                endAngle: AttributeReference<Angle>
+            ) {
+                self = .stops(stops: stops, center: center, startAngle: startAngle, endAngle: endAngle)
+            }
+            
+            func resolve(on element: ElementNode) -> any ShapeStyle {
+                switch self {
+                case .anyGradient(let gradient, let center, let startAngle, let endAngle):
+                    AngularGradient.angularGradient(gradient.resolve(on: element), center: center.resolve(on: element), startAngle: startAngle.resolve(on: element), endAngle: endAngle.resolve(on: element))
+                case .gradient(let gradient, let center, let startAngle, let endAngle):
+                    AngularGradient.angularGradient(gradient.resolve(on: element), center: center.resolve(on: element), startAngle: startAngle.resolve(on: element), endAngle: endAngle.resolve(on: element))
+                case .colors(let colors, let center, let startAngle, let endAngle):
+                    AngularGradient.angularGradient(colors: colors.map({ $0.resolve(on: element) }), center: center.resolve(on: element), startAngle: startAngle.resolve(on: element), endAngle: endAngle.resolve(on: element))
+                case .stops(let stops, let center, let startAngle, let endAngle):
+                    AngularGradient.angularGradient(stops: stops.map({ $0.resolve(on: element) }), center: center.resolve(on: element), startAngle: startAngle.resolve(on: element), endAngle: endAngle.resolve(on: element))
                 }
             }
         }
         
-        /// Use this modifier itself as a `ShapeStyle`. SwiftUI will apply it to the foreground style.
-        var value: any ShapeStyle {
-            switch self {
-            case let .blendMode(blendMode):
-                return AnyShapeStyle(.blendMode(blendMode.value))
-            case let .opacity(opacity):
-                return AnyShapeStyle(.opacity(opacity.value))
-            case let .shadow(shadow):
-                return AnyShapeStyle(.shadow(shadow.value))
-            case let .hierarchical(level):
-                switch level {
-                case .secondary:
-                    return AnyShapeStyle(.secondary)
-                case .tertiary:
-                    return AnyShapeStyle(.tertiary)
-                case .quaternary:
-                    return AnyShapeStyle(.quaternary)
-                case .quinary:
-                    if #available(iOS 16, macOS 12, tvOS 17, watchOS 10, visionOS 1, *) {
-                        return AnyShapeStyle(.quinary)
+        @ParseableExpression
+        enum _conicGradient {
+            static let name = "conicGradient"
+            
+            case anyGradient(gradient: AnyGradient.Resolvable, center: AttributeReference<UnitPoint>, angle: AttributeReference<Angle>)
+            case gradient(gradient: Gradient.Resolvable, center: AttributeReference<UnitPoint>, angle: AttributeReference<Angle>)
+            case colors(colors: [Color.Resolvable], center: AttributeReference<UnitPoint>, angle: AttributeReference<Angle>)
+            case stops(stops: [Gradient.Stop.Resolvable], center: AttributeReference<UnitPoint>, angle: AttributeReference<Angle>)
+            
+            init(_ gradient: AnyGradient.Resolvable, center: AttributeReference<UnitPoint> = .init(.center), angle: AttributeReference<Angle> = .init(.zero)) {
+                self = .anyGradient(gradient: gradient, center: center, angle: angle)
+            }
+            
+            init(_ gradient: Gradient.Resolvable, center: AttributeReference<UnitPoint>, angle: AttributeReference<Angle> = .init(.zero)) {
+                self = .gradient(gradient: gradient, center: center, angle: angle)
+            }
+            
+            init(colors: [Color.Resolvable], center: AttributeReference<UnitPoint>, angle: AttributeReference<Angle> = .init(.zero)) {
+                self = .colors(colors: colors, center: center, angle: angle)
+            }
+            
+            init(stops: [Gradient.Stop.Resolvable], center: AttributeReference<UnitPoint>, angle: AttributeReference<Angle> = .init(.zero)) {
+                self = .stops(stops: stops, center: center, angle: angle)
+            }
+            
+            func resolve(on element: ElementNode) -> any ShapeStyle {
+                switch self {
+                case .anyGradient(let gradient, let center, let angle):
+                    AngularGradient.conicGradient(gradient.resolve(on: element), center: center.resolve(on: element), angle: angle.resolve(on: element))
+                case .gradient(let gradient, let center, let angle):
+                    AngularGradient.conicGradient(gradient.resolve(on: element), center: center.resolve(on: element), angle: angle.resolve(on: element))
+                case .colors(let colors, let center, let angle):
+                    AngularGradient.conicGradient(colors: colors.map({ $0.resolve(on: element) }), center: center.resolve(on: element), angle: angle.resolve(on: element))
+                case .stops(let stops, let center, let angle):
+                    AngularGradient.conicGradient(stops: stops.map({ $0.resolve(on: element) }), center: center.resolve(on: element), angle: angle.resolve(on: element))
+                }
+            }
+        }
+        
+        @ParseableExpression
+        enum _ellipticalGradient {
+            static let name = "ellipticalGradient"
+            
+            case gradient(gradient: Gradient.Resolvable, center: AttributeReference<UnitPoint>, startRadiusFraction: AttributeReference<CGFloat>, endRadiusFraction: AttributeReference<CGFloat>)
+            case colors(colors: [Color.Resolvable], center: AttributeReference<UnitPoint>, startRadiusFraction: AttributeReference<CGFloat>, endRadiusFraction: AttributeReference<CGFloat>)
+            case stops(stops: [Gradient.Stop.Resolvable], center: AttributeReference<UnitPoint>, startRadiusFraction: AttributeReference<CGFloat>, endRadiusFraction: AttributeReference<CGFloat>)
+            case anyGradient(gradient: AnyGradient.Resolvable, center: AttributeReference<UnitPoint>, startRadiusFraction: AttributeReference<CGFloat>, endRadiusFraction: AttributeReference<CGFloat>)
+            
+            init(_ gradient: Gradient.Resolvable, center: AttributeReference<UnitPoint> = .init(.center), startRadiusFraction: AttributeReference<CGFloat> = .init(0), endRadiusFraction: AttributeReference<CGFloat> = .init(0.5)) {
+                self = .gradient(gradient: gradient, center: center, startRadiusFraction: startRadiusFraction, endRadiusFraction: endRadiusFraction)
+            }
+            
+            init(colors: [Color.Resolvable], center: AttributeReference<UnitPoint> = .init(.center), startRadiusFraction: AttributeReference<CGFloat> = .init(0), endRadiusFraction: AttributeReference<CGFloat> = .init(0.5)) {
+                self = .colors(colors: colors, center: center, startRadiusFraction: startRadiusFraction, endRadiusFraction: endRadiusFraction)
+            }
+            
+            init(stops: [Gradient.Stop.Resolvable], center: AttributeReference<UnitPoint> = .init(.center), startRadiusFraction: AttributeReference<CGFloat> = .init(0), endRadiusFraction: AttributeReference<CGFloat> = .init(0.5)) {
+                self = .stops(stops: stops, center: center, startRadiusFraction: startRadiusFraction, endRadiusFraction: endRadiusFraction)
+            }
+            
+            init(_ gradient: AnyGradient.Resolvable, center: AttributeReference<UnitPoint> = .init(.center), startRadiusFraction: AttributeReference<CGFloat> = .init(0), endRadiusFraction: AttributeReference<CGFloat> = .init(0.5)) {
+                self = .anyGradient(gradient: gradient, center: center, startRadiusFraction: startRadiusFraction, endRadiusFraction: endRadiusFraction)
+            }
+            
+            func resolve(on element: ElementNode) -> any ShapeStyle {
+                switch self {
+                case .gradient(let gradient, let center, let startRadiusFraction, let endRadiusFraction):
+                    EllipticalGradient.ellipticalGradient(gradient.resolve(on: element), center: center.resolve(on: element), startRadiusFraction: startRadiusFraction.resolve(on: element), endRadiusFraction: endRadiusFraction.resolve(on: element))
+                case .colors(let colors, let center, let startRadiusFraction, let endRadiusFraction):
+                    EllipticalGradient.ellipticalGradient(colors: colors.map({ $0.resolve(on: element) }), center: center.resolve(on: element), startRadiusFraction: startRadiusFraction.resolve(on: element), endRadiusFraction: endRadiusFraction.resolve(on: element))
+                case .stops(let stops, let center, let startRadiusFraction, let endRadiusFraction):
+                    EllipticalGradient.ellipticalGradient(stops: stops.map({ $0.resolve(on: element) }), center: center.resolve(on: element), startRadiusFraction: startRadiusFraction.resolve(on: element), endRadiusFraction: endRadiusFraction.resolve(on: element))
+                case .anyGradient(let gradient, let center, let startRadiusFraction, let endRadiusFraction):
+                    EllipticalGradient.ellipticalGradient(gradient.resolve(on: element), center: center.resolve(on: element), startRadiusFraction: startRadiusFraction.resolve(on: element), endRadiusFraction: endRadiusFraction.resolve(on: element))
+                }
+            }
+        }
+        
+        @ParseableExpression
+        enum _linearGradient {
+            static let name = "linearGradient"
+            
+            case gradient(gradient: Gradient.Resolvable, startPoint: AttributeReference<UnitPoint>, endPoint: AttributeReference<UnitPoint>)
+            case colors(colors: [Color.Resolvable], startPoint: AttributeReference<UnitPoint>, endPoint: AttributeReference<UnitPoint>)
+            case stops(stops: [Gradient.Stop.Resolvable], startPoint: AttributeReference<UnitPoint>, endPoint: AttributeReference<UnitPoint>)
+            case anyGradient(gradient: AnyGradient.Resolvable, startPoint: AttributeReference<UnitPoint>, endPoint: AttributeReference<UnitPoint>)
+            
+            init(_ gradient: Gradient.Resolvable, startPoint: AttributeReference<UnitPoint>, endPoint: AttributeReference<UnitPoint>) {
+                self = .gradient(gradient: gradient, startPoint: startPoint, endPoint: endPoint)
+            }
+            
+            init(colors: [Color.Resolvable], startPoint: AttributeReference<UnitPoint>, endPoint: AttributeReference<UnitPoint>) {
+                self = .colors(colors: colors, startPoint: startPoint, endPoint: endPoint)
+            }
+            
+            init(stops: [Gradient.Stop.Resolvable], startPoint: AttributeReference<UnitPoint>, endPoint: AttributeReference<UnitPoint>) {
+                self = .stops(stops: stops, startPoint: startPoint, endPoint: endPoint)
+            }
+            
+            init(_ gradient: AnyGradient.Resolvable, startPoint: AttributeReference<UnitPoint>, endPoint: AttributeReference<UnitPoint>) {
+                self = .anyGradient(gradient: gradient, startPoint: startPoint, endPoint: endPoint)
+            }
+            
+            func resolve(on element: ElementNode) -> any ShapeStyle {
+                switch self {
+                case .gradient(let gradient, let startPoint, let endPoint):
+                    LinearGradient.linearGradient(gradient.resolve(on: element), startPoint: startPoint.resolve(on: element), endPoint: endPoint.resolve(on: element))
+                case .colors(let colors, let startPoint, let endPoint):
+                    LinearGradient.linearGradient(colors: colors.map({ $0.resolve(on: element) }), startPoint: startPoint.resolve(on: element), endPoint: endPoint.resolve(on: element))
+                case .stops(let stops, let startPoint, let endPoint):
+                    LinearGradient.linearGradient(stops: stops.map({ $0.resolve(on: element) }), startPoint: startPoint.resolve(on: element), endPoint: endPoint.resolve(on: element))
+                case .anyGradient(let gradient, let startPoint, let endPoint):
+                    LinearGradient.linearGradient(gradient.resolve(on: element), startPoint: startPoint.resolve(on: element), endPoint: endPoint.resolve(on: element))
+                }
+            }
+        }
+        
+        @ParseableExpression
+        enum _radialGradient {
+            static let name = "radialGradient"
+            
+            case gradient(gradient: Gradient.Resolvable, center: AttributeReference<UnitPoint>, startRadius: AttributeReference<CGFloat>, endRadius: AttributeReference<CGFloat>)
+            case colors(colors: [Color.Resolvable], center: AttributeReference<UnitPoint>, startRadius: AttributeReference<CGFloat>, endRadius: AttributeReference<CGFloat>)
+            case stops(stops: [Gradient.Stop.Resolvable], center: AttributeReference<UnitPoint>, startRadius: AttributeReference<CGFloat>, endRadius: AttributeReference<CGFloat>)
+            case anyGradient(gradient: AnyGradient.Resolvable, center: AttributeReference<UnitPoint>, startRadius: AttributeReference<CGFloat>, endRadius: AttributeReference<CGFloat>)
+            
+            init(
+                _ gradient: Gradient.Resolvable,
+                center: AttributeReference<UnitPoint>,
+                startRadius: AttributeReference<CGFloat>,
+                endRadius: AttributeReference<CGFloat>
+            ) {
+                self = .gradient(gradient: gradient, center: center, startRadius: startRadius, endRadius: endRadius)
+            }
+            
+            init(
+                colors: [Color.Resolvable],
+                center: AttributeReference<UnitPoint>,
+                startRadius: AttributeReference<CGFloat>,
+                endRadius: AttributeReference<CGFloat>
+            ) {
+                self = .colors(colors: colors, center: center, startRadius: startRadius, endRadius: endRadius)
+            }
+            
+            init(
+                stops: [Gradient.Stop.Resolvable],
+                center: AttributeReference<UnitPoint>,
+                startRadius: AttributeReference<CGFloat>,
+                endRadius: AttributeReference<CGFloat>
+            ) {
+                self = .stops(stops: stops, center: center, startRadius: startRadius, endRadius: endRadius)
+            }
+            
+            init(
+                _ gradient: AnyGradient.Resolvable,
+                center: AttributeReference<UnitPoint> = .init(.center),
+                startRadius: AttributeReference<CGFloat> = .init(0),
+                endRadius: AttributeReference<CGFloat>
+            ) {
+                self = .anyGradient(gradient: gradient, center: center, startRadius: startRadius, endRadius: endRadius)
+            }
+            
+            func resolve(on element: ElementNode) -> any ShapeStyle {
+                switch self {
+                case .gradient(let gradient, let center, let startRadius, let endRadius):
+                    RadialGradient.radialGradient(
+                        gradient.resolve(on: element),
+                        center: center.resolve(on: element),
+                        startRadius: startRadius.resolve(on: element),
+                        endRadius: endRadius.resolve(on: element)
+                    )
+                case .colors(let colors, let center, let startRadius, let endRadius):
+                    RadialGradient.radialGradient(
+                        colors: colors.map({ $0.resolve(on: element) }),
+                        center: center.resolve(on: element),
+                        startRadius: startRadius.resolve(on: element),
+                        endRadius: endRadius.resolve(on: element)
+                    )
+                case .stops(let stops, let center, let startRadius, let endRadius):
+                    RadialGradient.radialGradient(
+                        stops: stops.map({ $0.resolve(on: element) }),
+                        center: center.resolve(on: element),
+                        startRadius: startRadius.resolve(on: element),
+                        endRadius: endRadius.resolve(on: element)
+                    )
+                case .anyGradient(let gradient, let center, let startRadius, let endRadius):
+                    RadialGradient.radialGradient(
+                        gradient.resolve(on: element),
+                        center: center.resolve(on: element),
+                        startRadius: startRadius.resolve(on: element),
+                        endRadius: endRadius.resolve(on: element)
+                    )
+                }
+            }
+        }
+        
+        @ParseableExpression
+        struct _image {
+            static let name = "image"
+            
+            let value: any ShapeStyle
+            
+            init(_ image: Image, sourceRect: CGRect = .init(x: 0, y: 0, width: 1, height: 1), scale: CGFloat = 1) {
+                self.value = ImagePaint.image(image, sourceRect: sourceRect, scale: scale)
+            }
+        }
+        
+        enum StyleModifier: ParseableModifierValue {
+            case blendMode(_blendMode)
+            case opacity(_opacity)
+            case shadow(_shadow)
+            case hierarchical(HierarchicalLevel)
+            
+            static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
+                OneOf {
+                    _blendMode.parser(in: context).map(Self.blendMode)
+                    _opacity.parser(in: context).map(Self.opacity)
+                    _shadow.parser(in: context).map(Self.shadow)
+                    HierarchicalLevel.parser(in: context).map(Self.hierarchical)
+                }
+            }
+            
+            @ParseableExpression
+            struct _blendMode {
+                static let name = "blendMode"
+                
+                let value: BlendMode
+                
+                init(_ value: BlendMode) {
+                    self.value = value
+                }
+            }
+            
+            @ParseableExpression
+            struct _opacity {
+                static let name = "opacity"
+                
+                let value: Double
+                
+                init(_ value: Double) {
+                    self.value = value
+                }
+            }
+            
+            @ParseableExpression
+            struct _shadow {
+                static let name = "shadow"
+                
+                let value: _ShadowStyle
+                
+                init(_ value: _ShadowStyle) {
+                    self.value = value
+                }
+            }
+            
+            enum HierarchicalLevel: String, CaseIterable, ParseableModifierValue {
+                typealias _ParserType = EnumParser<Self>
+                
+                static func parser(in context: ParseableModifierContext) -> EnumParser<Self> {
+                    .init(Dictionary(uniqueKeysWithValues: Self.allCases.map({ ($0.rawValue, $0) })))
+                }
+                
+                case secondary
+                case tertiary
+                case quaternary
+                case quinary
+            }
+            
+            /// Apply this modifier to an existing `ShapeStyle`.
+            func apply(to style: some ShapeStyle, on element: ElementNode) -> any ShapeStyle {
+                switch self {
+                case let .blendMode(blendMode):
+                    return style.blendMode(blendMode.value)
+                case let .opacity(opacity):
+                    return style.opacity(opacity.value)
+                case let .shadow(shadow):
+                    return style.shadow(shadow.value.resolve(on: element))
+                case let .hierarchical(level):
+                    if #available(iOS 17, macOS 14, tvOS 17, watchOS 10, visionOS 1, *) {
+                        switch level {
+                        case .secondary:
+                            return style.secondary
+                        case .tertiary:
+                            return style.tertiary
+                        case .quaternary:
+                            return style.quaternary
+                        case .quinary:
+                            return style.quinary
+                        }
                     } else {
+                        return style
+                    }
+                }
+            }
+            
+            /// Use this modifier itself as a `ShapeStyle`. SwiftUI will apply it to the foreground style.
+            func resolve(on element: ElementNode) -> any ShapeStyle {
+                switch self {
+                case let .blendMode(blendMode):
+                    return AnyShapeStyle(.blendMode(blendMode.value))
+                case let .opacity(opacity):
+                    return AnyShapeStyle(.opacity(opacity.value))
+                case let .shadow(shadow):
+                    return AnyShapeStyle(.shadow(shadow.value.resolve(on: element)))
+                case let .hierarchical(level):
+                    switch level {
+                    case .secondary:
+                        return AnyShapeStyle(.secondary)
+                    case .tertiary:
+                        return AnyShapeStyle(.tertiary)
+                    case .quaternary:
                         return AnyShapeStyle(.quaternary)
+                    case .quinary:
+                        if #available(iOS 16, macOS 12, tvOS 17, watchOS 10, visionOS 1, *) {
+                            return AnyShapeStyle(.quinary)
+                        } else {
+                            return AnyShapeStyle(.quaternary)
+                        }
                     }
                 }
             }

--- a/Sources/LiveViewNative/Stylesheets/ParseableTypes/ShapeStyles/Gradient+ParseableModifierValue.swift
+++ b/Sources/LiveViewNative/Stylesheets/ParseableTypes/ShapeStyles/Gradient+ParseableModifierValue.swift
@@ -17,17 +17,25 @@ import LiveViewNativeStylesheet
 /// Color("MyColor").gradient
 /// ```
 @_documentation(visibility: public)
-extension AnyGradient: ParseableModifierValue {
-    public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
-        _ThrowingParse { (base: SwiftUI.Color, members: [()]) in
-            guard !members.isEmpty else {
-                throw ModifierParseError(error: .missingRequiredArgument("gradient"), metadata: context.metadata)
+extension AnyGradient {
+    struct Resolvable: ParseableModifierValue {
+        let color: Color.Resolvable
+        
+        public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
+            _ThrowingParse { (base: Color.Resolvable, members: [()]) in
+                guard !members.isEmpty else {
+                    throw ModifierParseError(error: .missingRequiredArgument("gradient"), metadata: context.metadata)
+                }
+                return .init(color: base)
+            } with: {
+                _ColorParser(context: context) {
+                    ConstantAtomLiteral("gradient")
+                }
             }
-            return base.gradient
-        } with: {
-            _ColorParser(context: context) {
-                ConstantAtomLiteral("gradient")
-            }
+        }
+        
+        func resolve(on element: ElementNode) -> AnyGradient {
+            color.resolve(on: element).gradient
         }
     }
 }
@@ -41,23 +49,37 @@ extension AnyGradient: ParseableModifierValue {
 /// Gradient(stops: [Gradient.Stop(color: .red, location: 0), Gradient.Stop(color: .blue, location: 1)])
 /// ```
 @_documentation(visibility: public)
-extension Gradient: ParseableModifierValue {
-    public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
-        _Gradient.parser(in: context).map(\.value)
-    }
-    
-    @ParseableExpression
-    struct _Gradient {
-        static let name = "Gradient"
+extension Gradient {
+    enum Resolvable: ParseableModifierValue {
+        case colors([Color.Resolvable])
+        case stops([Gradient.Stop.Resolvable])
         
-        let value: Gradient
-        
-        init(colors: [Color]) {
-            self.value = .init(colors: colors)
+        public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
+            _Gradient.parser(in: context).map(\.value)
         }
         
-        init(stops: [Gradient.Stop]) {
-            self.value = .init(stops: stops)
+        @ParseableExpression
+        struct _Gradient {
+            static let name = "Gradient"
+            
+            let value: Resolvable
+            
+            init(colors: [Color.Resolvable]) {
+                self.value = .colors(colors)
+            }
+            
+            init(stops: [Gradient.Stop.Resolvable]) {
+                self.value = .stops(stops)
+            }
+        }
+        
+        func resolve(on element: ElementNode) -> Gradient {
+            switch self {
+            case .colors(let colors):
+                Gradient(colors: colors.map({ $0.resolve(on: element) }))
+            case .stops(let stops):
+                Gradient(stops: stops.map({ $0.resolve(on: element) }))
+            }
         }
     }
 }
@@ -71,136 +93,35 @@ extension Gradient: ParseableModifierValue {
 /// Gradient.Stop(color: .blue, location: 1)
 /// ```
 @_documentation(visibility: public)
-extension Gradient.Stop: ParseableModifierValue {
-    public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
-        MemberExpression {
-            ConstantAtomLiteral("Gradient")
-        } member: {
-            _Stop.parser(in: context).map(\.value)
-        }
-        .map({ _, member in
-            member
-        })
-    }
-    
-    @ParseableExpression
-    struct _Stop {
-        static let name = "Stop"
+extension Gradient.Stop {
+    struct Resolvable: ParseableModifierValue {
+        let color: Color.Resolvable
+        let location: AttributeReference<CGFloat>
         
-        let value: Gradient.Stop
-        
-        init(color: Color, location: CGFloat) {
-            self.value = .init(color: color, location: location)
-        }
-    }
-}
-
-extension AngularGradient: ParseableModifierValue {
-    public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
-        _AngularGradient.parser(in: context).map(\.value)
-    }
-    
-    @ParseableExpression
-    struct _AngularGradient {
-        static let name = "AngularGradient"
-        
-        let value: AngularGradient
-        
-        public init(gradient: Gradient, center: UnitPoint, startAngle: Angle = .zero, endAngle: Angle = .zero) {
-            self.value = .init(gradient: gradient, center: center, startAngle: startAngle, endAngle: endAngle)
+        public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
+            MemberExpression {
+                ConstantAtomLiteral("Gradient")
+            } member: {
+                _Stop.parser(in: context).map(\.value)
+            }
+            .map({ _, member in
+                member
+            })
         }
         
-        public init(colors: [Color], center: UnitPoint, startAngle: Angle, endAngle: Angle) {
-            self.value = .init(colors: colors, center: center, startAngle: startAngle, endAngle: endAngle)
+        @ParseableExpression
+        struct _Stop {
+            static let name = "Stop"
+            
+            let value: Gradient.Stop.Resolvable
+            
+            init(color: Color.Resolvable, location: AttributeReference<CGFloat>) {
+                self.value = .init(color: color, location: location)
+            }
         }
         
-        public init(stops: [Gradient.Stop], center: UnitPoint, startAngle: Angle, endAngle: Angle) {
-            self.value = .init(stops: stops, center: center, startAngle: startAngle, endAngle: endAngle)
-        }
-        
-        public init(gradient: Gradient, center: UnitPoint, angle: Angle = .zero) {
-            self.value = .init(gradient: gradient, center: center, angle: angle)
-        }
-        
-        public init(colors: [Color], center: UnitPoint, angle: Angle = .zero) {
-            self.value = .init(colors: colors, center: center, angle: angle)
-        }
-        
-        public init(stops: [Gradient.Stop], center: UnitPoint, angle: Angle = .zero) {
-            self.value = .init(stops: stops, center: center, angle: angle)
-        }
-    }
-}
-
-extension EllipticalGradient: ParseableModifierValue {
-    public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
-        _EllipticalGradient.parser(in: context).map(\.value)
-    }
-    
-    @ParseableExpression
-    struct _EllipticalGradient {
-        static let name = "EllipticalGradient"
-        
-        let value: EllipticalGradient
-        
-        init(gradient: Gradient, center: UnitPoint = .center, startRadiusFraction: CGFloat = 0, endRadiusFraction: CGFloat = 0.5) {
-            self.value = .init(gradient: gradient, center: center, startRadiusFraction: startRadiusFraction, endRadiusFraction: endRadiusFraction)
-        }
-        
-        init(colors: [Color], center: UnitPoint = .center, startRadiusFraction: CGFloat = 0, endRadiusFraction: CGFloat = 0.5) {
-            self.value = .init(colors: colors, center: center, startRadiusFraction: startRadiusFraction, endRadiusFraction: endRadiusFraction)
-        }
-        
-        init(stops: [Gradient.Stop], center: UnitPoint = .center, startRadiusFraction: CGFloat = 0, endRadiusFraction: CGFloat = 0.5) {
-            self.value = .init(stops: stops, center: center, startRadiusFraction: startRadiusFraction, endRadiusFraction: endRadiusFraction)
-        }
-    }
-}
-
-extension LinearGradient: ParseableModifierValue {
-    public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
-        _LinearGradient.parser(in: context).map(\.value)
-    }
-    
-    @ParseableExpression
-    struct _LinearGradient {
-        static let name = "LinearGradient"
-        
-        let value: LinearGradient
-        
-        init(gradient: Gradient, startPoint: UnitPoint, endPoint: UnitPoint) {
-            self.value = .init(gradient: gradient, startPoint: startPoint, endPoint: endPoint)
-        }
-        init(colors: [Color], startPoint: UnitPoint, endPoint: UnitPoint) {
-            self.value = .init(colors: colors, startPoint: startPoint, endPoint: endPoint)
-        }
-        init(stops: [Gradient.Stop], startPoint: UnitPoint, endPoint: UnitPoint) {
-            self.value = .init(stops: stops, startPoint: startPoint, endPoint: endPoint)
-        }
-    }
-}
-
-extension RadialGradient: ParseableModifierValue {
-    public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
-        _RadialGradient.parser(in: context).map(\.value)
-    }
-    
-    @ParseableExpression
-    struct _RadialGradient {
-        static let name = "RadialGradient"
-        
-        let value: RadialGradient
-        
-        init(gradient: Gradient, center: UnitPoint, startRadius: CGFloat, endRadius: CGFloat) {
-            self.value = .init(gradient: gradient, center: center, startRadius: startRadius, endRadius: endRadius)
-        }
-        
-        init(colors: [Color], center: UnitPoint, startRadius: CGFloat, endRadius: CGFloat) {
-            self.value = .init(colors: colors, center: center, startRadius: startRadius, endRadius: endRadius)
-        }
-        
-        init(stops: [Gradient.Stop], center: UnitPoint, startRadius: CGFloat, endRadius: CGFloat) {
-            self.value = .init(stops: stops, center: center, startRadius: startRadius, endRadius: endRadius)
+        func resolve(on element: ElementNode) -> Gradient.Stop {
+            .init(color: color.resolve(on: element), location: location.resolve(on: element))
         }
     }
 }

--- a/Sources/LiveViewNative/Stylesheets/ParseableTypes/ShapeStyles/ShadowStyle+ParseableModifierValue.swift
+++ b/Sources/LiveViewNative/Stylesheets/ParseableTypes/ShapeStyles/ShadowStyle+ParseableModifierValue.swift
@@ -38,13 +38,35 @@ import LiveViewNativeStylesheet
 /// .inner(color: .red, radius: 8, x: 10, y: -8)
 /// ```
 @_documentation(visibility: public)
-extension ShadowStyle: ParseableModifierValue {
+enum _ShadowStyle: ParseableModifierValue {
+    case drop(_drop)
+    case inner(_inner)
+    
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
-                _drop.parser(in: context).map(\.value)
-                _inner.parser(in: context).map(\.value)
+                _drop.parser(in: context).map(Self.drop)
+                _inner.parser(in: context).map(Self.inner)
             }
+        }
+    }
+    
+    func resolve(on element: ElementNode) -> ShadowStyle {
+        switch self {
+        case .drop(let drop):
+            .drop(
+                color: drop.color.resolve(on: element),
+                radius: drop.radius.resolve(on: element),
+                x: drop.x.resolve(on: element),
+                y: drop.y.resolve(on: element)
+            )
+        case .inner(let inner):
+            .inner(
+                color: inner.color.resolve(on: element),
+                radius: inner.radius.resolve(on: element),
+                x: inner.x.resolve(on: element),
+                y: inner.y.resolve(on: element)
+            )
         }
     }
     
@@ -52,10 +74,21 @@ extension ShadowStyle: ParseableModifierValue {
     struct _drop {
         static let name = "drop"
         
-        let value: ShadowStyle
+        let color: Color.Resolvable
+        let radius: AttributeReference<CGFloat>
+        let x: AttributeReference<CGFloat>
+        let y: AttributeReference<CGFloat>
         
-        init(color: Color = .init(.sRGBLinear, white: 0, opacity: 0.33), radius: CGFloat, x: CGFloat = 0, y: CGFloat = 0) {
-            self.value = .drop(color: color, radius: radius, x: x, y: y)
+        init(
+            color: Color.Resolvable = .init(.init(.sRGBLinear, white: 0, opacity: 0.33)),
+            radius: AttributeReference<CGFloat>,
+            x: AttributeReference<CGFloat> = .init(0),
+            y: AttributeReference<CGFloat> = .init(0)
+        ) {
+            self.color = color
+            self.radius = radius
+            self.x = x
+            self.y = y
         }
     }
     
@@ -63,10 +96,21 @@ extension ShadowStyle: ParseableModifierValue {
     struct _inner {
         static let name = "inner"
         
-        let value: ShadowStyle
+        let color: Color.Resolvable
+        let radius: AttributeReference<CGFloat>
+        let x: AttributeReference<CGFloat>
+        let y: AttributeReference<CGFloat>
         
-        init(color: Color = .init(.sRGBLinear, white: 0, opacity: 0.55), radius: CGFloat, x: CGFloat = 0, y: CGFloat = 0) {
-            self.value = .inner(color: color, radius: radius, x: x, y: y)
+        init(
+            color: Color.Resolvable = .init(.init(.sRGBLinear, white: 0, opacity: 0.55)),
+            radius: AttributeReference<CGFloat>,
+            x: AttributeReference<CGFloat> = .init(0),
+            y: AttributeReference<CGFloat> = .init(0)
+        ) {
+            self.color = color
+            self.radius = radius
+            self.x = x
+            self.y = y
         }
     }
 }

--- a/Sources/LiveViewNative/_GeneratedModifiers.swift
+++ b/Sources/LiveViewNative/_GeneratedModifiers.swift
@@ -694,19 +694,19 @@ struct _backgroundModifier<R: RootRegistry>: ViewModifier {
         indirect case _1(edges: SwiftUI.Edge.Set = .all )
         
         
-        indirect case _2(style: AnyShapeStyle,edges: SwiftUI.Edge.Set = .all )
+        indirect case _2(style: AnyShapeStyle.Resolvable,edges: SwiftUI.Edge.Set = .all )
         
         
         indirect case _3(shape: AnyShape,fillStyle: SwiftUI.FillStyle = FillStyle() )
         
         
-        indirect case _4(style: AnyShapeStyle,shape: AnyShape,fillStyle: SwiftUI.FillStyle = FillStyle() )
+        indirect case _4(style: AnyShapeStyle.Resolvable,shape: AnyShape,fillStyle: SwiftUI.FillStyle = FillStyle() )
         
         
         indirect case _5(shape: AnyInsettableShape,fillStyle: SwiftUI.FillStyle = FillStyle() )
         
         
-        indirect case _6(style: AnyShapeStyle,shape: AnyInsettableShape,fillStyle: SwiftUI.FillStyle = FillStyle() )
+        indirect case _6(style: AnyShapeStyle.Resolvable,shape: AnyInsettableShape,fillStyle: SwiftUI.FillStyle = FillStyle() )
         
     }
 
@@ -746,7 +746,7 @@ struct _backgroundModifier<R: RootRegistry>: ViewModifier {
     
     
     
-    init(_ style: AnyShapeStyle,ignoresSafeAreaEdges edges: SwiftUI.Edge.Set = .all ) {
+    init(_ style: AnyShapeStyle.Resolvable,ignoresSafeAreaEdges edges: SwiftUI.Edge.Set = .all ) {
         self.value = ._2(style: style, edges: edges)
         
     }
@@ -760,7 +760,7 @@ struct _backgroundModifier<R: RootRegistry>: ViewModifier {
     
     
     
-    init(_ style: AnyShapeStyle,in shape: AnyShape,fillStyle: SwiftUI.FillStyle = FillStyle() ) {
+    init(_ style: AnyShapeStyle.Resolvable,in shape: AnyShape,fillStyle: SwiftUI.FillStyle = FillStyle() ) {
         self.value = ._4(style: style, shape: shape, fillStyle: fillStyle)
         
     }
@@ -774,7 +774,7 @@ struct _backgroundModifier<R: RootRegistry>: ViewModifier {
     
     
     
-    init(_ style: AnyShapeStyle,in shape: AnyInsettableShape,fillStyle: SwiftUI.FillStyle = FillStyle() ) {
+    init(_ style: AnyShapeStyle.Resolvable,in shape: AnyInsettableShape,fillStyle: SwiftUI.FillStyle = FillStyle() ) {
         self.value = ._6(style: style, shape: shape, fillStyle: fillStyle)
         
     }
@@ -805,7 +805,7 @@ struct _backgroundModifier<R: RootRegistry>: ViewModifier {
             
             
             __content
-                .background(style, ignoresSafeAreaEdges: edges)
+                .background(style.resolve(on: element, in: context), ignoresSafeAreaEdges: edges)
             
         
         
@@ -821,7 +821,7 @@ struct _backgroundModifier<R: RootRegistry>: ViewModifier {
             
             
             __content
-                .background(style, in: shape, fillStyle: fillStyle)
+                .background(style.resolve(on: element, in: context), in: shape, fillStyle: fillStyle)
             
         
         
@@ -837,7 +837,7 @@ struct _backgroundModifier<R: RootRegistry>: ViewModifier {
             
             
             __content
-                .background(style, in: shape, fillStyle: fillStyle)
+                .background(style.resolve(on: element, in: context), in: shape, fillStyle: fillStyle)
             
         
         }
@@ -851,21 +851,21 @@ struct _backgroundStyleModifier<R: RootRegistry>: ViewModifier {
     enum Value {
         case _never
         
-        indirect case _0(style: AnyShapeStyle)
+        indirect case _0(style: AnyShapeStyle.Resolvable)
         
     }
 
     let value: Value
 
-    
-    
+    @ObservedElement private var element
+    @LiveContext<R> private var context
 
 
 
 
     
     
-    init(_ style: AnyShapeStyle) {
+    init(_ style: AnyShapeStyle.Resolvable) {
         self.value = ._0(style: style)
         
     }
@@ -880,7 +880,7 @@ struct _backgroundStyleModifier<R: RootRegistry>: ViewModifier {
             
             
             __content
-                .backgroundStyle(style)
+                .backgroundStyle(style.resolve(on: element, in: context))
             
         
         }
@@ -922,28 +922,28 @@ struct _badgeModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 12.0,visionOS 1.0,iOS 15.0, *)
+    @available(iOS 15.0,visionOS 1.0,macOS 12.0, *)
     init(_ count: AttributeReference<Swift.Int>) {
         self.value = ._0(count: count)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 12.0,visionOS 1.0,iOS 15.0, *)
+    @available(iOS 15.0,visionOS 1.0,macOS 12.0, *)
     init(_ label: TextReference?) {
         self.value = ._1(label: label)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 12.0,visionOS 1.0,iOS 15.0, *)
+    @available(macOS 12.0,iOS 15.0,visionOS 1.0, *)
     init(_ key: SwiftUI.LocalizedStringKey?) {
         self.value = ._2(key: key)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 12.0,visionOS 1.0,iOS 15.0, *)
+    @available(macOS 12.0,iOS 15.0,visionOS 1.0, *)
     init(_ label: AttributeReference<String>) {
         self.value = ._3(label: label)
         
@@ -956,7 +956,7 @@ struct _badgeModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(count):
-            if #available(macOS 12.0,visionOS 1.0,iOS 15.0, *) {
+            if #available(iOS 15.0,visionOS 1.0,macOS 12.0, *) {
             let count = count as! AttributeReference<Swift.Int>
             __content
                 .badge(count.resolve(on: element, in: context))
@@ -964,7 +964,7 @@ struct _badgeModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._1(label):
-            if #available(macOS 12.0,visionOS 1.0,iOS 15.0, *) {
+            if #available(iOS 15.0,visionOS 1.0,macOS 12.0, *) {
             let label = label as? TextReference
             __content
                 .badge(label?.resolve(on: element, in: context))
@@ -972,7 +972,7 @@ struct _badgeModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._2(key):
-            if #available(macOS 12.0,visionOS 1.0,iOS 15.0, *) {
+            if #available(macOS 12.0,iOS 15.0,visionOS 1.0, *) {
             let key = key as? SwiftUI.LocalizedStringKey
             __content
                 .badge(key)
@@ -980,7 +980,7 @@ struct _badgeModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._3(label):
-            if #available(macOS 12.0,visionOS 1.0,iOS 15.0, *) {
+            if #available(macOS 12.0,iOS 15.0,visionOS 1.0, *) {
             let label = label as! AttributeReference<String>
             __content
                 .badge(label.resolve(on: element, in: context))
@@ -1083,7 +1083,7 @@ struct _borderModifier<R: RootRegistry>: ViewModifier {
     enum Value {
         case _never
         
-        indirect case _0(content: AnyShapeStyle,width: AttributeReference<CoreFoundation.CGFloat> = .init(storage: .constant(1)) )
+        indirect case _0(content: AnyShapeStyle.Resolvable,width: AttributeReference<CoreFoundation.CGFloat> = .init(storage: .constant(1)) )
         
     }
 
@@ -1097,7 +1097,7 @@ struct _borderModifier<R: RootRegistry>: ViewModifier {
 
     
     
-    init(_ content: AnyShapeStyle,width: AttributeReference<CoreFoundation.CGFloat> = .init(storage: .constant(1)) ) {
+    init(_ content: AnyShapeStyle.Resolvable,width: AttributeReference<CoreFoundation.CGFloat> = .init(storage: .constant(1)) ) {
         self.value = ._0(content: content, width: width)
         
     }
@@ -1112,7 +1112,7 @@ struct _borderModifier<R: RootRegistry>: ViewModifier {
             
             
             __content
-                .border(content, width: width.resolve(on: element, in: context))
+                .border(content.resolve(on: element, in: context), width: width.resolve(on: element, in: context))
             
         
         }
@@ -1404,7 +1404,7 @@ struct _colorMultiplyModifier<R: RootRegistry>: ViewModifier {
     enum Value {
         case _never
         
-        indirect case _0(color: AttributeReference<SwiftUI.Color>)
+        indirect case _0(color: Color.Resolvable)
         
     }
 
@@ -1418,7 +1418,7 @@ struct _colorMultiplyModifier<R: RootRegistry>: ViewModifier {
 
     
     
-    init(_ color: AttributeReference<SwiftUI.Color>) {
+    init(_ color: Color.Resolvable) {
         self.value = ._0(color: color)
         
     }
@@ -1651,7 +1651,7 @@ struct _containerRelativeFrameModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 10.0,visionOS 1.0,iOS 17.0,macOS 14.0,tvOS 17.0, *)
+    @available(iOS 17.0,macOS 14.0,tvOS 17.0,watchOS 10.0,visionOS 1.0, *)
     init(_ axes: SwiftUI.Axis.Set,alignment: AttributeReference<SwiftUI.Alignment> = .init(storage: .constant(.center)) ) {
         self.value = ._0(axes: axes, alignment: alignment)
         
@@ -1671,7 +1671,7 @@ struct _containerRelativeFrameModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(axes, alignment):
-            if #available(watchOS 10.0,visionOS 1.0,iOS 17.0,macOS 14.0,tvOS 17.0, *) {
+            if #available(iOS 17.0,macOS 14.0,tvOS 17.0,watchOS 10.0,visionOS 1.0, *) {
             let axes = axes as! SwiftUI.Axis.Set
 let alignment = alignment as! AttributeReference<SwiftUI.Alignment>
             __content
@@ -1875,7 +1875,7 @@ struct _contextMenuModifier<R: RootRegistry>: ViewModifier {
     }
     
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS)
-    @available(iOS 16.0,tvOS 16.0,visionOS 1.0,macOS 13.0, *)
+    @available(tvOS 16.0,visionOS 1.0,macOS 13.0,iOS 16.0, *)
     init(menuItems: ViewReference=ViewReference(value: []),preview: ViewReference=ViewReference(value: [])) {
         self.value = ._1(menuItems: menuItems, preview: preview)
         
@@ -1896,7 +1896,7 @@ struct _contextMenuModifier<R: RootRegistry>: ViewModifier {
         
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS)
         case let ._1(menuItems, preview):
-            if #available(iOS 16.0,tvOS 16.0,visionOS 1.0,macOS 13.0, *) {
+            if #available(tvOS 16.0,visionOS 1.0,macOS 13.0,iOS 16.0, *) {
             let menuItems = menuItems as! ViewReference
 let preview = preview as! ViewReference
             __content
@@ -1970,7 +1970,7 @@ struct _controlGroupStyleModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS)
-    @available(iOS 15.0,macOS 12.0,tvOS 17.0,visionOS 1.0, *)
+    @available(visionOS 1.0,macOS 12.0,tvOS 17.0,iOS 15.0, *)
     init(_ style: AnyControlGroupStyle) {
         self.value = ._0(style: style)
         
@@ -1983,7 +1983,7 @@ struct _controlGroupStyleModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS)
         case let ._0(style):
-            if #available(iOS 15.0,macOS 12.0,tvOS 17.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,macOS 12.0,tvOS 17.0,iOS 15.0, *) {
             let style = style as! AnyControlGroupStyle
             __content
                 .controlGroupStyle(style)
@@ -2013,7 +2013,7 @@ struct _controlSizeModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
-    @available(iOS 15.0,macOS 10.15,visionOS 1.0,watchOS 9.0, *)
+    @available(watchOS 9.0,visionOS 1.0,macOS 10.15,iOS 15.0, *)
     init(_ controlSize: SwiftUI.ControlSize) {
         self.value = ._0(controlSize: controlSize)
         
@@ -2026,7 +2026,7 @@ struct _controlSizeModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
         case let ._0(controlSize):
-            if #available(iOS 15.0,macOS 10.15,visionOS 1.0,watchOS 9.0, *) {
+            if #available(watchOS 9.0,visionOS 1.0,macOS 10.15,iOS 15.0, *) {
             let controlSize = controlSize as! SwiftUI.ControlSize
             __content
                 .controlSize(controlSize)
@@ -2056,7 +2056,7 @@ struct _coordinateSpaceModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,tvOS 17.0,macOS 14.0,watchOS 10.0,iOS 17.0, *)
+    @available(macOS 14.0,visionOS 1.0,tvOS 17.0,iOS 17.0,watchOS 10.0, *)
     init(_ name: SwiftUI.NamedCoordinateSpace) {
         self.value = ._0(name: name)
         
@@ -2069,7 +2069,7 @@ struct _coordinateSpaceModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(name):
-            if #available(visionOS 1.0,tvOS 17.0,macOS 14.0,watchOS 10.0,iOS 17.0, *) {
+            if #available(macOS 14.0,visionOS 1.0,tvOS 17.0,iOS 17.0,watchOS 10.0, *) {
             let name = name as! SwiftUI.NamedCoordinateSpace
             __content
                 .coordinateSpace(name)
@@ -2099,7 +2099,7 @@ struct _datePickerStyleModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
-    @available(iOS 13.0,macOS 10.15,watchOS 10.0,visionOS 1.0, *)
+    @available(iOS 13.0,visionOS 1.0,watchOS 10.0,macOS 10.15, *)
     init(_ style: AnyDatePickerStyle) {
         self.value = ._0(style: style)
         
@@ -2112,7 +2112,7 @@ struct _datePickerStyleModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
         case let ._0(style):
-            if #available(iOS 13.0,macOS 10.15,watchOS 10.0,visionOS 1.0, *) {
+            if #available(iOS 13.0,visionOS 1.0,watchOS 10.0,macOS 10.15, *) {
             let style = style as! AnyDatePickerStyle
             __content
                 .datePickerStyle(style)
@@ -2142,7 +2142,7 @@ struct _defaultScrollAnchorModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 14.0,watchOS 10.0,tvOS 17.0,visionOS 1.0,iOS 17.0, *)
+    @available(watchOS 10.0,iOS 17.0,tvOS 17.0,macOS 14.0,visionOS 1.0, *)
     init(_ anchor: AttributeReference<SwiftUI.UnitPoint?>?) {
         self.value = ._0(anchor: anchor)
         
@@ -2155,7 +2155,7 @@ struct _defaultScrollAnchorModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(anchor):
-            if #available(macOS 14.0,watchOS 10.0,tvOS 17.0,visionOS 1.0,iOS 17.0, *) {
+            if #available(watchOS 10.0,iOS 17.0,tvOS 17.0,macOS 14.0,visionOS 1.0, *) {
             let anchor = anchor as? AttributeReference<SwiftUI.UnitPoint?>
             __content
                 .defaultScrollAnchor(anchor?.resolve(on: element, in: context))
@@ -2329,28 +2329,28 @@ struct _dialogSuppressionToggleModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 10.0,visionOS 1.0,tvOS 17.0,iOS 17.0,macOS 14.0, *)
+    @available(tvOS 17.0,watchOS 10.0,iOS 17.0,macOS 14.0,visionOS 1.0, *)
     init(_ titleKey: SwiftUI.LocalizedStringKey,isSuppressed: ChangeTracked<Swift.Bool>) {
         self.value = ._0(titleKey: titleKey)
         self.__0_isSuppressed = isSuppressed
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 10.0,visionOS 1.0,tvOS 17.0,iOS 17.0,macOS 14.0, *)
+    @available(watchOS 10.0,macOS 14.0,iOS 17.0,tvOS 17.0,visionOS 1.0, *)
     init(_ title: AttributeReference<String>,isSuppressed: ChangeTracked<Swift.Bool>) {
         self.value = ._1(title: title)
         self.__1_isSuppressed = isSuppressed
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 10.0,visionOS 1.0,tvOS 17.0,iOS 17.0,macOS 14.0, *)
+    @available(iOS 17.0,tvOS 17.0,watchOS 10.0,visionOS 1.0,macOS 14.0, *)
     init(_ label: TextReference,isSuppressed: ChangeTracked<Swift.Bool>) {
         self.value = ._2(label: label)
         self.__2_isSuppressed = isSuppressed
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 10.0,visionOS 1.0,tvOS 17.0,iOS 17.0,macOS 14.0, *)
+    @available(iOS 17.0,tvOS 17.0,watchOS 10.0,visionOS 1.0,macOS 14.0, *)
     init(isSuppressed: ChangeTracked<Swift.Bool>) {
         self.value = ._3
         self.__3_isSuppressed = isSuppressed
@@ -2363,7 +2363,7 @@ struct _dialogSuppressionToggleModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(titleKey):
-            if #available(watchOS 10.0,visionOS 1.0,tvOS 17.0,iOS 17.0,macOS 14.0, *) {
+            if #available(tvOS 17.0,watchOS 10.0,iOS 17.0,macOS 14.0,visionOS 1.0, *) {
             let titleKey = titleKey as! SwiftUI.LocalizedStringKey
             __content
                 .dialogSuppressionToggle(titleKey, isSuppressed: __0_isSuppressed.projectedValue)
@@ -2371,7 +2371,7 @@ struct _dialogSuppressionToggleModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(title):
-            if #available(watchOS 10.0,visionOS 1.0,tvOS 17.0,iOS 17.0,macOS 14.0, *) {
+            if #available(watchOS 10.0,macOS 14.0,iOS 17.0,tvOS 17.0,visionOS 1.0, *) {
             let title = title as! AttributeReference<String>
             __content
                 .dialogSuppressionToggle(title.resolve(on: element, in: context), isSuppressed: __1_isSuppressed.projectedValue)
@@ -2379,7 +2379,7 @@ struct _dialogSuppressionToggleModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._2(label):
-            if #available(watchOS 10.0,visionOS 1.0,tvOS 17.0,iOS 17.0,macOS 14.0, *) {
+            if #available(iOS 17.0,tvOS 17.0,watchOS 10.0,visionOS 1.0,macOS 14.0, *) {
             let label = label as! TextReference
             __content
                 .dialogSuppressionToggle(label.resolve(on: element, in: context), isSuppressed: __2_isSuppressed.projectedValue)
@@ -2387,7 +2387,7 @@ struct _dialogSuppressionToggleModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case ._3:
-            if #available(watchOS 10.0,visionOS 1.0,tvOS 17.0,iOS 17.0,macOS 14.0, *) {
+            if #available(iOS 17.0,tvOS 17.0,watchOS 10.0,visionOS 1.0,macOS 14.0, *) {
             
             __content
                 .dialogSuppressionToggle(isSuppressed: __3_isSuppressed.projectedValue)
@@ -2629,7 +2629,7 @@ struct _fileDialogCustomizationIDModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(visionOS 1.0,iOS 17.0,macOS 14.0, *)
+    @available(macOS 14.0,iOS 17.0,visionOS 1.0, *)
     init(_ id: AttributeReference<Swift.String>) {
         self.value = ._0(id: id)
         
@@ -2642,7 +2642,7 @@ struct _fileDialogCustomizationIDModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(id):
-            if #available(visionOS 1.0,iOS 17.0,macOS 14.0, *) {
+            if #available(macOS 14.0,iOS 17.0,visionOS 1.0, *) {
             let id = id as! AttributeReference<Swift.String>
             __content
                 .fileDialogCustomizationID(id.resolve(on: element, in: context))
@@ -2672,7 +2672,7 @@ struct _fileDialogImportsUnresolvedAliasesModifier<R: RootRegistry>: ViewModifie
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(visionOS 1.0,iOS 17.0,macOS 14.0, *)
+    @available(macOS 14.0,visionOS 1.0,iOS 17.0, *)
     init(_ imports: AttributeReference<Swift.Bool>) {
         self.value = ._0(imports: imports)
         
@@ -2685,7 +2685,7 @@ struct _fileDialogImportsUnresolvedAliasesModifier<R: RootRegistry>: ViewModifie
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(imports):
-            if #available(visionOS 1.0,iOS 17.0,macOS 14.0, *) {
+            if #available(macOS 14.0,visionOS 1.0,iOS 17.0, *) {
             let imports = imports as! AttributeReference<Swift.Bool>
             __content
                 .fileDialogImportsUnresolvedAliases(imports.resolve(on: element, in: context))
@@ -2715,7 +2715,7 @@ struct _findDisabledModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(visionOS)
-    @available(visionOS 1.0,iOS 16.0, *)
+    @available(iOS 16.0,visionOS 1.0, *)
     init(_ isDisabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(isDisabled: isDisabled)
         
@@ -2728,7 +2728,7 @@ struct _findDisabledModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(visionOS)
         case let ._0(isDisabled):
-            if #available(visionOS 1.0,iOS 16.0, *) {
+            if #available(iOS 16.0,visionOS 1.0, *) {
             let isDisabled = isDisabled as! AttributeReference<Swift.Bool>
             __content
                 .findDisabled(isDisabled.resolve(on: element, in: context))
@@ -2758,7 +2758,7 @@ struct _findNavigatorModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(visionOS)
-    @available(visionOS 1.0,iOS 16.0, *)
+    @available(iOS 16.0,visionOS 1.0, *)
     init(isPresented: ChangeTracked<Swift.Bool>) {
         self.value = ._0
         self.__0_isPresented = isPresented
@@ -2771,7 +2771,7 @@ struct _findNavigatorModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(visionOS)
         case ._0:
-            if #available(visionOS 1.0,iOS 16.0, *) {
+            if #available(iOS 16.0,visionOS 1.0, *) {
             
             __content
                 .findNavigator(isPresented: __0_isPresented.projectedValue)
@@ -2907,7 +2907,7 @@ struct _focusEffectDisabledModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(iOS 17.0,macOS 14.0,tvOS 17.0,watchOS 10.0,visionOS 1.0, *)
+    @available(iOS 17.0,tvOS 17.0,visionOS 1.0,watchOS 10.0,macOS 14.0, *)
     init(_ disabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(disabled: disabled)
         
@@ -2920,7 +2920,7 @@ struct _focusEffectDisabledModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(disabled):
-            if #available(iOS 17.0,macOS 14.0,tvOS 17.0,watchOS 10.0,visionOS 1.0, *) {
+            if #available(iOS 17.0,tvOS 17.0,visionOS 1.0,watchOS 10.0,macOS 14.0, *) {
             let disabled = disabled as! AttributeReference<Swift.Bool>
             __content
                 .focusEffectDisabled(disabled.resolve(on: element, in: context))
@@ -2950,7 +2950,7 @@ struct _focusSectionModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(macOS) || os(tvOS)
-    @available(tvOS 15.0,macOS 13.0, *)
+    @available(macOS 13.0,tvOS 15.0, *)
     init() {
         self.value = ._0
         
@@ -2963,7 +2963,7 @@ struct _focusSectionModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(macOS) || os(tvOS)
         case ._0:
-            if #available(tvOS 15.0,macOS 13.0, *) {
+            if #available(macOS 13.0,tvOS 15.0, *) {
             
             __content
                 .focusSection()
@@ -2998,14 +2998,14 @@ struct _focusableModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(iOS 17.0,macOS 12.0,tvOS 15.0,watchOS 8.0,visionOS 1.0, *)
+    @available(watchOS 8.0,visionOS 1.0,macOS 12.0,tvOS 15.0,iOS 17.0, *)
     init(_ isFocusable: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(isFocusable: isFocusable)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(iOS 17.0,macOS 14.0,tvOS 17.0,watchOS 10.0,visionOS 1.0, *)
+    @available(iOS 17.0,tvOS 17.0,visionOS 1.0,watchOS 10.0,macOS 14.0, *)
     init(_ isFocusable: AttributeReference<Swift.Bool> = .init(storage: .constant(true)), interactions: SwiftUI.FocusInteractions) {
         self.value = ._1(isFocusable: isFocusable, interactions: interactions)
         
@@ -3018,7 +3018,7 @@ struct _focusableModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(isFocusable):
-            if #available(iOS 17.0,macOS 12.0,tvOS 15.0,watchOS 8.0,visionOS 1.0, *) {
+            if #available(watchOS 8.0,visionOS 1.0,macOS 12.0,tvOS 15.0,iOS 17.0, *) {
             let isFocusable = isFocusable as! AttributeReference<Swift.Bool>
             __content
                 .focusable(isFocusable.resolve(on: element, in: context))
@@ -3026,7 +3026,7 @@ struct _focusableModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(isFocusable, interactions):
-            if #available(iOS 17.0,macOS 14.0,tvOS 17.0,watchOS 10.0,visionOS 1.0, *) {
+            if #available(iOS 17.0,tvOS 17.0,visionOS 1.0,watchOS 10.0,macOS 14.0, *) {
             let isFocusable = isFocusable as! AttributeReference<Swift.Bool>
 let interactions = interactions as! SwiftUI.FocusInteractions
             __content
@@ -3227,7 +3227,7 @@ struct _fullScreenCoverModifier<R: RootRegistry>: ViewModifier {
 @Event private var _0_onDismiss__0: Event.EventHandler
 
     #if os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(iOS 14.0,watchOS 7.0,tvOS 14.0,visionOS 1.0, *)
+    @available(tvOS 14.0,iOS 14.0,watchOS 7.0,visionOS 1.0, *)
     init(isPresented: ChangeTracked<Swift.Bool>,onDismiss onDismiss__0: Event=Event(), content: ViewReference=ViewReference(value: [])) {
         self.value = ._0(content: content)
         self.__0_isPresented = isPresented
@@ -3241,7 +3241,7 @@ self.__0_onDismiss__0 = onDismiss__0
             fatalError("unreachable")
         #if os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(content):
-            if #available(iOS 14.0,watchOS 7.0,tvOS 14.0,visionOS 1.0, *) {
+            if #available(tvOS 14.0,iOS 14.0,watchOS 7.0,visionOS 1.0, *) {
             let content = content as! ViewReference
             __content
                 .fullScreenCover(isPresented: __0_isPresented.projectedValue, onDismiss: { __0_onDismiss__0.wrappedValue() }, content: { content.resolve(on: element, in: context) })
@@ -3271,7 +3271,7 @@ struct _gaugeStyleModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
-    @available(iOS 16.0,macOS 13.0,visionOS 1.0,watchOS 7.0, *)
+    @available(watchOS 7.0,macOS 13.0,visionOS 1.0,iOS 16.0, *)
     init(_ style: AnyGaugeStyle) {
         self.value = ._0(style: style)
         
@@ -3284,7 +3284,7 @@ struct _gaugeStyleModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
         case let ._0(style):
-            if #available(iOS 16.0,macOS 13.0,visionOS 1.0,watchOS 7.0, *) {
+            if #available(watchOS 7.0,macOS 13.0,visionOS 1.0,iOS 16.0, *) {
             let style = style as! AnyGaugeStyle
             __content
                 .gaugeStyle(style)
@@ -3314,7 +3314,7 @@ struct _geometryGroupModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(iOS 17.0,tvOS 17.0,watchOS 10.0,visionOS 1.0,macOS 14.0, *)
+    @available(tvOS 17.0,iOS 17.0,watchOS 10.0,visionOS 1.0,macOS 14.0, *)
     init() {
         self.value = ._0
         
@@ -3327,7 +3327,7 @@ struct _geometryGroupModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case ._0:
-            if #available(iOS 17.0,tvOS 17.0,watchOS 10.0,visionOS 1.0,macOS 14.0, *) {
+            if #available(tvOS 17.0,iOS 17.0,watchOS 10.0,visionOS 1.0,macOS 14.0, *) {
             
             __content
                 .geometryGroup()
@@ -3679,7 +3679,7 @@ struct _groupBoxStyleModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 11.0,visionOS 1.0,iOS 14.0, *)
+    @available(iOS 14.0,visionOS 1.0,macOS 11.0, *)
     init(_ style: AnyGroupBoxStyle) {
         self.value = ._0(style: style)
         
@@ -3692,7 +3692,7 @@ struct _groupBoxStyleModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(style):
-            if #available(macOS 11.0,visionOS 1.0,iOS 14.0, *) {
+            if #available(iOS 14.0,visionOS 1.0,macOS 11.0, *) {
             let style = style as! AnyGroupBoxStyle
             __content
                 .groupBoxStyle(style)
@@ -3982,14 +3982,14 @@ struct _hoverEffectModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(tvOS) || os(visionOS)
-    @available(visionOS 1.0,iOS 13.4,tvOS 16.0, *)
+    @available(iOS 13.4,visionOS 1.0,tvOS 16.0, *)
     init(_ effect: SwiftUI.HoverEffect = .automatic ) {
         self.value = ._0(effect: effect)
         
     }
     #endif
     #if os(iOS) || os(tvOS) || os(visionOS)
-    @available(visionOS 1.0,iOS 17.0,tvOS 17.0, *)
+    @available(tvOS 17.0,iOS 17.0,visionOS 1.0, *)
     init(_ effect: SwiftUI.HoverEffect = .automatic, isEnabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._1(effect: effect, isEnabled: isEnabled)
         
@@ -4002,7 +4002,7 @@ struct _hoverEffectModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(tvOS) || os(visionOS)
         case let ._0(effect):
-            if #available(visionOS 1.0,iOS 13.4,tvOS 16.0, *) {
+            if #available(iOS 13.4,visionOS 1.0,tvOS 16.0, *) {
             let effect = effect as! SwiftUI.HoverEffect 
             __content
                 .hoverEffect(effect)
@@ -4010,7 +4010,7 @@ struct _hoverEffectModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(tvOS) || os(visionOS)
         case let ._1(effect, isEnabled):
-            if #available(visionOS 1.0,iOS 17.0,tvOS 17.0, *) {
+            if #available(tvOS 17.0,iOS 17.0,visionOS 1.0, *) {
             let effect = effect as! SwiftUI.HoverEffect 
 let isEnabled = isEnabled as! AttributeReference<Swift.Bool>
             __content
@@ -4041,7 +4041,7 @@ struct _hoverEffectDisabledModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(tvOS) || os(visionOS)
-    @available(visionOS 1.0,iOS 17.0,tvOS 17.0, *)
+    @available(tvOS 17.0,iOS 17.0,visionOS 1.0, *)
     init(_ disabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(disabled: disabled)
         
@@ -4054,7 +4054,7 @@ struct _hoverEffectDisabledModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(tvOS) || os(visionOS)
         case let ._0(disabled):
-            if #available(visionOS 1.0,iOS 17.0,tvOS 17.0, *) {
+            if #available(tvOS 17.0,iOS 17.0,visionOS 1.0, *) {
             let disabled = disabled as! AttributeReference<Swift.Bool>
             __content
                 .hoverEffectDisabled(disabled.resolve(on: element, in: context))
@@ -4213,7 +4213,7 @@ struct _indexViewStyleModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 8.0,visionOS 1.0,iOS 14.0,tvOS 14.0, *)
+    @available(tvOS 14.0,visionOS 1.0,iOS 14.0,watchOS 8.0, *)
     init(_ style: AnyIndexViewStyle) {
         self.value = ._0(style: style)
         
@@ -4226,7 +4226,7 @@ struct _indexViewStyleModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(style):
-            if #available(watchOS 8.0,visionOS 1.0,iOS 14.0,tvOS 14.0, *) {
+            if #available(tvOS 14.0,visionOS 1.0,iOS 14.0,watchOS 8.0, *) {
             let style = style as! AnyIndexViewStyle
             __content
                 .indexViewStyle(style)
@@ -4256,7 +4256,7 @@ struct _inspectorModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS)
-    @available(iOS 17.0,macOS 14.0, *)
+    @available(macOS 14.0,iOS 17.0, *)
     init(isPresented: ChangeTracked<Swift.Bool>,content: ViewReference=ViewReference(value: [])) {
         self.value = ._0(content: content)
         self.__0_isPresented = isPresented
@@ -4269,7 +4269,7 @@ struct _inspectorModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS)
         case let ._0(content):
-            if #available(iOS 17.0,macOS 14.0, *) {
+            if #available(macOS 14.0,iOS 17.0, *) {
             let content = content as! ViewReference
             __content
                 .inspector(isPresented: __0_isPresented.projectedValue, content: { content.resolve(on: element, in: context) })
@@ -4304,14 +4304,14 @@ struct _inspectorColumnWidthModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS)
-    @available(iOS 17.0,macOS 14.0, *)
+    @available(macOS 14.0,iOS 17.0, *)
     init(min: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), ideal: AttributeReference<CoreFoundation.CGFloat>,max: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)) ) {
         self.value = ._0(min: min, ideal: ideal, max: max)
         
     }
     #endif
     #if os(iOS) || os(macOS)
-    @available(iOS 17.0,macOS 14.0, *)
+    @available(macOS 14.0,iOS 17.0, *)
     init(_ width: AttributeReference<CoreFoundation.CGFloat>) {
         self.value = ._1(width: width)
         
@@ -4324,7 +4324,7 @@ struct _inspectorColumnWidthModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS)
         case let ._0(min, ideal, max):
-            if #available(iOS 17.0,macOS 14.0, *) {
+            if #available(macOS 14.0,iOS 17.0, *) {
             let min = min as? AttributeReference<CoreFoundation.CGFloat?>
 let ideal = ideal as! AttributeReference<CoreFoundation.CGFloat>
 let max = max as? AttributeReference<CoreFoundation.CGFloat?>
@@ -4334,7 +4334,7 @@ let max = max as? AttributeReference<CoreFoundation.CGFloat?>
         #endif
         #if os(iOS) || os(macOS)
         case let ._1(width):
-            if #available(iOS 17.0,macOS 14.0, *) {
+            if #available(macOS 14.0,iOS 17.0, *) {
             let width = width as! AttributeReference<CoreFoundation.CGFloat>
             __content
                 .inspectorColumnWidth(width.resolve(on: element, in: context))
@@ -4450,7 +4450,7 @@ struct _invalidatableContentModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0,visionOS 1.0, *)
+    @available(watchOS 10.0,iOS 17.0,tvOS 17.0,macOS 14.0,visionOS 1.0, *)
     init(_ invalidatable: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(invalidatable: invalidatable)
         
@@ -4463,7 +4463,7 @@ struct _invalidatableContentModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(invalidatable):
-            if #available(macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0,visionOS 1.0, *) {
+            if #available(watchOS 10.0,iOS 17.0,tvOS 17.0,macOS 14.0,visionOS 1.0, *) {
             let invalidatable = invalidatable as! AttributeReference<Swift.Bool>
             __content
                 .invalidatableContent(invalidatable.resolve(on: element, in: context))
@@ -4508,28 +4508,28 @@ struct _keyboardShortcutModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 11.0,visionOS 1.0,iOS 14.0, *)
+    @available(iOS 14.0,visionOS 1.0,macOS 11.0, *)
     init(_ key: SwiftUI.KeyEquivalent,modifiers: SwiftUI.EventModifiers = .command ) {
         self.value = ._0(key: key, modifiers: modifiers)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 11.0,visionOS 1.0,iOS 14.0, *)
+    @available(iOS 14.0,visionOS 1.0,macOS 11.0, *)
     init(_ shortcut: SwiftUI.KeyboardShortcut) {
         self.value = ._1(shortcut: shortcut)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 12.3,visionOS 1.0,iOS 15.4, *)
+    @available(iOS 15.4,visionOS 1.0,macOS 12.3, *)
     init(_ shortcut: SwiftUI.KeyboardShortcut?) {
         self.value = ._2(shortcut: shortcut)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 12.0,visionOS 1.0,iOS 15.0, *)
+    @available(iOS 15.0,visionOS 1.0,macOS 12.0, *)
     init(_ key: SwiftUI.KeyEquivalent,modifiers: SwiftUI.EventModifiers = .command, localization: SwiftUI.KeyboardShortcut.Localization) {
         self.value = ._3(key: key, modifiers: modifiers, localization: localization)
         
@@ -4542,7 +4542,7 @@ struct _keyboardShortcutModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(key, modifiers):
-            if #available(macOS 11.0,visionOS 1.0,iOS 14.0, *) {
+            if #available(iOS 14.0,visionOS 1.0,macOS 11.0, *) {
             let key = key as! SwiftUI.KeyEquivalent
 let modifiers = modifiers as! SwiftUI.EventModifiers 
             __content
@@ -4551,7 +4551,7 @@ let modifiers = modifiers as! SwiftUI.EventModifiers
         #endif
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._1(shortcut):
-            if #available(macOS 11.0,visionOS 1.0,iOS 14.0, *) {
+            if #available(iOS 14.0,visionOS 1.0,macOS 11.0, *) {
             let shortcut = shortcut as! SwiftUI.KeyboardShortcut
             __content
                 .keyboardShortcut(shortcut)
@@ -4559,7 +4559,7 @@ let modifiers = modifiers as! SwiftUI.EventModifiers
         #endif
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._2(shortcut):
-            if #available(macOS 12.3,visionOS 1.0,iOS 15.4, *) {
+            if #available(iOS 15.4,visionOS 1.0,macOS 12.3, *) {
             let shortcut = shortcut as? SwiftUI.KeyboardShortcut
             __content
                 .keyboardShortcut(shortcut)
@@ -4567,7 +4567,7 @@ let modifiers = modifiers as! SwiftUI.EventModifiers
         #endif
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._3(key, modifiers, localization):
-            if #available(macOS 12.0,visionOS 1.0,iOS 15.0, *) {
+            if #available(iOS 15.0,visionOS 1.0,macOS 12.0, *) {
             let key = key as! SwiftUI.KeyEquivalent
 let modifiers = modifiers as! SwiftUI.EventModifiers 
 let localization = localization as! SwiftUI.KeyboardShortcut.Localization
@@ -4599,7 +4599,7 @@ struct _keyboardTypeModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(tvOS) || os(visionOS)
-    @available(visionOS 1.0,iOS 13.0,tvOS 13.0, *)
+    @available(tvOS 13.0,visionOS 1.0,iOS 13.0, *)
     init(_ type: UIKit.UIKeyboardType) {
         self.value = ._0(type: type)
         
@@ -4612,7 +4612,7 @@ struct _keyboardTypeModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(tvOS) || os(visionOS)
         case let ._0(type):
-            if #available(visionOS 1.0,iOS 13.0,tvOS 13.0, *) {
+            if #available(tvOS 13.0,visionOS 1.0,iOS 13.0, *) {
             let type = type as! UIKit.UIKeyboardType
             __content
                 .keyboardType(type)
@@ -4967,10 +4967,10 @@ struct _listItemTintModifier<R: RootRegistry>: ViewModifier {
     enum Value {
         case _never
         
-        indirect case _0(tint: SwiftUI.ListItemTint?)
+        indirect case _0(tint: ListItemTint.Resolvable?)
         
         
-        indirect case _1(tint: AttributeReference<SwiftUI.Color?>?)
+        indirect case _1(tint: Color.Resolvable?)
         
     }
 
@@ -4986,14 +4986,14 @@ struct _listItemTintModifier<R: RootRegistry>: ViewModifier {
 
     
     
-    init(_ tint: SwiftUI.ListItemTint?) {
+    init(_ tint: ListItemTint.Resolvable?) {
         self.value = ._0(tint: tint)
         
     }
     
     
     
-    init(_ tint: AttributeReference<SwiftUI.Color?>?) {
+    init(_ tint: Color.Resolvable?) {
         self.value = ._1(tint: tint)
         
     }
@@ -5008,7 +5008,7 @@ struct _listItemTintModifier<R: RootRegistry>: ViewModifier {
             
             
             __content
-                .listItemTint(tint)
+                .listItemTint(tint?.resolve(on: element, in: context))
             
         
         
@@ -5215,7 +5215,7 @@ struct _listRowSeparatorModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(visionOS 1.0,iOS 15.0,macOS 13.0, *)
+    @available(macOS 13.0,iOS 15.0,visionOS 1.0, *)
     init(_ visibility: AttributeReference<SwiftUI.Visibility>,edges: SwiftUI.VerticalEdge.Set = .all ) {
         self.value = ._0(visibility: visibility, edges: edges)
         
@@ -5228,7 +5228,7 @@ struct _listRowSeparatorModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(visibility, edges):
-            if #available(visionOS 1.0,iOS 15.0,macOS 13.0, *) {
+            if #available(macOS 13.0,iOS 15.0,visionOS 1.0, *) {
             let visibility = visibility as! AttributeReference<SwiftUI.Visibility>
 let edges = edges as! SwiftUI.VerticalEdge.Set 
             __content
@@ -5259,8 +5259,8 @@ struct _listRowSeparatorTintModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(visionOS 1.0,iOS 15.0,macOS 13.0, *)
-    init(_ color: AttributeReference<SwiftUI.Color?>?,edges: SwiftUI.VerticalEdge.Set = .all ) {
+    @available(macOS 13.0,iOS 15.0,visionOS 1.0, *)
+    init(_ color: Color.Resolvable?,edges: SwiftUI.VerticalEdge.Set = .all ) {
         self.value = ._0(color: color, edges: edges)
         
     }
@@ -5272,8 +5272,8 @@ struct _listRowSeparatorTintModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(color, edges):
-            if #available(visionOS 1.0,iOS 15.0,macOS 13.0, *) {
-            let color = color as? AttributeReference<SwiftUI.Color?>
+            if #available(macOS 13.0,iOS 15.0,visionOS 1.0, *) {
+            let color = color as? Color.Resolvable
 let edges = edges as! SwiftUI.VerticalEdge.Set 
             __content
                 .listRowSeparatorTint(color?.resolve(on: element, in: context), edges: edges)
@@ -5303,7 +5303,7 @@ struct _listRowSpacingModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(visionOS)
-    @available(iOS 15.0,visionOS 1.0, *)
+    @available(visionOS 1.0,iOS 15.0, *)
     init(_ spacing: AttributeReference<CoreFoundation.CGFloat?>?) {
         self.value = ._0(spacing: spacing)
         
@@ -5316,7 +5316,7 @@ struct _listRowSpacingModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(visionOS)
         case let ._0(spacing):
-            if #available(iOS 15.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,iOS 15.0, *) {
             let spacing = spacing as? AttributeReference<CoreFoundation.CGFloat?>
             __content
                 .listRowSpacing(spacing?.resolve(on: element, in: context))
@@ -5346,7 +5346,7 @@ struct _listSectionSeparatorModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(visionOS 1.0,iOS 15.0,macOS 13.0, *)
+    @available(macOS 13.0,iOS 15.0,visionOS 1.0, *)
     init(_ visibility: AttributeReference<SwiftUI.Visibility>,edges: SwiftUI.VerticalEdge.Set = .all ) {
         self.value = ._0(visibility: visibility, edges: edges)
         
@@ -5359,7 +5359,7 @@ struct _listSectionSeparatorModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(visibility, edges):
-            if #available(visionOS 1.0,iOS 15.0,macOS 13.0, *) {
+            if #available(macOS 13.0,iOS 15.0,visionOS 1.0, *) {
             let visibility = visibility as! AttributeReference<SwiftUI.Visibility>
 let edges = edges as! SwiftUI.VerticalEdge.Set 
             __content
@@ -5390,8 +5390,8 @@ struct _listSectionSeparatorTintModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(visionOS 1.0,iOS 15.0,macOS 13.0, *)
-    init(_ color: AttributeReference<SwiftUI.Color?>?,edges: SwiftUI.VerticalEdge.Set = .all ) {
+    @available(macOS 13.0,visionOS 1.0,iOS 15.0, *)
+    init(_ color: Color.Resolvable?,edges: SwiftUI.VerticalEdge.Set = .all ) {
         self.value = ._0(color: color, edges: edges)
         
     }
@@ -5403,8 +5403,8 @@ struct _listSectionSeparatorTintModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(color, edges):
-            if #available(visionOS 1.0,iOS 15.0,macOS 13.0, *) {
-            let color = color as? AttributeReference<SwiftUI.Color?>
+            if #available(macOS 13.0,visionOS 1.0,iOS 15.0, *) {
+            let color = color as? Color.Resolvable
 let edges = edges as! SwiftUI.VerticalEdge.Set 
             __content
                 .listSectionSeparatorTint(color?.resolve(on: element, in: context), edges: edges)
@@ -5439,14 +5439,14 @@ struct _listSectionSpacingModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(visionOS) || os(watchOS)
-    @available(iOS 17.0,visionOS 1.0,watchOS 10.0, *)
+    @available(visionOS 1.0,iOS 17.0,watchOS 10.0, *)
     init(_ spacing: SwiftUI.ListSectionSpacing) {
         self.value = ._0(spacing: spacing)
         
     }
     #endif
     #if os(iOS) || os(visionOS) || os(watchOS)
-    @available(iOS 17.0,visionOS 1.0,watchOS 10.0, *)
+    @available(iOS 17.0,watchOS 10.0,visionOS 1.0, *)
     init(_ spacing: AttributeReference<CoreFoundation.CGFloat>) {
         self.value = ._1(spacing: spacing)
         
@@ -5459,7 +5459,7 @@ struct _listSectionSpacingModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(visionOS) || os(watchOS)
         case let ._0(spacing):
-            if #available(iOS 17.0,visionOS 1.0,watchOS 10.0, *) {
+            if #available(visionOS 1.0,iOS 17.0,watchOS 10.0, *) {
             let spacing = spacing as! SwiftUI.ListSectionSpacing
             __content
                 .listSectionSpacing(spacing)
@@ -5467,7 +5467,7 @@ struct _listSectionSpacingModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(visionOS) || os(watchOS)
         case let ._1(spacing):
-            if #available(iOS 17.0,visionOS 1.0,watchOS 10.0, *) {
+            if #available(iOS 17.0,watchOS 10.0,visionOS 1.0, *) {
             let spacing = spacing as! AttributeReference<CoreFoundation.CGFloat>
             __content
                 .listSectionSpacing(spacing.resolve(on: element, in: context))
@@ -5583,7 +5583,7 @@ struct _menuIndicatorModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS)
-    @available(iOS 15.0,macOS 12.0,tvOS 17.0,visionOS 1.0, *)
+    @available(iOS 15.0,tvOS 17.0,visionOS 1.0,macOS 12.0, *)
     init(_ visibility: AttributeReference<SwiftUI.Visibility>) {
         self.value = ._0(visibility: visibility)
         
@@ -5596,7 +5596,7 @@ struct _menuIndicatorModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS)
         case let ._0(visibility):
-            if #available(iOS 15.0,macOS 12.0,tvOS 17.0,visionOS 1.0, *) {
+            if #available(iOS 15.0,tvOS 17.0,visionOS 1.0,macOS 12.0, *) {
             let visibility = visibility as! AttributeReference<SwiftUI.Visibility>
             __content
                 .menuIndicator(visibility.resolve(on: element, in: context))
@@ -5669,7 +5669,7 @@ struct _menuStyleModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS)
-    @available(macOS 11.0,iOS 14.0,tvOS 17.0,visionOS 1.0, *)
+    @available(iOS 14.0,tvOS 17.0,macOS 11.0,visionOS 1.0, *)
     init(_ style: AnyMenuStyle) {
         self.value = ._0(style: style)
         
@@ -5682,7 +5682,7 @@ struct _menuStyleModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS)
         case let ._0(style):
-            if #available(macOS 11.0,iOS 14.0,tvOS 17.0,visionOS 1.0, *) {
+            if #available(iOS 14.0,tvOS 17.0,macOS 11.0,visionOS 1.0, *) {
             let style = style as! AnyMenuStyle
             __content
                 .menuStyle(style)
@@ -5884,7 +5884,7 @@ struct _navigationBarTitleDisplayModeModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(visionOS) || os(watchOS)
-    @available(iOS 14.0,visionOS 1.0,watchOS 8.0, *)
+    @available(iOS 14.0,watchOS 8.0,visionOS 1.0, *)
     init(_ displayMode: SwiftUI.NavigationBarItem.TitleDisplayMode) {
         self.value = ._0(displayMode: displayMode)
         
@@ -5897,7 +5897,7 @@ struct _navigationBarTitleDisplayModeModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(visionOS) || os(watchOS)
         case let ._0(displayMode):
-            if #available(iOS 14.0,visionOS 1.0,watchOS 8.0, *) {
+            if #available(iOS 14.0,watchOS 8.0,visionOS 1.0, *) {
             let displayMode = displayMode as! SwiftUI.NavigationBarItem.TitleDisplayMode
             __content
                 .navigationBarTitleDisplayMode(displayMode)
@@ -6086,21 +6086,21 @@ struct _navigationSubtitleModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(macOS) || targetEnvironment(macCatalyst)
-    @available(macCatalyst 14.0,macOS 11.0, *)
+    @available(macOS 11.0,macCatalyst 14.0, *)
     init(_ subtitle: TextReference) {
         self.value = ._0(subtitle: subtitle)
         
     }
     #endif
     #if os(macOS) || targetEnvironment(macCatalyst)
-    @available(macCatalyst 14.0,macOS 11.0, *)
+    @available(macOS 11.0,macCatalyst 14.0, *)
     init(_ subtitleKey: SwiftUI.LocalizedStringKey) {
         self.value = ._1(subtitleKey: subtitleKey)
         
     }
     #endif
     #if os(macOS) || targetEnvironment(macCatalyst)
-    @available(macCatalyst 14.0,macOS 11.0, *)
+    @available(macOS 11.0,macCatalyst 14.0, *)
     init(_ subtitle: AttributeReference<String>) {
         self.value = ._2(subtitle: subtitle)
         
@@ -6113,7 +6113,7 @@ struct _navigationSubtitleModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(macOS) || targetEnvironment(macCatalyst)
         case let ._0(subtitle):
-            if #available(macCatalyst 14.0,macOS 11.0, *) {
+            if #available(macOS 11.0,macCatalyst 14.0, *) {
             let subtitle = subtitle as! TextReference
             __content
                 .navigationSubtitle(subtitle.resolve(on: element, in: context))
@@ -6121,7 +6121,7 @@ struct _navigationSubtitleModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(macOS) || targetEnvironment(macCatalyst)
         case let ._1(subtitleKey):
-            if #available(macCatalyst 14.0,macOS 11.0, *) {
+            if #available(macOS 11.0,macCatalyst 14.0, *) {
             let subtitleKey = subtitleKey as! SwiftUI.LocalizedStringKey
             __content
                 .navigationSubtitle(subtitleKey)
@@ -6129,7 +6129,7 @@ struct _navigationSubtitleModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(macOS) || targetEnvironment(macCatalyst)
         case let ._2(subtitle):
-            if #available(macCatalyst 14.0,macOS 11.0, *) {
+            if #available(macOS 11.0,macCatalyst 14.0, *) {
             let subtitle = subtitle as! AttributeReference<String>
             __content
                 .navigationSubtitle(subtitle.resolve(on: element, in: context))
@@ -6200,7 +6200,7 @@ struct _navigationTitleModifier<R: RootRegistry>: ViewModifier {
     }
     
     #if os(watchOS)
-    @available(macOS 11.0,watchOS 7.0,tvOS 14.0,iOS 14.0, *)
+    @available(tvOS 14.0,macOS 11.0,iOS 14.0,watchOS 7.0, *)
     init(_ title: ViewReference=ViewReference(value: [])) {
         self.value = ._3(title: title)
         
@@ -6244,7 +6244,7 @@ struct _navigationTitleModifier<R: RootRegistry>: ViewModifier {
         
         #if os(watchOS)
         case let ._3(title):
-            if #available(macOS 11.0,watchOS 7.0,tvOS 14.0,iOS 14.0, *) {
+            if #available(tvOS 14.0,macOS 11.0,iOS 14.0,watchOS 7.0, *) {
             let title = title as! ViewReference
             __content
                 .navigationTitle({ title.resolve(on: element, in: context) })
@@ -6408,7 +6408,7 @@ struct _onDeleteCommandModifier<R: RootRegistry>: ViewModifier {
 @Event private var _0_action__0: Event.EventHandler
 
     #if os(macOS)
-    @available(tvOS 13.0,macOS 10.15, *)
+    @available(macOS 10.15,tvOS 13.0, *)
     init(perform action__0: Event=Event()) {
         self.value = ._0
         self.__0_action__0 = action__0
@@ -6421,7 +6421,7 @@ struct _onDeleteCommandModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(macOS)
         case ._0:
-            if #available(tvOS 13.0,macOS 10.15, *) {
+            if #available(macOS 10.15,tvOS 13.0, *) {
             
             __content
                 .onDeleteCommand(perform: { __0_action__0.wrappedValue() })
@@ -6494,7 +6494,7 @@ struct _onExitCommandModifier<R: RootRegistry>: ViewModifier {
 @Event private var _0_action__0: Event.EventHandler
 
     #if os(macOS) || os(tvOS)
-    @available(tvOS 13.0,macOS 10.15, *)
+    @available(macOS 10.15,tvOS 13.0, *)
     init(perform action__0: Event=Event()) {
         self.value = ._0
         self.__0_action__0 = action__0
@@ -6507,7 +6507,7 @@ struct _onExitCommandModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(macOS) || os(tvOS)
         case ._0:
-            if #available(tvOS 13.0,macOS 10.15, *) {
+            if #available(macOS 10.15,tvOS 13.0, *) {
             
             __content
                 .onExitCommand(perform: { __0_action__0.wrappedValue() })
@@ -6537,7 +6537,7 @@ struct _onHoverModifier<R: RootRegistry>: ViewModifier {
 @Event private var _0_action__1: Event.EventHandler
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(visionOS 1.0,iOS 13.4,macOS 10.15, *)
+    @available(iOS 13.4,visionOS 1.0,macOS 10.15, *)
     init(perform action__1: Event) {
         self.value = ._0
         self.__0_action__1 = action__1
@@ -6550,7 +6550,7 @@ struct _onHoverModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case ._0:
-            if #available(visionOS 1.0,iOS 13.4,macOS 10.15, *) {
+            if #available(iOS 13.4,visionOS 1.0,macOS 10.15, *) {
             
             __content
                 .onHover(perform: { __0_action__1.wrappedValue(value: $0) })
@@ -6587,7 +6587,7 @@ struct _onLongPressGestureModifier<R: RootRegistry>: ViewModifier {
 @Event private var _1_onPressingChanged__1: Event.EventHandler
 
     #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,iOS 13.0,watchOS 6.0,macOS 10.15,tvOS 14.0, *)
+    @available(visionOS 1.0,tvOS 14.0,macOS 10.15,watchOS 6.0,iOS 13.0, *)
     init(minimumDuration: AttributeReference<Swift.Double> = .init(storage: .constant(0.5)), maximumDistance: AttributeReference<CoreFoundation.CGFloat> = .init(storage: .constant(10)), perform action__0: Event,onPressingChanged onPressingChanged__1: Event=Event() ) {
         self.value = ._0(minimumDuration: minimumDuration, maximumDistance: maximumDistance)
         self.__0_action__0 = action__0
@@ -6595,7 +6595,7 @@ self.__0_onPressingChanged__1 = onPressingChanged__1
     }
     #endif
     #if os(tvOS)
-    @available(iOS 13.0,watchOS 6.0,macOS 10.15,tvOS 14.0, *)
+    @available(tvOS 14.0,macOS 10.15,watchOS 6.0,iOS 13.0, *)
     init(minimumDuration: AttributeReference<Swift.Double> = .init(storage: .constant(0.5)), perform action__0: Event,onPressingChanged onPressingChanged__1: Event=Event() ) {
         self.value = ._1(minimumDuration: minimumDuration)
         self.__1_action__0 = action__0
@@ -6609,7 +6609,7 @@ self.__1_onPressingChanged__1 = onPressingChanged__1
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
         case let ._0(minimumDuration, maximumDistance):
-            if #available(visionOS 1.0,iOS 13.0,watchOS 6.0,macOS 10.15,tvOS 14.0, *) {
+            if #available(visionOS 1.0,tvOS 14.0,macOS 10.15,watchOS 6.0,iOS 13.0, *) {
             let minimumDuration = minimumDuration as! AttributeReference<Swift.Double>
 let maximumDistance = maximumDistance as! AttributeReference<CoreFoundation.CGFloat>
             __content
@@ -6618,7 +6618,7 @@ let maximumDistance = maximumDistance as! AttributeReference<CoreFoundation.CGFl
         #endif
         #if os(tvOS)
         case let ._1(minimumDuration):
-            if #available(iOS 13.0,watchOS 6.0,macOS 10.15,tvOS 14.0, *) {
+            if #available(tvOS 14.0,macOS 10.15,watchOS 6.0,iOS 13.0, *) {
             let minimumDuration = minimumDuration as! AttributeReference<Swift.Double>
             __content
                 .onLongPressGesture(minimumDuration: minimumDuration.resolve(on: element, in: context), perform: { __1_action__0.wrappedValue() }, onPressingChanged: { __1_onPressingChanged__1.wrappedValue(value: $0) })
@@ -6693,7 +6693,7 @@ struct _onMoveCommandModifier<R: RootRegistry>: ViewModifier {
 @Event private var _0_action__1: Event.EventHandler
 
     #if os(macOS) || os(tvOS)
-    @available(tvOS 13.0,macOS 10.15, *)
+    @available(macOS 10.15,tvOS 13.0, *)
     init(perform action__1: Event=Event()) {
         self.value = ._0
         self.__0_action__1 = action__1
@@ -6706,7 +6706,7 @@ struct _onMoveCommandModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(macOS) || os(tvOS)
         case ._0:
-            if #available(tvOS 13.0,macOS 10.15, *) {
+            if #available(macOS 10.15,tvOS 13.0, *) {
             
             __content
                 .onMoveCommand(perform: { __0_action__1.wrappedValue(value: $0) })
@@ -6736,7 +6736,7 @@ struct _onPlayPauseCommandModifier<R: RootRegistry>: ViewModifier {
 @Event private var _0_action__0: Event.EventHandler
 
     #if os(tvOS)
-    @available(tvOS 13.0,macOS 10.15, *)
+    @available(macOS 10.15,tvOS 13.0, *)
     init(perform action__0: Event=Event()) {
         self.value = ._0
         self.__0_action__0 = action__0
@@ -6749,7 +6749,7 @@ struct _onPlayPauseCommandModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(tvOS)
         case ._0:
-            if #available(tvOS 13.0,macOS 10.15, *) {
+            if #available(macOS 10.15,tvOS 13.0, *) {
             
             __content
                 .onPlayPauseCommand(perform: { __0_action__0.wrappedValue() })
@@ -6791,7 +6791,7 @@ struct _onTapGestureModifier<R: RootRegistry>: ViewModifier {
     }
     
     #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
-    @available(iOS 17.0,macOS 14.0,watchOS 10.0,visionOS 1.0, *)
+    @available(iOS 17.0,visionOS 1.0,watchOS 10.0,macOS 14.0, *)
     init(count: AttributeReference<Swift.Int> = .init(storage: .constant(1)), coordinateSpace: AnyCoordinateSpaceProtocol = .local, perform action__1: Event) {
         self.value = ._1(count: count, coordinateSpace: coordinateSpace)
         self.__1_action__1 = action__1
@@ -6812,7 +6812,7 @@ struct _onTapGestureModifier<R: RootRegistry>: ViewModifier {
         
         #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
         case let ._1(count, coordinateSpace):
-            if #available(iOS 17.0,macOS 14.0,watchOS 10.0,visionOS 1.0, *) {
+            if #available(iOS 17.0,visionOS 1.0,watchOS 10.0,macOS 14.0, *) {
             let count = count as! AttributeReference<Swift.Int>
 let coordinateSpace = coordinateSpace as! AnyCoordinateSpaceProtocol 
             __content
@@ -6922,10 +6922,10 @@ struct _overlayModifier<R: RootRegistry>: ViewModifier {
         indirect case _0(alignment: AttributeReference<SwiftUI.Alignment> = .init(storage: .constant(.center)), content: ViewReference=ViewReference(value: []))
         
         
-        indirect case _1(style: AnyShapeStyle,edges: SwiftUI.Edge.Set = .all )
+        indirect case _1(style: AnyShapeStyle.Resolvable,edges: SwiftUI.Edge.Set = .all )
         
         
-        indirect case _2(style: AnyShapeStyle,shape: AnyShape,fillStyle: SwiftUI.FillStyle = FillStyle() )
+        indirect case _2(style: AnyShapeStyle.Resolvable,shape: AnyShape,fillStyle: SwiftUI.FillStyle = FillStyle() )
         
     }
 
@@ -6950,14 +6950,14 @@ struct _overlayModifier<R: RootRegistry>: ViewModifier {
     
     
     
-    init(_ style: AnyShapeStyle,ignoresSafeAreaEdges edges: SwiftUI.Edge.Set = .all ) {
+    init(_ style: AnyShapeStyle.Resolvable,ignoresSafeAreaEdges edges: SwiftUI.Edge.Set = .all ) {
         self.value = ._1(style: style, edges: edges)
         
     }
     
     
     
-    init(_ style: AnyShapeStyle,in shape: AnyShape,fillStyle: SwiftUI.FillStyle = FillStyle() ) {
+    init(_ style: AnyShapeStyle.Resolvable,in shape: AnyShape,fillStyle: SwiftUI.FillStyle = FillStyle() ) {
         self.value = ._2(style: style, shape: shape, fillStyle: fillStyle)
         
     }
@@ -6980,7 +6980,7 @@ struct _overlayModifier<R: RootRegistry>: ViewModifier {
             
             
             __content
-                .overlay(style, ignoresSafeAreaEdges: edges)
+                .overlay(style.resolve(on: element, in: context), ignoresSafeAreaEdges: edges)
             
         
         
@@ -6988,7 +6988,7 @@ struct _overlayModifier<R: RootRegistry>: ViewModifier {
             
             
             __content
-                .overlay(style, in: shape, fillStyle: fillStyle)
+                .overlay(style.resolve(on: element, in: context), in: shape, fillStyle: fillStyle)
             
         
         }
@@ -7467,14 +7467,14 @@ struct _presentationBackgroundModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(iOS 16.4,macOS 13.3,tvOS 16.4,watchOS 9.4,visionOS 1.0, *)
-    init(_ style: AnyShapeStyle) {
+    @available(iOS 16.4,visionOS 1.0,macOS 13.3,tvOS 16.4,watchOS 9.4, *)
+    init(_ style: AnyShapeStyle.Resolvable) {
         self.value = ._0(style: style)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(iOS 16.4,macOS 13.3,tvOS 16.4,watchOS 9.4,visionOS 1.0, *)
+    @available(iOS 16.4,visionOS 1.0,macOS 13.3,tvOS 16.4,watchOS 9.4, *)
     init(alignment: AttributeReference<SwiftUI.Alignment> = .init(storage: .constant(.center)), content: ViewReference=ViewReference(value: [])) {
         self.value = ._1(alignment: alignment, content: content)
         
@@ -7487,15 +7487,15 @@ struct _presentationBackgroundModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(style):
-            if #available(iOS 16.4,macOS 13.3,tvOS 16.4,watchOS 9.4,visionOS 1.0, *) {
-            let style = style as! AnyShapeStyle
+            if #available(iOS 16.4,visionOS 1.0,macOS 13.3,tvOS 16.4,watchOS 9.4, *) {
+            let style = style as! AnyShapeStyle.Resolvable
             __content
-                .presentationBackground(style)
+                .presentationBackground(style.resolve(on: element, in: context))
             } else { __content }
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(alignment, content):
-            if #available(iOS 16.4,macOS 13.3,tvOS 16.4,watchOS 9.4,visionOS 1.0, *) {
+            if #available(iOS 16.4,visionOS 1.0,macOS 13.3,tvOS 16.4,watchOS 9.4, *) {
             let alignment = alignment as! AttributeReference<SwiftUI.Alignment>
 let content = content as! ViewReference
             __content
@@ -7526,7 +7526,7 @@ struct _presentationBackgroundInteractionModifier<R: RootRegistry>: ViewModifier
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(iOS 16.4,macOS 13.3,tvOS 16.4,watchOS 9.4,visionOS 1.0, *)
+    @available(iOS 16.4,tvOS 16.4,watchOS 9.4,visionOS 1.0,macOS 13.3, *)
     init(_ interaction: SwiftUI.PresentationBackgroundInteraction) {
         self.value = ._0(interaction: interaction)
         
@@ -7539,7 +7539,7 @@ struct _presentationBackgroundInteractionModifier<R: RootRegistry>: ViewModifier
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(interaction):
-            if #available(iOS 16.4,macOS 13.3,tvOS 16.4,watchOS 9.4,visionOS 1.0, *) {
+            if #available(iOS 16.4,tvOS 16.4,watchOS 9.4,visionOS 1.0,macOS 13.3, *) {
             let interaction = interaction as! SwiftUI.PresentationBackgroundInteraction
             __content
                 .presentationBackgroundInteraction(interaction)
@@ -7574,14 +7574,14 @@ struct _presentationCompactAdaptationModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(iOS 16.4,macOS 13.3,tvOS 16.4,watchOS 9.4,visionOS 1.0, *)
+    @available(iOS 16.4,tvOS 16.4,watchOS 9.4,visionOS 1.0,macOS 13.3, *)
     init(_ adaptation: SwiftUI.PresentationAdaptation) {
         self.value = ._0(adaptation: adaptation)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(iOS 16.4,macOS 13.3,tvOS 16.4,watchOS 9.4,visionOS 1.0, *)
+    @available(iOS 16.4,visionOS 1.0,macOS 13.3,tvOS 16.4,watchOS 9.4, *)
     init(horizontal horizontalAdaptation: SwiftUI.PresentationAdaptation,vertical verticalAdaptation: SwiftUI.PresentationAdaptation) {
         self.value = ._1(horizontalAdaptation: horizontalAdaptation, verticalAdaptation: verticalAdaptation)
         
@@ -7594,7 +7594,7 @@ struct _presentationCompactAdaptationModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(adaptation):
-            if #available(iOS 16.4,macOS 13.3,tvOS 16.4,watchOS 9.4,visionOS 1.0, *) {
+            if #available(iOS 16.4,tvOS 16.4,watchOS 9.4,visionOS 1.0,macOS 13.3, *) {
             let adaptation = adaptation as! SwiftUI.PresentationAdaptation
             __content
                 .presentationCompactAdaptation(adaptation)
@@ -7602,7 +7602,7 @@ struct _presentationCompactAdaptationModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(horizontalAdaptation, verticalAdaptation):
-            if #available(iOS 16.4,macOS 13.3,tvOS 16.4,watchOS 9.4,visionOS 1.0, *) {
+            if #available(iOS 16.4,visionOS 1.0,macOS 13.3,tvOS 16.4,watchOS 9.4, *) {
             let horizontalAdaptation = horizontalAdaptation as! SwiftUI.PresentationAdaptation
 let verticalAdaptation = verticalAdaptation as! SwiftUI.PresentationAdaptation
             __content
@@ -7633,7 +7633,7 @@ struct _presentationContentInteractionModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(iOS 16.4,macOS 13.3,tvOS 16.4,watchOS 9.4,visionOS 1.0, *)
+    @available(iOS 16.4,tvOS 16.4,watchOS 9.4,visionOS 1.0,macOS 13.3, *)
     init(_ behavior: SwiftUI.PresentationContentInteraction) {
         self.value = ._0(behavior: behavior)
         
@@ -7646,7 +7646,7 @@ struct _presentationContentInteractionModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(behavior):
-            if #available(iOS 16.4,macOS 13.3,tvOS 16.4,watchOS 9.4,visionOS 1.0, *) {
+            if #available(iOS 16.4,tvOS 16.4,watchOS 9.4,visionOS 1.0,macOS 13.3, *) {
             let behavior = behavior as! SwiftUI.PresentationContentInteraction
             __content
                 .presentationContentInteraction(behavior)
@@ -7676,7 +7676,7 @@ struct _presentationCornerRadiusModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(iOS 16.4,macOS 13.3,tvOS 16.4,watchOS 9.4,visionOS 1.0, *)
+    @available(iOS 16.4,tvOS 16.4,watchOS 9.4,visionOS 1.0,macOS 13.3, *)
     init(_ cornerRadius: AttributeReference<CoreFoundation.CGFloat?>?) {
         self.value = ._0(cornerRadius: cornerRadius)
         
@@ -7689,7 +7689,7 @@ struct _presentationCornerRadiusModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(cornerRadius):
-            if #available(iOS 16.4,macOS 13.3,tvOS 16.4,watchOS 9.4,visionOS 1.0, *) {
+            if #available(iOS 16.4,tvOS 16.4,watchOS 9.4,visionOS 1.0,macOS 13.3, *) {
             let cornerRadius = cornerRadius as? AttributeReference<CoreFoundation.CGFloat?>
             __content
                 .presentationCornerRadius(cornerRadius?.resolve(on: element, in: context))
@@ -8063,7 +8063,7 @@ struct _replaceDisabledModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(visionOS)
-    @available(visionOS 1.0,iOS 16.0, *)
+    @available(iOS 16.0,visionOS 1.0, *)
     init(_ isDisabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(isDisabled: isDisabled)
         
@@ -8076,7 +8076,7 @@ struct _replaceDisabledModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(visionOS)
         case let ._0(isDisabled):
-            if #available(visionOS 1.0,iOS 16.0, *) {
+            if #available(iOS 16.0,visionOS 1.0, *) {
             let isDisabled = isDisabled as! AttributeReference<Swift.Bool>
             __content
                 .replaceDisabled(isDisabled.resolve(on: element, in: context))
@@ -8552,7 +8552,7 @@ struct _scrollBounceBehaviorModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 13.3,visionOS 1.0,tvOS 16.4,watchOS 9.4,iOS 16.4, *)
+    @available(watchOS 9.4,iOS 16.4,tvOS 16.4,macOS 13.3,visionOS 1.0, *)
     init(_ behavior: SwiftUI.ScrollBounceBehavior,axes: SwiftUI.Axis.Set = [.vertical] ) {
         self.value = ._0(behavior: behavior, axes: axes)
         
@@ -8565,7 +8565,7 @@ struct _scrollBounceBehaviorModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(behavior, axes):
-            if #available(macOS 13.3,visionOS 1.0,tvOS 16.4,watchOS 9.4,iOS 16.4, *) {
+            if #available(watchOS 9.4,iOS 16.4,tvOS 16.4,macOS 13.3,visionOS 1.0, *) {
             let behavior = behavior as! SwiftUI.ScrollBounceBehavior
 let axes = axes as! SwiftUI.Axis.Set 
             __content
@@ -8596,7 +8596,7 @@ struct _scrollClipDisabledModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 14.0,watchOS 10.0,tvOS 17.0,visionOS 1.0,iOS 17.0, *)
+    @available(watchOS 10.0,iOS 17.0,tvOS 17.0,macOS 14.0,visionOS 1.0, *)
     init(_ disabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(disabled: disabled)
         
@@ -8609,7 +8609,7 @@ struct _scrollClipDisabledModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(disabled):
-            if #available(macOS 14.0,watchOS 10.0,tvOS 17.0,visionOS 1.0,iOS 17.0, *) {
+            if #available(watchOS 10.0,iOS 17.0,tvOS 17.0,macOS 14.0,visionOS 1.0, *) {
             let disabled = disabled as! AttributeReference<Swift.Bool>
             __content
                 .scrollClipDisabled(disabled.resolve(on: element, in: context))
@@ -8639,7 +8639,7 @@ struct _scrollContentBackgroundModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,macOS 13.0,watchOS 9.0,iOS 16.0, *)
+    @available(visionOS 1.0,iOS 16.0,watchOS 9.0,macOS 13.0, *)
     init(_ visibility: AttributeReference<SwiftUI.Visibility>) {
         self.value = ._0(visibility: visibility)
         
@@ -8652,7 +8652,7 @@ struct _scrollContentBackgroundModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
         case let ._0(visibility):
-            if #available(visionOS 1.0,macOS 13.0,watchOS 9.0,iOS 16.0, *) {
+            if #available(visionOS 1.0,iOS 16.0,watchOS 9.0,macOS 13.0, *) {
             let visibility = visibility as! AttributeReference<SwiftUI.Visibility>
             __content
                 .scrollContentBackground(visibility.resolve(on: element, in: context))
@@ -8725,7 +8725,7 @@ struct _scrollDismissesKeyboardModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-    @available(macOS 13.0,tvOS 16.0,watchOS 9.0,iOS 16.0, *)
+    @available(watchOS 9.0,iOS 16.0,tvOS 16.0,macOS 13.0, *)
     init(_ mode: SwiftUI.ScrollDismissesKeyboardMode) {
         self.value = ._0(mode: mode)
         
@@ -8738,7 +8738,7 @@ struct _scrollDismissesKeyboardModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
         case let ._0(mode):
-            if #available(macOS 13.0,tvOS 16.0,watchOS 9.0,iOS 16.0, *) {
+            if #available(watchOS 9.0,iOS 16.0,tvOS 16.0,macOS 13.0, *) {
             let mode = mode as! SwiftUI.ScrollDismissesKeyboardMode
             __content
                 .scrollDismissesKeyboard(mode)
@@ -8816,14 +8816,14 @@ struct _scrollIndicatorsFlashModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 14.0,visionOS 1.0,tvOS 17.0,watchOS 10.0,iOS 17.0, *)
+    @available(iOS 17.0,tvOS 17.0,watchOS 10.0,visionOS 1.0,macOS 14.0, *)
     init(trigger value: AttributeReference<String>) {
         self.value = ._0(value: value)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 14.0,visionOS 1.0,tvOS 17.0,watchOS 10.0,iOS 17.0, *)
+    @available(iOS 17.0,tvOS 17.0,watchOS 10.0,visionOS 1.0,macOS 14.0, *)
     init(onAppear: AttributeReference<Swift.Bool>) {
         self.value = ._1(onAppear: onAppear)
         
@@ -8836,7 +8836,7 @@ struct _scrollIndicatorsFlashModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(value):
-            if #available(macOS 14.0,visionOS 1.0,tvOS 17.0,watchOS 10.0,iOS 17.0, *) {
+            if #available(iOS 17.0,tvOS 17.0,watchOS 10.0,visionOS 1.0,macOS 14.0, *) {
             let value = value as! AttributeReference<String>
             __content
                 .scrollIndicatorsFlash(trigger: value.resolve(on: element, in: context))
@@ -8844,7 +8844,7 @@ struct _scrollIndicatorsFlashModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(onAppear):
-            if #available(macOS 14.0,visionOS 1.0,tvOS 17.0,watchOS 10.0,iOS 17.0, *) {
+            if #available(iOS 17.0,tvOS 17.0,watchOS 10.0,visionOS 1.0,macOS 14.0, *) {
             let onAppear = onAppear as! AttributeReference<Swift.Bool>
             __content
                 .scrollIndicatorsFlash(onAppear: onAppear.resolve(on: element, in: context))
@@ -8874,7 +8874,7 @@ struct _scrollPositionModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 14.0,iOS 17.0,tvOS 17.0,visionOS 1.0,watchOS 10.0, *)
+    @available(watchOS 10.0,iOS 17.0,tvOS 17.0,macOS 14.0,visionOS 1.0, *)
     init(id: ChangeTracked<String?>,anchor: AttributeReference<SwiftUI.UnitPoint?>? = .init(storage: .constant(nil)) ) {
         self.value = ._0(anchor: anchor)
         self.__0_id = id
@@ -8887,7 +8887,7 @@ struct _scrollPositionModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(anchor):
-            if #available(macOS 14.0,iOS 17.0,tvOS 17.0,visionOS 1.0,watchOS 10.0, *) {
+            if #available(watchOS 10.0,iOS 17.0,tvOS 17.0,macOS 14.0,visionOS 1.0, *) {
             let anchor = anchor as? AttributeReference<SwiftUI.UnitPoint?>
             __content
                 .scrollPosition(id: __0_id.projectedValue, anchor: anchor?.resolve(on: element, in: context))
@@ -8917,7 +8917,7 @@ struct _scrollTargetBehaviorModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 10.0,visionOS 1.0,iOS 17.0,macOS 14.0,tvOS 17.0, *)
+    @available(tvOS 17.0,watchOS 10.0,iOS 17.0,macOS 14.0,visionOS 1.0, *)
     init(_ behavior: AnyScrollTargetBehavior) {
         self.value = ._0(behavior: behavior)
         
@@ -8930,7 +8930,7 @@ struct _scrollTargetBehaviorModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(behavior):
-            if #available(watchOS 10.0,visionOS 1.0,iOS 17.0,macOS 14.0,tvOS 17.0, *) {
+            if #available(tvOS 17.0,watchOS 10.0,iOS 17.0,macOS 14.0,visionOS 1.0, *) {
             let behavior = behavior as! AnyScrollTargetBehavior
             __content
                 .scrollTargetBehavior(behavior)
@@ -8960,7 +8960,7 @@ struct _scrollTargetLayoutModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 10.0,visionOS 1.0,iOS 17.0,macOS 14.0,tvOS 17.0, *)
+    @available(tvOS 17.0,watchOS 10.0,iOS 17.0,macOS 14.0,visionOS 1.0, *)
     init(isEnabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(isEnabled: isEnabled)
         
@@ -8973,7 +8973,7 @@ struct _scrollTargetLayoutModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(isEnabled):
-            if #available(watchOS 10.0,visionOS 1.0,iOS 17.0,macOS 14.0,tvOS 17.0, *) {
+            if #available(tvOS 17.0,watchOS 10.0,iOS 17.0,macOS 14.0,visionOS 1.0, *) {
             let isEnabled = isEnabled as! AttributeReference<Swift.Bool>
             __content
                 .scrollTargetLayout(isEnabled: isEnabled.resolve(on: element, in: context))
@@ -9046,7 +9046,7 @@ struct _searchPresentationToolbarBehaviorModifier<R: RootRegistry>: ViewModifier
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 14.1,watchOS 10.1,iOS 17.1,tvOS 17.1,visionOS 1.0, *)
+    @available(watchOS 10.1,iOS 17.1,tvOS 17.1,macOS 14.1,visionOS 1.0, *)
     init(_ behavior: SwiftUI.SearchPresentationToolbarBehavior) {
         self.value = ._0(behavior: behavior)
         
@@ -9059,7 +9059,7 @@ struct _searchPresentationToolbarBehaviorModifier<R: RootRegistry>: ViewModifier
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(behavior):
-            if #available(macOS 14.1,watchOS 10.1,iOS 17.1,tvOS 17.1,visionOS 1.0, *) {
+            if #available(watchOS 10.1,iOS 17.1,tvOS 17.1,macOS 14.1,visionOS 1.0, *) {
             let behavior = behavior as! SwiftUI.SearchPresentationToolbarBehavior
             __content
                 .searchPresentationToolbarBehavior(behavior)
@@ -9201,7 +9201,7 @@ struct _searchableModifier<R: RootRegistry>: ViewModifier {
     }
     
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(iOS 17.0,visionOS 1.0,macOS 14.0, *)
+    @available(macOS 14.0,iOS 17.0,visionOS 1.0, *)
     init(text: ChangeTracked<Swift.String>,isPresented: ChangeTracked<Swift.Bool>,placement: SwiftUI.SearchFieldPlacement = .automatic, prompt: TextReference? = nil ) {
         self.value = ._3(placement: placement, prompt: prompt)
         self.__3_text = text
@@ -9209,7 +9209,7 @@ self.__3_isPresented = isPresented
     }
     #endif
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(iOS 17.0,visionOS 1.0,macOS 14.0, *)
+    @available(macOS 14.0,iOS 17.0,visionOS 1.0, *)
     init(text: ChangeTracked<Swift.String>,isPresented: ChangeTracked<Swift.Bool>,placement: SwiftUI.SearchFieldPlacement = .automatic, prompt: SwiftUI.LocalizedStringKey) {
         self.value = ._4(placement: placement, prompt: prompt)
         self.__4_text = text
@@ -9217,7 +9217,7 @@ self.__4_isPresented = isPresented
     }
     #endif
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(iOS 17.0,visionOS 1.0,macOS 14.0, *)
+    @available(macOS 14.0,iOS 17.0,visionOS 1.0, *)
     init(text: ChangeTracked<Swift.String>,isPresented: ChangeTracked<Swift.Bool>,placement: SwiftUI.SearchFieldPlacement = .automatic, prompt: AttributeReference<String>) {
         self.value = ._5(placement: placement, prompt: prompt)
         self.__5_text = text
@@ -9255,7 +9255,7 @@ self.__5_isPresented = isPresented
         
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._3(placement, prompt):
-            if #available(iOS 17.0,visionOS 1.0,macOS 14.0, *) {
+            if #available(macOS 14.0,iOS 17.0,visionOS 1.0, *) {
             let placement = placement as! SwiftUI.SearchFieldPlacement 
 let prompt = prompt as? TextReference
             __content
@@ -9264,7 +9264,7 @@ let prompt = prompt as? TextReference
         #endif
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._4(placement, prompt):
-            if #available(iOS 17.0,visionOS 1.0,macOS 14.0, *) {
+            if #available(macOS 14.0,iOS 17.0,visionOS 1.0, *) {
             let placement = placement as! SwiftUI.SearchFieldPlacement 
 let prompt = prompt as! SwiftUI.LocalizedStringKey
             __content
@@ -9273,7 +9273,7 @@ let prompt = prompt as! SwiftUI.LocalizedStringKey
         #endif
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._5(placement, prompt):
-            if #available(iOS 17.0,visionOS 1.0,macOS 14.0, *) {
+            if #available(macOS 14.0,iOS 17.0,visionOS 1.0, *) {
             let placement = placement as! SwiftUI.SearchFieldPlacement 
 let prompt = prompt as! AttributeReference<String>
             __content
@@ -9304,7 +9304,7 @@ struct _selectionDisabledModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0,visionOS 1.0, *)
+    @available(tvOS 17.0,iOS 17.0,watchOS 10.0,visionOS 1.0,macOS 14.0, *)
     init(_ isDisabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(isDisabled: isDisabled)
         
@@ -9317,7 +9317,7 @@ struct _selectionDisabledModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(isDisabled):
-            if #available(macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0,visionOS 1.0, *) {
+            if #available(tvOS 17.0,iOS 17.0,watchOS 10.0,visionOS 1.0,macOS 14.0, *) {
             let isDisabled = isDisabled as! AttributeReference<Swift.Bool>
             __content
                 .selectionDisabled(isDisabled.resolve(on: element, in: context))
@@ -9334,7 +9334,7 @@ struct _shadowModifier<R: RootRegistry>: ViewModifier {
     enum Value {
         case _never
         
-        indirect case _0(color: AttributeReference<SwiftUI.Color> = .init(storage: .constant(Color(.sRGBLinear, white: 0, opacity: 0.33))), radius: AttributeReference<CoreFoundation.CGFloat>,x: AttributeReference<CoreFoundation.CGFloat> = .init(storage: .constant(0)), y: AttributeReference<CoreFoundation.CGFloat> = .init(storage: .constant(0)) )
+        indirect case _0(color: Color.Resolvable = .init(Color(.sRGBLinear, white: 0, opacity: 0.33)), radius: AttributeReference<CoreFoundation.CGFloat>,x: AttributeReference<CoreFoundation.CGFloat> = .init(storage: .constant(0)), y: AttributeReference<CoreFoundation.CGFloat> = .init(storage: .constant(0)) )
         
     }
 
@@ -9348,7 +9348,7 @@ struct _shadowModifier<R: RootRegistry>: ViewModifier {
 
     
     
-    init(color: AttributeReference<SwiftUI.Color> = .init(storage: .constant(Color(.sRGBLinear, white: 0, opacity: 0.33))), radius: AttributeReference<CoreFoundation.CGFloat>,x: AttributeReference<CoreFoundation.CGFloat> = .init(storage: .constant(0)), y: AttributeReference<CoreFoundation.CGFloat> = .init(storage: .constant(0)) ) {
+    init(color: Color.Resolvable = .init(Color(.sRGBLinear, white: 0, opacity: 0.33)), radius: AttributeReference<CoreFoundation.CGFloat>,x: AttributeReference<CoreFoundation.CGFloat> = .init(storage: .constant(0)), y: AttributeReference<CoreFoundation.CGFloat> = .init(storage: .constant(0)) ) {
         self.value = ._0(color: color, radius: radius, x: x, y: y)
         
     }
@@ -9649,7 +9649,7 @@ struct _statusBarHiddenModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(visionOS)
-    @available(visionOS 1.0,iOS 13.0, *)
+    @available(iOS 13.0,visionOS 1.0, *)
     init(_ hidden: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(hidden: hidden)
         
@@ -9662,7 +9662,7 @@ struct _statusBarHiddenModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(visionOS)
         case let ._0(hidden):
-            if #available(visionOS 1.0,iOS 13.0, *) {
+            if #available(iOS 13.0,visionOS 1.0, *) {
             let hidden = hidden as! AttributeReference<Swift.Bool>
             __content
                 .statusBarHidden(hidden.resolve(on: element, in: context))
@@ -9778,7 +9778,7 @@ struct _swipeActionsModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,macOS 12.0,watchOS 8.0,iOS 15.0, *)
+    @available(iOS 15.0,watchOS 8.0,visionOS 1.0,macOS 12.0, *)
     init(edge: SwiftUI.HorizontalEdge = .trailing, allowsFullSwipe: AttributeReference<Swift.Bool> = .init(storage: .constant(true)), content: ViewReference=ViewReference(value: [])) {
         self.value = ._0(edge: edge, allowsFullSwipe: allowsFullSwipe, content: content)
         
@@ -9791,7 +9791,7 @@ struct _swipeActionsModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
         case let ._0(edge, allowsFullSwipe, content):
-            if #available(visionOS 1.0,macOS 12.0,watchOS 8.0,iOS 15.0, *) {
+            if #available(iOS 15.0,watchOS 8.0,visionOS 1.0,macOS 12.0, *) {
             let edge = edge as! SwiftUI.HorizontalEdge 
 let allowsFullSwipe = allowsFullSwipe as! AttributeReference<Swift.Bool>
 let content = content as! ViewReference
@@ -9828,14 +9828,14 @@ struct _symbolEffectModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 10.0,visionOS 1.0,tvOS 17.0,iOS 17.0,macOS 14.0, *)
+    @available(iOS 17.0,tvOS 17.0,watchOS 10.0,visionOS 1.0,macOS 14.0, *)
     init(_ effect: AnyIndefiniteSymbolEffect,options: Symbols.SymbolEffectOptions = .default, isActive: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(effect: effect, options: options, isActive: isActive)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 10.0,visionOS 1.0,tvOS 17.0,iOS 17.0,macOS 14.0, *)
+    @available(iOS 17.0,tvOS 17.0,watchOS 10.0,visionOS 1.0,macOS 14.0, *)
     init(_ effect: AnyDiscreteSymbolEffect,options: Symbols.SymbolEffectOptions = .default, value: AttributeReference<String>) {
         self.value = ._1(effect: effect, options: options, value: value)
         
@@ -9848,7 +9848,7 @@ struct _symbolEffectModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(effect, options, isActive):
-            if #available(watchOS 10.0,visionOS 1.0,tvOS 17.0,iOS 17.0,macOS 14.0, *) {
+            if #available(iOS 17.0,tvOS 17.0,watchOS 10.0,visionOS 1.0,macOS 14.0, *) {
             let effect = effect as! AnyIndefiniteSymbolEffect
 let options = options as! Symbols.SymbolEffectOptions 
 let isActive = isActive as! AttributeReference<Swift.Bool>
@@ -9858,7 +9858,7 @@ let isActive = isActive as! AttributeReference<Swift.Bool>
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(effect, options, value):
-            if #available(watchOS 10.0,visionOS 1.0,tvOS 17.0,iOS 17.0,macOS 14.0, *) {
+            if #available(iOS 17.0,tvOS 17.0,watchOS 10.0,visionOS 1.0,macOS 14.0, *) {
             let effect = effect as! AnyDiscreteSymbolEffect
 let options = options as! Symbols.SymbolEffectOptions 
 let value = value as! AttributeReference<String>
@@ -9890,7 +9890,7 @@ struct _symbolEffectsRemovedModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0,visionOS 1.0, *)
+    @available(watchOS 10.0,iOS 17.0,tvOS 17.0,macOS 14.0,visionOS 1.0, *)
     init(_ isEnabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(isEnabled: isEnabled)
         
@@ -9903,7 +9903,7 @@ struct _symbolEffectsRemovedModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(isEnabled):
-            if #available(macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0,visionOS 1.0, *) {
+            if #available(watchOS 10.0,iOS 17.0,tvOS 17.0,macOS 14.0,visionOS 1.0, *) {
             let isEnabled = isEnabled as! AttributeReference<Swift.Bool>
             __content
                 .symbolEffectsRemoved(isEnabled.resolve(on: element, in: context))
@@ -10105,7 +10105,7 @@ struct _tableStyleModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 12.0,visionOS 1.0,iOS 16.0, *)
+    @available(iOS 16.0,visionOS 1.0,macOS 12.0, *)
     init(_ style: AnyTableStyle) {
         self.value = ._0(style: style)
         
@@ -10118,7 +10118,7 @@ struct _tableStyleModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(style):
-            if #available(macOS 12.0,visionOS 1.0,iOS 16.0, *) {
+            if #available(iOS 16.0,visionOS 1.0,macOS 12.0, *) {
             let style = style as! AnyTableStyle
             __content
                 .tableStyle(style)
@@ -10191,7 +10191,7 @@ struct _textContentTypeModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(tvOS) || os(visionOS)
-    @available(tvOS 13.0,visionOS 1.0,iOS 13.0, *)
+    @available(tvOS 13.0,iOS 13.0,visionOS 1.0, *)
     init(_ textContentType: UIKit.UITextContentType?) {
         self.value = ._0(textContentType: textContentType)
         
@@ -10204,7 +10204,7 @@ struct _textContentTypeModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(tvOS) || os(visionOS)
         case let ._0(textContentType):
-            if #available(tvOS 13.0,visionOS 1.0,iOS 13.0, *) {
+            if #available(tvOS 13.0,iOS 13.0,visionOS 1.0, *) {
             let textContentType = textContentType as? UIKit.UITextContentType
             __content
                 .textContentType(textContentType)
@@ -10234,7 +10234,7 @@ struct _textEditorStyleModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(visionOS 1.0,iOS 17.0,macOS 14.0, *)
+    @available(macOS 14.0,iOS 17.0,visionOS 1.0, *)
     init(_ style: AnyTextEditorStyle) {
         self.value = ._0(style: style)
         
@@ -10247,7 +10247,7 @@ struct _textEditorStyleModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(style):
-            if #available(visionOS 1.0,iOS 17.0,macOS 14.0, *) {
+            if #available(macOS 14.0,iOS 17.0,visionOS 1.0, *) {
             let style = style as! AnyTextEditorStyle
             __content
                 .textEditorStyle(style)
@@ -10320,7 +10320,7 @@ struct _textInputAutocapitalizationModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 8.0,visionOS 1.0,iOS 15.0,tvOS 15.0, *)
+    @available(watchOS 8.0,visionOS 1.0,tvOS 15.0,iOS 15.0, *)
     init(_ autocapitalization: SwiftUI.TextInputAutocapitalization?) {
         self.value = ._0(autocapitalization: autocapitalization)
         
@@ -10333,7 +10333,7 @@ struct _textInputAutocapitalizationModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(autocapitalization):
-            if #available(watchOS 8.0,visionOS 1.0,iOS 15.0,tvOS 15.0, *) {
+            if #available(watchOS 8.0,visionOS 1.0,tvOS 15.0,iOS 15.0, *) {
             let autocapitalization = autocapitalization as? SwiftUI.TextInputAutocapitalization
             __content
                 .textInputAutocapitalization(autocapitalization)
@@ -10363,7 +10363,7 @@ struct _textSelectionModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 12.0,visionOS 1.0,iOS 15.0, *)
+    @available(iOS 15.0,visionOS 1.0,macOS 12.0, *)
     init(_ selectability: AnyTextSelectability) {
         self.value = ._0(selectability: selectability)
         
@@ -10376,7 +10376,7 @@ struct _textSelectionModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(selectability):
-            if #available(macOS 12.0,visionOS 1.0,iOS 15.0, *) {
+            if #available(iOS 15.0,visionOS 1.0,macOS 12.0, *) {
             let selectability = selectability as! AnyTextSelectability
             __content
                 .textSelection(selectability)
@@ -10393,10 +10393,10 @@ struct _tintModifier<R: RootRegistry>: ViewModifier {
     enum Value {
         case _never
         
-        indirect case _0(tint: AnyShapeStyle)
+        indirect case _0(tint: AnyShapeStyle.Resolvable)
         
         
-        indirect case _1(tint: AttributeReference<SwiftUI.Color?>?)
+        indirect case _1(tint: Color.Resolvable?)
         
     }
 
@@ -10412,14 +10412,14 @@ struct _tintModifier<R: RootRegistry>: ViewModifier {
 
     
     
-    init(_ tint: AnyShapeStyle) {
+    init(_ tint: AnyShapeStyle.Resolvable) {
         self.value = ._0(tint: tint)
         
     }
     
     
     
-    init(_ tint: AttributeReference<SwiftUI.Color?>?) {
+    init(_ tint: Color.Resolvable?) {
         self.value = ._1(tint: tint)
         
     }
@@ -10434,7 +10434,7 @@ struct _tintModifier<R: RootRegistry>: ViewModifier {
             
             
             __content
-                .tint(tint)
+                .tint(tint.resolve(on: element, in: context))
             
         
         
@@ -10534,7 +10534,7 @@ struct _toolbarModifier<R: RootRegistry>: ViewModifier {
     }
     
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 14.0,watchOS 10.0,tvOS 17.0,visionOS 1.0,iOS 17.0, *)
+    @available(visionOS 1.0,tvOS 17.0,macOS 14.0,watchOS 10.0,iOS 17.0, *)
     init(removing defaultItemKind: SwiftUI.ToolbarDefaultItemKind?) {
         self.value = ._1(defaultItemKind: defaultItemKind)
         
@@ -10569,7 +10569,7 @@ struct _toolbarModifier<R: RootRegistry>: ViewModifier {
         
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(defaultItemKind):
-            if #available(macOS 14.0,watchOS 10.0,tvOS 17.0,visionOS 1.0,iOS 17.0, *) {
+            if #available(visionOS 1.0,tvOS 17.0,macOS 14.0,watchOS 10.0,iOS 17.0, *) {
             let defaultItemKind = defaultItemKind as? SwiftUI.ToolbarDefaultItemKind
             __content
                 .toolbar(removing: defaultItemKind)
@@ -10602,7 +10602,7 @@ struct _toolbarBackgroundModifier<R: RootRegistry>: ViewModifier {
     enum Value {
         case _never
         
-        indirect case _0(style: AnyShapeStyle,bars: SwiftUI.ToolbarPlacement)
+        indirect case _0(style: AnyShapeStyle.Resolvable,bars: SwiftUI.ToolbarPlacement)
         
         
         indirect case _1(visibility: AttributeReference<SwiftUI.Visibility>,bars: SwiftUI.ToolbarPlacement)
@@ -10621,7 +10621,7 @@ struct _toolbarBackgroundModifier<R: RootRegistry>: ViewModifier {
 
     
     
-    init(_ style: AnyShapeStyle,for bars: SwiftUI.ToolbarPlacement) {
+    init(_ style: AnyShapeStyle.Resolvable,for bars: SwiftUI.ToolbarPlacement) {
         self.value = ._0(style: style, bars: bars)
         
     }
@@ -10643,7 +10643,7 @@ struct _toolbarBackgroundModifier<R: RootRegistry>: ViewModifier {
             
             
             __content
-                .toolbarBackground(style, for: bars)
+                .toolbarBackground(style.resolve(on: element, in: context), for: bars)
             
         
         
@@ -10764,7 +10764,7 @@ struct _toolbarTitleDisplayModeModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(iOS 17.0,macOS 14.0,tvOS 17.0,visionOS 1.0,watchOS 10.0, *)
+    @available(iOS 17.0,tvOS 17.0,watchOS 10.0,visionOS 1.0,macOS 14.0, *)
     init(_ mode: SwiftUI.ToolbarTitleDisplayMode) {
         self.value = ._0(mode: mode)
         
@@ -10777,7 +10777,7 @@ struct _toolbarTitleDisplayModeModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(mode):
-            if #available(iOS 17.0,macOS 14.0,tvOS 17.0,visionOS 1.0,watchOS 10.0, *) {
+            if #available(iOS 17.0,tvOS 17.0,watchOS 10.0,visionOS 1.0,macOS 14.0, *) {
             let mode = mode as! SwiftUI.ToolbarTitleDisplayMode
             __content
                 .toolbarTitleDisplayMode(mode)
@@ -12030,16 +12030,16 @@ indirect case chunk12(_BuiltinModifierChunk12)
 indirect case chunk13(_BuiltinModifierChunk13)
 indirect case chunk14(_BuiltinModifierChunk14)
 indirect case chunk15(_BuiltinModifierChunk15)
-        indirect case _PrefersDefaultFocusModifier(LiveViewNative._PrefersDefaultFocusModifier<R>)
-indirect case _MaskModifier(LiveViewNative._MaskModifier<R>)
-indirect case _OnSubmitModifier(LiveViewNative._OnSubmitModifier)
+        indirect case _MaskModifier(LiveViewNative._MaskModifier<R>)
 indirect case _PresentationDetentsModifier(LiveViewNative._PresentationDetentsModifier)
 indirect case _SearchScopesModifier(LiveViewNative._SearchScopesModifier<R>)
-indirect case _PerspectiveRotationEffectModifier(LiveViewNative._PerspectiveRotationEffectModifier<R>)
-indirect case _Rotation3DEffectModifier(LiveViewNative._Rotation3DEffectModifier<R>)
-indirect case _SearchCompletionModifier(LiveViewNative._SearchCompletionModifier<R>)
 indirect case _MatchedGeometryEffectModifier(LiveViewNative._MatchedGeometryEffectModifier<R>)
+indirect case _OnSubmitModifier(LiveViewNative._OnSubmitModifier)
+indirect case _SearchCompletionModifier(LiveViewNative._SearchCompletionModifier<R>)
+indirect case _Rotation3DEffectModifier(LiveViewNative._Rotation3DEffectModifier<R>)
+indirect case _PerspectiveRotationEffectModifier(LiveViewNative._PerspectiveRotationEffectModifier<R>)
 indirect case _FocusScopeModifier(LiveViewNative._FocusScopeModifier<R>)
+indirect case _PrefersDefaultFocusModifier(LiveViewNative._PrefersDefaultFocusModifier<R>)
         indirect case _customRegistryModifier(R.CustomModifier)
         indirect case _anyTextModifier(_AnyTextModifier<R>)
         indirect case _anyImageModifier(_AnyImageModifier<R>)
@@ -12080,25 +12080,25 @@ case let .chunk14(chunk):
     content.modifier(chunk)
 case let .chunk15(chunk):
     content.modifier(chunk)
-            case let ._PrefersDefaultFocusModifier(modifier):
-    content.modifier(modifier)
-case let ._MaskModifier(modifier):
-    content.modifier(modifier)
-case let ._OnSubmitModifier(modifier):
+            case let ._MaskModifier(modifier):
     content.modifier(modifier)
 case let ._PresentationDetentsModifier(modifier):
     content.modifier(modifier)
 case let ._SearchScopesModifier(modifier):
     content.modifier(modifier)
-case let ._PerspectiveRotationEffectModifier(modifier):
+case let ._MatchedGeometryEffectModifier(modifier):
     content.modifier(modifier)
-case let ._Rotation3DEffectModifier(modifier):
+case let ._OnSubmitModifier(modifier):
     content.modifier(modifier)
 case let ._SearchCompletionModifier(modifier):
     content.modifier(modifier)
-case let ._MatchedGeometryEffectModifier(modifier):
+case let ._Rotation3DEffectModifier(modifier):
+    content.modifier(modifier)
+case let ._PerspectiveRotationEffectModifier(modifier):
     content.modifier(modifier)
 case let ._FocusScopeModifier(modifier):
+    content.modifier(modifier)
+case let ._PrefersDefaultFocusModifier(modifier):
     content.modifier(modifier)
             case let ._customRegistryModifier(modifier):
                 content.modifier(modifier)
@@ -12342,16 +12342,16 @@ _truncationModeModifier<R>.name: _truncationModeModifier<R>.parser(in: context).
 _unredactedModifier<R>.name: _unredactedModifier<R>.parser(in: context).map({ Output.chunk15(.unredacted($0)) }).eraseToAnyParser(),
 _upperLimbVisibilityModifier<R>.name: _upperLimbVisibilityModifier<R>.parser(in: context).map({ Output.chunk15(.upperLimbVisibility($0)) }).eraseToAnyParser(),
 _zIndexModifier<R>.name: _zIndexModifier<R>.parser(in: context).map({ Output.chunk15(.zIndex($0)) }).eraseToAnyParser(),
-                    LiveViewNative._PrefersDefaultFocusModifier<R>.name: LiveViewNative._PrefersDefaultFocusModifier<R>.parser(in: context).map(Output._PrefersDefaultFocusModifier).eraseToAnyParser(),
-LiveViewNative._MaskModifier<R>.name: LiveViewNative._MaskModifier<R>.parser(in: context).map(Output._MaskModifier).eraseToAnyParser(),
-LiveViewNative._OnSubmitModifier.name: LiveViewNative._OnSubmitModifier.parser(in: context).map(Output._OnSubmitModifier).eraseToAnyParser(),
+                    LiveViewNative._MaskModifier<R>.name: LiveViewNative._MaskModifier<R>.parser(in: context).map(Output._MaskModifier).eraseToAnyParser(),
 LiveViewNative._PresentationDetentsModifier.name: LiveViewNative._PresentationDetentsModifier.parser(in: context).map(Output._PresentationDetentsModifier).eraseToAnyParser(),
 LiveViewNative._SearchScopesModifier<R>.name: LiveViewNative._SearchScopesModifier<R>.parser(in: context).map(Output._SearchScopesModifier).eraseToAnyParser(),
-LiveViewNative._PerspectiveRotationEffectModifier<R>.name: LiveViewNative._PerspectiveRotationEffectModifier<R>.parser(in: context).map(Output._PerspectiveRotationEffectModifier).eraseToAnyParser(),
-LiveViewNative._Rotation3DEffectModifier<R>.name: LiveViewNative._Rotation3DEffectModifier<R>.parser(in: context).map(Output._Rotation3DEffectModifier).eraseToAnyParser(),
-LiveViewNative._SearchCompletionModifier<R>.name: LiveViewNative._SearchCompletionModifier<R>.parser(in: context).map(Output._SearchCompletionModifier).eraseToAnyParser(),
 LiveViewNative._MatchedGeometryEffectModifier<R>.name: LiveViewNative._MatchedGeometryEffectModifier<R>.parser(in: context).map(Output._MatchedGeometryEffectModifier).eraseToAnyParser(),
+LiveViewNative._OnSubmitModifier.name: LiveViewNative._OnSubmitModifier.parser(in: context).map(Output._OnSubmitModifier).eraseToAnyParser(),
+LiveViewNative._SearchCompletionModifier<R>.name: LiveViewNative._SearchCompletionModifier<R>.parser(in: context).map(Output._SearchCompletionModifier).eraseToAnyParser(),
+LiveViewNative._Rotation3DEffectModifier<R>.name: LiveViewNative._Rotation3DEffectModifier<R>.parser(in: context).map(Output._Rotation3DEffectModifier).eraseToAnyParser(),
+LiveViewNative._PerspectiveRotationEffectModifier<R>.name: LiveViewNative._PerspectiveRotationEffectModifier<R>.parser(in: context).map(Output._PerspectiveRotationEffectModifier).eraseToAnyParser(),
 LiveViewNative._FocusScopeModifier<R>.name: LiveViewNative._FocusScopeModifier<R>.parser(in: context).map(Output._FocusScopeModifier).eraseToAnyParser(),
+LiveViewNative._PrefersDefaultFocusModifier<R>.name: LiveViewNative._PrefersDefaultFocusModifier<R>.parser(in: context).map(Output._PrefersDefaultFocusModifier).eraseToAnyParser(),
                 ]
 
                 let deprecations = [
@@ -12628,7 +12628,7 @@ ConstantAtomLiteral("vertical").map({ () -> Self in
 /// * `.standard`
 /// * `.increased`
 @_documentation(visibility: public)
-@available(macOS 14.0,iOS 17.0,visionOS 1.0, *)
+@available(iOS 17.0,visionOS 1.0,macOS 14.0, *)
 extension BadgeProminence: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -12898,7 +12898,7 @@ ConstantAtomLiteral("plusLighter").map({ () -> Self in
 /// * `.enabled`
 /// * `.disabled`
 @_documentation(visibility: public)
-@available(visionOS 1.0,watchOS 10.0,macOS 14.0,tvOS 17.0,iOS 17.0, *)
+@available(tvOS 17.0,iOS 17.0,visionOS 1.0,watchOS 10.0,macOS 14.0, *)
 extension ButtonRepeatBehavior: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -13022,14 +13022,14 @@ ConstantAtomLiteral("dark").map({ () -> Self in
 /// * `.tabView`
 /// * `.navigation`
 @_documentation(visibility: public)
-@available(iOS 17.0,tvOS 17.0,macOS 14.0,watchOS 10.0,visionOS 1.0, *)
+@available(iOS 17.0,watchOS 10.0,visionOS 1.0,tvOS 17.0,macOS 14.0, *)
 extension ContainerBackgroundPlacement: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             ConstantAtomLiteral("tabView").map({ () -> Self in
 #if os(watchOS)
-if #available(iOS 17.0,tvOS 17.0,macOS 14.0,watchOS 10.0, *) {
+if #available(iOS 17.0,watchOS 10.0,tvOS 17.0,macOS 14.0, *) {
     return Self.tabView
 } else { fatalError("'tabView' is not available in this OS version") }
 #else
@@ -13038,7 +13038,7 @@ fatalError("'tabView' is not available on this OS")
 })
 ConstantAtomLiteral("navigation").map({ () -> Self in
 #if os(watchOS)
-if #available(iOS 17.0,tvOS 17.0,macOS 14.0,watchOS 10.0, *) {
+if #available(iOS 17.0,watchOS 10.0,tvOS 17.0,macOS 14.0, *) {
     return Self.navigation
 } else { fatalError("'navigation' is not available in this OS version") }
 #else
@@ -13058,7 +13058,7 @@ fatalError("'navigation' is not available on this OS")
 /// * `.scrollContent`
 /// * `.scrollIndicators`
 @_documentation(visibility: public)
-@available(iOS 17.0,tvOS 17.0,macOS 14.0,watchOS 10.0,visionOS 1.0, *)
+@available(watchOS 10.0,iOS 17.0,tvOS 17.0,macOS 14.0,visionOS 1.0, *)
 extension ContentMarginPlacement: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -13122,7 +13122,7 @@ extension ContentShapeKinds: ParseableModifierValue {
 })
 ConstantAtomLiteral("dragPreview").map({ () -> Self in
 #if os(iOS) || os(macOS) || os(visionOS)
-if #available(iOS 15.0,tvOS 15.0,macOS 12.0,watchOS 8.0,visionOS 1.0, *) {
+if #available(iOS 15.0,macOS 12.0,tvOS 15.0,watchOS 8.0,visionOS 1.0, *) {
     return Self.dragPreview
 } else { fatalError("'dragPreview' is not available in this OS version") }
 #else
@@ -13131,7 +13131,7 @@ fatalError("'dragPreview' is not available on this OS")
 })
 ConstantAtomLiteral("contextMenuPreview").map({ () -> Self in
 #if os(iOS) || os(tvOS) || os(visionOS)
-if #available(iOS 15.0,tvOS 17.0,macOS 12.0,watchOS 8.0,visionOS 1.0, *) {
+if #available(iOS 15.0,macOS 12.0,tvOS 17.0,watchOS 8.0,visionOS 1.0, *) {
     return Self.contextMenuPreview
 } else { fatalError("'contextMenuPreview' is not available in this OS version") }
 #else
@@ -13140,7 +13140,7 @@ fatalError("'contextMenuPreview' is not available on this OS")
 })
 ConstantAtomLiteral("hoverEffect").map({ () -> Self in
 #if os(iOS) || os(visionOS)
-if #available(iOS 15.0,tvOS 15.0,macOS 12.0,watchOS 8.0,visionOS 1.0, *) {
+if #available(iOS 15.0,macOS 12.0,tvOS 15.0,watchOS 8.0,visionOS 1.0, *) {
     return Self.hoverEffect
 } else { fatalError("'hoverEffect' is not available in this OS version") }
 #else
@@ -13149,7 +13149,7 @@ fatalError("'hoverEffect' is not available on this OS")
 })
 ConstantAtomLiteral("focusEffect").map({ () -> Self in
 #if os(macOS) || os(watchOS)
-if #available(iOS 15.0,tvOS 15.0,macOS 12.0,watchOS 8.0, *) {
+if #available(iOS 15.0,macOS 12.0,tvOS 15.0,watchOS 8.0, *) {
     return Self.focusEffect
 } else { fatalError("'focusEffect' is not available in this OS version") }
 #else
@@ -13158,7 +13158,7 @@ fatalError("'focusEffect' is not available on this OS")
 })
 ConstantAtomLiteral("accessibility").map({ () -> Self in
 #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-if #available(macOS 14.0,visionOS 1.0,iOS 17.0,watchOS 10.0,tvOS 17.0, *) {
+if #available(macOS 14.0,iOS 17.0,visionOS 1.0,watchOS 10.0,tvOS 17.0, *) {
     return Self.accessibility
 } else { fatalError("'accessibility' is not available in this OS version") }
 #else
@@ -13180,7 +13180,7 @@ fatalError("'accessibility' is not available on this OS")
 /// * `.large`
 /// * `.extraLarge`
 @_documentation(visibility: public)
-@available(watchOS 9.0,macOS 10.15,visionOS 1.0,iOS 15.0, *)
+@available(watchOS 9.0,iOS 15.0,macOS 10.15,visionOS 1.0, *)
 extension ControlSize: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -13214,7 +13214,7 @@ fatalError("'regular' is not available on this OS")
 })
 ConstantAtomLiteral("large").map({ () -> Self in
 #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
-if #available(watchOS 9.0,macOS 11.0,visionOS 1.0,iOS 15.0, *) {
+if #available(watchOS 9.0,iOS 15.0,macOS 11.0,visionOS 1.0, *) {
     return Self.large
 } else { fatalError("'large' is not available in this OS version") }
 #else
@@ -13223,7 +13223,7 @@ fatalError("'large' is not available on this OS")
 })
 ConstantAtomLiteral("extraLarge").map({ () -> Self in
 #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
-if #available(watchOS 10.0,macOS 14.0,visionOS 1.0,iOS 17.0, *) {
+if #available(watchOS 10.0,iOS 17.0,macOS 14.0,visionOS 1.0, *) {
     return Self.extraLarge
 } else { fatalError("'extraLarge' is not available in this OS version") }
 #else
@@ -13278,7 +13278,7 @@ ConstantAtomLiteral("userInitiated").map({ () -> Self in
 /// * `.critical`
 /// * `.standard`
 @_documentation(visibility: public)
-@available(iOS 17.0,watchOS 10.0,tvOS 17.0,macOS 13.0,visionOS 1.0, *)
+@available(tvOS 17.0,watchOS 10.0,visionOS 1.0,iOS 17.0,macOS 13.0, *)
 extension DialogSeverity: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -13303,7 +13303,7 @@ fatalError("'critical' is not available on this OS")
 })
 ConstantAtomLiteral("standard").map({ () -> Self in
 #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-if #available(macOS 14.0,watchOS 10.0,visionOS 1.0,tvOS 17.0,iOS 17.0, *) {
+if #available(tvOS 17.0,watchOS 10.0,visionOS 1.0,iOS 17.0,macOS 14.0, *) {
     return Self.standard
 } else { fatalError("'standard' is not available in this OS version") }
 #else
@@ -13488,7 +13488,7 @@ ConstantAtomLiteral("all").map({ () -> Self in
 /// * `.includeHiddenFiles`
 /// * `.displayFileExtensions`
 @_documentation(visibility: public)
-@available(macOS 14.0,iOS 17.0,visionOS 1.0, *)
+@available(iOS 17.0,visionOS 1.0,macOS 14.0, *)
 extension FileDialogBrowserOptions: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -13533,7 +13533,7 @@ fatalError("'displayFileExtensions' is not available on this OS")
 /// * `.edit`
 /// * `.automatic`
 @_documentation(visibility: public)
-@available(iOS 17.0,watchOS 10.0,tvOS 17.0,visionOS 1.0,macOS 14.0, *)
+@available(iOS 17.0,watchOS 10.0,visionOS 1.0,tvOS 17.0,macOS 14.0, *)
 extension FocusInteractions: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -13714,7 +13714,7 @@ ConstantAtomLiteral("trailing").map({ () -> Self in
 })
 ConstantAtomLiteral("listRowSeparatorLeading").map({ () -> Self in
 #if os(iOS) || os(macOS) || os(visionOS)
-if #available(macOS 13.0,iOS 16.0,visionOS 1.0, *) {
+if #available(iOS 16.0,visionOS 1.0,macOS 13.0, *) {
     return Self.listRowSeparatorLeading
 } else { fatalError("'listRowSeparatorLeading' is not available in this OS version") }
 #else
@@ -13723,7 +13723,7 @@ fatalError("'listRowSeparatorLeading' is not available on this OS")
 })
 ConstantAtomLiteral("listRowSeparatorTrailing").map({ () -> Self in
 #if os(iOS) || os(macOS) || os(visionOS)
-if #available(macOS 13.0,iOS 16.0,visionOS 1.0, *) {
+if #available(iOS 16.0,visionOS 1.0,macOS 13.0, *) {
     return Self.listRowSeparatorTrailing
 } else { fatalError("'listRowSeparatorTrailing' is not available in this OS version") }
 #else
@@ -13778,7 +13778,7 @@ ConstantAtomLiteral("trailing").map({ () -> Self in
 /// * `.highlight`
 /// * `.lift`
 @_documentation(visibility: public)
-@available(visionOS 1.0,iOS 13.4,tvOS 16.0, *)
+@available(tvOS 16.0,visionOS 1.0,iOS 13.4, *)
 extension HoverEffect: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -13794,7 +13794,7 @@ fatalError("'automatic' is not available on this OS")
 })
 ConstantAtomLiteral("highlight").map({ () -> Self in
 #if os(iOS) || os(tvOS) || os(visionOS)
-if #available(visionOS 1.0,iOS 13.4,tvOS 17.0, *) {
+if #available(tvOS 17.0,visionOS 1.0,iOS 13.4, *) {
     return Self.highlight
 } else { fatalError("'highlight' is not available in this OS version") }
 #else
@@ -13919,7 +13919,7 @@ extension MenuOrder: ParseableModifierValue {
 })
 ConstantAtomLiteral("priority").map({ () -> Self in
 #if os(iOS) || os(visionOS)
-if #available(watchOS 9.0,visionOS 1.0,macOS 13.0,tvOS 16.0,iOS 16.0, *) {
+if #available(tvOS 16.0,watchOS 9.0,iOS 16.0,macOS 13.0,visionOS 1.0, *) {
     return Self.priority
 } else { fatalError("'priority' is not available in this OS version") }
 #else
@@ -13950,7 +13950,7 @@ ConstantAtomLiteral("fixed").map({ () -> Self in
 /// * `.sheet`
 /// * `.fullScreenCover`
 @_documentation(visibility: public)
-@available(iOS 16.4,watchOS 9.4,tvOS 16.4,macOS 13.3,visionOS 1.0, *)
+@available(macOS 13.3,iOS 16.4,watchOS 9.4,tvOS 16.4,visionOS 1.0, *)
 extension PresentationAdaptation: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -14013,7 +14013,7 @@ fatalError("'fullScreenCover' is not available on this OS")
 /// * `.resizes`
 /// * `.scrolls`
 @_documentation(visibility: public)
-@available(visionOS 1.0,watchOS 9.4,macOS 13.3,tvOS 16.4,iOS 16.4, *)
+@available(tvOS 16.4,iOS 16.4,visionOS 1.0,watchOS 9.4,macOS 13.3, *)
 extension PresentationContentInteraction: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -14118,7 +14118,7 @@ ConstantAtomLiteral("privacy").map({ () -> Self in
 })
 ConstantAtomLiteral("invalidated").map({ () -> Self in
 #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-if #available(watchOS 10.0,visionOS 1.0,macOS 14.0,tvOS 17.0,iOS 17.0, *) {
+if #available(iOS 17.0,macOS 14.0,tvOS 17.0,watchOS 10.0,visionOS 1.0, *) {
     return Self.invalidated
 } else { fatalError("'invalidated' is not available in this OS version") }
 #else
@@ -14233,7 +14233,7 @@ extension ScenePadding: ParseableModifierValue {
 })
 ConstantAtomLiteral("navigationBar").map({ () -> Self in
 #if os(watchOS)
-if #available(iOS 16.0,tvOS 16.0,macOS 13.0,watchOS 9.0, *) {
+if #available(watchOS 9.0,iOS 16.0,tvOS 16.0,macOS 13.0, *) {
     return Self.navigationBar
 } else { fatalError("'navigationBar' is not available in this OS version") }
 #else
@@ -14253,7 +14253,7 @@ fatalError("'navigationBar' is not available on this OS")
 /// * `.always`
 /// * `.basedOnSize`
 @_documentation(visibility: public)
-@available(iOS 16.4,tvOS 16.4,macOS 13.3,watchOS 9.4,visionOS 1.0, *)
+@available(iOS 16.4,watchOS 9.4,visionOS 1.0,tvOS 16.4,macOS 13.3, *)
 extension ScrollBounceBehavior: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -14299,7 +14299,7 @@ fatalError("'basedOnSize' is not available on this OS")
 /// * `.interactively`
 /// * `.never`
 @_documentation(visibility: public)
-@available(iOS 16.0,tvOS 16.0,macOS 13.0,watchOS 9.0, *)
+@available(iOS 16.0,watchOS 9.0,tvOS 16.0,macOS 13.0, *)
 extension ScrollDismissesKeyboardMode: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -14408,7 +14408,7 @@ ConstantAtomLiteral("never").map({ () -> Self in
 /// * `.onTextEntry`
 /// * `.onSearchPresentation`
 @_documentation(visibility: public)
-@available(macOS 13.3,tvOS 16.4,watchOS 9.4,visionOS 1.0,iOS 16.4, *)
+@available(macOS 13.3,iOS 16.4,watchOS 9.4,tvOS 16.4,visionOS 1.0, *)
 extension SearchScopeActivation: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -14498,7 +14498,7 @@ ConstantAtomLiteral("content").map({ () -> Self in
 /// * `.enabled`
 /// * `.disabled`
 @_documentation(visibility: public)
-@available(watchOS 10.0,visionOS 1.0,macOS 14.0,tvOS 17.0,iOS 17.0, *)
+@available(tvOS 17.0,watchOS 10.0,iOS 17.0,macOS 14.0,visionOS 1.0, *)
 extension SpringLoadingBehavior: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -14681,7 +14681,7 @@ ConstantAtomLiteral("search").map({ () -> Self in
 /// Possible values:
 /// * `.sidebarToggle`
 @_documentation(visibility: public)
-@available(macOS 14.0,watchOS 10.0,visionOS 1.0,tvOS 17.0,iOS 17.0, *)
+@available(tvOS 17.0,watchOS 10.0,visionOS 1.0,iOS 17.0,macOS 14.0, *)
 extension ToolbarDefaultItemKind: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -14725,7 +14725,7 @@ extension ToolbarRole: ParseableModifierValue {
 })
 ConstantAtomLiteral("navigationStack").map({ () -> Self in
 #if os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
-if #available(iOS 16.0,watchOS 9.0,tvOS 16.0,visionOS 1.0,macOS 13.0, *) {
+if #available(iOS 16.0,watchOS 9.0,visionOS 1.0,tvOS 16.0,macOS 13.0, *) {
     return Self.navigationStack
 } else { fatalError("'navigationStack' is not available in this OS version") }
 #else
@@ -14734,7 +14734,7 @@ fatalError("'navigationStack' is not available on this OS")
 })
 ConstantAtomLiteral("browser").map({ () -> Self in
 #if os(iOS) || os(visionOS)
-if #available(iOS 16.0,watchOS 9.0,tvOS 16.0,visionOS 1.0,macOS 13.0, *) {
+if #available(iOS 16.0,watchOS 9.0,visionOS 1.0,tvOS 16.0,macOS 13.0, *) {
     return Self.browser
 } else { fatalError("'browser' is not available in this OS version") }
 #else
@@ -14743,7 +14743,7 @@ fatalError("'browser' is not available on this OS")
 })
 ConstantAtomLiteral("editor").map({ () -> Self in
 #if os(iOS) || os(macOS) || os(visionOS)
-if #available(iOS 16.0,watchOS 9.0,tvOS 16.0,visionOS 1.0,macOS 13.0, *) {
+if #available(iOS 16.0,watchOS 9.0,visionOS 1.0,tvOS 16.0,macOS 13.0, *) {
     return Self.editor
 } else { fatalError("'editor' is not available in this OS version") }
 #else
@@ -14764,7 +14764,7 @@ fatalError("'editor' is not available on this OS")
 /// * `.inlineLarge`
 /// * `.inline`
 @_documentation(visibility: public)
-@available(iOS 17.0,watchOS 10.0,tvOS 17.0,macOS 14.0,visionOS 1.0, *)
+@available(visionOS 1.0,iOS 17.0,watchOS 10.0,tvOS 17.0,macOS 14.0, *)
 extension ToolbarTitleDisplayMode: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {

--- a/Sources/ModifierGenerator/ModifierGenerator.swift
+++ b/Sources/ModifierGenerator/ModifierGenerator.swift
@@ -290,9 +290,12 @@ struct ModifierGenerator: ParsableCommand {
                 })
             let requiresContext = signatures.contains(where: {
                 $0.parameters.contains(where: {
-                    ["ViewReference", "TextReference", "AttributeReference", "InlineViewReference"].contains(
+                    ["ViewReference", "TextReference", "AttributeReference", "InlineViewReference", "AnyShapeStyle", "Color", "ListItemTint"].contains(
                         $0.type.as(IdentifierTypeSyntax.self)?.name.text
-                         ?? $0.type.as(OptionalTypeSyntax.self)?.wrappedType.as(IdentifierTypeSyntax.self)?.name.text
+                            ?? $0.type.as(OptionalTypeSyntax.self)?.wrappedType.as(IdentifierTypeSyntax.self)?.name.text
+                            ?? $0.type.as(MemberTypeSyntax.self)?.baseType.as(IdentifierTypeSyntax.self)?.name.text
+                            ?? $0.type.as(OptionalTypeSyntax.self)?.wrappedType
+                                .as(MemberTypeSyntax.self)?.baseType.as(IdentifierTypeSyntax.self)?.name.text
                     )
                 })
             })


### PR DESCRIPTION
Closes #1371 

This adds support for referencing attribute values for individual `Color` components.

```heex
<Text style='foregroundStyle(Color(.sRGB, red: attr("red"), green: 0, blue: 1))' red="0.25">hello, world!</Text>
<Text style='foregroundStyle(.linearGradient(colors: [Color(red: attr("a"), green: 0, blue: 0), Color(red: 0, green: 0, blue: attr("b"))], startPoint: .leading, endPoint: .trailing))' a="0" b="1">hello, world!</Text>
```

This also works in more complex cases, such as colors within a gradient.

`Color` is used extensively in various modifiers, so there were quite a few changes required for this to be supported.
Instead of using `Color` or `AnyShapeStyle` directly in a modifier, you must use `*.Resolvable` instead. This type can be resolved to a `Color`, `AnyShapeStyle`, or any other base type.

```swift
init(_ primary: Color.Resolvable, _ secondary: AnyShapeStyle.Resolvable) {
  ...
}

func body(content: Content) -> some View {
  content.foregroundStyle(primary.resolve(on: element), secondary.resolve(on: element))
}
```