### PR TITLE
Xcode 16 beta compatibility

### DIFF
--- a/Sources/BuiltinRegistryGenerator/BuiltinRegistryGenerator.swift
+++ b/Sources/BuiltinRegistryGenerator/BuiltinRegistryGenerator.swift
@@ -132,21 +132,24 @@ struct BuiltinRegistryGenerator: ParsableCommand {
             // [platform] [version], ...
             let platform = Reference(Substring.self)
             let version = Reference(Double?.self)
-            let expression = Regex {
-                Capture(as: platform) {
-                    OneOrMore(.word)
+            let platformExpr = Capture(as: platform) {
+                OneOrMore(.word)
+            }
+            let versionExpr = Capture(as: version) {
+                OneOrMore(.digit)
+                Optionally {
+                    "."
+                    OneOrMore(.digit)
                 }
+            } transform: {
+                Double($0)
+            }
+            
+            let expression = Regex {
+                platformExpr
                 Optionally {
                     OneOrMore(.whitespace)
-                    Capture(as: version) {
-                        OneOrMore(.digit)
-                        Optionally {
-                            "."
-                            OneOrMore(.digit)
-                        }
-                    } transform: {
-                        Double($0)
-                    }
+                    versionExpr
                 }
             }
             let availability = String(match[availability])


### PR DESCRIPTION
Some minor restructuring to support building with Swift 6 in Xcode 16.

1. Swift 6 struggles to evaluate the availability regex in the BuiltinRegistryGenerator. It has been split into simpler regex pieces.