### PR TITLE
Expose the `document` and updated `NodeRef` for addon libraries

### DIFF
--- a/Sources/LiveViewNative/Protocols/ContentBuilder.swift
+++ b/Sources/LiveViewNative/Protocols/ContentBuilder.swift
@@ -348,6 +348,11 @@ public struct ContentBuilderContext<R: RootRegistry, Builder: ContentBuilder>: D
             context.url
         }
         
+        @MainActor
+        public var document: Document? {
+            context.coordinator.document
+        }
+        
         func value<OtherBuilder: ContentBuilder>(for _: OtherBuilder.Type = OtherBuilder.self) -> ContentBuilderContext<R, OtherBuilder>.Value {
             return .init(
                 coordinatorEnvironment: coordinatorEnvironment,


### PR DESCRIPTION
This updates `ObservedElement.projectedValue` to publish the `NodeRef` of the children that change.

It also exposes the `Document` to `ContentBuilder` types.

These additions are necessary for efficient updates of child elements in the RealityKit addon library.