### PR TITLE
2024 platform updates support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,8 +52,8 @@ jobs:
       - name: Build for watchOS
         shell: bash
         run: |
-          xcodebuild -scheme LiveViewNative-Package -destination "platform=watchOS Simulator,name=Apple Watch Series 9 (45mm)" -skipMacroValidation -skipPackagePluginValidation
+          xcodebuild -scheme LiveViewNative-Package -destination "platform=watchOS Simulator,name=Apple Watch Series 10 (46mm)" -skipMacroValidation -skipPackagePluginValidation
       - name: Build for tvOS
         shell: bash
         run: |
-          xcodebuild -scheme LiveViewNative-Package -destination "platform=tvOS Simulator,name=Any tvOS Device" -skipMacroValidation -skipPackagePluginValidation
+          xcodebuild -scheme LiveViewNative-Package -destination "platform=tvOS Simulator,name=Apple TV" -skipMacroValidation -skipPackagePluginValidation

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,13 +14,13 @@ permissions:
 
 jobs:
   test:
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@v2
       - name: Setup Xcode Version
         shell: bash
         run: |
-          sudo xcode-select --switch /Applications/Xcode_15.4.app
+          sudo xcode-select --switch /Applications/Xcode_16.0.app
       - uses: irgaly/xcode-cache@v1
         with:
           key: xcode-cache-deriveddata-${{ github.workflow }}
@@ -29,7 +29,7 @@ jobs:
         shell: bash
         run: |
           xcodebuild -scheme BuiltinRegistryGenerator -destination "platform=macOS"
-          xcodebuild test -scheme LiveViewNative-Package -destination "platform=iOS Simulator,name=iPhone 15 Pro" -enableCodeCoverage YES -resultBundlePath TestResults -skipMacroValidation -skipPackagePluginValidation
+          xcodebuild test -scheme LiveViewNative-Package -destination "platform=iOS Simulator,name=iPhone 16 Pro" -enableCodeCoverage YES -resultBundlePath TestResults -skipMacroValidation -skipPackagePluginValidation
       - uses: kishikawakatsumi/xcresulttool@v1
         with:
           path: TestResults.xcresult
@@ -56,4 +56,4 @@ jobs:
       - name: Build for tvOS
         shell: bash
         run: |
-          xcodebuild -scheme LiveViewNative-Package -destination "name=Any tvOS Device" -skipMacroValidation -skipPackagePluginValidation
+          xcodebuild -scheme LiveViewNative-Package -destination "platform=tvOS Simulator,name=Any tvOS Device" -skipMacroValidation -skipPackagePluginValidation

--- a/Package.resolved
+++ b/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-argument-parser",
       "state" : {
-        "revision" : "41982a3656a71c768319979febd796c6fd111d5c",
-        "version" : "1.5.0"
+        "revision" : "fee6933f37fde9a5e12a1e4aeaa93fe60116ff2a",
+        "version" : "1.2.2"
       }
     },
     {
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-case-paths",
       "state" : {
-        "revision" : "71344dd930fde41e8f3adafe260adcbb2fc2a3dc",
-        "version" : "1.5.4"
+        "revision" : "40773cbaf8d71ed5357f297b1ba4073f5b24faaa",
+        "version" : "1.1.0"
       }
     },
     {
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-cmark.git",
       "state" : {
-        "revision" : "3bc2f3e25df0cecc5dc269f7ccae65d0f386f06a",
-        "version" : "0.4.0"
+        "revision" : "3ccff77b2dc5b96b77db3da0d68d28068593fa53",
+        "version" : "0.5.0"
       }
     },
     {
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
-        "revision" : "3d2dc41a01f9e49d84f0a3925fb858bed64f702d",
-        "version" : "1.1.2"
+        "revision" : "937e904258d22af6e447a0b72c0bc67583ef64a2",
+        "version" : "1.0.4"
       }
     },
     {
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-markdown.git",
       "state" : {
-        "revision" : "4aae40bf6fff5286e0e1672329d17824ce16e081",
-        "version" : "0.4.0"
+        "revision" : "8f79cb175981458a0a27e76cb42fee8e17b1a993",
+        "version" : "0.5.0"
       }
     },
     {
@@ -95,8 +95,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/scinfu/SwiftSoup.git",
       "state" : {
-        "revision" : "e2d11208519549c2e5798d70190472045633f22f",
-        "version" : "2.7.3"
+        "revision" : "8b6cf29eead8841a1fa7822481cb3af4ddaadba6",
+        "version" : "2.6.1"
       }
     },
     {
@@ -104,8 +104,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
       "state" : {
-        "revision" : "357ca1e5dd31f613a1d43320870ebc219386a495",
-        "version" : "1.2.2"
+        "revision" : "23cbf2294e350076ea4dbd7d5d047c1e76b03631",
+        "version" : "1.0.2"
       }
     }
   ],

--- a/Sources/LiveViewNative/Coordinators/LiveNavigationEntry.swift
+++ b/Sources/LiveViewNative/Coordinators/LiveNavigationEntry.swift
@@ -10,6 +10,7 @@ import Foundation
 public struct LiveNavigationEntry<R: RootRegistry>: Hashable {
     public let url: URL
     public let coordinator: LiveViewCoordinator<R>
+    let navigationTransition: Any?
     
     public static func == (lhs: Self, rhs: Self) -> Bool {
         lhs.url == rhs.url && lhs.coordinator === rhs.coordinator

--- a/Sources/LiveViewNative/Coordinators/LiveSessionCoordinator.swift
+++ b/Sources/LiveViewNative/Coordinators/LiveSessionCoordinator.swift
@@ -350,7 +350,7 @@ public class LiveSessionCoordinator<R: RootRegistry>: ObservableObject {
         
         var request = request
         request.url = request.url!.appendingLiveViewItems()
-        request.allHTTPHeaderFields = configuration.headers
+        request.allHTTPHeaderFields = await configuration.headers
         
         if let domValues {
             request.setValue(domValues.phxCSRFToken, forHTTPHeaderField: "x-csrf-token")
@@ -565,7 +565,7 @@ class LiveSessionURLSessionDelegate<R: RootRegistry>: NSObject, URLSessionTaskDe
         }
         
         var newRequest = request
-        newRequest.url = await url.appendingLiveViewItems()
+        newRequest.url = url.appendingLiveViewItems()
         return newRequest
     }
 }

--- a/Sources/LiveViewNative/Coordinators/LiveSessionCoordinator.swift
+++ b/Sources/LiveViewNative/Coordinators/LiveSessionCoordinator.swift
@@ -110,7 +110,7 @@ public class LiveSessionCoordinator<R: RootRegistry>: ObservableObject {
             delegateQueue: nil
         )
         
-        self.navigationPath = [.init(url: url, coordinator: .init(session: self, url: self.url))]
+        self.navigationPath = [.init(url: url, coordinator: .init(session: self, url: self.url), navigationTransition: nil)]
         
         self.mergedEventSubjects = self.navigationPath.first!.coordinator.eventSubject.compactMap({ [weak self] value in
             self.map({ ($0.navigationPath.first!.coordinator, value) })
@@ -208,7 +208,8 @@ public class LiveSessionCoordinator<R: RootRegistry>: ObservableObject {
                 self.navigationPath.last!.coordinator.url = responseURL
                 self.navigationPath[self.navigationPath.endIndex - 1] = .init(
                     url: responseURL,
-                    coordinator: self.navigationPath.last!.coordinator
+                    coordinator: self.navigationPath.last!.coordinator,
+                    navigationTransition: nil
                 )
                 url = responseURL
             } else {
@@ -304,7 +305,7 @@ public class LiveSessionCoordinator<R: RootRegistry>: ObservableObject {
         if let url {
             await self.disconnect(preserveNavigationPath: false)
             self.url = url
-            self.navigationPath = [.init(url: self.url, coordinator: self.navigationPath.first!.coordinator)]
+            self.navigationPath = [.init(url: self.url, coordinator: self.navigationPath.first!.coordinator, navigationTransition: nil)]
         } else {
             await self.disconnect(preserveNavigationPath: true)
         }
@@ -524,7 +525,7 @@ public class LiveSessionCoordinator<R: RootRegistry>: ObservableObject {
         switch redirect.mode {
         case .replaceTop:
             let coordinator = LiveViewCoordinator(session: self, url: redirect.to)
-            let entry = LiveNavigationEntry(url: redirect.to, coordinator: coordinator)
+            let entry = LiveNavigationEntry(url: redirect.to, coordinator: coordinator, navigationTransition: nil)
             switch redirect.kind {
             case .push:
                 navigationPath.append(entry)
@@ -543,7 +544,7 @@ public class LiveSessionCoordinator<R: RootRegistry>: ObservableObject {
             // patch is like `replaceTop`, but it does not disconnect.
             let coordinator = navigationPath.last!.coordinator
             coordinator.url = redirect.to
-            let entry = LiveNavigationEntry(url: redirect.to, coordinator: coordinator)
+            let entry = LiveNavigationEntry(url: redirect.to, coordinator: coordinator, navigationTransition: nil)
             switch redirect.kind {
             case .push:
                 navigationPath.append(entry)

--- a/Sources/LiveViewNative/Coordinators/LiveViewCoordinator.swift
+++ b/Sources/LiveViewNative/Coordinators/LiveViewCoordinator.swift
@@ -412,12 +412,7 @@ public class LiveViewCoordinator<R: RootRegistry>: ObservableObject {
                 // when the root changes, update the `NavStackEntry` itself.
                 self.objectWillChange.send()
             case .leaf:
-                // text nodes don't have their own views, changes to them need to be handled by the parent Text view
-                if let parent = doc.getParent(nodeRef) {
-                    self.elementChanged(nodeRef).send()
-                } else {
-                    self.elementChanged(nodeRef).send()
-                }
+                self.elementChanged(nodeRef).send()
             case .element:
                 // when a single element changes, send an update only to that element.
                 self.elementChanged(nodeRef).send()

--- a/Sources/LiveViewNative/Live/LiveView.swift
+++ b/Sources/LiveViewNative/Live/LiveView.swift
@@ -241,7 +241,7 @@ struct PhxMain<R: RootRegistry>: View {
     @EnvironmentObject private var session: LiveSessionCoordinator<R>
     
     var body: some View {
-        NavStackEntryView(.init(url: context.coordinator.url, coordinator: context.coordinator))
+        NavStackEntryView(.init(url: context.coordinator.url, coordinator: context.coordinator, navigationTransition: nil))
     }
 }
 

--- a/Sources/LiveViewNative/Property Wrappers/FormState.swift
+++ b/Sources/LiveViewNative/Property Wrappers/FormState.swift
@@ -274,7 +274,7 @@ private class FormStateData<Value: FormValue>: ObservableObject {
         // When the element updates from the server, sync the new value into the form.
         elementCancellable = element.projectedValue
             .receive(on: DispatchQueue.main)
-            .sink { [weak self, weak formModel] _ in
+            .sink { [weak formModel] _ in
                 // ignore server updates if the field is focused.
                 guard !isFocused.wrappedValue && !isEditing.wrappedValue else { return }
                 formModel?.setServerValue(

--- a/Sources/LiveViewNative/Stylesheets/Modifiers/Overrides/MatchedTransitionSourceModifier.swift
+++ b/Sources/LiveViewNative/Stylesheets/Modifiers/Overrides/MatchedTransitionSourceModifier.swift
@@ -1,0 +1,38 @@
+//
+//  MatchedTransitionSourceModifier.swift
+//  
+//
+//  Created by Carson Katri on 6/18/24.
+//
+
+import SwiftUI
+import LiveViewNativeStylesheet
+
+@_documentation(visibility: public)
+@ParseableExpression
+struct _MatchedTransitionSourceModifier<R: RootRegistry>: ViewModifier {
+    static var name: String { "matchedTransitionSource" }
+
+    @ObservedElement private var element
+    @LiveContext<R> private var context
+    @Environment(\.namespaces) private var namespaces
+
+    let id: AttributeReference<String>
+    let namespace: AttributeReference<String>
+
+    @available(visionOS 2.0, iOS 18.0, tvOS 18.0, macOS 15.0, watchOS 11.0, *)
+    init(id: AttributeReference<String>, in namespace: AttributeReference<String>) {
+        self.id = id
+        self.namespace = namespace
+    }
+
+    func body(content __content: Content) -> some View {
+        if #available(visionOS 2.0,iOS 18.0,tvOS 18.0,macOS 15.0,watchOS 11.0, *) {
+            __content
+                .matchedTransitionSource(
+                    id: id.resolve(on: element, in: context),
+                    in: namespaces[namespace.resolve(on: element, in: context)]!
+                )
+        } else { __content }
+    }
+}

--- a/Sources/LiveViewNative/Stylesheets/Modifiers/Overrides/NavigationTransitionModifier.swift
+++ b/Sources/LiveViewNative/Stylesheets/Modifiers/Overrides/NavigationTransitionModifier.swift
@@ -1,0 +1,76 @@
+//
+//  NavigationTransitionModifier.swift
+//  
+//
+//  Created by Carson.Katri on 6/18/24.
+//
+
+import SwiftUI
+import LiveViewNativeStylesheet
+
+// manual implementation
+// Requires namespace access.
+/// See [`SwiftUI.View/navigationTransition(_:)`](https://developer.apple.com/documentation/swiftui/view/navigationTransition(_:)) for more details on this ViewModifier.
+///
+/// - Note: This modifier must be applied to the ``SwiftUI/NavigationLink`` element to take effect.
+///
+/// ### navigationTransition(_:)
+/// - `style`: ``AnyNavigationTransition`` (required)
+///
+/// Create a namespace with the ``NamespaceContext`` element.
+///
+/// See [`SwiftUI.View/navigationTransition(_:)`](https://developer.apple.com/documentation/swiftui/view/navigationTransition(_:)) for more details on this ViewModifier.
+///
+/// Example:
+///
+/// ```html
+/// <NavigationLink
+///   destination="..."
+///   style='navigationTransition(.zoom(sourceID: attr("sourceID"), in: :namespace))'
+///   sourceID="target"
+/// >
+///   <Rectangle
+///     id="target"
+///     style='matchedTransitionSource(id: attr("id"), in: :namespace)'
+///   />
+/// </NavigationLink>
+/// ```
+@_documentation(visibility: public)
+@ParseableExpression
+struct _NavigationTransitionModifier<R: RootRegistry>: ViewModifier {
+    static var name: String { "navigationTransition" }
+    
+    let style: Any
+    
+    @ObservedElement private var element
+    @LiveContext<R> private var context
+    @Environment(\.namespaces) private var namespaces
+    
+    @available(iOS 18.0, watchOS 11.0, tvOS 18.0, macOS 15.0, visionOS 2.0, *)
+    init(_ style: AnyNavigationTransition) {
+        self.style = style
+    }
+
+    @ViewBuilder
+    func body(content: Content) -> some View {
+        if #available(iOS 18.0, watchOS 11.0, tvOS 18.0, macOS 15.0, visionOS 2.0, *) {
+            content
+                .environment(\._anyNavigationTransition, _AnyNavigationTransition(value: (style as! AnyNavigationTransition).resolve(on: element, in: context, namespaces: namespaces)))
+        } else {
+            content
+        }
+    }
+}
+
+@available(iOS 18.0, watchOS 11.0, tvOS 18.0, macOS 15.0, visionOS 2.0, *)
+struct _AnyNavigationTransition: NavigationTransition {
+    let value: any NavigationTransition
+    
+    func _outputs(for inputs: _NavigationTransitionInputs) -> _NavigationTransitionOutputs {
+        value._outputs(for: inputs)
+    }
+}
+
+extension EnvironmentValues {
+    @Entry var _anyNavigationTransition: Any?
+}

--- a/Sources/LiveViewNative/Stylesheets/ParseableTypes/AccessibilityActionCategory+ParseableModifierValue.swift
+++ b/Sources/LiveViewNative/Stylesheets/ParseableTypes/AccessibilityActionCategory+ParseableModifierValue.swift
@@ -10,7 +10,7 @@ import LiveViewNativeStylesheet
 
 @available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
 extension AccessibilityActionCategory: ParseableModifierValue {
-    static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
+    public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         OneOf {
             ImplicitStaticMember([
                 "default": Self.default,
@@ -22,6 +22,8 @@ extension AccessibilityActionCategory: ParseableModifierValue {
     
     @ParseableExpression
     struct ParseableAccessibilityActionCategory {
+        static let name: String = "AccessibilityActionCategory"
+        
         let value: AccessibilityActionCategory
         
         init(_ name: String) {

--- a/Sources/LiveViewNative/Stylesheets/ParseableTypes/AccessibilityActionCategory+ParseableModifierValue.swift
+++ b/Sources/LiveViewNative/Stylesheets/ParseableTypes/AccessibilityActionCategory+ParseableModifierValue.swift
@@ -1,0 +1,31 @@
+//
+//  AccessibilityActionCategory+ParseableModifierValue.swift
+//  LiveViewNative
+//
+//  Created by Carson Katri on 10/3/24.
+//
+
+import SwiftUI
+import LiveViewNativeStylesheet
+
+@available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
+extension AccessibilityActionCategory: ParseableModifierValue {
+    static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
+        OneOf {
+            ImplicitStaticMember([
+                "default": Self.default,
+                "edit": Self.edit
+            ])
+            ParseableAccessibilityActionCategory.parser(in: context).map(\.value)
+        }
+    }
+    
+    @ParseableExpression
+    struct ParseableAccessibilityActionCategory {
+        let value: AccessibilityActionCategory
+        
+        init(_ name: String) {
+            self.value = .init(name)
+        }
+    }
+}

--- a/Sources/LiveViewNative/Stylesheets/ParseableTypes/AnyGesture+ParseableModifierValue.swift
+++ b/Sources/LiveViewNative/Stylesheets/ParseableTypes/AnyGesture+ParseableModifierValue.swift
@@ -8,8 +8,6 @@
 import SwiftUI
 import LiveViewNativeStylesheet
 
-public typealias AnyUIGestureRecognizerRepresentable = AnyGesture<Any>
-
 /// See [`SwiftUI.Gesture`](https://developer.apple.com/documentation/swiftui/Gesture) for more details.
 ///
 /// ## Gestures

--- a/Sources/LiveViewNative/Stylesheets/ParseableTypes/AnyGesture+ParseableModifierValue.swift
+++ b/Sources/LiveViewNative/Stylesheets/ParseableTypes/AnyGesture+ParseableModifierValue.swift
@@ -8,6 +8,8 @@
 import SwiftUI
 import LiveViewNativeStylesheet
 
+public typealias AnyUIGestureRecognizerRepresentable = AnyGesture<Any>
+
 /// See [`SwiftUI.Gesture`](https://developer.apple.com/documentation/swiftui/Gesture) for more details.
 ///
 /// ## Gestures

--- a/Sources/LiveViewNative/Stylesheets/ParseableTypes/AnyNavigationTransition.swift
+++ b/Sources/LiveViewNative/Stylesheets/ParseableTypes/AnyNavigationTransition.swift
@@ -1,0 +1,53 @@
+//
+//  AnyNavigationTransition.swift
+//  
+//
+//  Created by Carson Katri on 6/18/24.
+//
+
+import SwiftUI
+import LiveViewNativeStylesheet
+
+@available(iOS 18.0, watchOS 11.0, tvOS 18.0, macOS 15.0, visionOS 2.0, *)
+enum AnyNavigationTransition: ParseableModifierValue {
+    case automatic
+    case zoom(Zoom)
+    
+    func resolve(
+        on element: ElementNode,
+        in context: LiveContext<some RootRegistry>,
+        namespaces: [String:Namespace.ID]
+    ) -> any NavigationTransition {
+        switch self {
+        case .automatic:
+            .automatic
+        case .zoom(let zoom):
+            .zoom(
+                sourceID: zoom.sourceID.resolve(on: element, in: context),
+                in: namespaces[zoom.namespace.resolve(on: element, in: context)]!
+            )
+        }
+    }
+    
+    static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
+        ImplicitStaticMember {
+            OneOf {
+                ConstantAtomLiteral("automatic").map({ Self.automatic })
+                Zoom.parser(in: context).map(Self.zoom)
+            }
+        }
+    }
+    
+    @ParseableExpression
+    struct Zoom: ParseableModifierValue {
+        static let name = "zoom"
+        
+        let sourceID: AttributeReference<String>
+        let namespace: AttributeReference<String>
+        
+        init(sourceID: AttributeReference<String>, in namespace: AttributeReference<String>) {
+            self.sourceID = sourceID
+            self.namespace = namespace
+        }
+    }
+}

--- a/Sources/LiveViewNative/Stylesheets/ParseableTypes/AnyNavigationTransition.swift
+++ b/Sources/LiveViewNative/Stylesheets/ParseableTypes/AnyNavigationTransition.swift
@@ -11,7 +11,9 @@ import LiveViewNativeStylesheet
 @available(iOS 18.0, watchOS 11.0, tvOS 18.0, macOS 15.0, visionOS 2.0, *)
 enum AnyNavigationTransition: ParseableModifierValue {
     case automatic
+    #if os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
     case zoom(Zoom)
+    #endif
     
     func resolve(
         on element: ElementNode,
@@ -21,11 +23,13 @@ enum AnyNavigationTransition: ParseableModifierValue {
         switch self {
         case .automatic:
             .automatic
+        #if os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case .zoom(let zoom):
             .zoom(
                 sourceID: zoom.sourceID.resolve(on: element, in: context),
                 in: namespaces[zoom.namespace.resolve(on: element, in: context)]!
             )
+        #endif
         }
     }
     
@@ -33,11 +37,14 @@ enum AnyNavigationTransition: ParseableModifierValue {
         ImplicitStaticMember {
             OneOf {
                 ConstantAtomLiteral("automatic").map({ Self.automatic })
+                #if os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
                 Zoom.parser(in: context).map(Self.zoom)
+                #endif
             }
         }
     }
     
+    #if os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
     @ParseableExpression
     struct Zoom: ParseableModifierValue {
         static let name = "zoom"
@@ -50,4 +57,5 @@ enum AnyNavigationTransition: ParseableModifierValue {
             self.namespace = namespace
         }
     }
+    #endif
 }

--- a/Sources/LiveViewNative/Stylesheets/ParseableTypes/AnyPresentationSizing.swift
+++ b/Sources/LiveViewNative/Stylesheets/ParseableTypes/AnyPresentationSizing.swift
@@ -20,7 +20,7 @@ import LiveViewNativeStylesheet
 /// - `fitted(horizontal: Bool, vertical: Bool)`
 /// - `sticky(horizontal: Bool, vertical: Bool)`
 @_documentation(visibility: public)
-@available(iOS 18.0, watchOS 11.0, tvOS 18.0, macOS 15.0, visionOS 1.0, *)
+@available(iOS 18.0, watchOS 11.0, tvOS 18.0, macOS 15.0, visionOS 2.0, *)
 struct AnyPresentationSizing: PresentationSizing, ParseableModifierValue {
     let value: any PresentationSizing
     

--- a/Sources/LiveViewNative/Stylesheets/ParseableTypes/AnyPresentationSizing.swift
+++ b/Sources/LiveViewNative/Stylesheets/ParseableTypes/AnyPresentationSizing.swift
@@ -1,0 +1,91 @@
+//
+//  AnyPresentationSizing.swift
+//  
+//
+//  Created by Carson Katri on 6/18/24.
+//
+
+import SwiftUI
+import LiveViewNativeStylesheet
+
+/// See [SwiftUI.PresentationSizing]() for more details.
+///
+/// Possible values:
+/// - `.automatic`
+/// - `.fitted`
+/// - `.form`
+/// - `.page`
+///
+/// Modifiers:
+/// - `fitted(horizontal: Bool, vertical: Bool)`
+/// - `sticky(horizontal: Bool, vertical: Bool)`
+@_documentation(visibility: public)
+@available(iOS 18.0, watchOS 11.0, tvOS 18.0, macOS 15.0, visionOS 1.0, *)
+struct AnyPresentationSizing: PresentationSizing, ParseableModifierValue {
+    let value: any PresentationSizing
+    
+    func proposedSize(for root: PresentationSizingRoot, context: PresentationSizingContext) -> ProposedViewSize {
+        value.proposedSize(for: root, context: context)
+    }
+    
+    static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
+        ChainedMemberExpression {
+            EnumParser([
+                "automatic": AutomaticPresentationSizing.automatic as any PresentationSizing,
+                "fitted": FittedPresentationSizing.fitted as any PresentationSizing,
+                "form": FormPresentationSizing.form as any PresentationSizing,
+                "page": PagePresentationSizing.page as any PresentationSizing
+            ])
+        } member: {
+            Modifier.parser(in: context)
+        }
+        .map { (base: any PresentationSizing, members: [Modifier]) in
+            Self(value: members.reduce(base) {
+                switch $1 {
+                case let .fitted(fitted):
+                    $0.fitted(horizontal: fitted.horizontal, vertical: fitted.vertical)
+                case let .sticky(sticky):
+                    $0.sticky(horizontal: sticky.horizontal, vertical: sticky.vertical)
+                }
+            })
+        }
+    }
+    
+    enum Modifier: ParseableModifierValue {
+        case fitted(Fitted)
+        case sticky(Sticky)
+        
+        static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
+            OneOf {
+                Fitted.parser(in: context).map(Self.fitted)
+                Sticky.parser(in: context).map(Self.sticky)
+            }
+        }
+        
+        @ParseableExpression
+        struct Fitted {
+            static let name = "fitted"
+            
+            let horizontal: Bool
+            let vertical: Bool
+            
+            init(horizontal: Bool, vertical: Bool) {
+                self.horizontal = horizontal
+                self.vertical = vertical
+            }
+        }
+        
+        @ParseableExpression
+        struct Sticky {
+            static let name = "sticky"
+            
+            let horizontal: Bool
+            let vertical: Bool
+            
+            init(horizontal: Bool, vertical: Bool) {
+                self.horizontal = horizontal
+                self.vertical = vertical
+            }
+        }
+    }
+}

--- a/Sources/LiveViewNative/Stylesheets/ParseableTypes/HandGestureShortcut+ParseableModifierValue.swift
+++ b/Sources/LiveViewNative/Stylesheets/ParseableTypes/HandGestureShortcut+ParseableModifierValue.swift
@@ -10,7 +10,7 @@ import LiveViewNativeStylesheet
 
 #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
 @available(iOS 18, macOS 15, tvOS 18, watchOS 11, *)
-extension HandGestureShortcut: @retroactive ParseableModifierValue {
+extension HandGestureShortcut: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember([
             "primaryAction": .primaryAction

--- a/Sources/LiveViewNative/Stylesheets/ParseableTypes/HandGestureShortcut+ParseableModifierValue.swift
+++ b/Sources/LiveViewNative/Stylesheets/ParseableTypes/HandGestureShortcut+ParseableModifierValue.swift
@@ -1,0 +1,20 @@
+//
+//  HandGestureShortcut+ParseableModifierValue.swift
+//  
+//
+//  Created by Carson Katri on 6/18/24.
+//
+
+import SwiftUI
+import LiveViewNativeStylesheet
+
+#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+@available(iOS 18, macOS 15, tvOS 18, watchOS 11, *)
+extension HandGestureShortcut: @retroactive ParseableModifierValue {
+    public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
+        ImplicitStaticMember([
+            "primaryAction": .primaryAction
+        ])
+    }
+}
+#endif

--- a/Sources/LiveViewNative/Stylesheets/ParseableTypes/MaterialActiveAppearance+ParseableModifierValue.swift
+++ b/Sources/LiveViewNative/Stylesheets/ParseableTypes/MaterialActiveAppearance+ParseableModifierValue.swift
@@ -17,7 +17,7 @@ import LiveViewNativeStylesheet
 /// - `.matchWindow`
 @_documentation(visibility: public)
 @available(iOS 18, macOS 15.0, tvOS 18, visionOS 2, watchOS 11, *)
-extension MaterialActiveAppearance: @retroactive ParseableModifierValue {
+extension MaterialActiveAppearance: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {

--- a/Sources/LiveViewNative/Stylesheets/ParseableTypes/MaterialActiveAppearance+ParseableModifierValue.swift
+++ b/Sources/LiveViewNative/Stylesheets/ParseableTypes/MaterialActiveAppearance+ParseableModifierValue.swift
@@ -1,0 +1,33 @@
+//
+//  MaterialActiveAppearance+ParseableModifierValue.swift
+//  
+//
+//  Created by Carson Katri on 6/18/24.
+//
+
+import SwiftUI
+import LiveViewNativeStylesheet
+
+/// See []() for more details.
+///
+/// Possible values:
+/// - `.inactive`
+/// - `.active`
+/// - `.automatic`
+/// - `.matchWindow`
+@_documentation(visibility: public)
+@available(iOS 18, macOS 15.0, tvOS 18, visionOS 2, watchOS 11, *)
+extension MaterialActiveAppearance: @retroactive ParseableModifierValue {
+    public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
+        ImplicitStaticMember {
+            OneOf {
+                #if os(macOS)
+                ConstantAtomLiteral("inactive").map({ Self.inactive })
+                #endif
+                ConstantAtomLiteral("active").map({ Self.active })
+                ConstantAtomLiteral("automatic").map({ Self.automatic })
+                ConstantAtomLiteral("matchWindow").map({ Self.matchWindow })
+            }
+        }
+    }
+}

--- a/Sources/LiveViewNative/Stylesheets/ParseableTypes/PointerStyle+ParseableModifierValue.swift
+++ b/Sources/LiveViewNative/Stylesheets/ParseableTypes/PointerStyle+ParseableModifierValue.swift
@@ -1,0 +1,151 @@
+//
+//  PointerStyle+ParseableModifierValue.swift
+//  
+//
+//  Created by Carson.Katri on 6/19/24.
+//
+
+import SwiftUI
+import LiveViewNativeStylesheet
+
+#if os(macOS) || os(visionOS)
+@available(macOS 15, visionOS 2, *)
+extension PointerStyle: @retroactive ParseableModifierValue {
+    public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
+        ImplicitStaticMember {
+            OneOf {
+                ColumnResize.parser(in: context).map(\.value)
+                FrameResize.parser(in: context).map(\.value)
+                Image.parser(in: context).map(\.value)
+                RowResize.parser(in: context).map(\.value)
+                #if os(visionOS)
+                Shape.parser(in: context).map(\.value)
+                #endif
+                
+                ConstantAtomLiteral("columnResize").map({ Self.columnResize })
+                ConstantAtomLiteral("default").map({ Self.`default` })
+                ConstantAtomLiteral("grabActive").map({ Self.grabActive })
+                ConstantAtomLiteral("grabIdle").map({ Self.grabIdle })
+                ConstantAtomLiteral("horizontalText").map({ Self.horizontalText })
+                ConstantAtomLiteral("link").map({ Self.link })
+                ConstantAtomLiteral("rectSelection").map({ Self.rectSelection })
+                ConstantAtomLiteral("rowResize").map({ Self.rowResize })
+                ConstantAtomLiteral("verticalText").map({ Self.verticalText })
+                ConstantAtomLiteral("zoomIn").map({ Self.zoomIn })
+                ConstantAtomLiteral("zoomOut").map({ Self.zoomOut })
+            }
+        }
+    }
+    
+    @ParseableExpression
+    struct ColumnResize {
+        static let name = "columnResize"
+        
+        let value: PointerStyle
+        
+        init(directions: HorizontalDirection.Set) {
+            self.value = .columnResize(directions: directions)
+        }
+    }
+    
+    @ParseableExpression
+    struct FrameResize {
+        static let name = "frameResize"
+        
+        let value: PointerStyle
+        
+        init(
+            position: FrameResizePosition,
+            directions: FrameResizeDirection.Set = .all
+        ) {
+            self.value = .frameResize(position: position, directions: directions)
+        }
+    }
+    
+    @ParseableExpression
+    struct Image {
+        static let name = "image"
+        
+        let value: PointerStyle
+        
+        init(
+            _ image: SwiftUI.Image,
+            hotSpot: UnitPoint
+        ) {
+            self.value = .image(image, hotSpot: hotSpot)
+        }
+    }
+    
+    @ParseableExpression
+    struct RowResize {
+        static let name = "rowResize"
+        
+        let value: PointerStyle
+        
+        init(directions: VerticalDirection.Set) {
+            self.value = .rowResize(directions: directions)
+        }
+    }
+    
+    #if os(visionOS)
+    @ParseableExpression
+    struct Shape {
+        static let name = "shape"
+        
+        let value: PointerStyle
+        
+        init(
+            _ shape: AnyShape,
+            eoFill: Bool = false,
+            size: CGSize
+        ) {
+            self.value = .shape(shape, eoFill: eoFill, size: size)
+        }
+    }
+    #endif
+}
+#endif
+
+@available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
+extension HorizontalDirection.Set: @retroactive ParseableModifierValue {
+    public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
+        OneOf {
+            Array<Self.Element>.parser(in: context).map({ Self.init($0) })
+            ImplicitStaticMember([
+                "all": Self.all,
+                "leading": Self.leading,
+                "trailing": Self.trailing,
+            ])
+        }
+    }
+}
+
+@available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
+extension VerticalDirection.Set: @retroactive ParseableModifierValue {
+    public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
+        OneOf {
+            Array<Self.Element>.parser(in: context).map({ Self.init($0) })
+            ImplicitStaticMember([
+                "all": Self.all,
+                "up": Self.up,
+                "down": Self.down,
+            ])
+        }
+    }
+}
+
+#if os(macOS)
+@available(macOS 15.0, *)
+extension FrameResizeDirection.Set: @retroactive ParseableModifierValue {
+    public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
+        OneOf {
+            Array<Self.Element>.parser(in: context).map({ Self.init($0) })
+            ImplicitStaticMember([
+                "all": Self.all,
+                "inward": Self.inward,
+                "outward": Self.outward,
+            ])
+        }
+    }
+}
+#endif

--- a/Sources/LiveViewNative/Stylesheets/ParseableTypes/PointerStyle+ParseableModifierValue.swift
+++ b/Sources/LiveViewNative/Stylesheets/ParseableTypes/PointerStyle+ParseableModifierValue.swift
@@ -14,16 +14,21 @@ extension PointerStyle: @retroactive ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
+                #if os(macOS)
                 ColumnResize.parser(in: context).map(\.value)
                 FrameResize.parser(in: context).map(\.value)
                 Image.parser(in: context).map(\.value)
                 RowResize.parser(in: context).map(\.value)
+                #endif
+                
                 #if os(visionOS)
                 Shape.parser(in: context).map(\.value)
                 #endif
                 
-                ConstantAtomLiteral("columnResize").map({ Self.columnResize })
                 ConstantAtomLiteral("default").map({ Self.`default` })
+                
+                #if os(macOS)
+                ConstantAtomLiteral("columnResize").map({ Self.columnResize })
                 ConstantAtomLiteral("grabActive").map({ Self.grabActive })
                 ConstantAtomLiteral("grabIdle").map({ Self.grabIdle })
                 ConstantAtomLiteral("horizontalText").map({ Self.horizontalText })
@@ -33,10 +38,12 @@ extension PointerStyle: @retroactive ParseableModifierValue {
                 ConstantAtomLiteral("verticalText").map({ Self.verticalText })
                 ConstantAtomLiteral("zoomIn").map({ Self.zoomIn })
                 ConstantAtomLiteral("zoomOut").map({ Self.zoomOut })
+                #endif
             }
         }
     }
     
+    #if os(macOS)
     @ParseableExpression
     struct ColumnResize {
         static let name = "columnResize"
@@ -86,6 +93,7 @@ extension PointerStyle: @retroactive ParseableModifierValue {
             self.value = .rowResize(directions: directions)
         }
     }
+    #endif
     
     #if os(visionOS)
     @ParseableExpression

--- a/Sources/LiveViewNative/Stylesheets/ParseableTypes/PointerStyle+ParseableModifierValue.swift
+++ b/Sources/LiveViewNative/Stylesheets/ParseableTypes/PointerStyle+ParseableModifierValue.swift
@@ -115,7 +115,7 @@ extension PointerStyle: @retroactive ParseableModifierValue {
 #endif
 
 @available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
-extension HorizontalDirection.Set: @retroactive ParseableModifierValue {
+extension HorizontalDirection.Set: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         OneOf {
             Array<Self.Element>.parser(in: context).map({ Self.init($0) })
@@ -129,7 +129,7 @@ extension HorizontalDirection.Set: @retroactive ParseableModifierValue {
 }
 
 @available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
-extension VerticalDirection.Set: @retroactive ParseableModifierValue {
+extension VerticalDirection.Set: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         OneOf {
             Array<Self.Element>.parser(in: context).map({ Self.init($0) })

--- a/Sources/LiveViewNative/Utils/Alignment.swift
+++ b/Sources/LiveViewNative/Utils/Alignment.swift
@@ -22,7 +22,7 @@ import LiveViewNativeCore
 /// - `bottomTrailing`
 /// - `leadingLastTextBaseline`
 /// - `trailingLastTextBaseline`
-extension Alignment: Decodable, AttributeDecodable {
+extension Alignment: @retroactive Decodable, AttributeDecodable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
         let string = try container.decode(String.self)
@@ -77,7 +77,7 @@ extension Alignment: Decodable, AttributeDecodable {
 /// - `trailing`
 /// - `listRowSeparatorLeading`
 /// - `listRowSeparatorTrailing`
-extension HorizontalAlignment: Decodable, AttributeDecodable {
+extension HorizontalAlignment: @retroactive Decodable, AttributeDecodable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
         let string = try container.decode(String.self)
@@ -122,7 +122,7 @@ extension HorizontalAlignment: Decodable, AttributeDecodable {
 /// - `bottom`
 /// - `firstTextBaseline`
 /// - `lastTextBaseline`
-extension VerticalAlignment: Decodable, AttributeDecodable {
+extension VerticalAlignment: @retroactive Decodable, AttributeDecodable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
         let string = try container.decode(String.self)

--- a/Sources/LiveViewNative/Utils/GridItem.swift
+++ b/Sources/LiveViewNative/Utils/GridItem.swift
@@ -18,7 +18,7 @@ import LiveViewNativeCore
 /// %{ size: %{ flexible: %{ minimum: 0, maximum: 100 } }, spacing: 1, alignment: :topLeading }
 /// %{ size: %{ adaptive: %{ minimum: 10 } } }
 /// ```
-extension GridItem: Decodable, AttributeDecodable {
+extension GridItem: @retroactive Decodable, AttributeDecodable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.init(
@@ -48,7 +48,7 @@ extension GridItem: Decodable, AttributeDecodable {
 /// * `:flexible`
 /// * `%{ flexible: %{ minimum: <optional value>, maximum: <optional value> } }`
 /// * `%{ adaptive: %{ minimum: <value>, maximum: <optional value> } }`
-extension GridItem.Size: Decodable {
+extension GridItem.Size: @retroactive Decodable {
     public init(from decoder: Decoder) throws {
         if let container = try? decoder.container(keyedBy: CodingKeys.self) {
             if container.contains(.fixed) {

--- a/Sources/LiveViewNative/Utils/Transaction.swift
+++ b/Sources/LiveViewNative/Utils/Transaction.swift
@@ -55,7 +55,7 @@ private struct CodableTransaction: Decodable {
 /// ```elixir
 /// %{ timingCurve: [0.1, 0.75, 0.85, 0.35] }
 /// ```
-extension Animation: Decodable {
+extension Animation: @retroactive Decodable {
     public init(from decoder: any Decoder) throws {
         if let standard = try? decoder.singleValueContainer().decode(String.self) {
             switch standard {

--- a/Sources/LiveViewNative/Utils/UnitPoint.swift
+++ b/Sources/LiveViewNative/Utils/UnitPoint.swift
@@ -88,7 +88,7 @@ extension UnitPoint {
     }
 }
 
-extension UnitPoint: Decodable {
+extension UnitPoint: @retroactive Decodable {
     public init(from decoder: any Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         if let named = try container.decodeIfPresent(String.self, forKey: .named) {

--- a/Sources/LiveViewNative/ViewModel.swift
+++ b/Sources/LiveViewNative/ViewModel.swift
@@ -156,7 +156,7 @@ public class FormModel: ObservableObject, CustomDebugStringConvertible {
     @MainActor
     private func pushFormEvent(_ event: String) async throws {
         // the `form` event type expects a URL encoded payload (e.g., `a=b&c=d`)
-        try await pushEventImpl("form", event, try buildFormQuery(), nil)
+        _ = try await pushEventImpl("form", event, try buildFormQuery(), nil)
     }
     
     public var debugDescription: String {

--- a/Sources/LiveViewNative/Views/Drawing and Graphics/ColorView.swift
+++ b/Sources/LiveViewNative/Views/Drawing and Graphics/ColorView.swift
@@ -92,7 +92,7 @@ struct ColorView<Root: RootRegistry>: View {
     }
 }
 
-extension SwiftUI.Color.RGBColorSpace: AttributeDecodable, Decodable {
+extension SwiftUI.Color.RGBColorSpace: @retroactive Decodable, AttributeDecodable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
         let string = try container.decode(String.self)
@@ -123,7 +123,7 @@ extension SwiftUI.Color.RGBColorSpace: AttributeDecodable, Decodable {
 }
 
 /// Helpers for creating a SwiftUI `Color`.
-extension SwiftUI.Color: Decodable {
+extension SwiftUI.Color: @retroactive Decodable {
     /// Decodes a color from one of several possible formats.
     ///
     /// The encoded value may be a dictionary containing an RGB color space (one of `srgb`, `srgb-linear`, or `display-p3`) in the `rgb_color_space_key`.

--- a/Sources/LiveViewNative/Views/Layout Containers/Presentation Containers/NavigationLink.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Presentation Containers/NavigationLink.swift
@@ -32,13 +32,18 @@ struct NavigationLink<Root: RootRegistry>: View {
     @_documentation(visibility: public)
     private var destination: String?
     
+    @LiveElementIgnored
+    @Environment(\._anyNavigationTransition)
+    private var anyNavigationTransition: Any?
+    
     @ViewBuilder
     public var body: some View {
         if let url = destination.flatMap({ URL(string: $0, relativeTo: $liveElement.context.coordinator.url) })?.appending(path: "").absoluteURL {
             SwiftUI.NavigationLink(
                 value: LiveNavigationEntry(
                     url: url,
-                    coordinator: LiveViewCoordinator(session: $liveElement.context.coordinator.session, url: url)
+                    coordinator: LiveViewCoordinator(session: $liveElement.context.coordinator.session, url: url),
+                    navigationTransition: anyNavigationTransition
                 )
             ) {
                 $liveElement.children()

--- a/Sources/LiveViewNative/Views/Navigation/NavigationStack.swift
+++ b/Sources/LiveViewNative/Views/Navigation/NavigationStack.swift
@@ -13,6 +13,10 @@ struct NavigationStack<Root: RootRegistry>: View {
     @EnvironmentObject
     private var session: LiveSessionCoordinator<Root>
     
+    @LiveElementIgnored
+    @Environment(\.namespaces)
+    private var namespaces
+    
     var body: some View {
         SwiftUI.NavigationStack(path: Binding {
             session.navigationPath.dropFirst()
@@ -23,7 +27,14 @@ struct NavigationStack<Root: RootRegistry>: View {
                 $liveElement.children()
             }
             .navigationDestination(for: LiveNavigationEntry<Root>.self) { destination in
-                NavStackEntryView(destination)
+                if #available(iOS 18.0, watchOS 11.0, tvOS 18.0, macOS 15.0, visionOS 2.0, *),
+                   let transition = destination.navigationTransition as? _AnyNavigationTransition
+                {
+                    NavStackEntryView(destination)
+                        .navigationTransition(transition)
+                } else {
+                    NavStackEntryView(destination)
+                }
             }
         }
     }

--- a/Sources/LiveViewNative/Views/Shapes/Shape.swift
+++ b/Sources/LiveViewNative/Views/Shapes/Shape.swift
@@ -94,7 +94,7 @@ extension Capsule {
 /// * `circular`
 /// * `continuous`
 @_documentation(visibility: public)
-extension RoundedCornerStyle: Decodable, AttributeDecodable {
+extension RoundedCornerStyle: @retroactive Decodable, AttributeDecodable {
     init?(string: String) {
         switch string {
         case "circular":

--- a/Sources/LiveViewNative/_GeneratedModifiers.swift
+++ b/Sources/LiveViewNative/_GeneratedModifiers.swift
@@ -78,7 +78,7 @@ struct _accessibilityActionsModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(tvOS 18.0,iOS 18.0,macOS 15.0,visionOS 2.0,watchOS 11.0, *)
+    @available(macOS 15.0,iOS 18.0,tvOS 18.0,visionOS 2.0,watchOS 11.0, *)
     init(category: SwiftUI.AccessibilityActionCategory,content content: ViewReference=ViewReference(value: [])) {
         self.value = ._0(category: category, content: content)
         
@@ -98,7 +98,7 @@ struct _accessibilityActionsModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(category, content):
-            if #available(tvOS 18.0,iOS 18.0,macOS 15.0,visionOS 2.0,watchOS 11.0, *) {
+            if #available(macOS 15.0,iOS 18.0,tvOS 18.0,visionOS 2.0,watchOS 11.0, *) {
             let category = category as! SwiftUI.AccessibilityActionCategory
 let content = content as! ViewReference
             
@@ -634,7 +634,7 @@ struct _allowsWindowActivationEventsModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(visionOS 2.0,macOS 15.0,iOS 18.0, *)
+    @available(visionOS 2.0,iOS 18.0,macOS 15.0, *)
     init(_ value: AttributeReference<Swift.Bool?>? = .init(storage: .constant(true)) ) {
         self.value = ._0(value: value)
         
@@ -647,7 +647,7 @@ struct _allowsWindowActivationEventsModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(value):
-            if #available(visionOS 2.0,macOS 15.0,iOS 18.0, *) {
+            if #available(visionOS 2.0,iOS 18.0,macOS 15.0, *) {
             let value = value as? AttributeReference<Swift.Bool?>
             
             __content
@@ -1092,28 +1092,28 @@ struct _badgeModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 12.0,visionOS 1.0,iOS 15.0, *)
+    @available(iOS 15.0,macOS 12.0,visionOS 1.0, *)
     init(_ count: AttributeReference<Swift.Int>) {
         self.value = ._0(count: count)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 12.0,visionOS 1.0,iOS 15.0, *)
+    @available(iOS 15.0,macOS 12.0,visionOS 1.0, *)
     init(_ label: TextReference?) {
         self.value = ._1(label: label)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 12.0,visionOS 1.0,iOS 15.0, *)
+    @available(iOS 15.0,macOS 12.0,visionOS 1.0, *)
     init(_ key: SwiftUICore.LocalizedStringKey?) {
         self.value = ._2(key: key)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 12.0,iOS 15.0,visionOS 1.0, *)
+    @available(iOS 15.0,macOS 12.0,visionOS 1.0, *)
     init(_ label: AttributeReference<String>) {
         self.value = ._3(label: label)
         
@@ -1126,7 +1126,7 @@ struct _badgeModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(count):
-            if #available(macOS 12.0,visionOS 1.0,iOS 15.0, *) {
+            if #available(iOS 15.0,macOS 12.0,visionOS 1.0, *) {
             let count = count as! AttributeReference<Swift.Int>
             
             __content
@@ -1137,7 +1137,7 @@ struct _badgeModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._1(label):
-            if #available(macOS 12.0,visionOS 1.0,iOS 15.0, *) {
+            if #available(iOS 15.0,macOS 12.0,visionOS 1.0, *) {
             let label = label as? TextReference
             __content._observeTextReference(label, on: element, in: context) { __content in
             __content
@@ -1148,7 +1148,7 @@ struct _badgeModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._2(key):
-            if #available(macOS 12.0,visionOS 1.0,iOS 15.0, *) {
+            if #available(iOS 15.0,macOS 12.0,visionOS 1.0, *) {
             let key = key as? SwiftUICore.LocalizedStringKey
             
             __content
@@ -1159,7 +1159,7 @@ struct _badgeModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._3(label):
-            if #available(macOS 12.0,iOS 15.0,visionOS 1.0, *) {
+            if #available(iOS 15.0,macOS 12.0,visionOS 1.0, *) {
             let label = label as! AttributeReference<String>
             
             __content
@@ -1193,7 +1193,7 @@ struct _badgeProminenceModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 14.0,visionOS 1.0,iOS 17.0, *)
+    @available(iOS 17.0,visionOS 1.0,macOS 14.0, *)
     init(_ prominence: SwiftUI.BadgeProminence) {
         self.value = ._0(prominence: prominence)
         
@@ -1206,7 +1206,7 @@ struct _badgeProminenceModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(prominence):
-            if #available(macOS 14.0,visionOS 1.0,iOS 17.0, *) {
+            if #available(iOS 17.0,visionOS 1.0,macOS 14.0, *) {
             let prominence = prominence as! SwiftUI.BadgeProminence
             
             __content
@@ -1947,14 +1947,14 @@ struct _containerRelativeFrameModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 10.0,iOS 17.0,tvOS 17.0,macOS 14.0,visionOS 1.0, *)
+    @available(macOS 14.0,iOS 17.0,tvOS 17.0,visionOS 1.0,watchOS 10.0, *)
     init(_ axes: SwiftUICore.Axis.Set,alignment: AttributeReference<SwiftUICore.Alignment> = .init(storage: .constant(.center)) ) {
         self.value = ._0(axes: axes, alignment: alignment)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(tvOS 17.0,watchOS 10.0,macOS 14.0,iOS 17.0,visionOS 1.0, *)
+    @available(macOS 14.0,iOS 17.0,tvOS 17.0,visionOS 1.0,watchOS 10.0, *)
     init(_ axes: SwiftUICore.Axis.Set,count: AttributeReference<Swift.Int>,span: AttributeReference<Swift.Int> = .init(storage: .constant(1)), spacing: AttributeReference<CoreFoundation.CGFloat>,alignment: AttributeReference<SwiftUICore.Alignment> = .init(storage: .constant(.center)) ) {
         self.value = ._1(axes: axes, count: count, span: span, spacing: spacing, alignment: alignment)
         
@@ -1967,7 +1967,7 @@ struct _containerRelativeFrameModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(axes, alignment):
-            if #available(watchOS 10.0,iOS 17.0,tvOS 17.0,macOS 14.0,visionOS 1.0, *) {
+            if #available(macOS 14.0,iOS 17.0,tvOS 17.0,visionOS 1.0,watchOS 10.0, *) {
             let axes = axes as! SwiftUICore.Axis.Set
 let alignment = alignment as! AttributeReference<SwiftUICore.Alignment>
             
@@ -1979,7 +1979,7 @@ let alignment = alignment as! AttributeReference<SwiftUICore.Alignment>
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(axes, count, span, spacing, alignment):
-            if #available(tvOS 17.0,watchOS 10.0,macOS 14.0,iOS 17.0,visionOS 1.0, *) {
+            if #available(macOS 14.0,iOS 17.0,tvOS 17.0,visionOS 1.0,watchOS 10.0, *) {
             let axes = axes as! SwiftUICore.Axis.Set
 let count = count as! AttributeReference<Swift.Int>
 let span = span as! AttributeReference<Swift.Int>
@@ -2074,21 +2074,21 @@ struct _contentMarginsModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,tvOS 17.0,watchOS 10.0,macOS 14.0,iOS 17.0, *)
+    @available(watchOS 10.0,tvOS 17.0,iOS 17.0,visionOS 1.0,macOS 14.0, *)
     init(_ edges: SwiftUICore.Edge.Set = .all, _ insets: SwiftUICore.EdgeInsets,for placement: SwiftUI.ContentMarginPlacement = .automatic ) {
         self.value = ._0(edges: edges, insets: insets, placement: placement)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,tvOS 17.0,watchOS 10.0,macOS 14.0,iOS 17.0, *)
+    @available(watchOS 10.0,tvOS 17.0,iOS 17.0,visionOS 1.0,macOS 14.0, *)
     init(_ edges: SwiftUICore.Edge.Set = .all, _ length: AttributeReference<CoreFoundation.CGFloat?>?,for placement: SwiftUI.ContentMarginPlacement = .automatic ) {
         self.value = ._1(edges: edges, length: length, placement: placement)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,tvOS 17.0,watchOS 10.0,macOS 14.0,iOS 17.0, *)
+    @available(watchOS 10.0,tvOS 17.0,iOS 17.0,visionOS 1.0,macOS 14.0, *)
     init(_ length: AttributeReference<CoreFoundation.CGFloat>,for placement: SwiftUI.ContentMarginPlacement = .automatic ) {
         self.value = ._2(length: length, placement: placement)
         
@@ -2101,7 +2101,7 @@ struct _contentMarginsModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(edges, insets, placement):
-            if #available(visionOS 1.0,tvOS 17.0,watchOS 10.0,macOS 14.0,iOS 17.0, *) {
+            if #available(watchOS 10.0,tvOS 17.0,iOS 17.0,visionOS 1.0,macOS 14.0, *) {
             let edges = edges as! SwiftUICore.Edge.Set 
 let insets = insets as! SwiftUICore.EdgeInsets
 let placement = placement as! SwiftUI.ContentMarginPlacement 
@@ -2114,7 +2114,7 @@ let placement = placement as! SwiftUI.ContentMarginPlacement
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(edges, length, placement):
-            if #available(visionOS 1.0,tvOS 17.0,watchOS 10.0,macOS 14.0,iOS 17.0, *) {
+            if #available(watchOS 10.0,tvOS 17.0,iOS 17.0,visionOS 1.0,macOS 14.0, *) {
             let edges = edges as! SwiftUICore.Edge.Set 
 let length = length as? AttributeReference<CoreFoundation.CGFloat?>
 let placement = placement as! SwiftUI.ContentMarginPlacement 
@@ -2127,7 +2127,7 @@ let placement = placement as! SwiftUI.ContentMarginPlacement
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._2(length, placement):
-            if #available(visionOS 1.0,tvOS 17.0,watchOS 10.0,macOS 14.0,iOS 17.0, *) {
+            if #available(watchOS 10.0,tvOS 17.0,iOS 17.0,visionOS 1.0,macOS 14.0, *) {
             let length = length as! AttributeReference<CoreFoundation.CGFloat>
 let placement = placement as! SwiftUI.ContentMarginPlacement 
             
@@ -2291,7 +2291,7 @@ struct _contextMenuModifier<R: RootRegistry>: ViewModifier {
     }
     
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS)
-    @available(visionOS 1.0,macOS 13.0,iOS 16.0,tvOS 16.0, *)
+    @available(tvOS 16.0,iOS 16.0,macOS 13.0,visionOS 1.0, *)
     init(menuItems: ViewReference=ViewReference(value: []),preview: ViewReference=ViewReference(value: [])) {
         self.value = ._1(menuItems: menuItems, preview: preview)
         
@@ -2315,7 +2315,7 @@ struct _contextMenuModifier<R: RootRegistry>: ViewModifier {
         
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS)
         case let ._1(menuItems, preview):
-            if #available(visionOS 1.0,macOS 13.0,iOS 16.0,tvOS 16.0, *) {
+            if #available(tvOS 16.0,iOS 16.0,macOS 13.0,visionOS 1.0, *) {
             let menuItems = menuItems as! ViewReference
 let preview = preview as! ViewReference
             
@@ -2397,7 +2397,7 @@ struct _controlGroupStyleModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS)
-    @available(macOS 12.0,iOS 15.0,tvOS 17.0,visionOS 1.0, *)
+    @available(visionOS 1.0,tvOS 17.0,iOS 15.0,macOS 12.0, *)
     init(_ style: AnyControlGroupStyle) {
         self.value = ._0(style: style)
         
@@ -2410,7 +2410,7 @@ struct _controlGroupStyleModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS)
         case let ._0(style):
-            if #available(macOS 12.0,iOS 15.0,tvOS 17.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,tvOS 17.0,iOS 15.0,macOS 12.0, *) {
             let style = style as! AnyControlGroupStyle
             
             __content
@@ -2444,7 +2444,7 @@ struct _controlSizeModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
-    @available(macOS 10.15,watchOS 9.0,iOS 15.0,visionOS 1.0, *)
+    @available(watchOS 9.0,iOS 15.0,visionOS 1.0,macOS 10.15, *)
     init(_ controlSize: SwiftUICore.ControlSize) {
         self.value = ._0(controlSize: controlSize)
         
@@ -2457,7 +2457,7 @@ struct _controlSizeModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
         case let ._0(controlSize):
-            if #available(macOS 10.15,watchOS 9.0,iOS 15.0,visionOS 1.0, *) {
+            if #available(watchOS 9.0,iOS 15.0,visionOS 1.0,macOS 10.15, *) {
             let controlSize = controlSize as! SwiftUICore.ControlSize
             
             __content
@@ -2491,7 +2491,7 @@ struct _coordinateSpaceModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0, *)
+    @available(visionOS 1.0,tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0, *)
     init(_ name: SwiftUICore.NamedCoordinateSpace) {
         self.value = ._0(name: name)
         
@@ -2504,7 +2504,7 @@ struct _coordinateSpaceModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(name):
-            if #available(visionOS 1.0,macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0, *) {
+            if #available(visionOS 1.0,tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0, *) {
             let name = name as! SwiftUICore.NamedCoordinateSpace
             
             __content
@@ -2538,7 +2538,7 @@ struct _datePickerStyleModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
-    @available(macOS 10.15,watchOS 10.0,iOS 13.0,visionOS 1.0, *)
+    @available(visionOS 1.0,iOS 13.0,watchOS 10.0,macOS 10.15, *)
     init(_ style: AnyDatePickerStyle) {
         self.value = ._0(style: style)
         
@@ -2551,7 +2551,7 @@ struct _datePickerStyleModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
         case let ._0(style):
-            if #available(macOS 10.15,watchOS 10.0,iOS 13.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,iOS 13.0,watchOS 10.0,macOS 10.15, *) {
             let style = style as! AnyDatePickerStyle
             
             __content
@@ -2632,7 +2632,7 @@ struct _defaultHoverEffectModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(tvOS) || os(visionOS)
-    @available(tvOS 17.0,iOS 17.0,visionOS 1.0, *)
+    @available(iOS 17.0,visionOS 1.0,tvOS 17.0, *)
     init(_ effect: SwiftUI.HoverEffect?) {
         self.value = ._0(effect: effect)
         
@@ -2645,7 +2645,7 @@ struct _defaultHoverEffectModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(tvOS) || os(visionOS)
         case let ._0(effect):
-            if #available(tvOS 17.0,iOS 17.0,visionOS 1.0, *) {
+            if #available(iOS 17.0,visionOS 1.0,tvOS 17.0, *) {
             let effect = effect as? SwiftUI.HoverEffect
             
             __content
@@ -2684,14 +2684,14 @@ struct _defaultScrollAnchorModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0,visionOS 1.0, *)
+    @available(tvOS 17.0,macOS 14.0,iOS 17.0,watchOS 10.0,visionOS 1.0, *)
     init(_ anchor: AttributeReference<SwiftUICore.UnitPoint?>?) {
         self.value = ._0(anchor: anchor)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 15.0,watchOS 11.0,iOS 18.0,tvOS 18.0,visionOS 2.0, *)
+    @available(tvOS 18.0,macOS 15.0,iOS 18.0,watchOS 11.0,visionOS 2.0, *)
     init(_ anchor: AttributeReference<SwiftUICore.UnitPoint?>?,for role: SwiftUI.ScrollAnchorRole) {
         self.value = ._1(anchor: anchor, role: role)
         
@@ -2704,7 +2704,7 @@ struct _defaultScrollAnchorModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(anchor):
-            if #available(macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0,visionOS 1.0, *) {
+            if #available(tvOS 17.0,macOS 14.0,iOS 17.0,watchOS 10.0,visionOS 1.0, *) {
             let anchor = anchor as? AttributeReference<SwiftUICore.UnitPoint?>
             
             __content
@@ -2715,7 +2715,7 @@ struct _defaultScrollAnchorModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(anchor, role):
-            if #available(macOS 15.0,watchOS 11.0,iOS 18.0,tvOS 18.0,visionOS 2.0, *) {
+            if #available(tvOS 18.0,macOS 15.0,iOS 18.0,watchOS 11.0,visionOS 2.0, *) {
             let anchor = anchor as? AttributeReference<SwiftUICore.UnitPoint?>
 let role = role as! SwiftUI.ScrollAnchorRole
             
@@ -2750,7 +2750,7 @@ struct _defaultWheelPickerItemHeightModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(visionOS) || os(watchOS)
-    @available(watchOS 6.0,visionOS 1.0, *)
+    @available(visionOS 1.0,watchOS 6.0, *)
     init(_ height: AttributeReference<CoreFoundation.CGFloat>) {
         self.value = ._0(height: height)
         
@@ -2763,7 +2763,7 @@ struct _defaultWheelPickerItemHeightModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(visionOS) || os(watchOS)
         case let ._0(height):
-            if #available(watchOS 6.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,watchOS 6.0, *) {
             let height = height as! AttributeReference<CoreFoundation.CGFloat>
             
             __content
@@ -2906,28 +2906,28 @@ struct _dialogSuppressionToggleModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,tvOS 17.0,watchOS 10.0,macOS 14.0,iOS 17.0, *)
+    @available(watchOS 10.0,tvOS 17.0,iOS 17.0,visionOS 1.0,macOS 14.0, *)
     init(_ titleKey: SwiftUICore.LocalizedStringKey,isSuppressed: ChangeTracked<Swift.Bool>) {
         self.value = ._0(titleKey: titleKey)
         self.__0_isSuppressed = isSuppressed
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,tvOS 17.0,watchOS 10.0,macOS 14.0,iOS 17.0, *)
+    @available(watchOS 10.0,tvOS 17.0,iOS 17.0,visionOS 1.0,macOS 14.0, *)
     init(_ title: AttributeReference<String>,isSuppressed: ChangeTracked<Swift.Bool>) {
         self.value = ._1(title: title)
         self.__1_isSuppressed = isSuppressed
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,tvOS 17.0,watchOS 10.0,macOS 14.0,iOS 17.0, *)
+    @available(watchOS 10.0,tvOS 17.0,iOS 17.0,visionOS 1.0,macOS 14.0, *)
     init(_ label: TextReference,isSuppressed: ChangeTracked<Swift.Bool>) {
         self.value = ._2(label: label)
         self.__2_isSuppressed = isSuppressed
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,tvOS 17.0,watchOS 10.0,macOS 14.0,iOS 17.0, *)
+    @available(watchOS 10.0,tvOS 17.0,iOS 17.0,visionOS 1.0,macOS 14.0, *)
     init(isSuppressed: ChangeTracked<Swift.Bool>) {
         self.value = ._3
         self.__3_isSuppressed = isSuppressed
@@ -2940,7 +2940,7 @@ struct _dialogSuppressionToggleModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(titleKey):
-            if #available(visionOS 1.0,tvOS 17.0,watchOS 10.0,macOS 14.0,iOS 17.0, *) {
+            if #available(watchOS 10.0,tvOS 17.0,iOS 17.0,visionOS 1.0,macOS 14.0, *) {
             let titleKey = titleKey as! SwiftUICore.LocalizedStringKey
             
             __content
@@ -2951,7 +2951,7 @@ struct _dialogSuppressionToggleModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(title):
-            if #available(visionOS 1.0,tvOS 17.0,watchOS 10.0,macOS 14.0,iOS 17.0, *) {
+            if #available(watchOS 10.0,tvOS 17.0,iOS 17.0,visionOS 1.0,macOS 14.0, *) {
             let title = title as! AttributeReference<String>
             
             __content
@@ -2962,7 +2962,7 @@ struct _dialogSuppressionToggleModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._2(label):
-            if #available(visionOS 1.0,tvOS 17.0,watchOS 10.0,macOS 14.0,iOS 17.0, *) {
+            if #available(watchOS 10.0,tvOS 17.0,iOS 17.0,visionOS 1.0,macOS 14.0, *) {
             let label = label as! TextReference
             __content._observeTextReference(label, on: element, in: context) { __content in
             __content
@@ -2973,7 +2973,7 @@ struct _dialogSuppressionToggleModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case ._3:
-            if #available(visionOS 1.0,tvOS 17.0,watchOS 10.0,macOS 14.0,iOS 17.0, *) {
+            if #available(watchOS 10.0,tvOS 17.0,iOS 17.0,visionOS 1.0,macOS 14.0, *) {
             
             
             __content
@@ -3418,7 +3418,7 @@ struct _fileDialogCustomizationIDModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 14.0,visionOS 1.0,iOS 17.0, *)
+    @available(iOS 17.0,macOS 14.0,visionOS 1.0, *)
     init(_ id: AttributeReference<Swift.String>) {
         self.value = ._0(id: id)
         
@@ -3431,7 +3431,7 @@ struct _fileDialogCustomizationIDModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(id):
-            if #available(macOS 14.0,visionOS 1.0,iOS 17.0, *) {
+            if #available(iOS 17.0,macOS 14.0,visionOS 1.0, *) {
             let id = id as! AttributeReference<Swift.String>
             
             __content
@@ -3465,7 +3465,7 @@ struct _fileDialogImportsUnresolvedAliasesModifier<R: RootRegistry>: ViewModifie
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 14.0,visionOS 1.0,iOS 17.0, *)
+    @available(iOS 17.0,macOS 14.0,visionOS 1.0, *)
     init(_ imports: AttributeReference<Swift.Bool>) {
         self.value = ._0(imports: imports)
         
@@ -3478,7 +3478,7 @@ struct _fileDialogImportsUnresolvedAliasesModifier<R: RootRegistry>: ViewModifie
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(imports):
-            if #available(macOS 14.0,visionOS 1.0,iOS 17.0, *) {
+            if #available(iOS 17.0,macOS 14.0,visionOS 1.0, *) {
             let imports = imports as! AttributeReference<Swift.Bool>
             
             __content
@@ -3512,7 +3512,7 @@ struct _findDisabledModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(visionOS)
-    @available(visionOS 1.0,iOS 16.0, *)
+    @available(iOS 16.0,visionOS 1.0, *)
     init(_ isDisabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(isDisabled: isDisabled)
         
@@ -3525,7 +3525,7 @@ struct _findDisabledModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(visionOS)
         case let ._0(isDisabled):
-            if #available(visionOS 1.0,iOS 16.0, *) {
+            if #available(iOS 16.0,visionOS 1.0, *) {
             let isDisabled = isDisabled as! AttributeReference<Swift.Bool>
             
             __content
@@ -3559,7 +3559,7 @@ struct _findNavigatorModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(visionOS)
-    @available(visionOS 1.0,iOS 16.0, *)
+    @available(iOS 16.0,visionOS 1.0, *)
     init(isPresented: ChangeTracked<Swift.Bool>) {
         self.value = ._0
         self.__0_isPresented = isPresented
@@ -3572,7 +3572,7 @@ struct _findNavigatorModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(visionOS)
         case ._0:
-            if #available(visionOS 1.0,iOS 16.0, *) {
+            if #available(iOS 16.0,visionOS 1.0, *) {
             
             
             __content
@@ -3723,7 +3723,7 @@ struct _focusEffectDisabledModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0,visionOS 1.0, *)
+    @available(watchOS 10.0,tvOS 17.0,visionOS 1.0,macOS 14.0,iOS 17.0, *)
     init(_ disabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(disabled: disabled)
         
@@ -3736,7 +3736,7 @@ struct _focusEffectDisabledModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(disabled):
-            if #available(macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0,visionOS 1.0, *) {
+            if #available(watchOS 10.0,tvOS 17.0,visionOS 1.0,macOS 14.0,iOS 17.0, *) {
             let disabled = disabled as! AttributeReference<Swift.Bool>
             
             __content
@@ -3822,14 +3822,14 @@ struct _focusableModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(iOS 17.0,watchOS 8.0,tvOS 15.0,visionOS 1.0,macOS 12.0, *)
+    @available(watchOS 8.0,tvOS 15.0,iOS 17.0,visionOS 1.0,macOS 12.0, *)
     init(_ isFocusable: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(isFocusable: isFocusable)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0,visionOS 1.0, *)
+    @available(watchOS 10.0,tvOS 17.0,visionOS 1.0,macOS 14.0,iOS 17.0, *)
     init(_ isFocusable: AttributeReference<Swift.Bool> = .init(storage: .constant(true)), interactions: SwiftUI.FocusInteractions) {
         self.value = ._1(isFocusable: isFocusable, interactions: interactions)
         
@@ -3842,7 +3842,7 @@ struct _focusableModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(isFocusable):
-            if #available(iOS 17.0,watchOS 8.0,tvOS 15.0,visionOS 1.0,macOS 12.0, *) {
+            if #available(watchOS 8.0,tvOS 15.0,iOS 17.0,visionOS 1.0,macOS 12.0, *) {
             let isFocusable = isFocusable as! AttributeReference<Swift.Bool>
             
             __content
@@ -3853,7 +3853,7 @@ struct _focusableModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(isFocusable, interactions):
-            if #available(macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0,visionOS 1.0, *) {
+            if #available(watchOS 10.0,tvOS 17.0,visionOS 1.0,macOS 14.0,iOS 17.0, *) {
             let isFocusable = isFocusable as! AttributeReference<Swift.Bool>
 let interactions = interactions as! SwiftUI.FocusInteractions
             
@@ -4078,7 +4078,7 @@ struct _fullScreenCoverModifier<R: RootRegistry>: ViewModifier {
 @Event private var _0_onDismiss__0: Event.EventHandler
 
     #if os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(tvOS 14.0,watchOS 7.0,iOS 14.0,visionOS 1.0, *)
+    @available(watchOS 7.0,tvOS 14.0,iOS 14.0,visionOS 1.0, *)
     init(isPresented: ChangeTracked<Swift.Bool>,onDismiss onDismiss__0: Event=Event(), content: ViewReference=ViewReference(value: [])) {
         self.value = ._0(content: content)
         self.__0_isPresented = isPresented
@@ -4092,7 +4092,7 @@ self.__0_onDismiss__0 = onDismiss__0
             fatalError("unreachable")
         #if os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(content):
-            if #available(tvOS 14.0,watchOS 7.0,iOS 14.0,visionOS 1.0, *) {
+            if #available(watchOS 7.0,tvOS 14.0,iOS 14.0,visionOS 1.0, *) {
             let content = content as! ViewReference
             
             __content
@@ -4126,7 +4126,7 @@ struct _gaugeStyleModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,watchOS 7.0,macOS 13.0,iOS 16.0, *)
+    @available(watchOS 7.0,iOS 16.0,visionOS 1.0,macOS 13.0, *)
     init(_ style: AnyGaugeStyle) {
         self.value = ._0(style: style)
         
@@ -4139,7 +4139,7 @@ struct _gaugeStyleModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
         case let ._0(style):
-            if #available(visionOS 1.0,watchOS 7.0,macOS 13.0,iOS 16.0, *) {
+            if #available(watchOS 7.0,iOS 16.0,visionOS 1.0,macOS 13.0, *) {
             let style = style as! AnyGaugeStyle
             
             __content
@@ -4173,7 +4173,7 @@ struct _geometryGroupModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 10.0,macOS 14.0,visionOS 1.0,tvOS 17.0,iOS 17.0, *)
+    @available(macOS 14.0,tvOS 17.0,iOS 17.0,visionOS 1.0,watchOS 10.0, *)
     init() {
         self.value = ._0
         
@@ -4186,7 +4186,7 @@ struct _geometryGroupModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case ._0:
-            if #available(watchOS 10.0,macOS 14.0,visionOS 1.0,tvOS 17.0,iOS 17.0, *) {
+            if #available(macOS 14.0,tvOS 17.0,iOS 17.0,visionOS 1.0,watchOS 10.0, *) {
             
             
             __content
@@ -4256,7 +4256,7 @@ struct _gestureModifier<R: RootRegistry>: ViewModifier {
     }
     
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 2.0,tvOS 18.0,iOS 18.0,macOS 15.0,watchOS 11.0, *)
+    @available(watchOS 11.0,tvOS 18.0,iOS 18.0,visionOS 2.0,macOS 15.0, *)
     init(_ gesture: _AnyGesture,name: AttributeReference<Swift.String>,isEnabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._3(gesture: gesture, name: name, isEnabled: isEnabled)
         
@@ -4302,7 +4302,7 @@ struct _gestureModifier<R: RootRegistry>: ViewModifier {
         
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._3(gesture, name, isEnabled):
-            if #available(visionOS 2.0,tvOS 18.0,iOS 18.0,macOS 15.0,watchOS 11.0, *) {
+            if #available(watchOS 11.0,tvOS 18.0,iOS 18.0,visionOS 2.0,macOS 15.0, *) {
             let gesture = gesture as! _AnyGesture
 let name = name as! AttributeReference<Swift.String>
 let isEnabled = isEnabled as! AttributeReference<Swift.Bool>
@@ -4691,7 +4691,7 @@ struct _handGestureShortcutModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-    @available(tvOS 18.0,watchOS 11.0,macOS 15.0,iOS 18.0, *)
+    @available(watchOS 11.0,tvOS 18.0,iOS 18.0,macOS 15.0, *)
     init(_ shortcut: SwiftUI.HandGestureShortcut,isEnabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(shortcut: shortcut, isEnabled: isEnabled)
         
@@ -4704,7 +4704,7 @@ struct _handGestureShortcutModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
         case let ._0(shortcut, isEnabled):
-            if #available(tvOS 18.0,watchOS 11.0,macOS 15.0,iOS 18.0, *) {
+            if #available(watchOS 11.0,tvOS 18.0,iOS 18.0,macOS 15.0, *) {
             let shortcut = shortcut as! SwiftUI.HandGestureShortcut
 let isEnabled = isEnabled as! AttributeReference<Swift.Bool>
             
@@ -4997,7 +4997,7 @@ struct _highPriorityGestureModifier<R: RootRegistry>: ViewModifier {
     }
     
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 2.0,tvOS 18.0,iOS 18.0,macOS 15.0,watchOS 11.0, *)
+    @available(watchOS 11.0,tvOS 18.0,iOS 18.0,visionOS 2.0,macOS 15.0, *)
     init(_ gesture: _AnyGesture,name: AttributeReference<Swift.String>,isEnabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._2(gesture: gesture, name: name, isEnabled: isEnabled)
         
@@ -5032,7 +5032,7 @@ struct _highPriorityGestureModifier<R: RootRegistry>: ViewModifier {
         
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._2(gesture, name, isEnabled):
-            if #available(visionOS 2.0,tvOS 18.0,iOS 18.0,macOS 15.0,watchOS 11.0, *) {
+            if #available(watchOS 11.0,tvOS 18.0,iOS 18.0,visionOS 2.0,macOS 15.0, *) {
             let gesture = gesture as! _AnyGesture
 let name = name as! AttributeReference<Swift.String>
 let isEnabled = isEnabled as! AttributeReference<Swift.Bool>
@@ -5127,7 +5127,7 @@ struct _hoverEffectModifier<R: RootRegistry>: ViewModifier {
     }
     #endif
     #if os(iOS) || os(tvOS) || os(visionOS)
-    @available(tvOS 17.0,iOS 17.0,visionOS 1.0, *)
+    @available(iOS 17.0,visionOS 1.0,tvOS 17.0, *)
     init(_ effect: SwiftUI.HoverEffect = .automatic, isEnabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._1(effect: effect, isEnabled: isEnabled)
         
@@ -5151,7 +5151,7 @@ struct _hoverEffectModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(tvOS) || os(visionOS)
         case let ._1(effect, isEnabled):
-            if #available(tvOS 17.0,iOS 17.0,visionOS 1.0, *) {
+            if #available(iOS 17.0,visionOS 1.0,tvOS 17.0, *) {
             let effect = effect as! SwiftUI.HoverEffect 
 let isEnabled = isEnabled as! AttributeReference<Swift.Bool>
             
@@ -5186,7 +5186,7 @@ struct _hoverEffectDisabledModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(tvOS) || os(visionOS)
-    @available(visionOS 1.0,tvOS 17.0,iOS 17.0, *)
+    @available(iOS 17.0,visionOS 1.0,tvOS 17.0, *)
     init(_ disabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(disabled: disabled)
         
@@ -5199,7 +5199,7 @@ struct _hoverEffectDisabledModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(tvOS) || os(visionOS)
         case let ._0(disabled):
-            if #available(visionOS 1.0,tvOS 17.0,iOS 17.0, *) {
+            if #available(iOS 17.0,visionOS 1.0,tvOS 17.0, *) {
             let disabled = disabled as! AttributeReference<Swift.Bool>
             
             __content
@@ -5516,7 +5516,7 @@ struct _indexViewStyleModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 8.0,iOS 14.0,tvOS 14.0,visionOS 1.0, *)
+    @available(watchOS 8.0,tvOS 14.0,iOS 14.0,visionOS 1.0, *)
     init(_ style: AnyIndexViewStyle) {
         self.value = ._0(style: style)
         
@@ -5529,7 +5529,7 @@ struct _indexViewStyleModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(style):
-            if #available(watchOS 8.0,iOS 14.0,tvOS 14.0,visionOS 1.0, *) {
+            if #available(watchOS 8.0,tvOS 14.0,iOS 14.0,visionOS 1.0, *) {
             let style = style as! AnyIndexViewStyle
             
             __content
@@ -5563,7 +5563,7 @@ struct _inspectorModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS)
-    @available(macOS 14.0,iOS 17.0, *)
+    @available(iOS 17.0,macOS 14.0, *)
     init(isPresented: ChangeTracked<Swift.Bool>,content: ViewReference=ViewReference(value: [])) {
         self.value = ._0(content: content)
         self.__0_isPresented = isPresented
@@ -5576,7 +5576,7 @@ struct _inspectorModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS)
         case let ._0(content):
-            if #available(macOS 14.0,iOS 17.0, *) {
+            if #available(iOS 17.0,macOS 14.0, *) {
             let content = content as! ViewReference
             
             __content
@@ -5615,14 +5615,14 @@ struct _inspectorColumnWidthModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS)
-    @available(macOS 14.0,iOS 17.0, *)
+    @available(iOS 17.0,macOS 14.0, *)
     init(min: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), ideal: AttributeReference<CoreFoundation.CGFloat>,max: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)) ) {
         self.value = ._0(min: min, ideal: ideal, max: max)
         
     }
     #endif
     #if os(iOS) || os(macOS)
-    @available(macOS 14.0,iOS 17.0, *)
+    @available(iOS 17.0,macOS 14.0, *)
     init(_ width: AttributeReference<CoreFoundation.CGFloat>) {
         self.value = ._1(width: width)
         
@@ -5635,7 +5635,7 @@ struct _inspectorColumnWidthModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS)
         case let ._0(min, ideal, max):
-            if #available(macOS 14.0,iOS 17.0, *) {
+            if #available(iOS 17.0,macOS 14.0, *) {
             let min = min as? AttributeReference<CoreFoundation.CGFloat?>
 let ideal = ideal as! AttributeReference<CoreFoundation.CGFloat>
 let max = max as? AttributeReference<CoreFoundation.CGFloat?>
@@ -5648,7 +5648,7 @@ let max = max as? AttributeReference<CoreFoundation.CGFloat?>
         #endif
         #if os(iOS) || os(macOS)
         case let ._1(width):
-            if #available(macOS 14.0,iOS 17.0, *) {
+            if #available(iOS 17.0,macOS 14.0, *) {
             let width = width as! AttributeReference<CoreFoundation.CGFloat>
             
             __content
@@ -5776,7 +5776,7 @@ struct _invalidatableContentModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(tvOS 17.0,watchOS 10.0,macOS 14.0,iOS 17.0,visionOS 1.0, *)
+    @available(macOS 14.0,iOS 17.0,tvOS 17.0,visionOS 1.0,watchOS 10.0, *)
     init(_ invalidatable: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(invalidatable: invalidatable)
         
@@ -5789,7 +5789,7 @@ struct _invalidatableContentModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(invalidatable):
-            if #available(tvOS 17.0,watchOS 10.0,macOS 14.0,iOS 17.0,visionOS 1.0, *) {
+            if #available(macOS 14.0,iOS 17.0,tvOS 17.0,visionOS 1.0,watchOS 10.0, *) {
             let invalidatable = invalidatable as! AttributeReference<Swift.Bool>
             
             __content
@@ -5838,28 +5838,28 @@ struct _keyboardShortcutModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 11.0,iOS 14.0,visionOS 1.0, *)
+    @available(visionOS 1.0,iOS 14.0,macOS 11.0, *)
     init(_ key: SwiftUI.KeyEquivalent,modifiers: SwiftUICore.EventModifiers = .command ) {
         self.value = ._0(key: key, modifiers: modifiers)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 11.0,iOS 14.0,visionOS 1.0, *)
+    @available(visionOS 1.0,iOS 14.0,macOS 11.0, *)
     init(_ shortcut: SwiftUI.KeyboardShortcut) {
         self.value = ._1(shortcut: shortcut)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 12.3,iOS 15.4,visionOS 1.0, *)
+    @available(visionOS 1.0,iOS 15.4,macOS 12.3, *)
     init(_ shortcut: SwiftUI.KeyboardShortcut?) {
         self.value = ._2(shortcut: shortcut)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 12.0,visionOS 1.0,iOS 15.0, *)
+    @available(visionOS 1.0,iOS 15.0,macOS 12.0, *)
     init(_ key: SwiftUI.KeyEquivalent,modifiers: SwiftUICore.EventModifiers = .command, localization: SwiftUI.KeyboardShortcut.Localization) {
         self.value = ._3(key: key, modifiers: modifiers, localization: localization)
         
@@ -5872,7 +5872,7 @@ struct _keyboardShortcutModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(key, modifiers):
-            if #available(macOS 11.0,iOS 14.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,iOS 14.0,macOS 11.0, *) {
             let key = key as! SwiftUI.KeyEquivalent
 let modifiers = modifiers as! SwiftUICore.EventModifiers 
             
@@ -5884,7 +5884,7 @@ let modifiers = modifiers as! SwiftUICore.EventModifiers
         #endif
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._1(shortcut):
-            if #available(macOS 11.0,iOS 14.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,iOS 14.0,macOS 11.0, *) {
             let shortcut = shortcut as! SwiftUI.KeyboardShortcut
             
             __content
@@ -5895,7 +5895,7 @@ let modifiers = modifiers as! SwiftUICore.EventModifiers
         #endif
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._2(shortcut):
-            if #available(macOS 12.3,iOS 15.4,visionOS 1.0, *) {
+            if #available(visionOS 1.0,iOS 15.4,macOS 12.3, *) {
             let shortcut = shortcut as? SwiftUI.KeyboardShortcut
             
             __content
@@ -5906,7 +5906,7 @@ let modifiers = modifiers as! SwiftUICore.EventModifiers
         #endif
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._3(key, modifiers, localization):
-            if #available(macOS 12.0,visionOS 1.0,iOS 15.0, *) {
+            if #available(visionOS 1.0,iOS 15.0,macOS 12.0, *) {
             let key = key as! SwiftUI.KeyEquivalent
 let modifiers = modifiers as! SwiftUICore.EventModifiers 
 let localization = localization as! SwiftUI.KeyboardShortcut.Localization
@@ -5942,7 +5942,7 @@ struct _keyboardTypeModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(tvOS) || os(visionOS)
-    @available(tvOS 13.0,iOS 13.0,visionOS 1.0, *)
+    @available(tvOS 13.0,visionOS 1.0,iOS 13.0, *)
     init(_ type: UIKit.UIKeyboardType) {
         self.value = ._0(type: type)
         
@@ -5955,7 +5955,7 @@ struct _keyboardTypeModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(tvOS) || os(visionOS)
         case let ._0(type):
-            if #available(tvOS 13.0,iOS 13.0,visionOS 1.0, *) {
+            if #available(tvOS 13.0,visionOS 1.0,iOS 13.0, *) {
             let type = type as! UIKit.UIKeyboardType
             
             __content
@@ -6130,7 +6130,7 @@ struct _labelsVisibilityModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 2.0,tvOS 18.0,watchOS 11.0,macOS 15.0,iOS 18.0, *)
+    @available(macOS 15.0,iOS 18.0,tvOS 18.0,watchOS 11.0,visionOS 2.0, *)
     init(_ visibility: AttributeReference<SwiftUI.Visibility>) {
         self.value = ._0(visibility: visibility)
         
@@ -6143,7 +6143,7 @@ struct _labelsVisibilityModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(visibility):
-            if #available(visionOS 2.0,tvOS 18.0,watchOS 11.0,macOS 15.0,iOS 18.0, *) {
+            if #available(macOS 15.0,iOS 18.0,tvOS 18.0,watchOS 11.0,visionOS 2.0, *) {
             let visibility = visibility as! AttributeReference<SwiftUI.Visibility>
             
             __content
@@ -6668,7 +6668,7 @@ struct _listRowSeparatorModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 13.0,visionOS 1.0,iOS 15.0, *)
+    @available(iOS 15.0,macOS 13.0,visionOS 1.0, *)
     init(_ visibility: AttributeReference<SwiftUI.Visibility>,edges: SwiftUICore.VerticalEdge.Set = .all ) {
         self.value = ._0(visibility: visibility, edges: edges)
         
@@ -6681,7 +6681,7 @@ struct _listRowSeparatorModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(visibility, edges):
-            if #available(macOS 13.0,visionOS 1.0,iOS 15.0, *) {
+            if #available(iOS 15.0,macOS 13.0,visionOS 1.0, *) {
             let visibility = visibility as! AttributeReference<SwiftUI.Visibility>
 let edges = edges as! SwiftUICore.VerticalEdge.Set 
             
@@ -6716,7 +6716,7 @@ struct _listRowSeparatorTintModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 13.0,visionOS 1.0,iOS 15.0, *)
+    @available(iOS 15.0,macOS 13.0,visionOS 1.0, *)
     init(_ color: Color.Resolvable?,edges: SwiftUICore.VerticalEdge.Set = .all ) {
         self.value = ._0(color: color, edges: edges)
         
@@ -6729,7 +6729,7 @@ struct _listRowSeparatorTintModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(color, edges):
-            if #available(macOS 13.0,visionOS 1.0,iOS 15.0, *) {
+            if #available(iOS 15.0,macOS 13.0,visionOS 1.0, *) {
             let color = color as? Color.Resolvable
 let edges = edges as! SwiftUICore.VerticalEdge.Set 
             
@@ -6811,7 +6811,7 @@ struct _listSectionSeparatorModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 13.0,visionOS 1.0,iOS 15.0, *)
+    @available(iOS 15.0,macOS 13.0,visionOS 1.0, *)
     init(_ visibility: AttributeReference<SwiftUI.Visibility>,edges: SwiftUICore.VerticalEdge.Set = .all ) {
         self.value = ._0(visibility: visibility, edges: edges)
         
@@ -6824,7 +6824,7 @@ struct _listSectionSeparatorModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(visibility, edges):
-            if #available(macOS 13.0,visionOS 1.0,iOS 15.0, *) {
+            if #available(iOS 15.0,macOS 13.0,visionOS 1.0, *) {
             let visibility = visibility as! AttributeReference<SwiftUI.Visibility>
 let edges = edges as! SwiftUICore.VerticalEdge.Set 
             
@@ -6859,7 +6859,7 @@ struct _listSectionSeparatorTintModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 13.0,visionOS 1.0,iOS 15.0, *)
+    @available(iOS 15.0,macOS 13.0,visionOS 1.0, *)
     init(_ color: Color.Resolvable?,edges: SwiftUICore.VerticalEdge.Set = .all ) {
         self.value = ._0(color: color, edges: edges)
         
@@ -6872,7 +6872,7 @@ struct _listSectionSeparatorTintModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(color, edges):
-            if #available(macOS 13.0,visionOS 1.0,iOS 15.0, *) {
+            if #available(iOS 15.0,macOS 13.0,visionOS 1.0, *) {
             let color = color as? Color.Resolvable
 let edges = edges as! SwiftUICore.VerticalEdge.Set 
             
@@ -7071,7 +7071,7 @@ struct _materialActiveAppearanceModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(iOS 18.0,watchOS 11.0,tvOS 18.0,visionOS 2.0,macOS 15.0, *)
+    @available(macOS 15.0,tvOS 18.0,iOS 18.0,visionOS 2.0,watchOS 11.0, *)
     init(_ appearance: SwiftUICore.MaterialActiveAppearance) {
         self.value = ._0(appearance: appearance)
         
@@ -7084,7 +7084,7 @@ struct _materialActiveAppearanceModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(appearance):
-            if #available(iOS 18.0,watchOS 11.0,tvOS 18.0,visionOS 2.0,macOS 15.0, *) {
+            if #available(macOS 15.0,tvOS 18.0,iOS 18.0,visionOS 2.0,watchOS 11.0, *) {
             let appearance = appearance as! SwiftUICore.MaterialActiveAppearance
             
             __content
@@ -7118,7 +7118,7 @@ struct _menuIndicatorModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS)
-    @available(tvOS 17.0,macOS 12.0,visionOS 1.0,iOS 15.0, *)
+    @available(tvOS 17.0,visionOS 1.0,iOS 15.0,macOS 12.0, *)
     init(_ visibility: AttributeReference<SwiftUI.Visibility>) {
         self.value = ._0(visibility: visibility)
         
@@ -7131,7 +7131,7 @@ struct _menuIndicatorModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS)
         case let ._0(visibility):
-            if #available(tvOS 17.0,macOS 12.0,visionOS 1.0,iOS 15.0, *) {
+            if #available(tvOS 17.0,visionOS 1.0,iOS 15.0,macOS 12.0, *) {
             let visibility = visibility as! AttributeReference<SwiftUI.Visibility>
             
             __content
@@ -7212,7 +7212,7 @@ struct _menuStyleModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS)
-    @available(visionOS 1.0,macOS 11.0,iOS 14.0,tvOS 17.0, *)
+    @available(macOS 11.0,visionOS 1.0,iOS 14.0,tvOS 17.0, *)
     init(_ style: AnyMenuStyle) {
         self.value = ._0(style: style)
         
@@ -7225,7 +7225,7 @@ struct _menuStyleModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS)
         case let ._0(style):
-            if #available(visionOS 1.0,macOS 11.0,iOS 14.0,tvOS 17.0, *) {
+            if #available(macOS 11.0,visionOS 1.0,iOS 14.0,tvOS 17.0, *) {
             let style = style as! AnyMenuStyle
             
             __content
@@ -7306,7 +7306,7 @@ struct _modifierKeyAlternateModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(macOS) || os(visionOS)
-    @available(macOS 15.0,visionOS 1.0, *)
+    @available(visionOS 1.0,macOS 15.0, *)
     init(_ modifiers: SwiftUICore.EventModifiers,_ alternate: ViewReference=ViewReference(value: [])) {
         self.value = ._0(modifiers: modifiers, alternate: alternate)
         
@@ -7319,7 +7319,7 @@ struct _modifierKeyAlternateModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(macOS) || os(visionOS)
         case let ._0(modifiers, alternate):
-            if #available(macOS 15.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,macOS 15.0, *) {
             let modifiers = modifiers as! SwiftUICore.EventModifiers
 let alternate = alternate as! ViewReference
             
@@ -7716,21 +7716,21 @@ struct _navigationSubtitleModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(macOS) || targetEnvironment(macCatalyst)
-    @available(macCatalyst 14.0,macOS 11.0, *)
+    @available(macOS 11.0,macCatalyst 14.0, *)
     init(_ subtitle: TextReference) {
         self.value = ._0(subtitle: subtitle)
         
     }
     #endif
     #if os(macOS) || targetEnvironment(macCatalyst)
-    @available(macCatalyst 14.0,macOS 11.0, *)
+    @available(macOS 11.0,macCatalyst 14.0, *)
     init(_ subtitleKey: SwiftUICore.LocalizedStringKey) {
         self.value = ._1(subtitleKey: subtitleKey)
         
     }
     #endif
     #if os(macOS) || targetEnvironment(macCatalyst)
-    @available(macCatalyst 14.0,macOS 11.0, *)
+    @available(macOS 11.0,macCatalyst 14.0, *)
     init(_ subtitle: AttributeReference<String>) {
         self.value = ._2(subtitle: subtitle)
         
@@ -7743,7 +7743,7 @@ struct _navigationSubtitleModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(macOS) || targetEnvironment(macCatalyst)
         case let ._0(subtitle):
-            if #available(macCatalyst 14.0,macOS 11.0, *) {
+            if #available(macOS 11.0,macCatalyst 14.0, *) {
             let subtitle = subtitle as! TextReference
             __content._observeTextReference(subtitle, on: element, in: context) { __content in
             __content
@@ -7754,7 +7754,7 @@ struct _navigationSubtitleModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(macOS) || targetEnvironment(macCatalyst)
         case let ._1(subtitleKey):
-            if #available(macCatalyst 14.0,macOS 11.0, *) {
+            if #available(macOS 11.0,macCatalyst 14.0, *) {
             let subtitleKey = subtitleKey as! SwiftUICore.LocalizedStringKey
             
             __content
@@ -7765,7 +7765,7 @@ struct _navigationSubtitleModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(macOS) || targetEnvironment(macCatalyst)
         case let ._2(subtitle):
-            if #available(macCatalyst 14.0,macOS 11.0, *) {
+            if #available(macOS 11.0,macCatalyst 14.0, *) {
             let subtitle = subtitle as! AttributeReference<String>
             
             __content
@@ -7840,7 +7840,7 @@ struct _navigationTitleModifier<R: RootRegistry>: ViewModifier {
     }
     
     #if os(watchOS)
-    @available(iOS 14.0,tvOS 14.0,watchOS 7.0,macOS 11.0, *)
+    @available(tvOS 14.0,macOS 11.0,iOS 14.0,watchOS 7.0, *)
     init(_ title: ViewReference=ViewReference(value: [])) {
         self.value = ._3(title: title)
         
@@ -7893,7 +7893,7 @@ struct _navigationTitleModifier<R: RootRegistry>: ViewModifier {
         
         #if os(watchOS)
         case let ._3(title):
-            if #available(iOS 14.0,tvOS 14.0,watchOS 7.0,macOS 11.0, *) {
+            if #available(tvOS 14.0,macOS 11.0,iOS 14.0,watchOS 7.0, *) {
             let title = title as! ViewReference
             
             __content
@@ -8078,7 +8078,7 @@ struct _onDeleteCommandModifier<R: RootRegistry>: ViewModifier {
 @Event private var _0_action__0: Event.EventHandler
 
     #if os(macOS)
-    @available(macOS 10.15,tvOS 13.0, *)
+    @available(tvOS 13.0,macOS 10.15, *)
     init(perform action__0: Event=Event()) {
         self.value = ._0
         self.__0_action__0 = action__0
@@ -8091,7 +8091,7 @@ struct _onDeleteCommandModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(macOS)
         case ._0:
-            if #available(macOS 10.15,tvOS 13.0, *) {
+            if #available(tvOS 13.0,macOS 10.15, *) {
             
             
             __content
@@ -8172,7 +8172,7 @@ struct _onExitCommandModifier<R: RootRegistry>: ViewModifier {
 @Event private var _0_action__0: Event.EventHandler
 
     #if os(macOS) || os(tvOS)
-    @available(macOS 10.15,tvOS 13.0, *)
+    @available(tvOS 13.0,macOS 10.15, *)
     init(perform action__0: Event=Event()) {
         self.value = ._0
         self.__0_action__0 = action__0
@@ -8185,7 +8185,7 @@ struct _onExitCommandModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(macOS) || os(tvOS)
         case ._0:
-            if #available(macOS 10.15,tvOS 13.0, *) {
+            if #available(tvOS 13.0,macOS 10.15, *) {
             
             
             __content
@@ -8219,7 +8219,7 @@ struct _onHoverModifier<R: RootRegistry>: ViewModifier {
 @Event private var _0_action__1: Event.EventHandler
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 10.15,visionOS 1.0,iOS 13.4, *)
+    @available(visionOS 1.0,iOS 13.4,macOS 10.15, *)
     init(perform action__1: Event) {
         self.value = ._0
         self.__0_action__1 = action__1
@@ -8232,7 +8232,7 @@ struct _onHoverModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case ._0:
-            if #available(macOS 10.15,visionOS 1.0,iOS 13.4, *) {
+            if #available(visionOS 1.0,iOS 13.4,macOS 10.15, *) {
             
             
             __content
@@ -8320,7 +8320,7 @@ struct _onLongPressGestureModifier<R: RootRegistry>: ViewModifier {
 @Event private var _1_onPressingChanged__1: Event.EventHandler
 
     #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,macOS 10.15,iOS 13.0,tvOS 14.0,watchOS 6.0, *)
+    @available(watchOS 6.0,iOS 13.0,tvOS 14.0,visionOS 1.0,macOS 10.15, *)
     init(minimumDuration: AttributeReference<Swift.Double> = .init(storage: .constant(0.5)), maximumDistance: AttributeReference<CoreFoundation.CGFloat> = .init(storage: .constant(10)), perform action__0: Event,onPressingChanged onPressingChanged__1: Event=Event() ) {
         self.value = ._0(minimumDuration: minimumDuration, maximumDistance: maximumDistance)
         self.__0_action__0 = action__0
@@ -8328,7 +8328,7 @@ self.__0_onPressingChanged__1 = onPressingChanged__1
     }
     #endif
     #if os(tvOS)
-    @available(macOS 10.15,iOS 13.0,tvOS 14.0,watchOS 6.0, *)
+    @available(watchOS 6.0,iOS 13.0,tvOS 14.0,macOS 10.15, *)
     init(minimumDuration: AttributeReference<Swift.Double> = .init(storage: .constant(0.5)), perform action__0: Event,onPressingChanged onPressingChanged__1: Event=Event() ) {
         self.value = ._1(minimumDuration: minimumDuration)
         self.__1_action__0 = action__0
@@ -8342,7 +8342,7 @@ self.__1_onPressingChanged__1 = onPressingChanged__1
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
         case let ._0(minimumDuration, maximumDistance):
-            if #available(visionOS 1.0,macOS 10.15,iOS 13.0,tvOS 14.0,watchOS 6.0, *) {
+            if #available(watchOS 6.0,iOS 13.0,tvOS 14.0,visionOS 1.0,macOS 10.15, *) {
             let minimumDuration = minimumDuration as! AttributeReference<Swift.Double>
 let maximumDistance = maximumDistance as! AttributeReference<CoreFoundation.CGFloat>
             
@@ -8354,7 +8354,7 @@ let maximumDistance = maximumDistance as! AttributeReference<CoreFoundation.CGFl
         #endif
         #if os(tvOS)
         case let ._1(minimumDuration):
-            if #available(macOS 10.15,iOS 13.0,tvOS 14.0,watchOS 6.0, *) {
+            if #available(watchOS 6.0,iOS 13.0,tvOS 14.0,macOS 10.15, *) {
             let minimumDuration = minimumDuration as! AttributeReference<Swift.Double>
             
             __content
@@ -8437,7 +8437,7 @@ struct _onModifierKeysChangedModifier<R: RootRegistry>: ViewModifier {
 @Event private var _0_action__2: Event.EventHandler
 
     #if os(macOS) || os(visionOS)
-    @available(macOS 15.0,visionOS 1.0, *)
+    @available(visionOS 1.0,macOS 15.0, *)
     init(mask: SwiftUICore.EventModifiers = .all, initial: AttributeReference<Swift.Bool> = .init(storage: .constant(true)), action action__2: Event) {
         self.value = ._0(mask: mask, initial: initial)
         self.__0_action__2 = action__2
@@ -8450,7 +8450,7 @@ struct _onModifierKeysChangedModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(macOS) || os(visionOS)
         case let ._0(mask, initial):
-            if #available(macOS 15.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,macOS 15.0, *) {
             let mask = mask as! SwiftUICore.EventModifiers 
 let initial = initial as! AttributeReference<Swift.Bool>
             
@@ -8485,7 +8485,7 @@ struct _onMoveCommandModifier<R: RootRegistry>: ViewModifier {
 @Event private var _0_action__1: Event.EventHandler
 
     #if os(macOS) || os(tvOS)
-    @available(macOS 10.15,tvOS 13.0, *)
+    @available(tvOS 13.0,macOS 10.15, *)
     init(perform action__1: Event=Event()) {
         self.value = ._0
         self.__0_action__1 = action__1
@@ -8498,7 +8498,7 @@ struct _onMoveCommandModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(macOS) || os(tvOS)
         case ._0:
-            if #available(macOS 10.15,tvOS 13.0, *) {
+            if #available(tvOS 13.0,macOS 10.15, *) {
             
             
             __content
@@ -8532,7 +8532,7 @@ struct _onPencilDoubleTapModifier<R: RootRegistry>: ViewModifier {
 @Event private var _0_action__1: Event.EventHandler
 
     #if os(iOS) || os(macOS)
-    @available(macOS 14.5,iOS 17.5, *)
+    @available(iOS 17.5,macOS 14.5, *)
     init(perform action__1: Event) {
         self.value = ._0
         self.__0_action__1 = action__1
@@ -8545,7 +8545,7 @@ struct _onPencilDoubleTapModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS)
         case ._0:
-            if #available(macOS 14.5,iOS 17.5, *) {
+            if #available(iOS 17.5,macOS 14.5, *) {
             
             
             __content
@@ -8626,7 +8626,7 @@ struct _onPlayPauseCommandModifier<R: RootRegistry>: ViewModifier {
 @Event private var _0_action__0: Event.EventHandler
 
     #if os(tvOS)
-    @available(macOS 10.15,tvOS 13.0, *)
+    @available(tvOS 13.0,macOS 10.15, *)
     init(perform action__0: Event=Event()) {
         self.value = ._0
         self.__0_action__0 = action__0
@@ -8639,7 +8639,7 @@ struct _onPlayPauseCommandModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(tvOS)
         case ._0:
-            if #available(macOS 10.15,tvOS 13.0, *) {
+            if #available(tvOS 13.0,macOS 10.15, *) {
             
             
             __content
@@ -8673,7 +8673,7 @@ struct _onScrollPhaseChangeModifier<R: RootRegistry>: ViewModifier {
 @Event private var _0_action__2: Event.EventHandler
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 2.0,macOS 15.0,iOS 18.0,tvOS 18.0,watchOS 11.0, *)
+    @available(visionOS 2.0,tvOS 18.0,iOS 18.0,macOS 15.0,watchOS 11.0, *)
     init(_ action__2: Event) {
         self.value = ._0
         self.__0_action__2 = action__2
@@ -8686,7 +8686,7 @@ struct _onScrollPhaseChangeModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case ._0:
-            if #available(visionOS 2.0,macOS 15.0,iOS 18.0,tvOS 18.0,watchOS 11.0, *) {
+            if #available(visionOS 2.0,tvOS 18.0,iOS 18.0,macOS 15.0,watchOS 11.0, *) {
             
             
             __content
@@ -8720,7 +8720,7 @@ struct _onScrollVisibilityChangeModifier<R: RootRegistry>: ViewModifier {
 @Event private var _0_action__1: Event.EventHandler
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 2.0,tvOS 18.0,watchOS 11.0,macOS 15.0,iOS 18.0, *)
+    @available(iOS 18.0,tvOS 18.0,visionOS 2.0,watchOS 11.0,macOS 15.0, *)
     init(threshold: AttributeReference<Swift.Double> = .init(storage: .constant(0.5)), action action__1: Event) {
         self.value = ._0(threshold: threshold)
         self.__0_action__1 = action__1
@@ -8733,7 +8733,7 @@ struct _onScrollVisibilityChangeModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(threshold):
-            if #available(visionOS 2.0,tvOS 18.0,watchOS 11.0,macOS 15.0,iOS 18.0, *) {
+            if #available(iOS 18.0,tvOS 18.0,visionOS 2.0,watchOS 11.0,macOS 15.0, *) {
             let threshold = threshold as! AttributeReference<Swift.Double>
             
             __content
@@ -8772,7 +8772,7 @@ struct _onTapGestureModifier<R: RootRegistry>: ViewModifier {
 @Event private var _1_action__0: Event.EventHandler
 
     #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
-    @available(macOS 14.0,watchOS 10.0,iOS 17.0,visionOS 1.0, *)
+    @available(iOS 17.0,macOS 14.0,watchOS 10.0,visionOS 1.0, *)
     init(count: AttributeReference<Swift.Int> = .init(storage: .constant(1)), coordinateSpace: AnyCoordinateSpaceProtocol = .local, perform action__1: Event) {
         self.value = ._0(count: count, coordinateSpace: coordinateSpace)
         self.__0_action__1 = action__1
@@ -8792,7 +8792,7 @@ struct _onTapGestureModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
         case let ._0(count, coordinateSpace):
-            if #available(macOS 14.0,watchOS 10.0,iOS 17.0,visionOS 1.0, *) {
+            if #available(iOS 17.0,macOS 14.0,watchOS 10.0,visionOS 1.0, *) {
             let count = count as! AttributeReference<Swift.Int>
 let coordinateSpace = coordinateSpace as! AnyCoordinateSpaceProtocol 
             
@@ -9357,7 +9357,7 @@ struct _pointerStyleModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(macOS) || os(visionOS)
-    @available(macOS 15.0,visionOS 2.0, *)
+    @available(visionOS 2.0,macOS 15.0, *)
     init(_ style: SwiftUI.PointerStyle?) {
         self.value = ._0(style: style)
         
@@ -9370,7 +9370,7 @@ struct _pointerStyleModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(macOS) || os(visionOS)
         case let ._0(style):
-            if #available(macOS 15.0,visionOS 2.0, *) {
+            if #available(visionOS 2.0,macOS 15.0, *) {
             let style = style as? SwiftUI.PointerStyle
             
             __content
@@ -9456,14 +9456,14 @@ struct _popoverModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 10.15,iOS 13.0,visionOS 1.0, *)
+    @available(visionOS 1.0,iOS 13.0,macOS 10.15, *)
     init(isPresented: ChangeTracked<Swift.Bool>,attachmentAnchor: SwiftUI.PopoverAttachmentAnchor = .rect(.bounds), arrowEdge: SwiftUICore.Edge = .top, content: ViewReference=ViewReference(value: [])) {
         self.value = ._0(attachmentAnchor: attachmentAnchor, arrowEdge: arrowEdge, content: content)
         self.__0_isPresented = isPresented
     }
     #endif
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 15.0,iOS 18.0,visionOS 2.0, *)
+    @available(visionOS 2.0,iOS 18.0,macOS 15.0, *)
     init(isPresented: ChangeTracked<Swift.Bool>,attachmentAnchor: SwiftUI.PopoverAttachmentAnchor = .rect(.bounds), content: ViewReference=ViewReference(value: [])) {
         self.value = ._1(attachmentAnchor: attachmentAnchor, content: content)
         self.__1_isPresented = isPresented
@@ -9476,7 +9476,7 @@ struct _popoverModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(attachmentAnchor, arrowEdge, content):
-            if #available(macOS 10.15,iOS 13.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,iOS 13.0,macOS 10.15, *) {
             let attachmentAnchor = attachmentAnchor as! SwiftUI.PopoverAttachmentAnchor 
 let arrowEdge = arrowEdge as! SwiftUICore.Edge 
 let content = content as! ViewReference
@@ -9489,7 +9489,7 @@ let content = content as! ViewReference
         #endif
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._1(attachmentAnchor, content):
-            if #available(macOS 15.0,iOS 18.0,visionOS 2.0, *) {
+            if #available(visionOS 2.0,iOS 18.0,macOS 15.0, *) {
             let attachmentAnchor = attachmentAnchor as! SwiftUI.PopoverAttachmentAnchor 
 let content = content as! ViewReference
             
@@ -9693,14 +9693,14 @@ struct _presentationBackgroundModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 9.4,macOS 13.3,visionOS 1.0,tvOS 16.4,iOS 16.4, *)
+    @available(watchOS 9.4,tvOS 16.4,iOS 16.4,visionOS 1.0,macOS 13.3, *)
     init(_ style: AnyShapeStyle.Resolvable) {
         self.value = ._0(style: style)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 9.4,macOS 13.3,visionOS 1.0,tvOS 16.4,iOS 16.4, *)
+    @available(watchOS 9.4,tvOS 16.4,iOS 16.4,visionOS 1.0,macOS 13.3, *)
     init(alignment: AttributeReference<SwiftUICore.Alignment> = .init(storage: .constant(.center)), content: ViewReference=ViewReference(value: [])) {
         self.value = ._1(alignment: alignment, content: content)
         
@@ -9713,7 +9713,7 @@ struct _presentationBackgroundModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(style):
-            if #available(watchOS 9.4,macOS 13.3,visionOS 1.0,tvOS 16.4,iOS 16.4, *) {
+            if #available(watchOS 9.4,tvOS 16.4,iOS 16.4,visionOS 1.0,macOS 13.3, *) {
             let style = style as! AnyShapeStyle.Resolvable
             
             __content
@@ -9724,7 +9724,7 @@ struct _presentationBackgroundModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(alignment, content):
-            if #available(watchOS 9.4,macOS 13.3,visionOS 1.0,tvOS 16.4,iOS 16.4, *) {
+            if #available(watchOS 9.4,tvOS 16.4,iOS 16.4,visionOS 1.0,macOS 13.3, *) {
             let alignment = alignment as! AttributeReference<SwiftUICore.Alignment>
 let content = content as! ViewReference
             
@@ -9759,7 +9759,7 @@ struct _presentationBackgroundInteractionModifier<R: RootRegistry>: ViewModifier
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 9.4,macOS 13.3,visionOS 1.0,tvOS 16.4,iOS 16.4, *)
+    @available(iOS 16.4,visionOS 1.0,macOS 13.3,tvOS 16.4,watchOS 9.4, *)
     init(_ interaction: SwiftUI.PresentationBackgroundInteraction) {
         self.value = ._0(interaction: interaction)
         
@@ -9772,7 +9772,7 @@ struct _presentationBackgroundInteractionModifier<R: RootRegistry>: ViewModifier
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(interaction):
-            if #available(watchOS 9.4,macOS 13.3,visionOS 1.0,tvOS 16.4,iOS 16.4, *) {
+            if #available(iOS 16.4,visionOS 1.0,macOS 13.3,tvOS 16.4,watchOS 9.4, *) {
             let interaction = interaction as! SwiftUI.PresentationBackgroundInteraction
             
             __content
@@ -9811,14 +9811,14 @@ struct _presentationCompactAdaptationModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 9.4,macOS 13.3,visionOS 1.0,tvOS 16.4,iOS 16.4, *)
+    @available(iOS 16.4,visionOS 1.0,macOS 13.3,tvOS 16.4,watchOS 9.4, *)
     init(_ adaptation: SwiftUI.PresentationAdaptation) {
         self.value = ._0(adaptation: adaptation)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 9.4,macOS 13.3,visionOS 1.0,tvOS 16.4,iOS 16.4, *)
+    @available(iOS 16.4,visionOS 1.0,macOS 13.3,tvOS 16.4,watchOS 9.4, *)
     init(horizontal horizontalAdaptation: SwiftUI.PresentationAdaptation,vertical verticalAdaptation: SwiftUI.PresentationAdaptation) {
         self.value = ._1(horizontalAdaptation: horizontalAdaptation, verticalAdaptation: verticalAdaptation)
         
@@ -9831,7 +9831,7 @@ struct _presentationCompactAdaptationModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(adaptation):
-            if #available(watchOS 9.4,macOS 13.3,visionOS 1.0,tvOS 16.4,iOS 16.4, *) {
+            if #available(iOS 16.4,visionOS 1.0,macOS 13.3,tvOS 16.4,watchOS 9.4, *) {
             let adaptation = adaptation as! SwiftUI.PresentationAdaptation
             
             __content
@@ -9842,7 +9842,7 @@ struct _presentationCompactAdaptationModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(horizontalAdaptation, verticalAdaptation):
-            if #available(watchOS 9.4,macOS 13.3,visionOS 1.0,tvOS 16.4,iOS 16.4, *) {
+            if #available(iOS 16.4,visionOS 1.0,macOS 13.3,tvOS 16.4,watchOS 9.4, *) {
             let horizontalAdaptation = horizontalAdaptation as! SwiftUI.PresentationAdaptation
 let verticalAdaptation = verticalAdaptation as! SwiftUI.PresentationAdaptation
             
@@ -9877,7 +9877,7 @@ struct _presentationContentInteractionModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,tvOS 16.4,watchOS 9.4,macOS 13.3,iOS 16.4, *)
+    @available(watchOS 9.4,tvOS 16.4,iOS 16.4,visionOS 1.0,macOS 13.3, *)
     init(_ behavior: SwiftUI.PresentationContentInteraction) {
         self.value = ._0(behavior: behavior)
         
@@ -9890,7 +9890,7 @@ struct _presentationContentInteractionModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(behavior):
-            if #available(visionOS 1.0,tvOS 16.4,watchOS 9.4,macOS 13.3,iOS 16.4, *) {
+            if #available(watchOS 9.4,tvOS 16.4,iOS 16.4,visionOS 1.0,macOS 13.3, *) {
             let behavior = behavior as! SwiftUI.PresentationContentInteraction
             
             __content
@@ -9924,7 +9924,7 @@ struct _presentationCornerRadiusModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(iOS 16.4,watchOS 9.4,tvOS 16.4,visionOS 1.0,macOS 13.3, *)
+    @available(macOS 13.3,iOS 16.4,tvOS 16.4,visionOS 1.0,watchOS 9.4, *)
     init(_ cornerRadius: AttributeReference<CoreFoundation.CGFloat?>?) {
         self.value = ._0(cornerRadius: cornerRadius)
         
@@ -9937,7 +9937,7 @@ struct _presentationCornerRadiusModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(cornerRadius):
-            if #available(iOS 16.4,watchOS 9.4,tvOS 16.4,visionOS 1.0,macOS 13.3, *) {
+            if #available(macOS 13.3,iOS 16.4,tvOS 16.4,visionOS 1.0,watchOS 9.4, *) {
             let cornerRadius = cornerRadius as? AttributeReference<CoreFoundation.CGFloat?>
             
             __content
@@ -10018,7 +10018,7 @@ struct _presentationSizingModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(tvOS 18.0,macOS 15.0,watchOS 11.0,visionOS 2.0,iOS 18.0, *)
+    @available(tvOS 18.0,macOS 15.0,iOS 18.0,visionOS 2.0,watchOS 11.0, *)
     init(_ sizing: AnyPresentationSizing) {
         self.value = ._0(sizing: sizing)
         
@@ -10031,7 +10031,7 @@ struct _presentationSizingModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(sizing):
-            if #available(tvOS 18.0,macOS 15.0,watchOS 11.0,visionOS 2.0,iOS 18.0, *) {
+            if #available(tvOS 18.0,macOS 15.0,iOS 18.0,visionOS 2.0,watchOS 11.0, *) {
             let sizing = sizing as! AnyPresentationSizing
             
             __content
@@ -10394,7 +10394,7 @@ struct _replaceDisabledModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(visionOS)
-    @available(visionOS 1.0,iOS 16.0, *)
+    @available(iOS 16.0,visionOS 1.0, *)
     init(_ isDisabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(isDisabled: isDisabled)
         
@@ -10407,7 +10407,7 @@ struct _replaceDisabledModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(visionOS)
         case let ._0(isDisabled):
-            if #available(visionOS 1.0,iOS 16.0, *) {
+            if #available(iOS 16.0,visionOS 1.0, *) {
             let isDisabled = isDisabled as! AttributeReference<Swift.Bool>
             
             __content
@@ -10568,21 +10568,21 @@ struct _safeAreaPaddingModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(tvOS 17.0,macOS 14.0,watchOS 10.0,visionOS 1.0,iOS 17.0, *)
+    @available(macOS 14.0,iOS 17.0,tvOS 17.0,visionOS 1.0,watchOS 10.0, *)
     init(_ insets: SwiftUICore.EdgeInsets) {
         self.value = ._0(insets: insets)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(tvOS 17.0,macOS 14.0,watchOS 10.0,visionOS 1.0,iOS 17.0, *)
+    @available(macOS 14.0,iOS 17.0,tvOS 17.0,visionOS 1.0,watchOS 10.0, *)
     init(_ edges: SwiftUICore.Edge.Set = .all, _ length: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)) ) {
         self.value = ._1(edges: edges, length: length)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(tvOS 17.0,macOS 14.0,watchOS 10.0,visionOS 1.0,iOS 17.0, *)
+    @available(tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0,visionOS 1.0, *)
     init(_ length: AttributeReference<CoreFoundation.CGFloat>) {
         self.value = ._2(length: length)
         
@@ -10595,7 +10595,7 @@ struct _safeAreaPaddingModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(insets):
-            if #available(tvOS 17.0,macOS 14.0,watchOS 10.0,visionOS 1.0,iOS 17.0, *) {
+            if #available(macOS 14.0,iOS 17.0,tvOS 17.0,visionOS 1.0,watchOS 10.0, *) {
             let insets = insets as! SwiftUICore.EdgeInsets
             
             __content
@@ -10606,7 +10606,7 @@ struct _safeAreaPaddingModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(edges, length):
-            if #available(tvOS 17.0,macOS 14.0,watchOS 10.0,visionOS 1.0,iOS 17.0, *) {
+            if #available(macOS 14.0,iOS 17.0,tvOS 17.0,visionOS 1.0,watchOS 10.0, *) {
             let edges = edges as! SwiftUICore.Edge.Set 
 let length = length as? AttributeReference<CoreFoundation.CGFloat?>
             
@@ -10618,7 +10618,7 @@ let length = length as? AttributeReference<CoreFoundation.CGFloat?>
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._2(length):
-            if #available(tvOS 17.0,macOS 14.0,watchOS 10.0,visionOS 1.0,iOS 17.0, *) {
+            if #available(tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0,visionOS 1.0, *) {
             let length = length as! AttributeReference<CoreFoundation.CGFloat>
             
             __content
@@ -11030,7 +11030,7 @@ struct _scrollBounceBehaviorModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(iOS 16.4,tvOS 16.4,watchOS 9.4,macOS 13.3,visionOS 1.0, *)
+    @available(visionOS 1.0,tvOS 16.4,iOS 16.4,macOS 13.3,watchOS 9.4, *)
     init(_ behavior: SwiftUI.ScrollBounceBehavior,axes: SwiftUICore.Axis.Set = [.vertical] ) {
         self.value = ._0(behavior: behavior, axes: axes)
         
@@ -11043,7 +11043,7 @@ struct _scrollBounceBehaviorModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(behavior, axes):
-            if #available(iOS 16.4,tvOS 16.4,watchOS 9.4,macOS 13.3,visionOS 1.0, *) {
+            if #available(visionOS 1.0,tvOS 16.4,iOS 16.4,macOS 13.3,watchOS 9.4, *) {
             let behavior = behavior as! SwiftUI.ScrollBounceBehavior
 let axes = axes as! SwiftUICore.Axis.Set 
             
@@ -11078,7 +11078,7 @@ struct _scrollClipDisabledModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0,visionOS 1.0, *)
+    @available(tvOS 17.0,visionOS 1.0,iOS 17.0,watchOS 10.0,macOS 14.0, *)
     init(_ disabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(disabled: disabled)
         
@@ -11091,7 +11091,7 @@ struct _scrollClipDisabledModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(disabled):
-            if #available(macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0,visionOS 1.0, *) {
+            if #available(tvOS 17.0,visionOS 1.0,iOS 17.0,watchOS 10.0,macOS 14.0, *) {
             let disabled = disabled as! AttributeReference<Swift.Bool>
             
             __content
@@ -11125,7 +11125,7 @@ struct _scrollContentBackgroundModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,macOS 13.0,iOS 16.0,watchOS 9.0, *)
+    @available(visionOS 1.0,iOS 16.0,macOS 13.0,watchOS 9.0, *)
     init(_ visibility: AttributeReference<SwiftUI.Visibility>) {
         self.value = ._0(visibility: visibility)
         
@@ -11138,7 +11138,7 @@ struct _scrollContentBackgroundModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
         case let ._0(visibility):
-            if #available(visionOS 1.0,macOS 13.0,iOS 16.0,watchOS 9.0, *) {
+            if #available(visionOS 1.0,iOS 16.0,macOS 13.0,watchOS 9.0, *) {
             let visibility = visibility as! AttributeReference<SwiftUI.Visibility>
             
             __content
@@ -11219,7 +11219,7 @@ struct _scrollDismissesKeyboardModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-    @available(macOS 13.0,watchOS 9.0,iOS 16.0,tvOS 16.0, *)
+    @available(tvOS 16.0,iOS 16.0,watchOS 9.0,macOS 13.0, *)
     init(_ mode: SwiftUI.ScrollDismissesKeyboardMode) {
         self.value = ._0(mode: mode)
         
@@ -11232,7 +11232,7 @@ struct _scrollDismissesKeyboardModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
         case let ._0(mode):
-            if #available(macOS 13.0,watchOS 9.0,iOS 16.0,tvOS 16.0, *) {
+            if #available(tvOS 16.0,iOS 16.0,watchOS 9.0,macOS 13.0, *) {
             let mode = mode as! SwiftUI.ScrollDismissesKeyboardMode
             
             __content
@@ -11318,14 +11318,14 @@ struct _scrollIndicatorsFlashModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0, *)
+    @available(tvOS 17.0,macOS 14.0,iOS 17.0,watchOS 10.0,visionOS 1.0, *)
     init(trigger value: AttributeReference<String>) {
         self.value = ._0(value: value)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(iOS 17.0,tvOS 17.0,watchOS 10.0,macOS 14.0,visionOS 1.0, *)
+    @available(tvOS 17.0,macOS 14.0,iOS 17.0,watchOS 10.0,visionOS 1.0, *)
     init(onAppear: AttributeReference<Swift.Bool>) {
         self.value = ._1(onAppear: onAppear)
         
@@ -11338,7 +11338,7 @@ struct _scrollIndicatorsFlashModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(value):
-            if #available(visionOS 1.0,macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0, *) {
+            if #available(tvOS 17.0,macOS 14.0,iOS 17.0,watchOS 10.0,visionOS 1.0, *) {
             let value = value as! AttributeReference<String>
             
             __content
@@ -11349,7 +11349,7 @@ struct _scrollIndicatorsFlashModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(onAppear):
-            if #available(iOS 17.0,tvOS 17.0,watchOS 10.0,macOS 14.0,visionOS 1.0, *) {
+            if #available(tvOS 17.0,macOS 14.0,iOS 17.0,watchOS 10.0,visionOS 1.0, *) {
             let onAppear = onAppear as! AttributeReference<Swift.Bool>
             
             __content
@@ -11383,7 +11383,7 @@ struct _scrollInputBehaviorModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(iOS 18.0,tvOS 18.0,watchOS 11.0,macOS 15.0,visionOS 2.0, *)
+    @available(visionOS 2.0,tvOS 18.0,iOS 18.0,macOS 15.0,watchOS 11.0, *)
     init(_ behavior: SwiftUI.ScrollInputBehavior,for input: SwiftUI.ScrollInputKind) {
         self.value = ._0(behavior: behavior, input: input)
         
@@ -11396,7 +11396,7 @@ struct _scrollInputBehaviorModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(behavior, input):
-            if #available(iOS 18.0,tvOS 18.0,watchOS 11.0,macOS 15.0,visionOS 2.0, *) {
+            if #available(visionOS 2.0,tvOS 18.0,iOS 18.0,macOS 15.0,watchOS 11.0, *) {
             let behavior = behavior as! SwiftUI.ScrollInputBehavior
 let input = input as! SwiftUI.ScrollInputKind
             
@@ -11431,7 +11431,7 @@ struct _scrollPositionModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,tvOS 17.0,watchOS 10.0,macOS 14.0,iOS 17.0, *)
+    @available(iOS 17.0,visionOS 1.0,macOS 14.0,tvOS 17.0,watchOS 10.0, *)
     init(id: ChangeTracked<String?>,anchor: AttributeReference<SwiftUICore.UnitPoint?>? = .init(storage: .constant(nil)) ) {
         self.value = ._0(anchor: anchor)
         self.__0_id = id
@@ -11444,7 +11444,7 @@ struct _scrollPositionModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(anchor):
-            if #available(visionOS 1.0,tvOS 17.0,watchOS 10.0,macOS 14.0,iOS 17.0, *) {
+            if #available(iOS 17.0,visionOS 1.0,macOS 14.0,tvOS 17.0,watchOS 10.0, *) {
             let anchor = anchor as? AttributeReference<SwiftUICore.UnitPoint?>
             
             __content
@@ -11478,7 +11478,7 @@ struct _scrollTargetBehaviorModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 10.0,iOS 17.0,tvOS 17.0,macOS 14.0,visionOS 1.0, *)
+    @available(tvOS 17.0,visionOS 1.0,iOS 17.0,watchOS 10.0,macOS 14.0, *)
     init(_ behavior: AnyScrollTargetBehavior) {
         self.value = ._0(behavior: behavior)
         
@@ -11491,7 +11491,7 @@ struct _scrollTargetBehaviorModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(behavior):
-            if #available(watchOS 10.0,iOS 17.0,tvOS 17.0,macOS 14.0,visionOS 1.0, *) {
+            if #available(tvOS 17.0,visionOS 1.0,iOS 17.0,watchOS 10.0,macOS 14.0, *) {
             let behavior = behavior as! AnyScrollTargetBehavior
             
             __content
@@ -11525,7 +11525,7 @@ struct _scrollTargetLayoutModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 10.0,iOS 17.0,tvOS 17.0,macOS 14.0,visionOS 1.0, *)
+    @available(macOS 14.0,iOS 17.0,tvOS 17.0,visionOS 1.0,watchOS 10.0, *)
     init(isEnabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(isEnabled: isEnabled)
         
@@ -11538,7 +11538,7 @@ struct _scrollTargetLayoutModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(isEnabled):
-            if #available(watchOS 10.0,iOS 17.0,tvOS 17.0,macOS 14.0,visionOS 1.0, *) {
+            if #available(macOS 14.0,iOS 17.0,tvOS 17.0,visionOS 1.0,watchOS 10.0, *) {
             let isEnabled = isEnabled as! AttributeReference<Swift.Bool>
             
             __content
@@ -11619,7 +11619,7 @@ struct _searchPresentationToolbarBehaviorModifier<R: RootRegistry>: ViewModifier
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 14.1,watchOS 10.1,iOS 17.1,tvOS 17.1,visionOS 1.0, *)
+    @available(macOS 14.1,iOS 17.1,tvOS 17.1,watchOS 10.1,visionOS 1.0, *)
     init(_ behavior: SwiftUI.SearchPresentationToolbarBehavior) {
         self.value = ._0(behavior: behavior)
         
@@ -11632,7 +11632,7 @@ struct _searchPresentationToolbarBehaviorModifier<R: RootRegistry>: ViewModifier
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(behavior):
-            if #available(macOS 14.1,watchOS 10.1,iOS 17.1,tvOS 17.1,visionOS 1.0, *) {
+            if #available(macOS 14.1,iOS 17.1,tvOS 17.1,watchOS 10.1,visionOS 1.0, *) {
             let behavior = behavior as! SwiftUI.SearchPresentationToolbarBehavior
             
             __content
@@ -11785,7 +11785,7 @@ struct _searchableModifier<R: RootRegistry>: ViewModifier {
     }
     
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(iOS 17.0,macOS 14.0,visionOS 1.0, *)
+    @available(macOS 14.0,visionOS 1.0,iOS 17.0, *)
     init(text: ChangeTracked<Swift.String>,isPresented: ChangeTracked<Swift.Bool>,placement: SwiftUI.SearchFieldPlacement = .automatic, prompt: TextReference? = nil ) {
         self.value = ._3(placement: placement, prompt: prompt)
         self.__3_text = text
@@ -11793,7 +11793,7 @@ self.__3_isPresented = isPresented
     }
     #endif
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(iOS 17.0,macOS 14.0,visionOS 1.0, *)
+    @available(macOS 14.0,visionOS 1.0,iOS 17.0, *)
     init(text: ChangeTracked<Swift.String>,isPresented: ChangeTracked<Swift.Bool>,placement: SwiftUI.SearchFieldPlacement = .automatic, prompt: SwiftUICore.LocalizedStringKey) {
         self.value = ._4(placement: placement, prompt: prompt)
         self.__4_text = text
@@ -11801,7 +11801,7 @@ self.__4_isPresented = isPresented
     }
     #endif
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(iOS 17.0,macOS 14.0,visionOS 1.0, *)
+    @available(macOS 14.0,visionOS 1.0,iOS 17.0, *)
     init(text: ChangeTracked<Swift.String>,isPresented: ChangeTracked<Swift.Bool>,placement: SwiftUI.SearchFieldPlacement = .automatic, prompt: AttributeReference<String>) {
         self.value = ._5(placement: placement, prompt: prompt)
         self.__5_text = text
@@ -11848,7 +11848,7 @@ self.__5_isPresented = isPresented
         
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._3(placement, prompt):
-            if #available(iOS 17.0,macOS 14.0,visionOS 1.0, *) {
+            if #available(macOS 14.0,visionOS 1.0,iOS 17.0, *) {
             let placement = placement as! SwiftUI.SearchFieldPlacement 
 let prompt = prompt as? TextReference
             __content._observeTextReference(prompt, on: element, in: context) { __content in
@@ -11860,7 +11860,7 @@ let prompt = prompt as? TextReference
         #endif
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._4(placement, prompt):
-            if #available(iOS 17.0,macOS 14.0,visionOS 1.0, *) {
+            if #available(macOS 14.0,visionOS 1.0,iOS 17.0, *) {
             let placement = placement as! SwiftUI.SearchFieldPlacement 
 let prompt = prompt as! SwiftUICore.LocalizedStringKey
             
@@ -11872,7 +11872,7 @@ let prompt = prompt as! SwiftUICore.LocalizedStringKey
         #endif
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._5(placement, prompt):
-            if #available(iOS 17.0,macOS 14.0,visionOS 1.0, *) {
+            if #available(macOS 14.0,visionOS 1.0,iOS 17.0, *) {
             let placement = placement as! SwiftUI.SearchFieldPlacement 
 let prompt = prompt as! AttributeReference<String>
             
@@ -11907,7 +11907,7 @@ struct _sectionActionsModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 15.0,visionOS 2.0,iOS 18.0, *)
+    @available(visionOS 2.0,iOS 18.0,macOS 15.0, *)
     init(content: ViewReference=ViewReference(value: [])) {
         self.value = ._0(content: content)
         
@@ -11920,7 +11920,7 @@ struct _sectionActionsModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(content):
-            if #available(macOS 15.0,visionOS 2.0,iOS 18.0, *) {
+            if #available(visionOS 2.0,iOS 18.0,macOS 15.0, *) {
             let content = content as! ViewReference
             
             __content
@@ -11954,7 +11954,7 @@ struct _selectionDisabledModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0, *)
+    @available(watchOS 10.0,tvOS 17.0,iOS 17.0,visionOS 1.0,macOS 14.0, *)
     init(_ isDisabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(isDisabled: isDisabled)
         
@@ -11967,7 +11967,7 @@ struct _selectionDisabledModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(isDisabled):
-            if #available(visionOS 1.0,macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0, *) {
+            if #available(watchOS 10.0,tvOS 17.0,iOS 17.0,visionOS 1.0,macOS 14.0, *) {
             let isDisabled = isDisabled as! AttributeReference<Swift.Bool>
             
             __content
@@ -12120,7 +12120,7 @@ struct _simultaneousGestureModifier<R: RootRegistry>: ViewModifier {
     }
     
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 2.0,tvOS 18.0,iOS 18.0,macOS 15.0,watchOS 11.0, *)
+    @available(watchOS 11.0,tvOS 18.0,iOS 18.0,visionOS 2.0,macOS 15.0, *)
     init(_ gesture: _AnyGesture,name: AttributeReference<Swift.String>,isEnabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._2(gesture: gesture, name: name, isEnabled: isEnabled)
         
@@ -12155,7 +12155,7 @@ struct _simultaneousGestureModifier<R: RootRegistry>: ViewModifier {
         
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._2(gesture, name, isEnabled):
-            if #available(visionOS 2.0,tvOS 18.0,iOS 18.0,macOS 15.0,watchOS 11.0, *) {
+            if #available(watchOS 11.0,tvOS 18.0,iOS 18.0,visionOS 2.0,macOS 15.0, *) {
             let gesture = gesture as! _AnyGesture
 let name = name as! AttributeReference<Swift.String>
 let isEnabled = isEnabled as! AttributeReference<Swift.Bool>
@@ -12379,7 +12379,7 @@ struct _statusBarHiddenModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(visionOS)
-    @available(visionOS 1.0,iOS 13.0, *)
+    @available(iOS 13.0,visionOS 1.0, *)
     init(_ hidden: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(hidden: hidden)
         
@@ -12392,7 +12392,7 @@ struct _statusBarHiddenModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(visionOS)
         case let ._0(hidden):
-            if #available(visionOS 1.0,iOS 13.0, *) {
+            if #available(iOS 13.0,visionOS 1.0, *) {
             let hidden = hidden as! AttributeReference<Swift.Bool>
             
             __content
@@ -12567,7 +12567,7 @@ struct _swipeActionsModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
-    @available(macOS 12.0,watchOS 8.0,iOS 15.0,visionOS 1.0, *)
+    @available(visionOS 1.0,iOS 15.0,macOS 12.0,watchOS 8.0, *)
     init(edge: SwiftUICore.HorizontalEdge = .trailing, allowsFullSwipe: AttributeReference<Swift.Bool> = .init(storage: .constant(true)), content: ViewReference=ViewReference(value: [])) {
         self.value = ._0(edge: edge, allowsFullSwipe: allowsFullSwipe, content: content)
         
@@ -12580,7 +12580,7 @@ struct _swipeActionsModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
         case let ._0(edge, allowsFullSwipe, content):
-            if #available(macOS 12.0,watchOS 8.0,iOS 15.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,iOS 15.0,macOS 12.0,watchOS 8.0, *) {
             let edge = edge as! SwiftUICore.HorizontalEdge 
 let allowsFullSwipe = allowsFullSwipe as! AttributeReference<Swift.Bool>
 let content = content as! ViewReference
@@ -12621,14 +12621,14 @@ struct _symbolEffectModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 10.0,iOS 17.0,tvOS 17.0,macOS 14.0,visionOS 1.0, *)
+    @available(macOS 14.0,iOS 17.0,tvOS 17.0,visionOS 1.0,watchOS 10.0, *)
     init(_ effect: AnyIndefiniteSymbolEffect,options: Symbols.SymbolEffectOptions = .default, isActive: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(effect: effect, options: options, isActive: isActive)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 10.0,iOS 17.0,tvOS 17.0,macOS 14.0,visionOS 1.0, *)
+    @available(macOS 14.0,iOS 17.0,tvOS 17.0,visionOS 1.0,watchOS 10.0, *)
     init(_ effect: AnyDiscreteSymbolEffect,options: Symbols.SymbolEffectOptions = .default, value: AttributeReference<String>) {
         self.value = ._1(effect: effect, options: options, value: value)
         
@@ -12641,7 +12641,7 @@ struct _symbolEffectModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(effect, options, isActive):
-            if #available(watchOS 10.0,iOS 17.0,tvOS 17.0,macOS 14.0,visionOS 1.0, *) {
+            if #available(macOS 14.0,iOS 17.0,tvOS 17.0,visionOS 1.0,watchOS 10.0, *) {
             let effect = effect as! AnyIndefiniteSymbolEffect
 let options = options as! Symbols.SymbolEffectOptions 
 let isActive = isActive as! AttributeReference<Swift.Bool>
@@ -12654,7 +12654,7 @@ let isActive = isActive as! AttributeReference<Swift.Bool>
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(effect, options, value):
-            if #available(watchOS 10.0,iOS 17.0,tvOS 17.0,macOS 14.0,visionOS 1.0, *) {
+            if #available(macOS 14.0,iOS 17.0,tvOS 17.0,visionOS 1.0,watchOS 10.0, *) {
             let effect = effect as! AnyDiscreteSymbolEffect
 let options = options as! Symbols.SymbolEffectOptions 
 let value = value as! AttributeReference<String>
@@ -12690,7 +12690,7 @@ struct _symbolEffectsRemovedModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0, *)
+    @available(watchOS 10.0,tvOS 17.0,iOS 17.0,visionOS 1.0,macOS 14.0, *)
     init(_ isEnabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(isEnabled: isEnabled)
         
@@ -12703,7 +12703,7 @@ struct _symbolEffectsRemovedModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(isEnabled):
-            if #available(visionOS 1.0,macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0, *) {
+            if #available(watchOS 10.0,tvOS 17.0,iOS 17.0,visionOS 1.0,macOS 14.0, *) {
             let isEnabled = isEnabled as! AttributeReference<Swift.Bool>
             
             __content
@@ -12831,7 +12831,7 @@ struct _tabViewSidebarBottomBarModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 15.0,visionOS 2.0,iOS 18.0, *)
+    @available(iOS 18.0,macOS 15.0,visionOS 2.0, *)
     init(content: ViewReference=ViewReference(value: [])) {
         self.value = ._0(content: content)
         
@@ -12844,7 +12844,7 @@ struct _tabViewSidebarBottomBarModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(content):
-            if #available(macOS 15.0,visionOS 2.0,iOS 18.0, *) {
+            if #available(iOS 18.0,macOS 15.0,visionOS 2.0, *) {
             let content = content as! ViewReference
             
             __content
@@ -12878,7 +12878,7 @@ struct _tabViewSidebarFooterModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 15.0,visionOS 2.0,iOS 18.0, *)
+    @available(iOS 18.0,macOS 15.0,visionOS 2.0, *)
     init(content: ViewReference=ViewReference(value: [])) {
         self.value = ._0(content: content)
         
@@ -12891,7 +12891,7 @@ struct _tabViewSidebarFooterModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(content):
-            if #available(macOS 15.0,visionOS 2.0,iOS 18.0, *) {
+            if #available(iOS 18.0,macOS 15.0,visionOS 2.0, *) {
             let content = content as! ViewReference
             
             __content
@@ -12925,7 +12925,7 @@ struct _tabViewSidebarHeaderModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 15.0,visionOS 2.0,iOS 18.0, *)
+    @available(iOS 18.0,macOS 15.0,visionOS 2.0, *)
     init(content: ViewReference=ViewReference(value: [])) {
         self.value = ._0(content: content)
         
@@ -12938,7 +12938,7 @@ struct _tabViewSidebarHeaderModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(content):
-            if #available(macOS 15.0,visionOS 2.0,iOS 18.0, *) {
+            if #available(iOS 18.0,macOS 15.0,visionOS 2.0, *) {
             let content = content as! ViewReference
             
             __content
@@ -13019,7 +13019,7 @@ struct _tableStyleModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(iOS 16.0,macOS 12.0,visionOS 1.0, *)
+    @available(macOS 12.0,visionOS 1.0,iOS 16.0, *)
     init(_ style: AnyTableStyle) {
         self.value = ._0(style: style)
         
@@ -13032,7 +13032,7 @@ struct _tableStyleModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(style):
-            if #available(iOS 16.0,macOS 12.0,visionOS 1.0, *) {
+            if #available(macOS 12.0,visionOS 1.0,iOS 16.0, *) {
             let style = style as! AnyTableStyle
             
             __content
@@ -13113,7 +13113,7 @@ struct _textContentTypeModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(tvOS) || os(visionOS)
-    @available(tvOS 13.0,visionOS 1.0,iOS 13.0, *)
+    @available(visionOS 1.0,iOS 13.0,tvOS 13.0, *)
     init(_ textContentType: UIKit.UITextContentType?) {
         self.value = ._0(textContentType: textContentType)
         
@@ -13126,7 +13126,7 @@ struct _textContentTypeModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(tvOS) || os(visionOS)
         case let ._0(textContentType):
-            if #available(tvOS 13.0,visionOS 1.0,iOS 13.0, *) {
+            if #available(visionOS 1.0,iOS 13.0,tvOS 13.0, *) {
             let textContentType = textContentType as? UIKit.UITextContentType
             
             __content
@@ -13160,7 +13160,7 @@ struct _textEditorStyleModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(visionOS 1.0,iOS 17.0,macOS 14.0, *)
+    @available(macOS 14.0,visionOS 1.0,iOS 17.0, *)
     init(_ style: AnyTextEditorStyle) {
         self.value = ._0(style: style)
         
@@ -13173,7 +13173,7 @@ struct _textEditorStyleModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(style):
-            if #available(visionOS 1.0,iOS 17.0,macOS 14.0, *) {
+            if #available(macOS 14.0,visionOS 1.0,iOS 17.0, *) {
             let style = style as! AnyTextEditorStyle
             
             __content
@@ -13254,7 +13254,7 @@ struct _textInputAutocapitalizationModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(tvOS 15.0,watchOS 8.0,visionOS 1.0,iOS 15.0, *)
+    @available(iOS 15.0,tvOS 15.0,visionOS 1.0,watchOS 8.0, *)
     init(_ autocapitalization: SwiftUI.TextInputAutocapitalization?) {
         self.value = ._0(autocapitalization: autocapitalization)
         
@@ -13267,7 +13267,7 @@ struct _textInputAutocapitalizationModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(autocapitalization):
-            if #available(tvOS 15.0,watchOS 8.0,visionOS 1.0,iOS 15.0, *) {
+            if #available(iOS 15.0,tvOS 15.0,visionOS 1.0,watchOS 8.0, *) {
             let autocapitalization = autocapitalization as? SwiftUI.TextInputAutocapitalization
             
             __content
@@ -13395,7 +13395,7 @@ struct _textSelectionModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(visionOS 1.0,macOS 12.0,iOS 15.0, *)
+    @available(iOS 15.0,macOS 12.0,visionOS 1.0, *)
     init(_ selectability: AnyTextSelectability) {
         self.value = ._0(selectability: selectability)
         
@@ -13408,7 +13408,7 @@ struct _textSelectionModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(selectability):
-            if #available(visionOS 1.0,macOS 12.0,iOS 15.0, *) {
+            if #available(iOS 15.0,macOS 12.0,visionOS 1.0, *) {
             let selectability = selectability as! AnyTextSelectability
             
             __content
@@ -13442,7 +13442,7 @@ struct _textSelectionAffinityModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 11.0,macOS 15.0,visionOS 2.0,tvOS 18.0,iOS 18.0, *)
+    @available(iOS 18.0,visionOS 2.0,macOS 15.0,tvOS 18.0,watchOS 11.0, *)
     init(_ affinity: SwiftUI.TextSelectionAffinity) {
         self.value = ._0(affinity: affinity)
         
@@ -13455,7 +13455,7 @@ struct _textSelectionAffinityModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(affinity):
-            if #available(watchOS 11.0,macOS 15.0,visionOS 2.0,tvOS 18.0,iOS 18.0, *) {
+            if #available(iOS 18.0,visionOS 2.0,macOS 15.0,tvOS 18.0,watchOS 11.0, *) {
             let affinity = affinity as! SwiftUI.TextSelectionAffinity
             
             __content
@@ -13616,7 +13616,7 @@ struct _toolbarModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0, *)
+    @available(iOS 17.0,visionOS 1.0,macOS 14.0,tvOS 17.0,watchOS 10.0, *)
     init(removing defaultItemKind: SwiftUI.ToolbarDefaultItemKind?) {
         self.value = ._0(defaultItemKind: defaultItemKind)
         
@@ -13643,7 +13643,7 @@ struct _toolbarModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(defaultItemKind):
-            if #available(visionOS 1.0,macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0, *) {
+            if #available(iOS 17.0,visionOS 1.0,macOS 14.0,tvOS 17.0,watchOS 10.0, *) {
             let defaultItemKind = defaultItemKind as? SwiftUI.ToolbarDefaultItemKind
             
             __content
@@ -13746,7 +13746,7 @@ struct _toolbarBackgroundVisibilityModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(tvOS 18.0,macOS 15.0,watchOS 11.0,visionOS 2.0,iOS 18.0, *)
+    @available(tvOS 18.0,visionOS 2.0,iOS 18.0,watchOS 11.0,macOS 15.0, *)
     init(_ visibility: AttributeReference<SwiftUI.Visibility>,for bars: SwiftUI.ToolbarPlacement) {
         self.value = ._0(visibility: visibility, bars: bars)
         
@@ -13759,7 +13759,7 @@ struct _toolbarBackgroundVisibilityModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(visibility, bars):
-            if #available(tvOS 18.0,macOS 15.0,watchOS 11.0,visionOS 2.0,iOS 18.0, *) {
+            if #available(tvOS 18.0,visionOS 2.0,iOS 18.0,watchOS 11.0,macOS 15.0, *) {
             let visibility = visibility as! AttributeReference<SwiftUI.Visibility>
 let bars = bars as! SwiftUI.ToolbarPlacement
             
@@ -13935,7 +13935,7 @@ struct _toolbarTitleDisplayModeModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0,visionOS 1.0, *)
+    @available(macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0,visionOS 1.0, *)
     init(_ mode: SwiftUI.ToolbarTitleDisplayMode) {
         self.value = ._0(mode: mode)
         
@@ -13948,7 +13948,7 @@ struct _toolbarTitleDisplayModeModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(mode):
-            if #available(macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0,visionOS 1.0, *) {
+            if #available(macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0,visionOS 1.0, *) {
             let mode = mode as! SwiftUI.ToolbarTitleDisplayMode
             
             __content
@@ -14029,7 +14029,7 @@ struct _toolbarVisibilityModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(tvOS 18.0,macOS 15.0,watchOS 11.0,visionOS 2.0,iOS 18.0, *)
+    @available(watchOS 11.0,tvOS 18.0,iOS 18.0,visionOS 2.0,macOS 15.0, *)
     init(_ visibility: AttributeReference<SwiftUI.Visibility>,for bars: SwiftUI.ToolbarPlacement) {
         self.value = ._0(visibility: visibility, bars: bars)
         
@@ -14042,7 +14042,7 @@ struct _toolbarVisibilityModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(visibility, bars):
-            if #available(tvOS 18.0,macOS 15.0,watchOS 11.0,visionOS 2.0,iOS 18.0, *) {
+            if #available(watchOS 11.0,tvOS 18.0,iOS 18.0,visionOS 2.0,macOS 15.0, *) {
             let visibility = visibility as! AttributeReference<SwiftUI.Visibility>
 let bars = bars as! SwiftUI.ToolbarPlacement
             
@@ -14688,7 +14688,7 @@ struct _windowToolbarFullScreenVisibilityModifier<R: RootRegistry>: ViewModifier
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 2.0,macOS 15.0,watchOS 11.0,iOS 18.0,tvOS 18.0, *)
+    @available(watchOS 11.0,tvOS 18.0,iOS 18.0,visionOS 2.0,macOS 15.0, *)
     init(_ visibility: SwiftUI.WindowToolbarFullScreenVisibility) {
         self.value = ._0(visibility: visibility)
         
@@ -14701,7 +14701,7 @@ struct _windowToolbarFullScreenVisibilityModifier<R: RootRegistry>: ViewModifier
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(visibility):
-            if #available(visionOS 2.0,macOS 15.0,watchOS 11.0,iOS 18.0,tvOS 18.0, *) {
+            if #available(watchOS 11.0,tvOS 18.0,iOS 18.0,visionOS 2.0,macOS 15.0, *) {
             let visibility = visibility as! SwiftUI.WindowToolbarFullScreenVisibility
             
             __content
@@ -14735,7 +14735,7 @@ struct _writingToolsBehaviorModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS)
-    @available(macOS 15.0,iOS 18.0, *)
+    @available(iOS 18.0,macOS 15.0, *)
     init(_ behavior: SwiftUI.WritingToolsBehavior) {
         self.value = ._0(behavior: behavior)
         
@@ -14748,7 +14748,7 @@ struct _writingToolsBehaviorModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS)
         case let ._0(behavior):
-            if #available(macOS 15.0,iOS 18.0, *) {
+            if #available(iOS 18.0,macOS 15.0, *) {
             let behavior = behavior as! SwiftUI.WritingToolsBehavior
             
             __content
@@ -15777,18 +15777,18 @@ indirect case chunk15(_BuiltinModifierChunk15)
 indirect case chunk16(_BuiltinModifierChunk16)
 indirect case chunk17(_BuiltinModifierChunk17)
 indirect case chunk18(_BuiltinModifierChunk18)
-        indirect case _Rotation3DEffectModifier(LiveViewNative._Rotation3DEffectModifier<R>)
+        indirect case _PresentationDetentsModifier(LiveViewNative._PresentationDetentsModifier)
+indirect case _Rotation3DEffectModifier(LiveViewNative._Rotation3DEffectModifier<R>)
 indirect case _SearchScopesModifier(LiveViewNative._SearchScopesModifier<R>)
-indirect case _MatchedTransitionSourceModifier(LiveViewNative._MatchedTransitionSourceModifier<R>)
-indirect case _PerspectiveRotationEffectModifier(LiveViewNative._PerspectiveRotationEffectModifier<R>)
-indirect case _NavigationTransitionModifier(LiveViewNative._NavigationTransitionModifier<R>)
-indirect case _SearchCompletionModifier(LiveViewNative._SearchCompletionModifier<R>)
-indirect case _PrefersDefaultFocusModifier(LiveViewNative._PrefersDefaultFocusModifier<R>)
 indirect case _MaskModifier(LiveViewNative._MaskModifier<R>)
 indirect case _MatchedGeometryEffectModifier(LiveViewNative._MatchedGeometryEffectModifier<R>)
-indirect case _OnSubmitModifier(LiveViewNative._OnSubmitModifier)
-indirect case _PresentationDetentsModifier(LiveViewNative._PresentationDetentsModifier)
 indirect case _FocusScopeModifier(LiveViewNative._FocusScopeModifier<R>)
+indirect case _PrefersDefaultFocusModifier(LiveViewNative._PrefersDefaultFocusModifier<R>)
+indirect case _NavigationTransitionModifier(LiveViewNative._NavigationTransitionModifier<R>)
+indirect case _OnSubmitModifier(LiveViewNative._OnSubmitModifier)
+indirect case _MatchedTransitionSourceModifier(LiveViewNative._MatchedTransitionSourceModifier<R>)
+indirect case _SearchCompletionModifier(LiveViewNative._SearchCompletionModifier<R>)
+indirect case _PerspectiveRotationEffectModifier(LiveViewNative._PerspectiveRotationEffectModifier<R>)
         indirect case _customRegistryModifier(R.CustomModifier)
         indirect case _anyTextModifier(_AnyTextModifier<R>)
         indirect case _anyImageModifier(_AnyImageModifier<R>)
@@ -15835,29 +15835,29 @@ case let .chunk17(chunk):
     content.modifier(chunk)
 case let .chunk18(chunk):
     content.modifier(chunk)
-            case let ._Rotation3DEffectModifier(modifier):
+            case let ._PresentationDetentsModifier(modifier):
+    content.modifier(modifier)
+case let ._Rotation3DEffectModifier(modifier):
     content.modifier(modifier)
 case let ._SearchScopesModifier(modifier):
-    content.modifier(modifier)
-case let ._MatchedTransitionSourceModifier(modifier):
-    content.modifier(modifier)
-case let ._PerspectiveRotationEffectModifier(modifier):
-    content.modifier(modifier)
-case let ._NavigationTransitionModifier(modifier):
-    content.modifier(modifier)
-case let ._SearchCompletionModifier(modifier):
-    content.modifier(modifier)
-case let ._PrefersDefaultFocusModifier(modifier):
     content.modifier(modifier)
 case let ._MaskModifier(modifier):
     content.modifier(modifier)
 case let ._MatchedGeometryEffectModifier(modifier):
     content.modifier(modifier)
+case let ._FocusScopeModifier(modifier):
+    content.modifier(modifier)
+case let ._PrefersDefaultFocusModifier(modifier):
+    content.modifier(modifier)
+case let ._NavigationTransitionModifier(modifier):
+    content.modifier(modifier)
 case let ._OnSubmitModifier(modifier):
     content.modifier(modifier)
-case let ._PresentationDetentsModifier(modifier):
+case let ._MatchedTransitionSourceModifier(modifier):
     content.modifier(modifier)
-case let ._FocusScopeModifier(modifier):
+case let ._SearchCompletionModifier(modifier):
+    content.modifier(modifier)
+case let ._PerspectiveRotationEffectModifier(modifier):
     content.modifier(modifier)
             case let ._customRegistryModifier(modifier):
                 content.modifier(modifier)
@@ -16143,18 +16143,18 @@ _windowResizeBehaviorModifier<R>.name: _windowResizeBehaviorModifier<R>.parser(i
 _windowToolbarFullScreenVisibilityModifier<R>.name: _windowToolbarFullScreenVisibilityModifier<R>.parser(in: context).map({ Output.chunk18(.windowToolbarFullScreenVisibility($0)) }).eraseToAnyParser(),
 _writingToolsBehaviorModifier<R>.name: _writingToolsBehaviorModifier<R>.parser(in: context).map({ Output.chunk18(.writingToolsBehavior($0)) }).eraseToAnyParser(),
 _zIndexModifier<R>.name: _zIndexModifier<R>.parser(in: context).map({ Output.chunk18(.zIndex($0)) }).eraseToAnyParser(),
-                    LiveViewNative._Rotation3DEffectModifier<R>.name: LiveViewNative._Rotation3DEffectModifier<R>.parser(in: context).map(Output._Rotation3DEffectModifier).eraseToAnyParser(),
+                    LiveViewNative._PresentationDetentsModifier.name: LiveViewNative._PresentationDetentsModifier.parser(in: context).map(Output._PresentationDetentsModifier).eraseToAnyParser(),
+LiveViewNative._Rotation3DEffectModifier<R>.name: LiveViewNative._Rotation3DEffectModifier<R>.parser(in: context).map(Output._Rotation3DEffectModifier).eraseToAnyParser(),
 LiveViewNative._SearchScopesModifier<R>.name: LiveViewNative._SearchScopesModifier<R>.parser(in: context).map(Output._SearchScopesModifier).eraseToAnyParser(),
-LiveViewNative._MatchedTransitionSourceModifier<R>.name: LiveViewNative._MatchedTransitionSourceModifier<R>.parser(in: context).map(Output._MatchedTransitionSourceModifier).eraseToAnyParser(),
-LiveViewNative._PerspectiveRotationEffectModifier<R>.name: LiveViewNative._PerspectiveRotationEffectModifier<R>.parser(in: context).map(Output._PerspectiveRotationEffectModifier).eraseToAnyParser(),
-LiveViewNative._NavigationTransitionModifier<R>.name: LiveViewNative._NavigationTransitionModifier<R>.parser(in: context).map(Output._NavigationTransitionModifier).eraseToAnyParser(),
-LiveViewNative._SearchCompletionModifier<R>.name: LiveViewNative._SearchCompletionModifier<R>.parser(in: context).map(Output._SearchCompletionModifier).eraseToAnyParser(),
-LiveViewNative._PrefersDefaultFocusModifier<R>.name: LiveViewNative._PrefersDefaultFocusModifier<R>.parser(in: context).map(Output._PrefersDefaultFocusModifier).eraseToAnyParser(),
 LiveViewNative._MaskModifier<R>.name: LiveViewNative._MaskModifier<R>.parser(in: context).map(Output._MaskModifier).eraseToAnyParser(),
 LiveViewNative._MatchedGeometryEffectModifier<R>.name: LiveViewNative._MatchedGeometryEffectModifier<R>.parser(in: context).map(Output._MatchedGeometryEffectModifier).eraseToAnyParser(),
-LiveViewNative._OnSubmitModifier.name: LiveViewNative._OnSubmitModifier.parser(in: context).map(Output._OnSubmitModifier).eraseToAnyParser(),
-LiveViewNative._PresentationDetentsModifier.name: LiveViewNative._PresentationDetentsModifier.parser(in: context).map(Output._PresentationDetentsModifier).eraseToAnyParser(),
 LiveViewNative._FocusScopeModifier<R>.name: LiveViewNative._FocusScopeModifier<R>.parser(in: context).map(Output._FocusScopeModifier).eraseToAnyParser(),
+LiveViewNative._PrefersDefaultFocusModifier<R>.name: LiveViewNative._PrefersDefaultFocusModifier<R>.parser(in: context).map(Output._PrefersDefaultFocusModifier).eraseToAnyParser(),
+LiveViewNative._NavigationTransitionModifier<R>.name: LiveViewNative._NavigationTransitionModifier<R>.parser(in: context).map(Output._NavigationTransitionModifier).eraseToAnyParser(),
+LiveViewNative._OnSubmitModifier.name: LiveViewNative._OnSubmitModifier.parser(in: context).map(Output._OnSubmitModifier).eraseToAnyParser(),
+LiveViewNative._MatchedTransitionSourceModifier<R>.name: LiveViewNative._MatchedTransitionSourceModifier<R>.parser(in: context).map(Output._MatchedTransitionSourceModifier).eraseToAnyParser(),
+LiveViewNative._SearchCompletionModifier<R>.name: LiveViewNative._SearchCompletionModifier<R>.parser(in: context).map(Output._SearchCompletionModifier).eraseToAnyParser(),
+LiveViewNative._PerspectiveRotationEffectModifier<R>.name: LiveViewNative._PerspectiveRotationEffectModifier<R>.parser(in: context).map(Output._PerspectiveRotationEffectModifier).eraseToAnyParser(),
                 ]
 
                 let deprecations = [
@@ -16350,7 +16350,7 @@ ConstantAtomLiteral("content").map({ () -> Self in
 /// * `.tabBar`
 /// * `.sidebar`
 @_documentation(visibility: public)
-@available(watchOS 11.0,tvOS 18.0,visionOS 2.0,macOS 15.0,iOS 18.0, *)
+@available(iOS 18.0,tvOS 18.0,macOS 15.0,visionOS 2.0,watchOS 11.0, *)
 extension AdaptableTabBarPlacement: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -16468,7 +16468,7 @@ ConstantAtomLiteral("vertical").map({ () -> Self in
 /// * `.standard`
 /// * `.increased`
 @_documentation(visibility: public)
-@available(visionOS 1.0,macOS 14.0,iOS 17.0, *)
+@available(iOS 17.0,visionOS 1.0,macOS 14.0, *)
 extension BadgeProminence: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -16696,7 +16696,7 @@ ConstantAtomLiteral("plusLighter").map({ () -> Self in
 /// * `.enabled`
 /// * `.disabled`
 @_documentation(visibility: public)
-@available(tvOS 17.0,watchOS 10.0,macOS 14.0,iOS 17.0,visionOS 1.0, *)
+@available(macOS 14.0,tvOS 17.0,iOS 17.0,watchOS 10.0,visionOS 1.0, *)
 extension ButtonRepeatBehavior: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -16815,35 +16815,35 @@ ConstantAtomLiteral("dark").map({ () -> Self in
 /// * `.navigationSplitView`
 /// * `.window`
 @_documentation(visibility: public)
-@available(watchOS 10.0,tvOS 17.0,visionOS 1.0,macOS 14.0,iOS 17.0, *)
+@available(watchOS 10.0,tvOS 17.0,iOS 17.0,visionOS 1.0,macOS 14.0, *)
 extension ContainerBackgroundPlacement: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             #if os(watchOS)
 ConstantAtomLiteral("tabView").map({ () -> Self in
-if #available(watchOS 10.0,tvOS 17.0,macOS 14.0,iOS 17.0, *) {
+if #available(watchOS 10.0,tvOS 17.0,iOS 17.0,macOS 14.0, *) {
     return Self.tabView
 } else { fatalError("'tabView' is not available in this OS version") }
 })
 #endif
 #if os(iOS) || os(watchOS)
 ConstantAtomLiteral("navigation").map({ () -> Self in
-if #available(watchOS 10.0,tvOS 17.0,macOS 14.0,iOS 18.0, *) {
+if #available(watchOS 10.0,tvOS 17.0,iOS 18.0,macOS 14.0, *) {
     return Self.navigation
 } else { fatalError("'navigation' is not available in this OS version") }
 })
 #endif
 #if os(iOS) || os(watchOS)
 ConstantAtomLiteral("navigationSplitView").map({ () -> Self in
-if #available(watchOS 11.0,tvOS 17.0,macOS 14.0,iOS 18.0, *) {
+if #available(watchOS 11.0,tvOS 17.0,iOS 18.0,macOS 14.0, *) {
     return Self.navigationSplitView
 } else { fatalError("'navigationSplitView' is not available in this OS version") }
 })
 #endif
 #if os(macOS)
 ConstantAtomLiteral("window").map({ () -> Self in
-if #available(watchOS 10.0,tvOS 17.0,macOS 15.0,iOS 17.0, *) {
+if #available(watchOS 10.0,tvOS 17.0,iOS 17.0,macOS 15.0, *) {
     return Self.window
 } else { fatalError("'window' is not available in this OS version") }
 })
@@ -16864,7 +16864,7 @@ if #available(watchOS 10.0,tvOS 17.0,macOS 15.0,iOS 17.0, *) {
 /// * `.scrollContent`
 /// * `.scrollIndicators`
 @_documentation(visibility: public)
-@available(watchOS 10.0,tvOS 17.0,visionOS 1.0,macOS 14.0,iOS 17.0, *)
+@available(macOS 14.0,iOS 17.0,tvOS 17.0,visionOS 1.0,watchOS 10.0, *)
 extension ContentMarginPlacement: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -16923,35 +16923,35 @@ ConstantAtomLiteral("interaction").map({ () -> Self in
 
 #if os(iOS) || os(macOS) || os(visionOS)
 ConstantAtomLiteral("dragPreview").map({ () -> Self in
-if #available(tvOS 15.0,watchOS 8.0,macOS 12.0,iOS 15.0,visionOS 1.0, *) {
+if #available(tvOS 15.0,iOS 15.0,macOS 12.0,watchOS 8.0,visionOS 1.0, *) {
     return Self.dragPreview
 } else { fatalError("'dragPreview' is not available in this OS version") }
 })
 #endif
 #if os(iOS) || os(tvOS) || os(visionOS)
 ConstantAtomLiteral("contextMenuPreview").map({ () -> Self in
-if #available(tvOS 17.0,watchOS 8.0,macOS 12.0,iOS 15.0,visionOS 1.0, *) {
+if #available(tvOS 17.0,iOS 15.0,macOS 12.0,watchOS 8.0,visionOS 1.0, *) {
     return Self.contextMenuPreview
 } else { fatalError("'contextMenuPreview' is not available in this OS version") }
 })
 #endif
 #if os(iOS) || os(tvOS) || os(visionOS)
 ConstantAtomLiteral("hoverEffect").map({ () -> Self in
-if #available(tvOS 18.0,watchOS 8.0,macOS 12.0,iOS 15.0,visionOS 1.0, *) {
+if #available(tvOS 18.0,iOS 15.0,macOS 12.0,watchOS 8.0,visionOS 1.0, *) {
     return Self.hoverEffect
 } else { fatalError("'hoverEffect' is not available in this OS version") }
 })
 #endif
 #if os(macOS) || os(watchOS)
 ConstantAtomLiteral("focusEffect").map({ () -> Self in
-if #available(tvOS 15.0,watchOS 8.0,macOS 12.0,iOS 15.0, *) {
+if #available(tvOS 15.0,iOS 15.0,macOS 12.0,watchOS 8.0, *) {
     return Self.focusEffect
 } else { fatalError("'focusEffect' is not available in this OS version") }
 })
 #endif
 #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
 ConstantAtomLiteral("accessibility").map({ () -> Self in
-if #available(visionOS 1.0,iOS 17.0,macOS 14.0,watchOS 10.0,tvOS 17.0, *) {
+if #available(visionOS 1.0,watchOS 10.0,tvOS 17.0,macOS 14.0,iOS 17.0, *) {
     return Self.accessibility
 } else { fatalError("'accessibility' is not available in this OS version") }
 })
@@ -16974,7 +16974,7 @@ if #available(visionOS 1.0,iOS 17.0,macOS 14.0,watchOS 10.0,tvOS 17.0, *) {
 /// * `.large`
 /// * `.extraLarge`
 @_documentation(visibility: public)
-@available(visionOS 1.0,watchOS 9.0,macOS 10.15,iOS 15.0, *)
+@available(iOS 15.0,macOS 10.15,visionOS 1.0,watchOS 9.0, *)
 extension ControlSize: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -17002,14 +17002,14 @@ ConstantAtomLiteral("regular").map({ () -> Self in
 #endif
 #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
 ConstantAtomLiteral("large").map({ () -> Self in
-if #available(visionOS 1.0,watchOS 9.0,macOS 11.0,iOS 15.0, *) {
+if #available(iOS 15.0,macOS 11.0,visionOS 1.0,watchOS 9.0, *) {
     return Self.large
 } else { fatalError("'large' is not available in this OS version") }
 })
 #endif
 #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
 ConstantAtomLiteral("extraLarge").map({ () -> Self in
-if #available(visionOS 1.0,watchOS 10.0,macOS 14.0,iOS 17.0, *) {
+if #available(iOS 17.0,macOS 14.0,visionOS 1.0,watchOS 10.0, *) {
     return Self.extraLarge
 } else { fatalError("'extraLarge' is not available in this OS version") }
 })
@@ -17064,7 +17064,7 @@ ConstantAtomLiteral("userInitiated").map({ () -> Self in
 /// * `.critical`
 /// * `.standard`
 @_documentation(visibility: public)
-@available(tvOS 17.0,watchOS 10.0,macOS 13.0,iOS 17.0,visionOS 1.0, *)
+@available(macOS 13.0,iOS 17.0,tvOS 17.0,visionOS 1.0,watchOS 10.0, *)
 extension DialogSeverity: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -17085,7 +17085,7 @@ ConstantAtomLiteral("critical").map({ () -> Self in
 #endif
 #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
 ConstantAtomLiteral("standard").map({ () -> Self in
-if #available(tvOS 17.0,watchOS 10.0,macOS 14.0,iOS 17.0,visionOS 1.0, *) {
+if #available(macOS 14.0,iOS 17.0,tvOS 17.0,visionOS 1.0,watchOS 10.0, *) {
     return Self.standard
 } else { fatalError("'standard' is not available in this OS version") }
 })
@@ -17256,7 +17256,7 @@ ConstantAtomLiteral("all").map({ () -> Self in
 /// * `.includeHiddenFiles`
 /// * `.displayFileExtensions`
 @_documentation(visibility: public)
-@available(iOS 17.0,macOS 14.0,visionOS 1.0, *)
+@available(visionOS 1.0,iOS 17.0,macOS 14.0, *)
 extension FileDialogBrowserOptions: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -17298,7 +17298,7 @@ ConstantAtomLiteral("displayFileExtensions").map({ () -> Self in
 /// * `.edit`
 /// * `.automatic`
 @_documentation(visibility: public)
-@available(watchOS 10.0,tvOS 17.0,visionOS 1.0,macOS 14.0,iOS 17.0, *)
+@available(macOS 14.0,tvOS 17.0,iOS 17.0,watchOS 10.0,visionOS 1.0, *)
 extension FocusInteractions: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -17325,6 +17325,122 @@ ConstantAtomLiteral("automatic").map({ () -> Self in
 })
 #endif
                 AtomLiteral().fail(outputType: FocusInteractions.self) {
+                    ModifierParseError(error: .unknownArgument($0), metadata: context.metadata)
+                }
+            }
+        }
+    }
+}
+#endif
+#if os(macOS)
+/// See [`SwiftUI.FrameResizeDirection`](https://developer.apple.com/documentation/swiftui/FrameResizeDirection) for more details.
+///
+/// Possible values:
+/// * `.inward`
+/// * `.outward`
+@_documentation(visibility: public)
+@available(macOS 15.0, *)
+extension FrameResizeDirection: ParseableModifierValue {
+    public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
+        ImplicitStaticMember {
+            OneOf {
+            #if os(macOS)
+ConstantAtomLiteral("inward").map({ () -> Self in
+
+    return Self.inward
+
+})
+#endif
+#if os(macOS)
+ConstantAtomLiteral("outward").map({ () -> Self in
+
+    return Self.outward
+
+})
+#endif
+                AtomLiteral().fail(outputType: FrameResizeDirection.self) {
+                    ModifierParseError(error: .unknownArgument($0), metadata: context.metadata)
+                }
+            }
+        }
+    }
+}
+#endif
+#if os(macOS)
+/// See [`SwiftUI.FrameResizePosition`](https://developer.apple.com/documentation/swiftui/FrameResizePosition) for more details.
+///
+/// Possible values:
+/// * `.top`
+/// * `.leading`
+/// * `.bottom`
+/// * `.trailing`
+/// * `.topLeading`
+/// * `.topTrailing`
+/// * `.bottomLeading`
+/// * `.bottomTrailing`
+@_documentation(visibility: public)
+@available(macOS 15.0, *)
+extension FrameResizePosition: ParseableModifierValue {
+    public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
+        ImplicitStaticMember {
+            OneOf {
+            #if os(macOS)
+ConstantAtomLiteral("top").map({ () -> Self in
+
+    return Self.top
+
+})
+#endif
+#if os(macOS)
+ConstantAtomLiteral("leading").map({ () -> Self in
+
+    return Self.leading
+
+})
+#endif
+#if os(macOS)
+ConstantAtomLiteral("bottom").map({ () -> Self in
+
+    return Self.bottom
+
+})
+#endif
+#if os(macOS)
+ConstantAtomLiteral("trailing").map({ () -> Self in
+
+    return Self.trailing
+
+})
+#endif
+#if os(macOS)
+ConstantAtomLiteral("topLeading").map({ () -> Self in
+
+    return Self.topLeading
+
+})
+#endif
+#if os(macOS)
+ConstantAtomLiteral("topTrailing").map({ () -> Self in
+
+    return Self.topTrailing
+
+})
+#endif
+#if os(macOS)
+ConstantAtomLiteral("bottomLeading").map({ () -> Self in
+
+    return Self.bottomLeading
+
+})
+#endif
+#if os(macOS)
+ConstantAtomLiteral("bottomTrailing").map({ () -> Self in
+
+    return Self.bottomTrailing
+
+})
+#endif
+                AtomLiteral().fail(outputType: FrameResizePosition.self) {
                     ModifierParseError(error: .unknownArgument($0), metadata: context.metadata)
                 }
             }
@@ -17434,7 +17550,7 @@ ConstantAtomLiteral("never").map({ () -> Self in
 /// * `.center`
 /// * `.trailing`
 @_documentation(visibility: public)
-@available(visionOS 1.0,macOS 13.0,iOS 16.0, *)
+@available(iOS 16.0,macOS 13.0,visionOS 1.0, *)
 extension HorizontalAlignment: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -17475,6 +17591,40 @@ ConstantAtomLiteral("trailing").map({ () -> Self in
 })
 
                 AtomLiteral().fail(outputType: HorizontalAlignment.self) {
+                    ModifierParseError(error: .unknownArgument($0), metadata: context.metadata)
+                }
+            }
+        }
+    }
+}
+#endif
+#if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+/// See [`SwiftUI.HorizontalDirection`](https://developer.apple.com/documentation/swiftui/HorizontalDirection) for more details.
+///
+/// Possible values:
+/// * `.leading`
+/// * `.trailing`
+@_documentation(visibility: public)
+@available(tvOS 18.0,iOS 18.0,macOS 15.0,watchOS 11.0,visionOS 2.0, *)
+extension HorizontalDirection: ParseableModifierValue {
+    public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
+        ImplicitStaticMember {
+            OneOf {
+            #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+ConstantAtomLiteral("leading").map({ () -> Self in
+
+    return Self.leading
+
+})
+#endif
+#if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+ConstantAtomLiteral("trailing").map({ () -> Self in
+
+    return Self.trailing
+
+})
+#endif
+                AtomLiteral().fail(outputType: HorizontalDirection.self) {
                     ModifierParseError(error: .unknownArgument($0), metadata: context.metadata)
                 }
             }
@@ -17524,7 +17674,7 @@ ConstantAtomLiteral("trailing").map({ () -> Self in
 /// * `.highlight`
 /// * `.lift`
 @_documentation(visibility: public)
-@available(visionOS 1.0,tvOS 16.0,iOS 13.4, *)
+@available(tvOS 16.0,iOS 13.4,visionOS 1.0, *)
 extension HoverEffect: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -17538,7 +17688,7 @@ ConstantAtomLiteral("automatic").map({ () -> Self in
 #endif
 #if os(iOS) || os(tvOS) || os(visionOS)
 ConstantAtomLiteral("highlight").map({ () -> Self in
-if #available(visionOS 1.0,tvOS 17.0,iOS 13.4, *) {
+if #available(tvOS 17.0,iOS 13.4,visionOS 1.0, *) {
     return Self.highlight
 } else { fatalError("'highlight' is not available in this OS version") }
 })
@@ -17565,7 +17715,7 @@ ConstantAtomLiteral("lift").map({ () -> Self in
 /// * `.defaultAction`
 /// * `.cancelAction`
 @_documentation(visibility: public)
-@available(macOS 11.0,visionOS 1.0,iOS 14.0, *)
+@available(iOS 14.0,visionOS 1.0,macOS 11.0, *)
 extension KeyboardShortcut: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -17656,7 +17806,7 @@ ConstantAtomLiteral("automatic").map({ () -> Self in
 
 #if os(iOS) || os(visionOS)
 ConstantAtomLiteral("priority").map({ () -> Self in
-if #available(tvOS 16.0,watchOS 9.0,macOS 13.0,iOS 16.0,visionOS 1.0, *) {
+if #available(watchOS 9.0,visionOS 1.0,macOS 13.0,iOS 16.0,tvOS 16.0, *) {
     return Self.priority
 } else { fatalError("'priority' is not available in this OS version") }
 })
@@ -17686,7 +17836,7 @@ ConstantAtomLiteral("fixed").map({ () -> Self in
 /// * `.sheet`
 /// * `.fullScreenCover`
 @_documentation(visibility: public)
-@available(visionOS 1.0,macOS 13.3,watchOS 9.4,iOS 16.4,tvOS 16.4, *)
+@available(visionOS 1.0,tvOS 16.4,watchOS 9.4,iOS 16.4,macOS 13.3, *)
 extension PresentationAdaptation: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -17742,7 +17892,7 @@ ConstantAtomLiteral("fullScreenCover").map({ () -> Self in
 /// * `.resizes`
 /// * `.scrolls`
 @_documentation(visibility: public)
-@available(macOS 13.3,watchOS 9.4,visionOS 1.0,tvOS 16.4,iOS 16.4, *)
+@available(macOS 13.3,tvOS 16.4,iOS 16.4,watchOS 9.4,visionOS 1.0, *)
 extension PresentationContentInteraction: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -17839,7 +17989,7 @@ ConstantAtomLiteral("privacy").map({ () -> Self in
 
 #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
 ConstantAtomLiteral("invalidated").map({ () -> Self in
-if #available(visionOS 1.0,iOS 17.0,macOS 14.0,watchOS 10.0,tvOS 17.0, *) {
+if #available(tvOS 17.0,iOS 17.0,macOS 14.0,visionOS 1.0,watchOS 10.0, *) {
     return Self.invalidated
 } else { fatalError("'invalidated' is not available in this OS version") }
 })
@@ -17949,7 +18099,7 @@ ConstantAtomLiteral("minimum").map({ () -> Self in
 
 #if os(watchOS)
 ConstantAtomLiteral("navigationBar").map({ () -> Self in
-if #available(watchOS 9.0,macOS 13.0,tvOS 16.0,iOS 16.0, *) {
+if #available(tvOS 16.0,iOS 16.0,macOS 13.0,watchOS 9.0, *) {
     return Self.navigationBar
 } else { fatalError("'navigationBar' is not available in this OS version") }
 })
@@ -17970,7 +18120,7 @@ if #available(watchOS 9.0,macOS 13.0,tvOS 16.0,iOS 16.0, *) {
 /// * `.sizeChanges`
 /// * `.alignment`
 @_documentation(visibility: public)
-@available(watchOS 11.0,tvOS 18.0,visionOS 2.0,macOS 15.0,iOS 18.0, *)
+@available(watchOS 11.0,tvOS 18.0,iOS 18.0,visionOS 2.0,macOS 15.0, *)
 extension ScrollAnchorRole: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -18012,7 +18162,7 @@ ConstantAtomLiteral("alignment").map({ () -> Self in
 /// * `.always`
 /// * `.basedOnSize`
 @_documentation(visibility: public)
-@available(watchOS 9.4,tvOS 16.4,visionOS 1.0,macOS 13.3,iOS 16.4, *)
+@available(watchOS 9.4,tvOS 16.4,iOS 16.4,visionOS 1.0,macOS 13.3, *)
 extension ScrollBounceBehavior: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -18055,7 +18205,7 @@ ConstantAtomLiteral("basedOnSize").map({ () -> Self in
 /// * `.interactively`
 /// * `.never`
 @_documentation(visibility: public)
-@available(watchOS 9.0,tvOS 16.0,macOS 13.0,iOS 16.0, *)
+@available(watchOS 9.0,tvOS 16.0,iOS 16.0,macOS 13.0, *)
 extension ScrollDismissesKeyboardMode: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -18154,7 +18304,7 @@ ConstantAtomLiteral("never").map({ () -> Self in
 /// * `.onTextEntry`
 /// * `.onSearchPresentation`
 @_documentation(visibility: public)
-@available(tvOS 16.4,watchOS 9.4,macOS 13.3,iOS 16.4,visionOS 1.0, *)
+@available(iOS 16.4,tvOS 16.4,visionOS 1.0,watchOS 9.4,macOS 13.3, *)
 extension SearchScopeActivation: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -18238,7 +18388,7 @@ ConstantAtomLiteral("content").map({ () -> Self in
 /// * `.enabled`
 /// * `.disabled`
 @_documentation(visibility: public)
-@available(watchOS 10.0,tvOS 17.0,visionOS 1.0,macOS 14.0,iOS 17.0, *)
+@available(watchOS 10.0,visionOS 1.0,macOS 14.0,iOS 17.0,tvOS 17.0, *)
 extension SpringLoadingBehavior: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -18404,7 +18554,7 @@ ConstantAtomLiteral("search").map({ () -> Self in
 /// * `.upstream`
 /// * `.downstream`
 @_documentation(visibility: public)
-@available(visionOS 2.0,macOS 15.0,watchOS 11.0,iOS 18.0,tvOS 18.0, *)
+@available(macOS 15.0,iOS 18.0,tvOS 18.0,visionOS 2.0,watchOS 11.0, *)
 extension TextSelectionAffinity: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -18445,7 +18595,7 @@ ConstantAtomLiteral("downstream").map({ () -> Self in
 /// * `.sidebarToggle`
 /// * `.title`
 @_documentation(visibility: public)
-@available(tvOS 17.0,watchOS 10.0,macOS 14.0,iOS 17.0,visionOS 1.0, *)
+@available(macOS 14.0,iOS 17.0,tvOS 17.0,visionOS 1.0,watchOS 10.0, *)
 extension ToolbarDefaultItemKind: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -18459,7 +18609,7 @@ ConstantAtomLiteral("sidebarToggle").map({ () -> Self in
 #endif
 #if os(iOS) || os(macOS) || os(visionOS)
 ConstantAtomLiteral("title").map({ () -> Self in
-if #available(tvOS 17.0,watchOS 10.0,macOS 15.0,iOS 18.0,visionOS 2.0, *) {
+if #available(macOS 15.0,iOS 18.0,tvOS 17.0,visionOS 2.0,watchOS 10.0, *) {
     return Self.title
 } else { fatalError("'title' is not available in this OS version") }
 })
@@ -18495,21 +18645,21 @@ ConstantAtomLiteral("automatic").map({ () -> Self in
 
 #if os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
 ConstantAtomLiteral("navigationStack").map({ () -> Self in
-if #available(watchOS 9.0,tvOS 16.0,visionOS 1.0,macOS 13.0,iOS 16.0, *) {
+if #available(macOS 13.0,iOS 16.0,tvOS 16.0,visionOS 1.0,watchOS 9.0, *) {
     return Self.navigationStack
 } else { fatalError("'navigationStack' is not available in this OS version") }
 })
 #endif
 #if os(iOS) || os(visionOS)
 ConstantAtomLiteral("browser").map({ () -> Self in
-if #available(watchOS 9.0,tvOS 16.0,visionOS 1.0,macOS 13.0,iOS 16.0, *) {
+if #available(macOS 13.0,iOS 16.0,tvOS 16.0,visionOS 1.0,watchOS 9.0, *) {
     return Self.browser
 } else { fatalError("'browser' is not available in this OS version") }
 })
 #endif
 #if os(iOS) || os(macOS) || os(visionOS)
 ConstantAtomLiteral("editor").map({ () -> Self in
-if #available(watchOS 9.0,tvOS 16.0,visionOS 1.0,macOS 13.0,iOS 16.0, *) {
+if #available(macOS 13.0,iOS 16.0,tvOS 16.0,visionOS 1.0,watchOS 9.0, *) {
     return Self.editor
 } else { fatalError("'editor' is not available in this OS version") }
 })
@@ -18531,7 +18681,7 @@ if #available(watchOS 9.0,tvOS 16.0,visionOS 1.0,macOS 13.0,iOS 16.0, *) {
 /// * `.inlineLarge`
 /// * `.inline`
 @_documentation(visibility: public)
-@available(visionOS 1.0,macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0, *)
+@available(macOS 14.0,iOS 17.0,tvOS 17.0,visionOS 1.0,watchOS 10.0, *)
 extension ToolbarTitleDisplayMode: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -18630,6 +18780,40 @@ ConstantAtomLiteral("lastTextBaseline").map({ () -> Self in
     }
 }
 
+#if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+/// See [`SwiftUI.VerticalDirection`](https://developer.apple.com/documentation/swiftui/VerticalDirection) for more details.
+///
+/// Possible values:
+/// * `.up`
+/// * `.down`
+@_documentation(visibility: public)
+@available(tvOS 18.0,iOS 18.0,macOS 15.0,watchOS 11.0,visionOS 2.0, *)
+extension VerticalDirection: ParseableModifierValue {
+    public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
+        ImplicitStaticMember {
+            OneOf {
+            #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+ConstantAtomLiteral("up").map({ () -> Self in
+
+    return Self.up
+
+})
+#endif
+#if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+ConstantAtomLiteral("down").map({ () -> Self in
+
+    return Self.down
+
+})
+#endif
+                AtomLiteral().fail(outputType: VerticalDirection.self) {
+                    ModifierParseError(error: .unknownArgument($0), metadata: context.metadata)
+                }
+            }
+        }
+    }
+}
+#endif
 
 /// See [`SwiftUI.VerticalEdge`](https://developer.apple.com/documentation/swiftui/VerticalEdge) for more details.
 ///
@@ -18706,3 +18890,45 @@ ConstantAtomLiteral("hidden").map({ () -> Self in
     }
 }
 
+#if os(macOS)
+/// See [`SwiftUI.WindowInteractionBehavior`](https://developer.apple.com/documentation/swiftui/WindowInteractionBehavior) for more details.
+///
+/// Possible values:
+/// * `.automatic`
+/// * `.enabled`
+/// * `.disabled`
+@_documentation(visibility: public)
+@available(macOS 15.0, *)
+extension WindowInteractionBehavior: ParseableModifierValue {
+    public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
+        ImplicitStaticMember {
+            OneOf {
+            #if os(macOS)
+ConstantAtomLiteral("automatic").map({ () -> Self in
+
+    return Self.automatic
+
+})
+#endif
+#if os(macOS)
+ConstantAtomLiteral("enabled").map({ () -> Self in
+
+    return Self.enabled
+
+})
+#endif
+#if os(macOS)
+ConstantAtomLiteral("disabled").map({ () -> Self in
+
+    return Self.disabled
+
+})
+#endif
+                AtomLiteral().fail(outputType: WindowInteractionBehavior.self) {
+                    ModifierParseError(error: .unknownArgument($0), metadata: context.metadata)
+                }
+            }
+        }
+    }
+}
+#endif

--- a/Sources/LiveViewNative/_GeneratedModifiers.swift
+++ b/Sources/LiveViewNative/_GeneratedModifiers.swift
@@ -78,7 +78,7 @@ struct _accessibilityActionsModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 15.0,watchOS 11.0,iOS 18.0,tvOS 18.0,visionOS 2.0, *)
+    @available(visionOS 2.0,macOS 15.0,tvOS 18.0,iOS 18.0,watchOS 11.0, *)
     init(category: SwiftUI.AccessibilityActionCategory,content content: ViewReference=ViewReference(value: [])) {
         self.value = ._0(category: category, content: content)
         
@@ -98,7 +98,7 @@ struct _accessibilityActionsModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(category, content):
-            if #available(macOS 15.0,watchOS 11.0,iOS 18.0,tvOS 18.0,visionOS 2.0, *) {
+            if #available(visionOS 2.0,macOS 15.0,tvOS 18.0,iOS 18.0,watchOS 11.0, *) {
             let category = category as! SwiftUI.AccessibilityActionCategory
 let content = content as! ViewReference
             
@@ -634,7 +634,7 @@ struct _allowsWindowActivationEventsModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 15.0,visionOS 2.0,iOS 18.0, *)
+    @available(iOS 18.0,visionOS 2.0,macOS 15.0, *)
     init(_ value: AttributeReference<Swift.Bool?>? = .init(storage: .constant(true)) ) {
         self.value = ._0(value: value)
         
@@ -647,7 +647,7 @@ struct _allowsWindowActivationEventsModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(value):
-            if #available(macOS 15.0,visionOS 2.0,iOS 18.0, *) {
+            if #available(iOS 18.0,visionOS 2.0,macOS 15.0, *) {
             let value = value as? AttributeReference<Swift.Bool?>
             
             __content
@@ -1092,28 +1092,28 @@ struct _badgeModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(visionOS 1.0,macOS 12.0,iOS 15.0, *)
+    @available(macOS 12.0,iOS 15.0,visionOS 1.0, *)
     init(_ count: AttributeReference<Swift.Int>) {
         self.value = ._0(count: count)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 12.0,visionOS 1.0,iOS 15.0, *)
+    @available(macOS 12.0,iOS 15.0,visionOS 1.0, *)
     init(_ label: TextReference?) {
         self.value = ._1(label: label)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 12.0,visionOS 1.0,iOS 15.0, *)
+    @available(macOS 12.0,iOS 15.0,visionOS 1.0, *)
     init(_ key: SwiftUICore.LocalizedStringKey?) {
         self.value = ._2(key: key)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 12.0,visionOS 1.0,iOS 15.0, *)
+    @available(macOS 12.0,iOS 15.0,visionOS 1.0, *)
     init(_ label: AttributeReference<String>) {
         self.value = ._3(label: label)
         
@@ -1126,7 +1126,7 @@ struct _badgeModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(count):
-            if #available(visionOS 1.0,macOS 12.0,iOS 15.0, *) {
+            if #available(macOS 12.0,iOS 15.0,visionOS 1.0, *) {
             let count = count as! AttributeReference<Swift.Int>
             
             __content
@@ -1137,7 +1137,7 @@ struct _badgeModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._1(label):
-            if #available(macOS 12.0,visionOS 1.0,iOS 15.0, *) {
+            if #available(macOS 12.0,iOS 15.0,visionOS 1.0, *) {
             let label = label as? TextReference
             __content._observeTextReference(label, on: element, in: context) { __content in
             __content
@@ -1148,7 +1148,7 @@ struct _badgeModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._2(key):
-            if #available(macOS 12.0,visionOS 1.0,iOS 15.0, *) {
+            if #available(macOS 12.0,iOS 15.0,visionOS 1.0, *) {
             let key = key as? SwiftUICore.LocalizedStringKey
             
             __content
@@ -1159,7 +1159,7 @@ struct _badgeModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._3(label):
-            if #available(macOS 12.0,visionOS 1.0,iOS 15.0, *) {
+            if #available(macOS 12.0,iOS 15.0,visionOS 1.0, *) {
             let label = label as! AttributeReference<String>
             
             __content
@@ -1193,7 +1193,7 @@ struct _badgeProminenceModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(visionOS 1.0,macOS 14.0,iOS 17.0, *)
+    @available(macOS 14.0,iOS 17.0,visionOS 1.0, *)
     init(_ prominence: SwiftUI.BadgeProminence) {
         self.value = ._0(prominence: prominence)
         
@@ -1206,7 +1206,7 @@ struct _badgeProminenceModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(prominence):
-            if #available(visionOS 1.0,macOS 14.0,iOS 17.0, *) {
+            if #available(macOS 14.0,iOS 17.0,visionOS 1.0, *) {
             let prominence = prominence as! SwiftUI.BadgeProminence
             
             __content
@@ -1947,14 +1947,14 @@ struct _containerRelativeFrameModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0,visionOS 1.0, *)
+    @available(visionOS 1.0,tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0, *)
     init(_ axes: SwiftUICore.Axis.Set,alignment: AttributeReference<SwiftUICore.Alignment> = .init(storage: .constant(.center)) ) {
         self.value = ._0(axes: axes, alignment: alignment)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0,visionOS 1.0, *)
+    @available(visionOS 1.0,tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0, *)
     init(_ axes: SwiftUICore.Axis.Set,count: AttributeReference<Swift.Int>,span: AttributeReference<Swift.Int> = .init(storage: .constant(1)), spacing: AttributeReference<CoreFoundation.CGFloat>,alignment: AttributeReference<SwiftUICore.Alignment> = .init(storage: .constant(.center)) ) {
         self.value = ._1(axes: axes, count: count, span: span, spacing: spacing, alignment: alignment)
         
@@ -1967,7 +1967,7 @@ struct _containerRelativeFrameModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(axes, alignment):
-            if #available(tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0, *) {
             let axes = axes as! SwiftUICore.Axis.Set
 let alignment = alignment as! AttributeReference<SwiftUICore.Alignment>
             
@@ -1979,7 +1979,7 @@ let alignment = alignment as! AttributeReference<SwiftUICore.Alignment>
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(axes, count, span, spacing, alignment):
-            if #available(tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0, *) {
             let axes = axes as! SwiftUICore.Axis.Set
 let count = count as! AttributeReference<Swift.Int>
 let span = span as! AttributeReference<Swift.Int>
@@ -2074,21 +2074,21 @@ struct _contentMarginsModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0,visionOS 1.0, *)
+    @available(watchOS 10.0,visionOS 1.0,iOS 17.0,macOS 14.0,tvOS 17.0, *)
     init(_ edges: SwiftUICore.Edge.Set = .all, _ insets: SwiftUICore.EdgeInsets,for placement: SwiftUI.ContentMarginPlacement = .automatic ) {
         self.value = ._0(edges: edges, insets: insets, placement: placement)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0,visionOS 1.0, *)
+    @available(watchOS 10.0,visionOS 1.0,iOS 17.0,macOS 14.0,tvOS 17.0, *)
     init(_ edges: SwiftUICore.Edge.Set = .all, _ length: AttributeReference<CoreFoundation.CGFloat?>?,for placement: SwiftUI.ContentMarginPlacement = .automatic ) {
         self.value = ._1(edges: edges, length: length, placement: placement)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0,visionOS 1.0, *)
+    @available(watchOS 10.0,visionOS 1.0,iOS 17.0,macOS 14.0,tvOS 17.0, *)
     init(_ length: AttributeReference<CoreFoundation.CGFloat>,for placement: SwiftUI.ContentMarginPlacement = .automatic ) {
         self.value = ._2(length: length, placement: placement)
         
@@ -2101,7 +2101,7 @@ struct _contentMarginsModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(edges, insets, placement):
-            if #available(tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0,visionOS 1.0, *) {
+            if #available(watchOS 10.0,visionOS 1.0,iOS 17.0,macOS 14.0,tvOS 17.0, *) {
             let edges = edges as! SwiftUICore.Edge.Set 
 let insets = insets as! SwiftUICore.EdgeInsets
 let placement = placement as! SwiftUI.ContentMarginPlacement 
@@ -2114,7 +2114,7 @@ let placement = placement as! SwiftUI.ContentMarginPlacement
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(edges, length, placement):
-            if #available(tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0,visionOS 1.0, *) {
+            if #available(watchOS 10.0,visionOS 1.0,iOS 17.0,macOS 14.0,tvOS 17.0, *) {
             let edges = edges as! SwiftUICore.Edge.Set 
 let length = length as? AttributeReference<CoreFoundation.CGFloat?>
 let placement = placement as! SwiftUI.ContentMarginPlacement 
@@ -2127,7 +2127,7 @@ let placement = placement as! SwiftUI.ContentMarginPlacement
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._2(length, placement):
-            if #available(tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0,visionOS 1.0, *) {
+            if #available(watchOS 10.0,visionOS 1.0,iOS 17.0,macOS 14.0,tvOS 17.0, *) {
             let length = length as! AttributeReference<CoreFoundation.CGFloat>
 let placement = placement as! SwiftUI.ContentMarginPlacement 
             
@@ -2291,7 +2291,7 @@ struct _contextMenuModifier<R: RootRegistry>: ViewModifier {
     }
     
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS)
-    @available(macOS 13.0,iOS 16.0,tvOS 16.0,visionOS 1.0, *)
+    @available(macOS 13.0,tvOS 16.0,iOS 16.0,visionOS 1.0, *)
     init(menuItems: ViewReference=ViewReference(value: []),preview: ViewReference=ViewReference(value: [])) {
         self.value = ._1(menuItems: menuItems, preview: preview)
         
@@ -2315,7 +2315,7 @@ struct _contextMenuModifier<R: RootRegistry>: ViewModifier {
         
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS)
         case let ._1(menuItems, preview):
-            if #available(macOS 13.0,iOS 16.0,tvOS 16.0,visionOS 1.0, *) {
+            if #available(macOS 13.0,tvOS 16.0,iOS 16.0,visionOS 1.0, *) {
             let menuItems = menuItems as! ViewReference
 let preview = preview as! ViewReference
             
@@ -2397,7 +2397,7 @@ struct _controlGroupStyleModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS)
-    @available(tvOS 17.0,iOS 15.0,macOS 12.0,visionOS 1.0, *)
+    @available(macOS 12.0,iOS 15.0,tvOS 17.0,visionOS 1.0, *)
     init(_ style: AnyControlGroupStyle) {
         self.value = ._0(style: style)
         
@@ -2410,7 +2410,7 @@ struct _controlGroupStyleModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS)
         case let ._0(style):
-            if #available(tvOS 17.0,iOS 15.0,macOS 12.0,visionOS 1.0, *) {
+            if #available(macOS 12.0,iOS 15.0,tvOS 17.0,visionOS 1.0, *) {
             let style = style as! AnyControlGroupStyle
             
             __content
@@ -2444,7 +2444,7 @@ struct _controlSizeModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
-    @available(iOS 15.0,visionOS 1.0,macOS 10.15,watchOS 9.0, *)
+    @available(macOS 10.15,iOS 15.0,watchOS 9.0,visionOS 1.0, *)
     init(_ controlSize: SwiftUICore.ControlSize) {
         self.value = ._0(controlSize: controlSize)
         
@@ -2457,7 +2457,7 @@ struct _controlSizeModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
         case let ._0(controlSize):
-            if #available(iOS 15.0,visionOS 1.0,macOS 10.15,watchOS 9.0, *) {
+            if #available(macOS 10.15,iOS 15.0,watchOS 9.0,visionOS 1.0, *) {
             let controlSize = controlSize as! SwiftUICore.ControlSize
             
             __content
@@ -2491,7 +2491,7 @@ struct _coordinateSpaceModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 10.0,tvOS 17.0,macOS 14.0,iOS 17.0,visionOS 1.0, *)
+    @available(visionOS 1.0,tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0, *)
     init(_ name: SwiftUICore.NamedCoordinateSpace) {
         self.value = ._0(name: name)
         
@@ -2504,7 +2504,7 @@ struct _coordinateSpaceModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(name):
-            if #available(watchOS 10.0,tvOS 17.0,macOS 14.0,iOS 17.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0, *) {
             let name = name as! SwiftUICore.NamedCoordinateSpace
             
             __content
@@ -2538,7 +2538,7 @@ struct _datePickerStyleModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
-    @available(macOS 10.15,visionOS 1.0,iOS 13.0,watchOS 10.0, *)
+    @available(visionOS 1.0,macOS 10.15,watchOS 10.0,iOS 13.0, *)
     init(_ style: AnyDatePickerStyle) {
         self.value = ._0(style: style)
         
@@ -2551,7 +2551,7 @@ struct _datePickerStyleModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
         case let ._0(style):
-            if #available(macOS 10.15,visionOS 1.0,iOS 13.0,watchOS 10.0, *) {
+            if #available(visionOS 1.0,macOS 10.15,watchOS 10.0,iOS 13.0, *) {
             let style = style as! AnyDatePickerStyle
             
             __content
@@ -2632,7 +2632,7 @@ struct _defaultHoverEffectModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(tvOS) || os(visionOS)
-    @available(tvOS 17.0,visionOS 1.0,iOS 17.0, *)
+    @available(visionOS 1.0,tvOS 17.0,iOS 17.0, *)
     init(_ effect: SwiftUI.HoverEffect?) {
         self.value = ._0(effect: effect)
         
@@ -2645,7 +2645,7 @@ struct _defaultHoverEffectModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(tvOS) || os(visionOS)
         case let ._0(effect):
-            if #available(tvOS 17.0,visionOS 1.0,iOS 17.0, *) {
+            if #available(visionOS 1.0,tvOS 17.0,iOS 17.0, *) {
             let effect = effect as? SwiftUI.HoverEffect
             
             __content
@@ -2684,14 +2684,14 @@ struct _defaultScrollAnchorModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0,visionOS 1.0, *)
+    @available(visionOS 1.0,macOS 14.0,tvOS 17.0,iOS 17.0,watchOS 10.0, *)
     init(_ anchor: AttributeReference<SwiftUICore.UnitPoint?>?) {
         self.value = ._0(anchor: anchor)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 11.0,tvOS 18.0,macOS 15.0,iOS 18.0,visionOS 2.0, *)
+    @available(visionOS 2.0,macOS 15.0,tvOS 18.0,iOS 18.0,watchOS 11.0, *)
     init(_ anchor: AttributeReference<SwiftUICore.UnitPoint?>?,for role: SwiftUI.ScrollAnchorRole) {
         self.value = ._1(anchor: anchor, role: role)
         
@@ -2704,7 +2704,7 @@ struct _defaultScrollAnchorModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(anchor):
-            if #available(macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,macOS 14.0,tvOS 17.0,iOS 17.0,watchOS 10.0, *) {
             let anchor = anchor as? AttributeReference<SwiftUICore.UnitPoint?>
             
             __content
@@ -2715,7 +2715,7 @@ struct _defaultScrollAnchorModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(anchor, role):
-            if #available(watchOS 11.0,tvOS 18.0,macOS 15.0,iOS 18.0,visionOS 2.0, *) {
+            if #available(visionOS 2.0,macOS 15.0,tvOS 18.0,iOS 18.0,watchOS 11.0, *) {
             let anchor = anchor as? AttributeReference<SwiftUICore.UnitPoint?>
 let role = role as! SwiftUI.ScrollAnchorRole
             
@@ -2906,28 +2906,28 @@ struct _dialogSuppressionToggleModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0,visionOS 1.0, *)
+    @available(visionOS 1.0,macOS 14.0,tvOS 17.0,iOS 17.0,watchOS 10.0, *)
     init(_ titleKey: SwiftUICore.LocalizedStringKey,isSuppressed: ChangeTracked<Swift.Bool>) {
         self.value = ._0(titleKey: titleKey)
         self.__0_isSuppressed = isSuppressed
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0,visionOS 1.0, *)
+    @available(visionOS 1.0,macOS 14.0,tvOS 17.0,iOS 17.0,watchOS 10.0, *)
     init(_ title: AttributeReference<String>,isSuppressed: ChangeTracked<Swift.Bool>) {
         self.value = ._1(title: title)
         self.__1_isSuppressed = isSuppressed
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0,visionOS 1.0, *)
+    @available(visionOS 1.0,macOS 14.0,tvOS 17.0,iOS 17.0,watchOS 10.0, *)
     init(_ label: TextReference,isSuppressed: ChangeTracked<Swift.Bool>) {
         self.value = ._2(label: label)
         self.__2_isSuppressed = isSuppressed
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0,visionOS 1.0, *)
+    @available(visionOS 1.0,macOS 14.0,tvOS 17.0,iOS 17.0,watchOS 10.0, *)
     init(isSuppressed: ChangeTracked<Swift.Bool>) {
         self.value = ._3
         self.__3_isSuppressed = isSuppressed
@@ -2940,7 +2940,7 @@ struct _dialogSuppressionToggleModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(titleKey):
-            if #available(tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,macOS 14.0,tvOS 17.0,iOS 17.0,watchOS 10.0, *) {
             let titleKey = titleKey as! SwiftUICore.LocalizedStringKey
             
             __content
@@ -2951,7 +2951,7 @@ struct _dialogSuppressionToggleModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(title):
-            if #available(tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,macOS 14.0,tvOS 17.0,iOS 17.0,watchOS 10.0, *) {
             let title = title as! AttributeReference<String>
             
             __content
@@ -2962,7 +2962,7 @@ struct _dialogSuppressionToggleModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._2(label):
-            if #available(tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,macOS 14.0,tvOS 17.0,iOS 17.0,watchOS 10.0, *) {
             let label = label as! TextReference
             __content._observeTextReference(label, on: element, in: context) { __content in
             __content
@@ -2973,7 +2973,7 @@ struct _dialogSuppressionToggleModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case ._3:
-            if #available(tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,macOS 14.0,tvOS 17.0,iOS 17.0,watchOS 10.0, *) {
             
             
             __content
@@ -3418,7 +3418,7 @@ struct _fileDialogCustomizationIDModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 14.0,visionOS 1.0,iOS 17.0, *)
+    @available(macOS 14.0,iOS 17.0,visionOS 1.0, *)
     init(_ id: AttributeReference<Swift.String>) {
         self.value = ._0(id: id)
         
@@ -3431,7 +3431,7 @@ struct _fileDialogCustomizationIDModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(id):
-            if #available(macOS 14.0,visionOS 1.0,iOS 17.0, *) {
+            if #available(macOS 14.0,iOS 17.0,visionOS 1.0, *) {
             let id = id as! AttributeReference<Swift.String>
             
             __content
@@ -3465,7 +3465,7 @@ struct _fileDialogImportsUnresolvedAliasesModifier<R: RootRegistry>: ViewModifie
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(visionOS 1.0,macOS 14.0,iOS 17.0, *)
+    @available(macOS 14.0,visionOS 1.0,iOS 17.0, *)
     init(_ imports: AttributeReference<Swift.Bool>) {
         self.value = ._0(imports: imports)
         
@@ -3478,7 +3478,7 @@ struct _fileDialogImportsUnresolvedAliasesModifier<R: RootRegistry>: ViewModifie
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(imports):
-            if #available(visionOS 1.0,macOS 14.0,iOS 17.0, *) {
+            if #available(macOS 14.0,visionOS 1.0,iOS 17.0, *) {
             let imports = imports as! AttributeReference<Swift.Bool>
             
             __content
@@ -3723,7 +3723,7 @@ struct _focusEffectDisabledModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 14.0,visionOS 1.0,tvOS 17.0,iOS 17.0,watchOS 10.0, *)
+    @available(macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0,visionOS 1.0, *)
     init(_ disabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(disabled: disabled)
         
@@ -3736,7 +3736,7 @@ struct _focusEffectDisabledModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(disabled):
-            if #available(macOS 14.0,visionOS 1.0,tvOS 17.0,iOS 17.0,watchOS 10.0, *) {
+            if #available(macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0,visionOS 1.0, *) {
             let disabled = disabled as! AttributeReference<Swift.Bool>
             
             __content
@@ -3822,14 +3822,14 @@ struct _focusableModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 8.0,iOS 17.0,visionOS 1.0,macOS 12.0,tvOS 15.0, *)
+    @available(macOS 12.0,iOS 17.0,tvOS 15.0,watchOS 8.0,visionOS 1.0, *)
     init(_ isFocusable: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(isFocusable: isFocusable)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 14.0,visionOS 1.0,tvOS 17.0,iOS 17.0,watchOS 10.0, *)
+    @available(macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0,visionOS 1.0, *)
     init(_ isFocusable: AttributeReference<Swift.Bool> = .init(storage: .constant(true)), interactions: SwiftUI.FocusInteractions) {
         self.value = ._1(isFocusable: isFocusable, interactions: interactions)
         
@@ -3842,7 +3842,7 @@ struct _focusableModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(isFocusable):
-            if #available(watchOS 8.0,iOS 17.0,visionOS 1.0,macOS 12.0,tvOS 15.0, *) {
+            if #available(macOS 12.0,iOS 17.0,tvOS 15.0,watchOS 8.0,visionOS 1.0, *) {
             let isFocusable = isFocusable as! AttributeReference<Swift.Bool>
             
             __content
@@ -3853,7 +3853,7 @@ struct _focusableModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(isFocusable, interactions):
-            if #available(macOS 14.0,visionOS 1.0,tvOS 17.0,iOS 17.0,watchOS 10.0, *) {
+            if #available(macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0,visionOS 1.0, *) {
             let isFocusable = isFocusable as! AttributeReference<Swift.Bool>
 let interactions = interactions as! SwiftUI.FocusInteractions
             
@@ -4078,7 +4078,7 @@ struct _fullScreenCoverModifier<R: RootRegistry>: ViewModifier {
 @Event private var _0_onDismiss__0: Event.EventHandler
 
     #if os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 7.0,iOS 14.0,tvOS 14.0,visionOS 1.0, *)
+    @available(visionOS 1.0,watchOS 7.0,tvOS 14.0,iOS 14.0, *)
     init(isPresented: ChangeTracked<Swift.Bool>,onDismiss onDismiss__0: Event=Event(), content: ViewReference=ViewReference(value: [])) {
         self.value = ._0(content: content)
         self.__0_isPresented = isPresented
@@ -4092,7 +4092,7 @@ self.__0_onDismiss__0 = onDismiss__0
             fatalError("unreachable")
         #if os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(content):
-            if #available(watchOS 7.0,iOS 14.0,tvOS 14.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,watchOS 7.0,tvOS 14.0,iOS 14.0, *) {
             let content = content as! ViewReference
             
             __content
@@ -4126,7 +4126,7 @@ struct _gaugeStyleModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 7.0,macOS 13.0,iOS 16.0,visionOS 1.0, *)
+    @available(visionOS 1.0,macOS 13.0,watchOS 7.0,iOS 16.0, *)
     init(_ style: AnyGaugeStyle) {
         self.value = ._0(style: style)
         
@@ -4139,7 +4139,7 @@ struct _gaugeStyleModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
         case let ._0(style):
-            if #available(watchOS 7.0,macOS 13.0,iOS 16.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,macOS 13.0,watchOS 7.0,iOS 16.0, *) {
             let style = style as! AnyGaugeStyle
             
             __content
@@ -4173,7 +4173,7 @@ struct _geometryGroupModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0,visionOS 1.0, *)
+    @available(macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0,visionOS 1.0, *)
     init() {
         self.value = ._0
         
@@ -4186,7 +4186,7 @@ struct _geometryGroupModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case ._0:
-            if #available(tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0,visionOS 1.0, *) {
+            if #available(macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0,visionOS 1.0, *) {
             
             
             __content
@@ -4244,7 +4244,7 @@ struct _gestureModifier<R: RootRegistry>: ViewModifier {
     }
     
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(tvOS 18.0,watchOS 11.0,iOS 18.0,macOS 15.0,visionOS 2.0, *)
+    @available(watchOS 11.0,iOS 18.0,visionOS 2.0,tvOS 18.0,macOS 15.0, *)
     init(_ gesture: _AnyGesture,name: AttributeReference<Swift.String>,isEnabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._2(gesture: gesture, name: name, isEnabled: isEnabled)
         
@@ -4279,7 +4279,7 @@ struct _gestureModifier<R: RootRegistry>: ViewModifier {
         
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._2(gesture, name, isEnabled):
-            if #available(tvOS 18.0,watchOS 11.0,iOS 18.0,macOS 15.0,visionOS 2.0, *) {
+            if #available(watchOS 11.0,iOS 18.0,visionOS 2.0,tvOS 18.0,macOS 15.0, *) {
             let gesture = gesture as! _AnyGesture
 let name = name as! AttributeReference<Swift.String>
 let isEnabled = isEnabled as! AttributeReference<Swift.Bool>
@@ -4621,7 +4621,7 @@ struct _groupBoxStyleModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(visionOS 1.0,macOS 11.0,iOS 14.0, *)
+    @available(macOS 11.0,visionOS 1.0,iOS 14.0, *)
     init(_ style: AnyGroupBoxStyle) {
         self.value = ._0(style: style)
         
@@ -4634,7 +4634,7 @@ struct _groupBoxStyleModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(style):
-            if #available(visionOS 1.0,macOS 11.0,iOS 14.0, *) {
+            if #available(macOS 11.0,visionOS 1.0,iOS 14.0, *) {
             let style = style as! AnyGroupBoxStyle
             
             __content
@@ -4668,7 +4668,7 @@ struct _handGestureShortcutModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-    @available(watchOS 11.0,tvOS 18.0,macOS 15.0,iOS 18.0, *)
+    @available(macOS 15.0,tvOS 18.0,iOS 18.0,watchOS 11.0, *)
     init(_ shortcut: SwiftUI.HandGestureShortcut,isEnabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(shortcut: shortcut, isEnabled: isEnabled)
         
@@ -4681,7 +4681,7 @@ struct _handGestureShortcutModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
         case let ._0(shortcut, isEnabled):
-            if #available(watchOS 11.0,tvOS 18.0,macOS 15.0,iOS 18.0, *) {
+            if #available(macOS 15.0,tvOS 18.0,iOS 18.0,watchOS 11.0, *) {
             let shortcut = shortcut as! SwiftUI.HandGestureShortcut
 let isEnabled = isEnabled as! AttributeReference<Swift.Bool>
             
@@ -4974,7 +4974,7 @@ struct _highPriorityGestureModifier<R: RootRegistry>: ViewModifier {
     }
     
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(tvOS 18.0,watchOS 11.0,iOS 18.0,macOS 15.0,visionOS 2.0, *)
+    @available(watchOS 11.0,iOS 18.0,visionOS 2.0,tvOS 18.0,macOS 15.0, *)
     init(_ gesture: _AnyGesture,name: AttributeReference<Swift.String>,isEnabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._2(gesture: gesture, name: name, isEnabled: isEnabled)
         
@@ -5009,7 +5009,7 @@ struct _highPriorityGestureModifier<R: RootRegistry>: ViewModifier {
         
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._2(gesture, name, isEnabled):
-            if #available(tvOS 18.0,watchOS 11.0,iOS 18.0,macOS 15.0,visionOS 2.0, *) {
+            if #available(watchOS 11.0,iOS 18.0,visionOS 2.0,tvOS 18.0,macOS 15.0, *) {
             let gesture = gesture as! _AnyGesture
 let name = name as! AttributeReference<Swift.String>
 let isEnabled = isEnabled as! AttributeReference<Swift.Bool>
@@ -5097,14 +5097,14 @@ struct _hoverEffectModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(tvOS) || os(visionOS)
-    @available(tvOS 16.0,visionOS 1.0,iOS 13.4, *)
+    @available(visionOS 1.0,tvOS 16.0,iOS 13.4, *)
     init(_ effect: SwiftUI.HoverEffect = .automatic ) {
         self.value = ._0(effect: effect)
         
     }
     #endif
     #if os(iOS) || os(tvOS) || os(visionOS)
-    @available(tvOS 17.0,visionOS 1.0,iOS 17.0, *)
+    @available(visionOS 1.0,tvOS 17.0,iOS 17.0, *)
     init(_ effect: SwiftUI.HoverEffect = .automatic, isEnabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._1(effect: effect, isEnabled: isEnabled)
         
@@ -5117,7 +5117,7 @@ struct _hoverEffectModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(tvOS) || os(visionOS)
         case let ._0(effect):
-            if #available(tvOS 16.0,visionOS 1.0,iOS 13.4, *) {
+            if #available(visionOS 1.0,tvOS 16.0,iOS 13.4, *) {
             let effect = effect as! SwiftUI.HoverEffect 
             
             __content
@@ -5128,7 +5128,7 @@ struct _hoverEffectModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(tvOS) || os(visionOS)
         case let ._1(effect, isEnabled):
-            if #available(tvOS 17.0,visionOS 1.0,iOS 17.0, *) {
+            if #available(visionOS 1.0,tvOS 17.0,iOS 17.0, *) {
             let effect = effect as! SwiftUI.HoverEffect 
 let isEnabled = isEnabled as! AttributeReference<Swift.Bool>
             
@@ -5163,7 +5163,7 @@ struct _hoverEffectDisabledModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(tvOS) || os(visionOS)
-    @available(tvOS 17.0,visionOS 1.0,iOS 17.0, *)
+    @available(visionOS 1.0,tvOS 17.0,iOS 17.0, *)
     init(_ disabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(disabled: disabled)
         
@@ -5176,7 +5176,7 @@ struct _hoverEffectDisabledModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(tvOS) || os(visionOS)
         case let ._0(disabled):
-            if #available(tvOS 17.0,visionOS 1.0,iOS 17.0, *) {
+            if #available(visionOS 1.0,tvOS 17.0,iOS 17.0, *) {
             let disabled = disabled as! AttributeReference<Swift.Bool>
             
             __content
@@ -5493,7 +5493,7 @@ struct _indexViewStyleModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 8.0,tvOS 14.0,iOS 14.0,visionOS 1.0, *)
+    @available(visionOS 1.0,watchOS 8.0,tvOS 14.0,iOS 14.0, *)
     init(_ style: AnyIndexViewStyle) {
         self.value = ._0(style: style)
         
@@ -5506,7 +5506,7 @@ struct _indexViewStyleModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(style):
-            if #available(watchOS 8.0,tvOS 14.0,iOS 14.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,watchOS 8.0,tvOS 14.0,iOS 14.0, *) {
             let style = style as! AnyIndexViewStyle
             
             __content
@@ -5753,7 +5753,7 @@ struct _invalidatableContentModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(tvOS 17.0,macOS 14.0,iOS 17.0,watchOS 10.0,visionOS 1.0, *)
+    @available(macOS 14.0,iOS 17.0,watchOS 10.0,visionOS 1.0,tvOS 17.0, *)
     init(_ invalidatable: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(invalidatable: invalidatable)
         
@@ -5766,7 +5766,7 @@ struct _invalidatableContentModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(invalidatable):
-            if #available(tvOS 17.0,macOS 14.0,iOS 17.0,watchOS 10.0,visionOS 1.0, *) {
+            if #available(macOS 14.0,iOS 17.0,watchOS 10.0,visionOS 1.0,tvOS 17.0, *) {
             let invalidatable = invalidatable as! AttributeReference<Swift.Bool>
             
             __content
@@ -5815,28 +5815,28 @@ struct _keyboardShortcutModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 11.0,visionOS 1.0,iOS 14.0, *)
+    @available(macOS 11.0,iOS 14.0,visionOS 1.0, *)
     init(_ key: SwiftUI.KeyEquivalent,modifiers: SwiftUICore.EventModifiers = .command ) {
         self.value = ._0(key: key, modifiers: modifiers)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 11.0,visionOS 1.0,iOS 14.0, *)
+    @available(macOS 11.0,iOS 14.0,visionOS 1.0, *)
     init(_ shortcut: SwiftUI.KeyboardShortcut) {
         self.value = ._1(shortcut: shortcut)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 12.3,visionOS 1.0,iOS 15.4, *)
+    @available(macOS 12.3,iOS 15.4,visionOS 1.0, *)
     init(_ shortcut: SwiftUI.KeyboardShortcut?) {
         self.value = ._2(shortcut: shortcut)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 12.0,visionOS 1.0,iOS 15.0, *)
+    @available(macOS 12.0,iOS 15.0,visionOS 1.0, *)
     init(_ key: SwiftUI.KeyEquivalent,modifiers: SwiftUICore.EventModifiers = .command, localization: SwiftUI.KeyboardShortcut.Localization) {
         self.value = ._3(key: key, modifiers: modifiers, localization: localization)
         
@@ -5849,7 +5849,7 @@ struct _keyboardShortcutModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(key, modifiers):
-            if #available(macOS 11.0,visionOS 1.0,iOS 14.0, *) {
+            if #available(macOS 11.0,iOS 14.0,visionOS 1.0, *) {
             let key = key as! SwiftUI.KeyEquivalent
 let modifiers = modifiers as! SwiftUICore.EventModifiers 
             
@@ -5861,7 +5861,7 @@ let modifiers = modifiers as! SwiftUICore.EventModifiers
         #endif
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._1(shortcut):
-            if #available(macOS 11.0,visionOS 1.0,iOS 14.0, *) {
+            if #available(macOS 11.0,iOS 14.0,visionOS 1.0, *) {
             let shortcut = shortcut as! SwiftUI.KeyboardShortcut
             
             __content
@@ -5872,7 +5872,7 @@ let modifiers = modifiers as! SwiftUICore.EventModifiers
         #endif
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._2(shortcut):
-            if #available(macOS 12.3,visionOS 1.0,iOS 15.4, *) {
+            if #available(macOS 12.3,iOS 15.4,visionOS 1.0, *) {
             let shortcut = shortcut as? SwiftUI.KeyboardShortcut
             
             __content
@@ -5883,7 +5883,7 @@ let modifiers = modifiers as! SwiftUICore.EventModifiers
         #endif
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._3(key, modifiers, localization):
-            if #available(macOS 12.0,visionOS 1.0,iOS 15.0, *) {
+            if #available(macOS 12.0,iOS 15.0,visionOS 1.0, *) {
             let key = key as! SwiftUI.KeyEquivalent
 let modifiers = modifiers as! SwiftUICore.EventModifiers 
 let localization = localization as! SwiftUI.KeyboardShortcut.Localization
@@ -5919,7 +5919,7 @@ struct _keyboardTypeModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(tvOS) || os(visionOS)
-    @available(tvOS 13.0,visionOS 1.0,iOS 13.0, *)
+    @available(tvOS 13.0,iOS 13.0,visionOS 1.0, *)
     init(_ type: UIKit.UIKeyboardType) {
         self.value = ._0(type: type)
         
@@ -5932,7 +5932,7 @@ struct _keyboardTypeModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(tvOS) || os(visionOS)
         case let ._0(type):
-            if #available(tvOS 13.0,visionOS 1.0,iOS 13.0, *) {
+            if #available(tvOS 13.0,iOS 13.0,visionOS 1.0, *) {
             let type = type as! UIKit.UIKeyboardType
             
             __content
@@ -6107,7 +6107,7 @@ struct _labelsVisibilityModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(tvOS 18.0,iOS 18.0,macOS 15.0,watchOS 11.0,visionOS 2.0, *)
+    @available(macOS 15.0,iOS 18.0,tvOS 18.0,watchOS 11.0,visionOS 2.0, *)
     init(_ visibility: AttributeReference<SwiftUI.Visibility>) {
         self.value = ._0(visibility: visibility)
         
@@ -6120,7 +6120,7 @@ struct _labelsVisibilityModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(visibility):
-            if #available(tvOS 18.0,iOS 18.0,macOS 15.0,watchOS 11.0,visionOS 2.0, *) {
+            if #available(macOS 15.0,iOS 18.0,tvOS 18.0,watchOS 11.0,visionOS 2.0, *) {
             let visibility = visibility as! AttributeReference<SwiftUI.Visibility>
             
             __content
@@ -6645,7 +6645,7 @@ struct _listRowSeparatorModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(visionOS 1.0,macOS 13.0,iOS 15.0, *)
+    @available(macOS 13.0,iOS 15.0,visionOS 1.0, *)
     init(_ visibility: AttributeReference<SwiftUI.Visibility>,edges: SwiftUICore.VerticalEdge.Set = .all ) {
         self.value = ._0(visibility: visibility, edges: edges)
         
@@ -6658,7 +6658,7 @@ struct _listRowSeparatorModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(visibility, edges):
-            if #available(visionOS 1.0,macOS 13.0,iOS 15.0, *) {
+            if #available(macOS 13.0,iOS 15.0,visionOS 1.0, *) {
             let visibility = visibility as! AttributeReference<SwiftUI.Visibility>
 let edges = edges as! SwiftUICore.VerticalEdge.Set 
             
@@ -6693,7 +6693,7 @@ struct _listRowSeparatorTintModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(visionOS 1.0,macOS 13.0,iOS 15.0, *)
+    @available(macOS 13.0,iOS 15.0,visionOS 1.0, *)
     init(_ color: Color.Resolvable?,edges: SwiftUICore.VerticalEdge.Set = .all ) {
         self.value = ._0(color: color, edges: edges)
         
@@ -6706,7 +6706,7 @@ struct _listRowSeparatorTintModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(color, edges):
-            if #available(visionOS 1.0,macOS 13.0,iOS 15.0, *) {
+            if #available(macOS 13.0,iOS 15.0,visionOS 1.0, *) {
             let color = color as? Color.Resolvable
 let edges = edges as! SwiftUICore.VerticalEdge.Set 
             
@@ -6788,7 +6788,7 @@ struct _listSectionSeparatorModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 13.0,visionOS 1.0,iOS 15.0, *)
+    @available(macOS 13.0,iOS 15.0,visionOS 1.0, *)
     init(_ visibility: AttributeReference<SwiftUI.Visibility>,edges: SwiftUICore.VerticalEdge.Set = .all ) {
         self.value = ._0(visibility: visibility, edges: edges)
         
@@ -6801,7 +6801,7 @@ struct _listSectionSeparatorModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(visibility, edges):
-            if #available(macOS 13.0,visionOS 1.0,iOS 15.0, *) {
+            if #available(macOS 13.0,iOS 15.0,visionOS 1.0, *) {
             let visibility = visibility as! AttributeReference<SwiftUI.Visibility>
 let edges = edges as! SwiftUICore.VerticalEdge.Set 
             
@@ -6836,7 +6836,7 @@ struct _listSectionSeparatorTintModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 13.0,visionOS 1.0,iOS 15.0, *)
+    @available(macOS 13.0,iOS 15.0,visionOS 1.0, *)
     init(_ color: Color.Resolvable?,edges: SwiftUICore.VerticalEdge.Set = .all ) {
         self.value = ._0(color: color, edges: edges)
         
@@ -6849,7 +6849,7 @@ struct _listSectionSeparatorTintModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(color, edges):
-            if #available(macOS 13.0,visionOS 1.0,iOS 15.0, *) {
+            if #available(macOS 13.0,iOS 15.0,visionOS 1.0, *) {
             let color = color as? Color.Resolvable
 let edges = edges as! SwiftUICore.VerticalEdge.Set 
             
@@ -7048,7 +7048,7 @@ struct _materialActiveAppearanceModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(tvOS 18.0,iOS 18.0,macOS 15.0,watchOS 11.0,visionOS 2.0, *)
+    @available(macOS 15.0,iOS 18.0,tvOS 18.0,watchOS 11.0,visionOS 2.0, *)
     init(_ appearance: SwiftUICore.MaterialActiveAppearance) {
         self.value = ._0(appearance: appearance)
         
@@ -7061,7 +7061,7 @@ struct _materialActiveAppearanceModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(appearance):
-            if #available(tvOS 18.0,iOS 18.0,macOS 15.0,watchOS 11.0,visionOS 2.0, *) {
+            if #available(macOS 15.0,iOS 18.0,tvOS 18.0,watchOS 11.0,visionOS 2.0, *) {
             let appearance = appearance as! SwiftUICore.MaterialActiveAppearance
             
             __content
@@ -7095,7 +7095,7 @@ struct _menuIndicatorModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS)
-    @available(macOS 12.0,visionOS 1.0,tvOS 17.0,iOS 15.0, *)
+    @available(macOS 12.0,iOS 15.0,tvOS 17.0,visionOS 1.0, *)
     init(_ visibility: AttributeReference<SwiftUI.Visibility>) {
         self.value = ._0(visibility: visibility)
         
@@ -7108,7 +7108,7 @@ struct _menuIndicatorModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS)
         case let ._0(visibility):
-            if #available(macOS 12.0,visionOS 1.0,tvOS 17.0,iOS 15.0, *) {
+            if #available(macOS 12.0,iOS 15.0,tvOS 17.0,visionOS 1.0, *) {
             let visibility = visibility as! AttributeReference<SwiftUI.Visibility>
             
             __content
@@ -7189,7 +7189,7 @@ struct _menuStyleModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS)
-    @available(macOS 11.0,iOS 14.0,tvOS 17.0,visionOS 1.0, *)
+    @available(macOS 11.0,iOS 14.0,visionOS 1.0,tvOS 17.0, *)
     init(_ style: AnyMenuStyle) {
         self.value = ._0(style: style)
         
@@ -7202,7 +7202,7 @@ struct _menuStyleModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS)
         case let ._0(style):
-            if #available(macOS 11.0,iOS 14.0,tvOS 17.0,visionOS 1.0, *) {
+            if #available(macOS 11.0,iOS 14.0,visionOS 1.0,tvOS 17.0, *) {
             let style = style as! AnyMenuStyle
             
             __content
@@ -7472,7 +7472,7 @@ struct _navigationBarTitleDisplayModeModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,watchOS 8.0,iOS 14.0, *)
+    @available(visionOS 1.0,iOS 14.0,watchOS 8.0, *)
     init(_ displayMode: SwiftUI.NavigationBarItem.TitleDisplayMode) {
         self.value = ._0(displayMode: displayMode)
         
@@ -7485,7 +7485,7 @@ struct _navigationBarTitleDisplayModeModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(visionOS) || os(watchOS)
         case let ._0(displayMode):
-            if #available(visionOS 1.0,watchOS 8.0,iOS 14.0, *) {
+            if #available(visionOS 1.0,iOS 14.0,watchOS 8.0, *) {
             let displayMode = displayMode as! SwiftUI.NavigationBarItem.TitleDisplayMode
             
             __content
@@ -7693,21 +7693,21 @@ struct _navigationSubtitleModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(macOS) || targetEnvironment(macCatalyst)
-    @available(macCatalyst 14.0,macOS 11.0, *)
+    @available(macOS 11.0,macCatalyst 14.0, *)
     init(_ subtitle: TextReference) {
         self.value = ._0(subtitle: subtitle)
         
     }
     #endif
     #if os(macOS) || targetEnvironment(macCatalyst)
-    @available(macCatalyst 14.0,macOS 11.0, *)
+    @available(macOS 11.0,macCatalyst 14.0, *)
     init(_ subtitleKey: SwiftUICore.LocalizedStringKey) {
         self.value = ._1(subtitleKey: subtitleKey)
         
     }
     #endif
     #if os(macOS) || targetEnvironment(macCatalyst)
-    @available(macCatalyst 14.0,macOS 11.0, *)
+    @available(macOS 11.0,macCatalyst 14.0, *)
     init(_ subtitle: AttributeReference<String>) {
         self.value = ._2(subtitle: subtitle)
         
@@ -7720,7 +7720,7 @@ struct _navigationSubtitleModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(macOS) || targetEnvironment(macCatalyst)
         case let ._0(subtitle):
-            if #available(macCatalyst 14.0,macOS 11.0, *) {
+            if #available(macOS 11.0,macCatalyst 14.0, *) {
             let subtitle = subtitle as! TextReference
             __content._observeTextReference(subtitle, on: element, in: context) { __content in
             __content
@@ -7731,7 +7731,7 @@ struct _navigationSubtitleModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(macOS) || targetEnvironment(macCatalyst)
         case let ._1(subtitleKey):
-            if #available(macCatalyst 14.0,macOS 11.0, *) {
+            if #available(macOS 11.0,macCatalyst 14.0, *) {
             let subtitleKey = subtitleKey as! SwiftUICore.LocalizedStringKey
             
             __content
@@ -7742,7 +7742,7 @@ struct _navigationSubtitleModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(macOS) || targetEnvironment(macCatalyst)
         case let ._2(subtitle):
-            if #available(macCatalyst 14.0,macOS 11.0, *) {
+            if #available(macOS 11.0,macCatalyst 14.0, *) {
             let subtitle = subtitle as! AttributeReference<String>
             
             __content
@@ -7817,7 +7817,7 @@ struct _navigationTitleModifier<R: RootRegistry>: ViewModifier {
     }
     
     #if os(watchOS)
-    @available(macOS 11.0,tvOS 14.0,watchOS 7.0,iOS 14.0, *)
+    @available(macOS 11.0,tvOS 14.0,iOS 14.0,watchOS 7.0, *)
     init(_ title: ViewReference=ViewReference(value: [])) {
         self.value = ._3(title: title)
         
@@ -7870,7 +7870,7 @@ struct _navigationTitleModifier<R: RootRegistry>: ViewModifier {
         
         #if os(watchOS)
         case let ._3(title):
-            if #available(macOS 11.0,tvOS 14.0,watchOS 7.0,iOS 14.0, *) {
+            if #available(macOS 11.0,tvOS 14.0,iOS 14.0,watchOS 7.0, *) {
             let title = title as! ViewReference
             
             __content
@@ -8055,7 +8055,7 @@ struct _onDeleteCommandModifier<R: RootRegistry>: ViewModifier {
 @Event private var _0_action__0: Event.EventHandler
 
     #if os(macOS)
-    @available(tvOS 13.0,macOS 10.15, *)
+    @available(macOS 10.15,tvOS 13.0, *)
     init(perform action__0: Event=Event()) {
         self.value = ._0
         self.__0_action__0 = action__0
@@ -8068,7 +8068,7 @@ struct _onDeleteCommandModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(macOS)
         case ._0:
-            if #available(tvOS 13.0,macOS 10.15, *) {
+            if #available(macOS 10.15,tvOS 13.0, *) {
             
             
             __content
@@ -8149,7 +8149,7 @@ struct _onExitCommandModifier<R: RootRegistry>: ViewModifier {
 @Event private var _0_action__0: Event.EventHandler
 
     #if os(macOS) || os(tvOS)
-    @available(tvOS 13.0,macOS 10.15, *)
+    @available(macOS 10.15,tvOS 13.0, *)
     init(perform action__0: Event=Event()) {
         self.value = ._0
         self.__0_action__0 = action__0
@@ -8162,7 +8162,7 @@ struct _onExitCommandModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(macOS) || os(tvOS)
         case ._0:
-            if #available(tvOS 13.0,macOS 10.15, *) {
+            if #available(macOS 10.15,tvOS 13.0, *) {
             
             
             __content
@@ -8196,7 +8196,7 @@ struct _onHoverModifier<R: RootRegistry>: ViewModifier {
 @Event private var _0_action__1: Event.EventHandler
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(visionOS 1.0,macOS 10.15,iOS 13.4, *)
+    @available(macOS 10.15,iOS 13.4,visionOS 1.0, *)
     init(perform action__1: Event) {
         self.value = ._0
         self.__0_action__1 = action__1
@@ -8209,7 +8209,7 @@ struct _onHoverModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case ._0:
-            if #available(visionOS 1.0,macOS 10.15,iOS 13.4, *) {
+            if #available(macOS 10.15,iOS 13.4,visionOS 1.0, *) {
             
             
             __content
@@ -8297,7 +8297,7 @@ struct _onLongPressGestureModifier<R: RootRegistry>: ViewModifier {
 @Event private var _1_onPressingChanged__1: Event.EventHandler
 
     #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
-    @available(macOS 10.15,visionOS 1.0,tvOS 14.0,watchOS 6.0,iOS 13.0, *)
+    @available(watchOS 6.0,iOS 13.0,visionOS 1.0,tvOS 14.0,macOS 10.15, *)
     init(minimumDuration: AttributeReference<Swift.Double> = .init(storage: .constant(0.5)), maximumDistance: AttributeReference<CoreFoundation.CGFloat> = .init(storage: .constant(10)), perform action__0: Event,onPressingChanged onPressingChanged__1: Event=Event() ) {
         self.value = ._0(minimumDuration: minimumDuration, maximumDistance: maximumDistance)
         self.__0_action__0 = action__0
@@ -8305,7 +8305,7 @@ self.__0_onPressingChanged__1 = onPressingChanged__1
     }
     #endif
     #if os(tvOS)
-    @available(watchOS 6.0,tvOS 14.0,macOS 10.15,iOS 13.0, *)
+    @available(watchOS 6.0,iOS 13.0,tvOS 14.0,macOS 10.15, *)
     init(minimumDuration: AttributeReference<Swift.Double> = .init(storage: .constant(0.5)), perform action__0: Event,onPressingChanged onPressingChanged__1: Event=Event() ) {
         self.value = ._1(minimumDuration: minimumDuration)
         self.__1_action__0 = action__0
@@ -8319,7 +8319,7 @@ self.__1_onPressingChanged__1 = onPressingChanged__1
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
         case let ._0(minimumDuration, maximumDistance):
-            if #available(macOS 10.15,visionOS 1.0,tvOS 14.0,watchOS 6.0,iOS 13.0, *) {
+            if #available(watchOS 6.0,iOS 13.0,visionOS 1.0,tvOS 14.0,macOS 10.15, *) {
             let minimumDuration = minimumDuration as! AttributeReference<Swift.Double>
 let maximumDistance = maximumDistance as! AttributeReference<CoreFoundation.CGFloat>
             
@@ -8331,7 +8331,7 @@ let maximumDistance = maximumDistance as! AttributeReference<CoreFoundation.CGFl
         #endif
         #if os(tvOS)
         case let ._1(minimumDuration):
-            if #available(watchOS 6.0,tvOS 14.0,macOS 10.15,iOS 13.0, *) {
+            if #available(watchOS 6.0,iOS 13.0,tvOS 14.0,macOS 10.15, *) {
             let minimumDuration = minimumDuration as! AttributeReference<Swift.Double>
             
             __content
@@ -8414,7 +8414,7 @@ struct _onModifierKeysChangedModifier<R: RootRegistry>: ViewModifier {
 @Event private var _0_action__2: Event.EventHandler
 
     #if os(macOS) || os(visionOS)
-    @available(visionOS 1.0,macOS 15.0, *)
+    @available(macOS 15.0,visionOS 1.0, *)
     init(mask: SwiftUICore.EventModifiers = .all, initial: AttributeReference<Swift.Bool> = .init(storage: .constant(true)), action action__2: Event) {
         self.value = ._0(mask: mask, initial: initial)
         self.__0_action__2 = action__2
@@ -8427,7 +8427,7 @@ struct _onModifierKeysChangedModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(macOS) || os(visionOS)
         case let ._0(mask, initial):
-            if #available(visionOS 1.0,macOS 15.0, *) {
+            if #available(macOS 15.0,visionOS 1.0, *) {
             let mask = mask as! SwiftUICore.EventModifiers 
 let initial = initial as! AttributeReference<Swift.Bool>
             
@@ -8462,7 +8462,7 @@ struct _onMoveCommandModifier<R: RootRegistry>: ViewModifier {
 @Event private var _0_action__1: Event.EventHandler
 
     #if os(macOS) || os(tvOS)
-    @available(tvOS 13.0,macOS 10.15, *)
+    @available(macOS 10.15,tvOS 13.0, *)
     init(perform action__1: Event=Event()) {
         self.value = ._0
         self.__0_action__1 = action__1
@@ -8475,7 +8475,7 @@ struct _onMoveCommandModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(macOS) || os(tvOS)
         case ._0:
-            if #available(tvOS 13.0,macOS 10.15, *) {
+            if #available(macOS 10.15,tvOS 13.0, *) {
             
             
             __content
@@ -8603,7 +8603,7 @@ struct _onPlayPauseCommandModifier<R: RootRegistry>: ViewModifier {
 @Event private var _0_action__0: Event.EventHandler
 
     #if os(tvOS)
-    @available(tvOS 13.0,macOS 10.15, *)
+    @available(macOS 10.15,tvOS 13.0, *)
     init(perform action__0: Event=Event()) {
         self.value = ._0
         self.__0_action__0 = action__0
@@ -8616,7 +8616,7 @@ struct _onPlayPauseCommandModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(tvOS)
         case ._0:
-            if #available(tvOS 13.0,macOS 10.15, *) {
+            if #available(macOS 10.15,tvOS 13.0, *) {
             
             
             __content
@@ -8650,7 +8650,7 @@ struct _onScrollPhaseChangeModifier<R: RootRegistry>: ViewModifier {
 @Event private var _0_action__2: Event.EventHandler
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 11.0,tvOS 18.0,macOS 15.0,iOS 18.0,visionOS 2.0, *)
+    @available(macOS 15.0,watchOS 11.0,tvOS 18.0,iOS 18.0,visionOS 2.0, *)
     init(_ action__2: Event) {
         self.value = ._0
         self.__0_action__2 = action__2
@@ -8663,7 +8663,7 @@ struct _onScrollPhaseChangeModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case ._0:
-            if #available(watchOS 11.0,tvOS 18.0,macOS 15.0,iOS 18.0,visionOS 2.0, *) {
+            if #available(macOS 15.0,watchOS 11.0,tvOS 18.0,iOS 18.0,visionOS 2.0, *) {
             
             
             __content
@@ -8697,7 +8697,7 @@ struct _onScrollVisibilityChangeModifier<R: RootRegistry>: ViewModifier {
 @Event private var _0_action__1: Event.EventHandler
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 11.0,tvOS 18.0,macOS 15.0,iOS 18.0,visionOS 2.0, *)
+    @available(visionOS 2.0,macOS 15.0,tvOS 18.0,iOS 18.0,watchOS 11.0, *)
     init(threshold: AttributeReference<Swift.Double> = .init(storage: .constant(0.5)), action action__1: Event) {
         self.value = ._0(threshold: threshold)
         self.__0_action__1 = action__1
@@ -8710,7 +8710,7 @@ struct _onScrollVisibilityChangeModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(threshold):
-            if #available(watchOS 11.0,tvOS 18.0,macOS 15.0,iOS 18.0,visionOS 2.0, *) {
+            if #available(visionOS 2.0,macOS 15.0,tvOS 18.0,iOS 18.0,watchOS 11.0, *) {
             let threshold = threshold as! AttributeReference<Swift.Double>
             
             __content
@@ -8749,7 +8749,7 @@ struct _onTapGestureModifier<R: RootRegistry>: ViewModifier {
 @Event private var _1_action__0: Event.EventHandler
 
     #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
-    @available(macOS 14.0,watchOS 10.0,visionOS 1.0,iOS 17.0, *)
+    @available(macOS 14.0,iOS 17.0,watchOS 10.0,visionOS 1.0, *)
     init(count: AttributeReference<Swift.Int> = .init(storage: .constant(1)), coordinateSpace: AnyCoordinateSpaceProtocol = .local, perform action__1: Event) {
         self.value = ._0(count: count, coordinateSpace: coordinateSpace)
         self.__0_action__1 = action__1
@@ -8769,7 +8769,7 @@ struct _onTapGestureModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
         case let ._0(count, coordinateSpace):
-            if #available(macOS 14.0,watchOS 10.0,visionOS 1.0,iOS 17.0, *) {
+            if #available(macOS 14.0,iOS 17.0,watchOS 10.0,visionOS 1.0, *) {
             let count = count as! AttributeReference<Swift.Int>
 let coordinateSpace = coordinateSpace as! AnyCoordinateSpaceProtocol 
             
@@ -9334,7 +9334,7 @@ struct _pointerStyleModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(macOS) || os(visionOS)
-    @available(visionOS 2.0,macOS 15.0, *)
+    @available(macOS 15.0,visionOS 2.0, *)
     init(_ style: SwiftUI.PointerStyle?) {
         self.value = ._0(style: style)
         
@@ -9347,7 +9347,7 @@ struct _pointerStyleModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(macOS) || os(visionOS)
         case let ._0(style):
-            if #available(visionOS 2.0,macOS 15.0, *) {
+            if #available(macOS 15.0,visionOS 2.0, *) {
             let style = style as? SwiftUI.PointerStyle
             
             __content
@@ -9440,7 +9440,7 @@ struct _popoverModifier<R: RootRegistry>: ViewModifier {
     }
     #endif
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(visionOS 2.0,macOS 15.0,iOS 18.0, *)
+    @available(macOS 15.0,visionOS 2.0,iOS 18.0, *)
     init(isPresented: ChangeTracked<Swift.Bool>,attachmentAnchor: SwiftUI.PopoverAttachmentAnchor = .rect(.bounds), content: ViewReference=ViewReference(value: [])) {
         self.value = ._1(attachmentAnchor: attachmentAnchor, content: content)
         self.__1_isPresented = isPresented
@@ -9466,7 +9466,7 @@ let content = content as! ViewReference
         #endif
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._1(attachmentAnchor, content):
-            if #available(visionOS 2.0,macOS 15.0,iOS 18.0, *) {
+            if #available(macOS 15.0,visionOS 2.0,iOS 18.0, *) {
             let attachmentAnchor = attachmentAnchor as! SwiftUI.PopoverAttachmentAnchor 
 let content = content as! ViewReference
             
@@ -9670,14 +9670,14 @@ struct _presentationBackgroundModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 9.4,iOS 16.4,visionOS 1.0,macOS 13.3,tvOS 16.4, *)
+    @available(macOS 13.3,iOS 16.4,tvOS 16.4,watchOS 9.4,visionOS 1.0, *)
     init(_ style: AnyShapeStyle.Resolvable) {
         self.value = ._0(style: style)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 13.3,iOS 16.4,watchOS 9.4,tvOS 16.4,visionOS 1.0, *)
+    @available(macOS 13.3,iOS 16.4,tvOS 16.4,watchOS 9.4,visionOS 1.0, *)
     init(alignment: AttributeReference<SwiftUICore.Alignment> = .init(storage: .constant(.center)), content: ViewReference=ViewReference(value: [])) {
         self.value = ._1(alignment: alignment, content: content)
         
@@ -9690,7 +9690,7 @@ struct _presentationBackgroundModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(style):
-            if #available(watchOS 9.4,iOS 16.4,visionOS 1.0,macOS 13.3,tvOS 16.4, *) {
+            if #available(macOS 13.3,iOS 16.4,tvOS 16.4,watchOS 9.4,visionOS 1.0, *) {
             let style = style as! AnyShapeStyle.Resolvable
             
             __content
@@ -9701,7 +9701,7 @@ struct _presentationBackgroundModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(alignment, content):
-            if #available(macOS 13.3,iOS 16.4,watchOS 9.4,tvOS 16.4,visionOS 1.0, *) {
+            if #available(macOS 13.3,iOS 16.4,tvOS 16.4,watchOS 9.4,visionOS 1.0, *) {
             let alignment = alignment as! AttributeReference<SwiftUICore.Alignment>
 let content = content as! ViewReference
             
@@ -9736,7 +9736,7 @@ struct _presentationBackgroundInteractionModifier<R: RootRegistry>: ViewModifier
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 13.3,iOS 16.4,watchOS 9.4,tvOS 16.4,visionOS 1.0, *)
+    @available(visionOS 1.0,macOS 13.3,tvOS 16.4,iOS 16.4,watchOS 9.4, *)
     init(_ interaction: SwiftUI.PresentationBackgroundInteraction) {
         self.value = ._0(interaction: interaction)
         
@@ -9749,7 +9749,7 @@ struct _presentationBackgroundInteractionModifier<R: RootRegistry>: ViewModifier
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(interaction):
-            if #available(macOS 13.3,iOS 16.4,watchOS 9.4,tvOS 16.4,visionOS 1.0, *) {
+            if #available(visionOS 1.0,macOS 13.3,tvOS 16.4,iOS 16.4,watchOS 9.4, *) {
             let interaction = interaction as! SwiftUI.PresentationBackgroundInteraction
             
             __content
@@ -9788,14 +9788,14 @@ struct _presentationCompactAdaptationModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 13.3,visionOS 1.0,tvOS 16.4,iOS 16.4,watchOS 9.4, *)
+    @available(visionOS 1.0,macOS 13.3,tvOS 16.4,iOS 16.4,watchOS 9.4, *)
     init(_ adaptation: SwiftUI.PresentationAdaptation) {
         self.value = ._0(adaptation: adaptation)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 13.3,visionOS 1.0,tvOS 16.4,iOS 16.4,watchOS 9.4, *)
+    @available(visionOS 1.0,macOS 13.3,tvOS 16.4,iOS 16.4,watchOS 9.4, *)
     init(horizontal horizontalAdaptation: SwiftUI.PresentationAdaptation,vertical verticalAdaptation: SwiftUI.PresentationAdaptation) {
         self.value = ._1(horizontalAdaptation: horizontalAdaptation, verticalAdaptation: verticalAdaptation)
         
@@ -9808,7 +9808,7 @@ struct _presentationCompactAdaptationModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(adaptation):
-            if #available(macOS 13.3,visionOS 1.0,tvOS 16.4,iOS 16.4,watchOS 9.4, *) {
+            if #available(visionOS 1.0,macOS 13.3,tvOS 16.4,iOS 16.4,watchOS 9.4, *) {
             let adaptation = adaptation as! SwiftUI.PresentationAdaptation
             
             __content
@@ -9819,7 +9819,7 @@ struct _presentationCompactAdaptationModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(horizontalAdaptation, verticalAdaptation):
-            if #available(macOS 13.3,visionOS 1.0,tvOS 16.4,iOS 16.4,watchOS 9.4, *) {
+            if #available(visionOS 1.0,macOS 13.3,tvOS 16.4,iOS 16.4,watchOS 9.4, *) {
             let horizontalAdaptation = horizontalAdaptation as! SwiftUI.PresentationAdaptation
 let verticalAdaptation = verticalAdaptation as! SwiftUI.PresentationAdaptation
             
@@ -9854,7 +9854,7 @@ struct _presentationContentInteractionModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 13.3,visionOS 1.0,tvOS 16.4,watchOS 9.4,iOS 16.4, *)
+    @available(visionOS 1.0,macOS 13.3,tvOS 16.4,iOS 16.4,watchOS 9.4, *)
     init(_ behavior: SwiftUI.PresentationContentInteraction) {
         self.value = ._0(behavior: behavior)
         
@@ -9867,7 +9867,7 @@ struct _presentationContentInteractionModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(behavior):
-            if #available(macOS 13.3,visionOS 1.0,tvOS 16.4,watchOS 9.4,iOS 16.4, *) {
+            if #available(visionOS 1.0,macOS 13.3,tvOS 16.4,iOS 16.4,watchOS 9.4, *) {
             let behavior = behavior as! SwiftUI.PresentationContentInteraction
             
             __content
@@ -9901,7 +9901,7 @@ struct _presentationCornerRadiusModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 13.3,visionOS 1.0,tvOS 16.4,watchOS 9.4,iOS 16.4, *)
+    @available(visionOS 1.0,macOS 13.3,tvOS 16.4,iOS 16.4,watchOS 9.4, *)
     init(_ cornerRadius: AttributeReference<CoreFoundation.CGFloat?>?) {
         self.value = ._0(cornerRadius: cornerRadius)
         
@@ -9914,7 +9914,7 @@ struct _presentationCornerRadiusModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(cornerRadius):
-            if #available(macOS 13.3,visionOS 1.0,tvOS 16.4,watchOS 9.4,iOS 16.4, *) {
+            if #available(visionOS 1.0,macOS 13.3,tvOS 16.4,iOS 16.4,watchOS 9.4, *) {
             let cornerRadius = cornerRadius as? AttributeReference<CoreFoundation.CGFloat?>
             
             __content
@@ -9995,7 +9995,7 @@ struct _presentationSizingModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 15.0,visionOS 2.0,tvOS 18.0,iOS 18.0,watchOS 11.0, *)
+    @available(macOS 15.0,watchOS 11.0,tvOS 18.0,iOS 18.0,visionOS 2.0, *)
     init(_ sizing: AnyPresentationSizing) {
         self.value = ._0(sizing: sizing)
         
@@ -10008,7 +10008,7 @@ struct _presentationSizingModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(sizing):
-            if #available(macOS 15.0,visionOS 2.0,tvOS 18.0,iOS 18.0,watchOS 11.0, *) {
+            if #available(macOS 15.0,watchOS 11.0,tvOS 18.0,iOS 18.0,visionOS 2.0, *) {
             let sizing = sizing as! AnyPresentationSizing
             
             __content
@@ -10545,21 +10545,21 @@ struct _safeAreaPaddingModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 14.0,visionOS 1.0,tvOS 17.0,iOS 17.0,watchOS 10.0, *)
+    @available(macOS 14.0,watchOS 10.0,tvOS 17.0,iOS 17.0,visionOS 1.0, *)
     init(_ insets: SwiftUICore.EdgeInsets) {
         self.value = ._0(insets: insets)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(tvOS 17.0,watchOS 10.0,iOS 17.0,visionOS 1.0,macOS 14.0, *)
+    @available(macOS 14.0,watchOS 10.0,tvOS 17.0,iOS 17.0,visionOS 1.0, *)
     init(_ edges: SwiftUICore.Edge.Set = .all, _ length: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)) ) {
         self.value = ._1(edges: edges, length: length)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(tvOS 17.0,watchOS 10.0,iOS 17.0,visionOS 1.0,macOS 14.0, *)
+    @available(macOS 14.0,watchOS 10.0,tvOS 17.0,iOS 17.0,visionOS 1.0, *)
     init(_ length: AttributeReference<CoreFoundation.CGFloat>) {
         self.value = ._2(length: length)
         
@@ -10572,7 +10572,7 @@ struct _safeAreaPaddingModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(insets):
-            if #available(macOS 14.0,visionOS 1.0,tvOS 17.0,iOS 17.0,watchOS 10.0, *) {
+            if #available(macOS 14.0,watchOS 10.0,tvOS 17.0,iOS 17.0,visionOS 1.0, *) {
             let insets = insets as! SwiftUICore.EdgeInsets
             
             __content
@@ -10583,7 +10583,7 @@ struct _safeAreaPaddingModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(edges, length):
-            if #available(tvOS 17.0,watchOS 10.0,iOS 17.0,visionOS 1.0,macOS 14.0, *) {
+            if #available(macOS 14.0,watchOS 10.0,tvOS 17.0,iOS 17.0,visionOS 1.0, *) {
             let edges = edges as! SwiftUICore.Edge.Set 
 let length = length as? AttributeReference<CoreFoundation.CGFloat?>
             
@@ -10595,7 +10595,7 @@ let length = length as? AttributeReference<CoreFoundation.CGFloat?>
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._2(length):
-            if #available(tvOS 17.0,watchOS 10.0,iOS 17.0,visionOS 1.0,macOS 14.0, *) {
+            if #available(macOS 14.0,watchOS 10.0,tvOS 17.0,iOS 17.0,visionOS 1.0, *) {
             let length = length as! AttributeReference<CoreFoundation.CGFloat>
             
             __content
@@ -11007,7 +11007,7 @@ struct _scrollBounceBehaviorModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 9.4,tvOS 16.4,macOS 13.3,iOS 16.4,visionOS 1.0, *)
+    @available(macOS 13.3,watchOS 9.4,tvOS 16.4,iOS 16.4,visionOS 1.0, *)
     init(_ behavior: SwiftUI.ScrollBounceBehavior,axes: SwiftUICore.Axis.Set = [.vertical] ) {
         self.value = ._0(behavior: behavior, axes: axes)
         
@@ -11020,7 +11020,7 @@ struct _scrollBounceBehaviorModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(behavior, axes):
-            if #available(watchOS 9.4,tvOS 16.4,macOS 13.3,iOS 16.4,visionOS 1.0, *) {
+            if #available(macOS 13.3,watchOS 9.4,tvOS 16.4,iOS 16.4,visionOS 1.0, *) {
             let behavior = behavior as! SwiftUI.ScrollBounceBehavior
 let axes = axes as! SwiftUICore.Axis.Set 
             
@@ -11055,7 +11055,7 @@ struct _scrollClipDisabledModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(tvOS 17.0,macOS 14.0,iOS 17.0,watchOS 10.0,visionOS 1.0, *)
+    @available(macOS 14.0,watchOS 10.0,tvOS 17.0,iOS 17.0,visionOS 1.0, *)
     init(_ disabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(disabled: disabled)
         
@@ -11068,7 +11068,7 @@ struct _scrollClipDisabledModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(disabled):
-            if #available(tvOS 17.0,macOS 14.0,iOS 17.0,watchOS 10.0,visionOS 1.0, *) {
+            if #available(macOS 14.0,watchOS 10.0,tvOS 17.0,iOS 17.0,visionOS 1.0, *) {
             let disabled = disabled as! AttributeReference<Swift.Bool>
             
             __content
@@ -11102,7 +11102,7 @@ struct _scrollContentBackgroundModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
-    @available(iOS 16.0,macOS 13.0,watchOS 9.0,visionOS 1.0, *)
+    @available(visionOS 1.0,macOS 13.0,watchOS 9.0,iOS 16.0, *)
     init(_ visibility: AttributeReference<SwiftUI.Visibility>) {
         self.value = ._0(visibility: visibility)
         
@@ -11115,7 +11115,7 @@ struct _scrollContentBackgroundModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
         case let ._0(visibility):
-            if #available(iOS 16.0,macOS 13.0,watchOS 9.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,macOS 13.0,watchOS 9.0,iOS 16.0, *) {
             let visibility = visibility as! AttributeReference<SwiftUI.Visibility>
             
             __content
@@ -11196,7 +11196,7 @@ struct _scrollDismissesKeyboardModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-    @available(watchOS 9.0,tvOS 16.0,macOS 13.0,iOS 16.0, *)
+    @available(macOS 13.0,watchOS 9.0,tvOS 16.0,iOS 16.0, *)
     init(_ mode: SwiftUI.ScrollDismissesKeyboardMode) {
         self.value = ._0(mode: mode)
         
@@ -11209,7 +11209,7 @@ struct _scrollDismissesKeyboardModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
         case let ._0(mode):
-            if #available(watchOS 9.0,tvOS 16.0,macOS 13.0,iOS 16.0, *) {
+            if #available(macOS 13.0,watchOS 9.0,tvOS 16.0,iOS 16.0, *) {
             let mode = mode as! SwiftUI.ScrollDismissesKeyboardMode
             
             __content
@@ -11295,14 +11295,14 @@ struct _scrollIndicatorsFlashModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0,visionOS 1.0, *)
+    @available(visionOS 1.0,macOS 14.0,tvOS 17.0,iOS 17.0,watchOS 10.0, *)
     init(trigger value: AttributeReference<String>) {
         self.value = ._0(value: value)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0,visionOS 1.0, *)
+    @available(visionOS 1.0,macOS 14.0,tvOS 17.0,iOS 17.0,watchOS 10.0, *)
     init(onAppear: AttributeReference<Swift.Bool>) {
         self.value = ._1(onAppear: onAppear)
         
@@ -11315,7 +11315,7 @@ struct _scrollIndicatorsFlashModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(value):
-            if #available(tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,macOS 14.0,tvOS 17.0,iOS 17.0,watchOS 10.0, *) {
             let value = value as! AttributeReference<String>
             
             __content
@@ -11326,7 +11326,7 @@ struct _scrollIndicatorsFlashModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(onAppear):
-            if #available(tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,macOS 14.0,tvOS 17.0,iOS 17.0,watchOS 10.0, *) {
             let onAppear = onAppear as! AttributeReference<Swift.Bool>
             
             __content
@@ -11360,7 +11360,7 @@ struct _scrollPositionModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0,visionOS 1.0, *)
+    @available(macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0,visionOS 1.0, *)
     init(id: ChangeTracked<String?>,anchor: AttributeReference<SwiftUICore.UnitPoint?>? = .init(storage: .constant(nil)) ) {
         self.value = ._0(anchor: anchor)
         self.__0_id = id
@@ -11373,7 +11373,7 @@ struct _scrollPositionModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(anchor):
-            if #available(tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0,visionOS 1.0, *) {
+            if #available(macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0,visionOS 1.0, *) {
             let anchor = anchor as? AttributeReference<SwiftUICore.UnitPoint?>
             
             __content
@@ -11407,7 +11407,7 @@ struct _scrollTargetBehaviorModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 10.0,tvOS 17.0,macOS 14.0,iOS 17.0,visionOS 1.0, *)
+    @available(macOS 14.0,watchOS 10.0,tvOS 17.0,iOS 17.0,visionOS 1.0, *)
     init(_ behavior: AnyScrollTargetBehavior) {
         self.value = ._0(behavior: behavior)
         
@@ -11420,7 +11420,7 @@ struct _scrollTargetBehaviorModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(behavior):
-            if #available(watchOS 10.0,tvOS 17.0,macOS 14.0,iOS 17.0,visionOS 1.0, *) {
+            if #available(macOS 14.0,watchOS 10.0,tvOS 17.0,iOS 17.0,visionOS 1.0, *) {
             let behavior = behavior as! AnyScrollTargetBehavior
             
             __content
@@ -11454,7 +11454,7 @@ struct _scrollTargetLayoutModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0,visionOS 1.0, *)
+    @available(macOS 14.0,iOS 17.0,watchOS 10.0,visionOS 1.0,tvOS 17.0, *)
     init(isEnabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(isEnabled: isEnabled)
         
@@ -11467,7 +11467,7 @@ struct _scrollTargetLayoutModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(isEnabled):
-            if #available(macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0,visionOS 1.0, *) {
+            if #available(macOS 14.0,iOS 17.0,watchOS 10.0,visionOS 1.0,tvOS 17.0, *) {
             let isEnabled = isEnabled as! AttributeReference<Swift.Bool>
             
             __content
@@ -11548,7 +11548,7 @@ struct _searchPresentationToolbarBehaviorModifier<R: RootRegistry>: ViewModifier
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 10.1,iOS 17.1,visionOS 1.0,macOS 14.1,tvOS 17.1, *)
+    @available(visionOS 1.0,macOS 14.1,tvOS 17.1,iOS 17.1,watchOS 10.1, *)
     init(_ behavior: SwiftUI.SearchPresentationToolbarBehavior) {
         self.value = ._0(behavior: behavior)
         
@@ -11561,7 +11561,7 @@ struct _searchPresentationToolbarBehaviorModifier<R: RootRegistry>: ViewModifier
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(behavior):
-            if #available(watchOS 10.1,iOS 17.1,visionOS 1.0,macOS 14.1,tvOS 17.1, *) {
+            if #available(visionOS 1.0,macOS 14.1,tvOS 17.1,iOS 17.1,watchOS 10.1, *) {
             let behavior = behavior as! SwiftUI.SearchPresentationToolbarBehavior
             
             __content
@@ -11714,7 +11714,7 @@ struct _searchableModifier<R: RootRegistry>: ViewModifier {
     }
     
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 14.0,visionOS 1.0,iOS 17.0, *)
+    @available(iOS 17.0,visionOS 1.0,macOS 14.0, *)
     init(text: ChangeTracked<Swift.String>,isPresented: ChangeTracked<Swift.Bool>,placement: SwiftUI.SearchFieldPlacement = .automatic, prompt: TextReference? = nil ) {
         self.value = ._3(placement: placement, prompt: prompt)
         self.__3_text = text
@@ -11722,7 +11722,7 @@ self.__3_isPresented = isPresented
     }
     #endif
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 14.0,visionOS 1.0,iOS 17.0, *)
+    @available(iOS 17.0,visionOS 1.0,macOS 14.0, *)
     init(text: ChangeTracked<Swift.String>,isPresented: ChangeTracked<Swift.Bool>,placement: SwiftUI.SearchFieldPlacement = .automatic, prompt: SwiftUICore.LocalizedStringKey) {
         self.value = ._4(placement: placement, prompt: prompt)
         self.__4_text = text
@@ -11730,7 +11730,7 @@ self.__4_isPresented = isPresented
     }
     #endif
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 14.0,visionOS 1.0,iOS 17.0, *)
+    @available(iOS 17.0,visionOS 1.0,macOS 14.0, *)
     init(text: ChangeTracked<Swift.String>,isPresented: ChangeTracked<Swift.Bool>,placement: SwiftUI.SearchFieldPlacement = .automatic, prompt: AttributeReference<String>) {
         self.value = ._5(placement: placement, prompt: prompt)
         self.__5_text = text
@@ -11777,7 +11777,7 @@ self.__5_isPresented = isPresented
         
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._3(placement, prompt):
-            if #available(macOS 14.0,visionOS 1.0,iOS 17.0, *) {
+            if #available(iOS 17.0,visionOS 1.0,macOS 14.0, *) {
             let placement = placement as! SwiftUI.SearchFieldPlacement 
 let prompt = prompt as? TextReference
             __content._observeTextReference(prompt, on: element, in: context) { __content in
@@ -11789,7 +11789,7 @@ let prompt = prompt as? TextReference
         #endif
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._4(placement, prompt):
-            if #available(macOS 14.0,visionOS 1.0,iOS 17.0, *) {
+            if #available(iOS 17.0,visionOS 1.0,macOS 14.0, *) {
             let placement = placement as! SwiftUI.SearchFieldPlacement 
 let prompt = prompt as! SwiftUICore.LocalizedStringKey
             
@@ -11801,7 +11801,7 @@ let prompt = prompt as! SwiftUICore.LocalizedStringKey
         #endif
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._5(placement, prompt):
-            if #available(macOS 14.0,visionOS 1.0,iOS 17.0, *) {
+            if #available(iOS 17.0,visionOS 1.0,macOS 14.0, *) {
             let placement = placement as! SwiftUI.SearchFieldPlacement 
 let prompt = prompt as! AttributeReference<String>
             
@@ -11836,7 +11836,7 @@ struct _sectionActionsModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(visionOS 2.0,macOS 15.0,iOS 18.0, *)
+    @available(macOS 15.0,iOS 18.0,visionOS 2.0, *)
     init(content: ViewReference=ViewReference(value: [])) {
         self.value = ._0(content: content)
         
@@ -11849,7 +11849,7 @@ struct _sectionActionsModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(content):
-            if #available(visionOS 2.0,macOS 15.0,iOS 18.0, *) {
+            if #available(macOS 15.0,iOS 18.0,visionOS 2.0, *) {
             let content = content as! ViewReference
             
             __content
@@ -11883,7 +11883,7 @@ struct _selectionDisabledModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,tvOS 17.0,macOS 14.0,iOS 17.0,watchOS 10.0, *)
+    @available(watchOS 10.0,macOS 14.0,iOS 17.0,visionOS 1.0,tvOS 17.0, *)
     init(_ isDisabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(isDisabled: isDisabled)
         
@@ -11896,7 +11896,7 @@ struct _selectionDisabledModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(isDisabled):
-            if #available(visionOS 1.0,tvOS 17.0,macOS 14.0,iOS 17.0,watchOS 10.0, *) {
+            if #available(watchOS 10.0,macOS 14.0,iOS 17.0,visionOS 1.0,tvOS 17.0, *) {
             let isDisabled = isDisabled as! AttributeReference<Swift.Bool>
             
             __content
@@ -12049,7 +12049,7 @@ struct _simultaneousGestureModifier<R: RootRegistry>: ViewModifier {
     }
     
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(tvOS 18.0,watchOS 11.0,iOS 18.0,macOS 15.0,visionOS 2.0, *)
+    @available(watchOS 11.0,iOS 18.0,visionOS 2.0,tvOS 18.0,macOS 15.0, *)
     init(_ gesture: _AnyGesture,name: AttributeReference<Swift.String>,isEnabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._2(gesture: gesture, name: name, isEnabled: isEnabled)
         
@@ -12084,7 +12084,7 @@ struct _simultaneousGestureModifier<R: RootRegistry>: ViewModifier {
         
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._2(gesture, name, isEnabled):
-            if #available(tvOS 18.0,watchOS 11.0,iOS 18.0,macOS 15.0,visionOS 2.0, *) {
+            if #available(watchOS 11.0,iOS 18.0,visionOS 2.0,tvOS 18.0,macOS 15.0, *) {
             let gesture = gesture as! _AnyGesture
 let name = name as! AttributeReference<Swift.String>
 let isEnabled = isEnabled as! AttributeReference<Swift.Bool>
@@ -12496,7 +12496,7 @@ struct _swipeActionsModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
-    @available(macOS 12.0,visionOS 1.0,watchOS 8.0,iOS 15.0, *)
+    @available(visionOS 1.0,macOS 12.0,watchOS 8.0,iOS 15.0, *)
     init(edge: SwiftUICore.HorizontalEdge = .trailing, allowsFullSwipe: AttributeReference<Swift.Bool> = .init(storage: .constant(true)), content: ViewReference=ViewReference(value: [])) {
         self.value = ._0(edge: edge, allowsFullSwipe: allowsFullSwipe, content: content)
         
@@ -12509,7 +12509,7 @@ struct _swipeActionsModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
         case let ._0(edge, allowsFullSwipe, content):
-            if #available(macOS 12.0,visionOS 1.0,watchOS 8.0,iOS 15.0, *) {
+            if #available(visionOS 1.0,macOS 12.0,watchOS 8.0,iOS 15.0, *) {
             let edge = edge as! SwiftUICore.HorizontalEdge 
 let allowsFullSwipe = allowsFullSwipe as! AttributeReference<Swift.Bool>
 let content = content as! ViewReference
@@ -12550,14 +12550,14 @@ struct _symbolEffectModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,iOS 17.0,macOS 14.0,watchOS 10.0,tvOS 17.0, *)
+    @available(watchOS 10.0,visionOS 1.0,iOS 17.0,macOS 14.0,tvOS 17.0, *)
     init(_ effect: AnyIndefiniteSymbolEffect,options: Symbols.SymbolEffectOptions = .default, isActive: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(effect: effect, options: options, isActive: isActive)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 14.0,watchOS 10.0,visionOS 1.0,tvOS 17.0,iOS 17.0, *)
+    @available(watchOS 10.0,visionOS 1.0,iOS 17.0,macOS 14.0,tvOS 17.0, *)
     init(_ effect: AnyDiscreteSymbolEffect,options: Symbols.SymbolEffectOptions = .default, value: AttributeReference<String>) {
         self.value = ._1(effect: effect, options: options, value: value)
         
@@ -12570,7 +12570,7 @@ struct _symbolEffectModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(effect, options, isActive):
-            if #available(visionOS 1.0,iOS 17.0,macOS 14.0,watchOS 10.0,tvOS 17.0, *) {
+            if #available(watchOS 10.0,visionOS 1.0,iOS 17.0,macOS 14.0,tvOS 17.0, *) {
             let effect = effect as! AnyIndefiniteSymbolEffect
 let options = options as! Symbols.SymbolEffectOptions 
 let isActive = isActive as! AttributeReference<Swift.Bool>
@@ -12583,7 +12583,7 @@ let isActive = isActive as! AttributeReference<Swift.Bool>
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(effect, options, value):
-            if #available(macOS 14.0,watchOS 10.0,visionOS 1.0,tvOS 17.0,iOS 17.0, *) {
+            if #available(watchOS 10.0,visionOS 1.0,iOS 17.0,macOS 14.0,tvOS 17.0, *) {
             let effect = effect as! AnyDiscreteSymbolEffect
 let options = options as! Symbols.SymbolEffectOptions 
 let value = value as! AttributeReference<String>
@@ -12619,7 +12619,7 @@ struct _symbolEffectsRemovedModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0,visionOS 1.0, *)
+    @available(watchOS 10.0,macOS 14.0,iOS 17.0,visionOS 1.0,tvOS 17.0, *)
     init(_ isEnabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(isEnabled: isEnabled)
         
@@ -12632,7 +12632,7 @@ struct _symbolEffectsRemovedModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(isEnabled):
-            if #available(macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0,visionOS 1.0, *) {
+            if #available(watchOS 10.0,macOS 14.0,iOS 17.0,visionOS 1.0,tvOS 17.0, *) {
             let isEnabled = isEnabled as! AttributeReference<Swift.Bool>
             
             __content
@@ -12760,7 +12760,7 @@ struct _tabViewSidebarBottomBarModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 15.0,visionOS 2.0,iOS 18.0, *)
+    @available(macOS 15.0,iOS 18.0,visionOS 2.0, *)
     init(content: ViewReference=ViewReference(value: [])) {
         self.value = ._0(content: content)
         
@@ -12773,7 +12773,7 @@ struct _tabViewSidebarBottomBarModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(content):
-            if #available(macOS 15.0,visionOS 2.0,iOS 18.0, *) {
+            if #available(macOS 15.0,iOS 18.0,visionOS 2.0, *) {
             let content = content as! ViewReference
             
             __content
@@ -12807,7 +12807,7 @@ struct _tabViewSidebarFooterModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 15.0,visionOS 2.0,iOS 18.0, *)
+    @available(macOS 15.0,iOS 18.0,visionOS 2.0, *)
     init(content: ViewReference=ViewReference(value: [])) {
         self.value = ._0(content: content)
         
@@ -12820,7 +12820,7 @@ struct _tabViewSidebarFooterModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(content):
-            if #available(macOS 15.0,visionOS 2.0,iOS 18.0, *) {
+            if #available(macOS 15.0,iOS 18.0,visionOS 2.0, *) {
             let content = content as! ViewReference
             
             __content
@@ -12854,7 +12854,7 @@ struct _tabViewSidebarHeaderModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(visionOS 2.0,macOS 15.0,iOS 18.0, *)
+    @available(macOS 15.0,iOS 18.0,visionOS 2.0, *)
     init(content: ViewReference=ViewReference(value: [])) {
         self.value = ._0(content: content)
         
@@ -12867,7 +12867,7 @@ struct _tabViewSidebarHeaderModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(content):
-            if #available(visionOS 2.0,macOS 15.0,iOS 18.0, *) {
+            if #available(macOS 15.0,iOS 18.0,visionOS 2.0, *) {
             let content = content as! ViewReference
             
             __content
@@ -12948,7 +12948,7 @@ struct _tableStyleModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 12.0,visionOS 1.0,iOS 16.0, *)
+    @available(macOS 12.0,iOS 16.0,visionOS 1.0, *)
     init(_ style: AnyTableStyle) {
         self.value = ._0(style: style)
         
@@ -12961,7 +12961,7 @@ struct _tableStyleModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(style):
-            if #available(macOS 12.0,visionOS 1.0,iOS 16.0, *) {
+            if #available(macOS 12.0,iOS 16.0,visionOS 1.0, *) {
             let style = style as! AnyTableStyle
             
             __content
@@ -13042,7 +13042,7 @@ struct _textContentTypeModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(tvOS) || os(visionOS)
-    @available(tvOS 13.0,visionOS 1.0,iOS 13.0, *)
+    @available(visionOS 1.0,tvOS 13.0,iOS 13.0, *)
     init(_ textContentType: UIKit.UITextContentType?) {
         self.value = ._0(textContentType: textContentType)
         
@@ -13055,7 +13055,7 @@ struct _textContentTypeModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(tvOS) || os(visionOS)
         case let ._0(textContentType):
-            if #available(tvOS 13.0,visionOS 1.0,iOS 13.0, *) {
+            if #available(visionOS 1.0,tvOS 13.0,iOS 13.0, *) {
             let textContentType = textContentType as? UIKit.UITextContentType
             
             __content
@@ -13089,7 +13089,7 @@ struct _textEditorStyleModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 14.0,visionOS 1.0,iOS 17.0, *)
+    @available(macOS 14.0,iOS 17.0,visionOS 1.0, *)
     init(_ style: AnyTextEditorStyle) {
         self.value = ._0(style: style)
         
@@ -13102,7 +13102,7 @@ struct _textEditorStyleModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(style):
-            if #available(macOS 14.0,visionOS 1.0,iOS 17.0, *) {
+            if #available(macOS 14.0,iOS 17.0,visionOS 1.0, *) {
             let style = style as! AnyTextEditorStyle
             
             __content
@@ -13183,7 +13183,7 @@ struct _textInputAutocapitalizationModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(tvOS 15.0,iOS 15.0,watchOS 8.0,visionOS 1.0, *)
+    @available(visionOS 1.0,watchOS 8.0,tvOS 15.0,iOS 15.0, *)
     init(_ autocapitalization: SwiftUI.TextInputAutocapitalization?) {
         self.value = ._0(autocapitalization: autocapitalization)
         
@@ -13196,7 +13196,7 @@ struct _textInputAutocapitalizationModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(autocapitalization):
-            if #available(tvOS 15.0,iOS 15.0,watchOS 8.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,watchOS 8.0,tvOS 15.0,iOS 15.0, *) {
             let autocapitalization = autocapitalization as? SwiftUI.TextInputAutocapitalization
             
             __content
@@ -13324,7 +13324,7 @@ struct _textSelectionModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(visionOS 1.0,macOS 12.0,iOS 15.0, *)
+    @available(iOS 15.0,visionOS 1.0,macOS 12.0, *)
     init(_ selectability: AnyTextSelectability) {
         self.value = ._0(selectability: selectability)
         
@@ -13337,7 +13337,7 @@ struct _textSelectionModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(selectability):
-            if #available(visionOS 1.0,macOS 12.0,iOS 15.0, *) {
+            if #available(iOS 15.0,visionOS 1.0,macOS 12.0, *) {
             let selectability = selectability as! AnyTextSelectability
             
             __content
@@ -13371,7 +13371,7 @@ struct _textSelectionAffinityModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 11.0,iOS 18.0,visionOS 2.0,macOS 15.0,tvOS 18.0, *)
+    @available(visionOS 2.0,macOS 15.0,tvOS 18.0,iOS 18.0,watchOS 11.0, *)
     init(_ affinity: SwiftUI.TextSelectionAffinity) {
         self.value = ._0(affinity: affinity)
         
@@ -13384,7 +13384,7 @@ struct _textSelectionAffinityModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(affinity):
-            if #available(watchOS 11.0,iOS 18.0,visionOS 2.0,macOS 15.0,tvOS 18.0, *) {
+            if #available(visionOS 2.0,macOS 15.0,tvOS 18.0,iOS 18.0,watchOS 11.0, *) {
             let affinity = affinity as! SwiftUI.TextSelectionAffinity
             
             __content
@@ -13545,7 +13545,7 @@ struct _toolbarModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 14.0,iOS 17.0,watchOS 10.0,tvOS 17.0,visionOS 1.0, *)
+    @available(watchOS 10.0,iOS 17.0,visionOS 1.0,tvOS 17.0,macOS 14.0, *)
     init(removing defaultItemKind: SwiftUI.ToolbarDefaultItemKind?) {
         self.value = ._0(defaultItemKind: defaultItemKind)
         
@@ -13572,7 +13572,7 @@ struct _toolbarModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(defaultItemKind):
-            if #available(macOS 14.0,iOS 17.0,watchOS 10.0,tvOS 17.0,visionOS 1.0, *) {
+            if #available(watchOS 10.0,iOS 17.0,visionOS 1.0,tvOS 17.0,macOS 14.0, *) {
             let defaultItemKind = defaultItemKind as? SwiftUI.ToolbarDefaultItemKind
             
             __content
@@ -13675,7 +13675,7 @@ struct _toolbarBackgroundVisibilityModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 15.0,visionOS 2.0,tvOS 18.0,iOS 18.0,watchOS 11.0, *)
+    @available(macOS 15.0,watchOS 11.0,tvOS 18.0,iOS 18.0,visionOS 2.0, *)
     init(_ visibility: AttributeReference<SwiftUI.Visibility>,for bars: SwiftUI.ToolbarPlacement) {
         self.value = ._0(visibility: visibility, bars: bars)
         
@@ -13688,7 +13688,7 @@ struct _toolbarBackgroundVisibilityModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(visibility, bars):
-            if #available(macOS 15.0,visionOS 2.0,tvOS 18.0,iOS 18.0,watchOS 11.0, *) {
+            if #available(macOS 15.0,watchOS 11.0,tvOS 18.0,iOS 18.0,visionOS 2.0, *) {
             let visibility = visibility as! AttributeReference<SwiftUI.Visibility>
 let bars = bars as! SwiftUI.ToolbarPlacement
             
@@ -13864,7 +13864,7 @@ struct _toolbarTitleDisplayModeModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 14.0,visionOS 1.0,tvOS 17.0,iOS 17.0,watchOS 10.0, *)
+    @available(macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0,visionOS 1.0, *)
     init(_ mode: SwiftUI.ToolbarTitleDisplayMode) {
         self.value = ._0(mode: mode)
         
@@ -13877,7 +13877,7 @@ struct _toolbarTitleDisplayModeModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(mode):
-            if #available(macOS 14.0,visionOS 1.0,tvOS 17.0,iOS 17.0,watchOS 10.0, *) {
+            if #available(macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0,visionOS 1.0, *) {
             let mode = mode as! SwiftUI.ToolbarTitleDisplayMode
             
             __content
@@ -13958,7 +13958,7 @@ struct _toolbarVisibilityModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(tvOS 18.0,macOS 15.0,iOS 18.0,watchOS 11.0,visionOS 2.0, *)
+    @available(macOS 15.0,watchOS 11.0,tvOS 18.0,iOS 18.0,visionOS 2.0, *)
     init(_ visibility: AttributeReference<SwiftUI.Visibility>,for bars: SwiftUI.ToolbarPlacement) {
         self.value = ._0(visibility: visibility, bars: bars)
         
@@ -13971,7 +13971,7 @@ struct _toolbarVisibilityModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(visibility, bars):
-            if #available(tvOS 18.0,macOS 15.0,iOS 18.0,watchOS 11.0,visionOS 2.0, *) {
+            if #available(macOS 15.0,watchOS 11.0,tvOS 18.0,iOS 18.0,visionOS 2.0, *) {
             let visibility = visibility as! AttributeReference<SwiftUI.Visibility>
 let bars = bars as! SwiftUI.ToolbarPlacement
             
@@ -14617,7 +14617,7 @@ struct _windowToolbarFullScreenVisibilityModifier<R: RootRegistry>: ViewModifier
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(tvOS 18.0,macOS 15.0,iOS 18.0,watchOS 11.0,visionOS 2.0, *)
+    @available(macOS 15.0,watchOS 11.0,tvOS 18.0,iOS 18.0,visionOS 2.0, *)
     init(_ visibility: SwiftUI.WindowToolbarFullScreenVisibility) {
         self.value = ._0(visibility: visibility)
         
@@ -14630,7 +14630,7 @@ struct _windowToolbarFullScreenVisibilityModifier<R: RootRegistry>: ViewModifier
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(visibility):
-            if #available(tvOS 18.0,macOS 15.0,iOS 18.0,watchOS 11.0,visionOS 2.0, *) {
+            if #available(macOS 15.0,watchOS 11.0,tvOS 18.0,iOS 18.0,visionOS 2.0, *) {
             let visibility = visibility as! SwiftUI.WindowToolbarFullScreenVisibility
             
             __content
@@ -15703,18 +15703,18 @@ indirect case chunk15(_BuiltinModifierChunk15)
 indirect case chunk16(_BuiltinModifierChunk16)
 indirect case chunk17(_BuiltinModifierChunk17)
 indirect case chunk18(_BuiltinModifierChunk18)
-        indirect case _MaskModifier(LiveViewNative._MaskModifier<R>)
-indirect case _Rotation3DEffectModifier(LiveViewNative._Rotation3DEffectModifier<R>)
-indirect case _FocusScopeModifier(LiveViewNative._FocusScopeModifier<R>)
-indirect case _OnSubmitModifier(LiveViewNative._OnSubmitModifier)
-indirect case _NavigationTransitionModifier(LiveViewNative._NavigationTransitionModifier<R>)
-indirect case _SearchCompletionModifier(LiveViewNative._SearchCompletionModifier<R>)
-indirect case _MatchedGeometryEffectModifier(LiveViewNative._MatchedGeometryEffectModifier<R>)
-indirect case _MatchedTransitionSourceModifier(LiveViewNative._MatchedTransitionSourceModifier<R>)
+        indirect case _SearchCompletionModifier(LiveViewNative._SearchCompletionModifier<R>)
 indirect case _PerspectiveRotationEffectModifier(LiveViewNative._PerspectiveRotationEffectModifier<R>)
 indirect case _SearchScopesModifier(LiveViewNative._SearchScopesModifier<R>)
-indirect case _PrefersDefaultFocusModifier(LiveViewNative._PrefersDefaultFocusModifier<R>)
+indirect case _MatchedGeometryEffectModifier(LiveViewNative._MatchedGeometryEffectModifier<R>)
+indirect case _Rotation3DEffectModifier(LiveViewNative._Rotation3DEffectModifier<R>)
 indirect case _PresentationDetentsModifier(LiveViewNative._PresentationDetentsModifier)
+indirect case _MatchedTransitionSourceModifier(LiveViewNative._MatchedTransitionSourceModifier<R>)
+indirect case _OnSubmitModifier(LiveViewNative._OnSubmitModifier)
+indirect case _FocusScopeModifier(LiveViewNative._FocusScopeModifier<R>)
+indirect case _NavigationTransitionModifier(LiveViewNative._NavigationTransitionModifier<R>)
+indirect case _PrefersDefaultFocusModifier(LiveViewNative._PrefersDefaultFocusModifier<R>)
+indirect case _MaskModifier(LiveViewNative._MaskModifier<R>)
         indirect case _customRegistryModifier(R.CustomModifier)
         indirect case _anyTextModifier(_AnyTextModifier<R>)
         indirect case _anyImageModifier(_AnyImageModifier<R>)
@@ -15761,29 +15761,29 @@ case let .chunk17(chunk):
     content.modifier(chunk)
 case let .chunk18(chunk):
     content.modifier(chunk)
-            case let ._MaskModifier(modifier):
-    content.modifier(modifier)
-case let ._Rotation3DEffectModifier(modifier):
-    content.modifier(modifier)
-case let ._FocusScopeModifier(modifier):
-    content.modifier(modifier)
-case let ._OnSubmitModifier(modifier):
-    content.modifier(modifier)
-case let ._NavigationTransitionModifier(modifier):
-    content.modifier(modifier)
-case let ._SearchCompletionModifier(modifier):
-    content.modifier(modifier)
-case let ._MatchedGeometryEffectModifier(modifier):
-    content.modifier(modifier)
-case let ._MatchedTransitionSourceModifier(modifier):
+            case let ._SearchCompletionModifier(modifier):
     content.modifier(modifier)
 case let ._PerspectiveRotationEffectModifier(modifier):
     content.modifier(modifier)
 case let ._SearchScopesModifier(modifier):
     content.modifier(modifier)
-case let ._PrefersDefaultFocusModifier(modifier):
+case let ._MatchedGeometryEffectModifier(modifier):
+    content.modifier(modifier)
+case let ._Rotation3DEffectModifier(modifier):
     content.modifier(modifier)
 case let ._PresentationDetentsModifier(modifier):
+    content.modifier(modifier)
+case let ._MatchedTransitionSourceModifier(modifier):
+    content.modifier(modifier)
+case let ._OnSubmitModifier(modifier):
+    content.modifier(modifier)
+case let ._FocusScopeModifier(modifier):
+    content.modifier(modifier)
+case let ._NavigationTransitionModifier(modifier):
+    content.modifier(modifier)
+case let ._PrefersDefaultFocusModifier(modifier):
+    content.modifier(modifier)
+case let ._MaskModifier(modifier):
     content.modifier(modifier)
             case let ._customRegistryModifier(modifier):
                 content.modifier(modifier)
@@ -16068,18 +16068,18 @@ _windowResizeBehaviorModifier<R>.name: _windowResizeBehaviorModifier<R>.parser(i
 _windowToolbarFullScreenVisibilityModifier<R>.name: _windowToolbarFullScreenVisibilityModifier<R>.parser(in: context).map({ Output.chunk18(.windowToolbarFullScreenVisibility($0)) }).eraseToAnyParser(),
 _writingToolsBehaviorModifier<R>.name: _writingToolsBehaviorModifier<R>.parser(in: context).map({ Output.chunk18(.writingToolsBehavior($0)) }).eraseToAnyParser(),
 _zIndexModifier<R>.name: _zIndexModifier<R>.parser(in: context).map({ Output.chunk18(.zIndex($0)) }).eraseToAnyParser(),
-                    LiveViewNative._MaskModifier<R>.name: LiveViewNative._MaskModifier<R>.parser(in: context).map(Output._MaskModifier).eraseToAnyParser(),
-LiveViewNative._Rotation3DEffectModifier<R>.name: LiveViewNative._Rotation3DEffectModifier<R>.parser(in: context).map(Output._Rotation3DEffectModifier).eraseToAnyParser(),
-LiveViewNative._FocusScopeModifier<R>.name: LiveViewNative._FocusScopeModifier<R>.parser(in: context).map(Output._FocusScopeModifier).eraseToAnyParser(),
-LiveViewNative._OnSubmitModifier.name: LiveViewNative._OnSubmitModifier.parser(in: context).map(Output._OnSubmitModifier).eraseToAnyParser(),
-LiveViewNative._NavigationTransitionModifier<R>.name: LiveViewNative._NavigationTransitionModifier<R>.parser(in: context).map(Output._NavigationTransitionModifier).eraseToAnyParser(),
-LiveViewNative._SearchCompletionModifier<R>.name: LiveViewNative._SearchCompletionModifier<R>.parser(in: context).map(Output._SearchCompletionModifier).eraseToAnyParser(),
-LiveViewNative._MatchedGeometryEffectModifier<R>.name: LiveViewNative._MatchedGeometryEffectModifier<R>.parser(in: context).map(Output._MatchedGeometryEffectModifier).eraseToAnyParser(),
-LiveViewNative._MatchedTransitionSourceModifier<R>.name: LiveViewNative._MatchedTransitionSourceModifier<R>.parser(in: context).map(Output._MatchedTransitionSourceModifier).eraseToAnyParser(),
+                    LiveViewNative._SearchCompletionModifier<R>.name: LiveViewNative._SearchCompletionModifier<R>.parser(in: context).map(Output._SearchCompletionModifier).eraseToAnyParser(),
 LiveViewNative._PerspectiveRotationEffectModifier<R>.name: LiveViewNative._PerspectiveRotationEffectModifier<R>.parser(in: context).map(Output._PerspectiveRotationEffectModifier).eraseToAnyParser(),
 LiveViewNative._SearchScopesModifier<R>.name: LiveViewNative._SearchScopesModifier<R>.parser(in: context).map(Output._SearchScopesModifier).eraseToAnyParser(),
-LiveViewNative._PrefersDefaultFocusModifier<R>.name: LiveViewNative._PrefersDefaultFocusModifier<R>.parser(in: context).map(Output._PrefersDefaultFocusModifier).eraseToAnyParser(),
+LiveViewNative._MatchedGeometryEffectModifier<R>.name: LiveViewNative._MatchedGeometryEffectModifier<R>.parser(in: context).map(Output._MatchedGeometryEffectModifier).eraseToAnyParser(),
+LiveViewNative._Rotation3DEffectModifier<R>.name: LiveViewNative._Rotation3DEffectModifier<R>.parser(in: context).map(Output._Rotation3DEffectModifier).eraseToAnyParser(),
 LiveViewNative._PresentationDetentsModifier.name: LiveViewNative._PresentationDetentsModifier.parser(in: context).map(Output._PresentationDetentsModifier).eraseToAnyParser(),
+LiveViewNative._MatchedTransitionSourceModifier<R>.name: LiveViewNative._MatchedTransitionSourceModifier<R>.parser(in: context).map(Output._MatchedTransitionSourceModifier).eraseToAnyParser(),
+LiveViewNative._OnSubmitModifier.name: LiveViewNative._OnSubmitModifier.parser(in: context).map(Output._OnSubmitModifier).eraseToAnyParser(),
+LiveViewNative._FocusScopeModifier<R>.name: LiveViewNative._FocusScopeModifier<R>.parser(in: context).map(Output._FocusScopeModifier).eraseToAnyParser(),
+LiveViewNative._NavigationTransitionModifier<R>.name: LiveViewNative._NavigationTransitionModifier<R>.parser(in: context).map(Output._NavigationTransitionModifier).eraseToAnyParser(),
+LiveViewNative._PrefersDefaultFocusModifier<R>.name: LiveViewNative._PrefersDefaultFocusModifier<R>.parser(in: context).map(Output._PrefersDefaultFocusModifier).eraseToAnyParser(),
+LiveViewNative._MaskModifier<R>.name: LiveViewNative._MaskModifier<R>.parser(in: context).map(Output._MaskModifier).eraseToAnyParser(),
                 ]
 
                 let deprecations = [
@@ -16275,7 +16275,7 @@ ConstantAtomLiteral("content").map({ () -> Self in
 /// * `.tabBar`
 /// * `.sidebar`
 @_documentation(visibility: public)
-@available(tvOS 18.0,watchOS 11.0,visionOS 2.0,macOS 15.0,iOS 18.0, *)
+@available(watchOS 11.0,iOS 18.0,tvOS 18.0,visionOS 2.0,macOS 15.0, *)
 extension AdaptableTabBarPlacement: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -16393,7 +16393,7 @@ ConstantAtomLiteral("vertical").map({ () -> Self in
 /// * `.standard`
 /// * `.increased`
 @_documentation(visibility: public)
-@available(iOS 17.0,visionOS 1.0,macOS 14.0, *)
+@available(macOS 14.0,iOS 17.0,visionOS 1.0, *)
 extension BadgeProminence: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -16621,7 +16621,7 @@ ConstantAtomLiteral("plusLighter").map({ () -> Self in
 /// * `.enabled`
 /// * `.disabled`
 @_documentation(visibility: public)
-@available(iOS 17.0,visionOS 1.0,macOS 14.0,watchOS 10.0,tvOS 17.0, *)
+@available(watchOS 10.0,iOS 17.0,tvOS 17.0,visionOS 1.0,macOS 14.0, *)
 extension ButtonRepeatBehavior: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -16740,35 +16740,35 @@ ConstantAtomLiteral("dark").map({ () -> Self in
 /// * `.navigationSplitView`
 /// * `.window`
 @_documentation(visibility: public)
-@available(macOS 14.0,watchOS 10.0,tvOS 17.0,visionOS 1.0,iOS 17.0, *)
+@available(iOS 17.0,tvOS 17.0,watchOS 10.0,macOS 14.0,visionOS 1.0, *)
 extension ContainerBackgroundPlacement: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             #if os(watchOS)
 ConstantAtomLiteral("tabView").map({ () -> Self in
-if #available(macOS 14.0,watchOS 10.0,tvOS 17.0,iOS 17.0, *) {
+if #available(iOS 17.0,tvOS 17.0,watchOS 10.0,macOS 14.0, *) {
     return Self.tabView
 } else { fatalError("'tabView' is not available in this OS version") }
 })
 #endif
 #if os(iOS) || os(watchOS)
 ConstantAtomLiteral("navigation").map({ () -> Self in
-if #available(macOS 14.0,watchOS 10.0,tvOS 17.0,iOS 18.0, *) {
+if #available(iOS 18.0,tvOS 17.0,watchOS 10.0,macOS 14.0, *) {
     return Self.navigation
 } else { fatalError("'navigation' is not available in this OS version") }
 })
 #endif
 #if os(iOS) || os(watchOS)
 ConstantAtomLiteral("navigationSplitView").map({ () -> Self in
-if #available(macOS 14.0,watchOS 11.0,tvOS 17.0,iOS 18.0, *) {
+if #available(iOS 18.0,tvOS 17.0,watchOS 11.0,macOS 14.0, *) {
     return Self.navigationSplitView
 } else { fatalError("'navigationSplitView' is not available in this OS version") }
 })
 #endif
 #if os(macOS)
 ConstantAtomLiteral("window").map({ () -> Self in
-if #available(macOS 15.0,watchOS 10.0,tvOS 17.0,iOS 17.0, *) {
+if #available(iOS 17.0,tvOS 17.0,watchOS 10.0,macOS 15.0, *) {
     return Self.window
 } else { fatalError("'window' is not available in this OS version") }
 })
@@ -16789,7 +16789,7 @@ if #available(macOS 15.0,watchOS 10.0,tvOS 17.0,iOS 17.0, *) {
 /// * `.scrollContent`
 /// * `.scrollIndicators`
 @_documentation(visibility: public)
-@available(macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0,visionOS 1.0, *)
+@available(macOS 14.0,watchOS 10.0,visionOS 1.0,iOS 17.0,tvOS 17.0, *)
 extension ContentMarginPlacement: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -16848,35 +16848,35 @@ ConstantAtomLiteral("interaction").map({ () -> Self in
 
 #if os(iOS) || os(macOS) || os(visionOS)
 ConstantAtomLiteral("dragPreview").map({ () -> Self in
-if #available(tvOS 15.0,macOS 12.0,watchOS 8.0,visionOS 1.0,iOS 15.0, *) {
+if #available(watchOS 8.0,visionOS 1.0,macOS 12.0,iOS 15.0,tvOS 15.0, *) {
     return Self.dragPreview
 } else { fatalError("'dragPreview' is not available in this OS version") }
 })
 #endif
 #if os(iOS) || os(tvOS) || os(visionOS)
 ConstantAtomLiteral("contextMenuPreview").map({ () -> Self in
-if #available(tvOS 17.0,macOS 12.0,watchOS 8.0,visionOS 1.0,iOS 15.0, *) {
+if #available(watchOS 8.0,visionOS 1.0,macOS 12.0,iOS 15.0,tvOS 17.0, *) {
     return Self.contextMenuPreview
 } else { fatalError("'contextMenuPreview' is not available in this OS version") }
 })
 #endif
 #if os(iOS) || os(tvOS) || os(visionOS)
 ConstantAtomLiteral("hoverEffect").map({ () -> Self in
-if #available(tvOS 18.0,macOS 12.0,watchOS 8.0,visionOS 1.0,iOS 15.0, *) {
+if #available(watchOS 8.0,visionOS 1.0,macOS 12.0,iOS 15.0,tvOS 18.0, *) {
     return Self.hoverEffect
 } else { fatalError("'hoverEffect' is not available in this OS version") }
 })
 #endif
 #if os(macOS) || os(watchOS)
 ConstantAtomLiteral("focusEffect").map({ () -> Self in
-if #available(tvOS 15.0,macOS 12.0,watchOS 8.0,iOS 15.0, *) {
+if #available(watchOS 8.0,macOS 12.0,iOS 15.0,tvOS 15.0, *) {
     return Self.focusEffect
 } else { fatalError("'focusEffect' is not available in this OS version") }
 })
 #endif
 #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
 ConstantAtomLiteral("accessibility").map({ () -> Self in
-if #available(macOS 14.0,visionOS 1.0,watchOS 10.0,tvOS 17.0,iOS 17.0, *) {
+if #available(iOS 17.0,tvOS 17.0,watchOS 10.0,macOS 14.0,visionOS 1.0, *) {
     return Self.accessibility
 } else { fatalError("'accessibility' is not available in this OS version") }
 })
@@ -16899,7 +16899,7 @@ if #available(macOS 14.0,visionOS 1.0,watchOS 10.0,tvOS 17.0,iOS 17.0, *) {
 /// * `.large`
 /// * `.extraLarge`
 @_documentation(visibility: public)
-@available(iOS 15.0,visionOS 1.0,macOS 10.15,watchOS 9.0, *)
+@available(iOS 15.0,watchOS 9.0,macOS 10.15,visionOS 1.0, *)
 extension ControlSize: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -16927,14 +16927,14 @@ ConstantAtomLiteral("regular").map({ () -> Self in
 #endif
 #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
 ConstantAtomLiteral("large").map({ () -> Self in
-if #available(iOS 15.0,visionOS 1.0,macOS 11.0,watchOS 9.0, *) {
+if #available(iOS 15.0,watchOS 9.0,macOS 11.0,visionOS 1.0, *) {
     return Self.large
 } else { fatalError("'large' is not available in this OS version") }
 })
 #endif
 #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
 ConstantAtomLiteral("extraLarge").map({ () -> Self in
-if #available(iOS 17.0,visionOS 1.0,macOS 14.0,watchOS 10.0, *) {
+if #available(iOS 17.0,watchOS 10.0,macOS 14.0,visionOS 1.0, *) {
     return Self.extraLarge
 } else { fatalError("'extraLarge' is not available in this OS version") }
 })
@@ -16989,7 +16989,7 @@ ConstantAtomLiteral("userInitiated").map({ () -> Self in
 /// * `.critical`
 /// * `.standard`
 @_documentation(visibility: public)
-@available(tvOS 17.0,watchOS 10.0,visionOS 1.0,macOS 13.0,iOS 17.0, *)
+@available(iOS 17.0,tvOS 17.0,watchOS 10.0,macOS 13.0,visionOS 1.0, *)
 extension DialogSeverity: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -17010,7 +17010,7 @@ ConstantAtomLiteral("critical").map({ () -> Self in
 #endif
 #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
 ConstantAtomLiteral("standard").map({ () -> Self in
-if #available(tvOS 17.0,watchOS 10.0,visionOS 1.0,macOS 14.0,iOS 17.0, *) {
+if #available(iOS 17.0,tvOS 17.0,watchOS 10.0,macOS 14.0,visionOS 1.0, *) {
     return Self.standard
 } else { fatalError("'standard' is not available in this OS version") }
 })
@@ -17181,7 +17181,7 @@ ConstantAtomLiteral("all").map({ () -> Self in
 /// * `.includeHiddenFiles`
 /// * `.displayFileExtensions`
 @_documentation(visibility: public)
-@available(macOS 14.0,visionOS 1.0,iOS 17.0, *)
+@available(iOS 17.0,visionOS 1.0,macOS 14.0, *)
 extension FileDialogBrowserOptions: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -17223,7 +17223,7 @@ ConstantAtomLiteral("displayFileExtensions").map({ () -> Self in
 /// * `.edit`
 /// * `.automatic`
 @_documentation(visibility: public)
-@available(iOS 17.0,visionOS 1.0,macOS 14.0,watchOS 10.0,tvOS 17.0, *)
+@available(watchOS 10.0,iOS 17.0,tvOS 17.0,visionOS 1.0,macOS 14.0, *)
 extension FocusInteractions: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -17465,7 +17465,7 @@ ConstantAtomLiteral("never").map({ () -> Self in
     }
 }
 #endif
-#if os(iOS) || os(macOS) || os(visionOS)
+
 /// See [`SwiftUI.HorizontalAlignment`](https://developer.apple.com/documentation/swiftui/HorizontalAlignment) for more details.
 ///
 /// Possible values:
@@ -17475,23 +17475,23 @@ ConstantAtomLiteral("never").map({ () -> Self in
 /// * `.center`
 /// * `.trailing`
 @_documentation(visibility: public)
-@available(macOS 13.0,visionOS 1.0,iOS 16.0, *)
+
 extension HorizontalAlignment: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             #if os(iOS) || os(macOS) || os(visionOS)
 ConstantAtomLiteral("listRowSeparatorLeading").map({ () -> Self in
-
+if #available(iOS 16.0,visionOS 1.0,macOS 13.0, *) {
     return Self.listRowSeparatorLeading
-
+} else { fatalError("'listRowSeparatorLeading' is not available in this OS version") }
 })
 #endif
 #if os(iOS) || os(macOS) || os(visionOS)
 ConstantAtomLiteral("listRowSeparatorTrailing").map({ () -> Self in
-
+if #available(iOS 16.0,visionOS 1.0,macOS 13.0, *) {
     return Self.listRowSeparatorTrailing
-
+} else { fatalError("'listRowSeparatorTrailing' is not available in this OS version") }
 })
 #endif
 
@@ -17522,7 +17522,7 @@ ConstantAtomLiteral("trailing").map({ () -> Self in
         }
     }
 }
-#endif
+
 #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
 /// See [`SwiftUI.HorizontalDirection`](https://developer.apple.com/documentation/swiftui/HorizontalDirection) for more details.
 ///
@@ -17530,7 +17530,7 @@ ConstantAtomLiteral("trailing").map({ () -> Self in
 /// * `.leading`
 /// * `.trailing`
 @_documentation(visibility: public)
-@available(iOS 18.0,tvOS 18.0,watchOS 11.0,visionOS 2.0,macOS 15.0, *)
+@available(watchOS 11.0,visionOS 2.0,macOS 15.0,iOS 18.0,tvOS 18.0, *)
 extension HorizontalDirection: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -17599,7 +17599,7 @@ ConstantAtomLiteral("trailing").map({ () -> Self in
 /// * `.highlight`
 /// * `.lift`
 @_documentation(visibility: public)
-@available(tvOS 16.0,visionOS 1.0,iOS 13.4, *)
+@available(iOS 13.4,visionOS 1.0,tvOS 16.0, *)
 extension HoverEffect: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -17613,7 +17613,7 @@ ConstantAtomLiteral("automatic").map({ () -> Self in
 #endif
 #if os(iOS) || os(tvOS) || os(visionOS)
 ConstantAtomLiteral("highlight").map({ () -> Self in
-if #available(tvOS 17.0,visionOS 1.0,iOS 13.4, *) {
+if #available(iOS 13.4,visionOS 1.0,tvOS 17.0, *) {
     return Self.highlight
 } else { fatalError("'highlight' is not available in this OS version") }
 })
@@ -17640,7 +17640,7 @@ ConstantAtomLiteral("lift").map({ () -> Self in
 /// * `.defaultAction`
 /// * `.cancelAction`
 @_documentation(visibility: public)
-@available(macOS 11.0,visionOS 1.0,iOS 14.0, *)
+@available(macOS 11.0,iOS 14.0,visionOS 1.0, *)
 extension KeyboardShortcut: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -17731,7 +17731,7 @@ ConstantAtomLiteral("automatic").map({ () -> Self in
 
 #if os(iOS) || os(visionOS)
 ConstantAtomLiteral("priority").map({ () -> Self in
-if #available(tvOS 16.0,macOS 13.0,iOS 16.0,watchOS 9.0,visionOS 1.0, *) {
+if #available(macOS 13.0,watchOS 9.0,visionOS 1.0,iOS 16.0,tvOS 16.0, *) {
     return Self.priority
 } else { fatalError("'priority' is not available in this OS version") }
 })
@@ -17761,7 +17761,7 @@ ConstantAtomLiteral("fixed").map({ () -> Self in
 /// * `.sheet`
 /// * `.fullScreenCover`
 @_documentation(visibility: public)
-@available(watchOS 9.4,visionOS 1.0,tvOS 16.4,iOS 16.4,macOS 13.3, *)
+@available(iOS 16.4,tvOS 16.4,watchOS 9.4,macOS 13.3,visionOS 1.0, *)
 extension PresentationAdaptation: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -17817,7 +17817,7 @@ ConstantAtomLiteral("fullScreenCover").map({ () -> Self in
 /// * `.resizes`
 /// * `.scrolls`
 @_documentation(visibility: public)
-@available(iOS 16.4,visionOS 1.0,macOS 13.3,watchOS 9.4,tvOS 16.4, *)
+@available(watchOS 9.4,iOS 16.4,tvOS 16.4,visionOS 1.0,macOS 13.3, *)
 extension PresentationContentInteraction: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -17914,7 +17914,7 @@ ConstantAtomLiteral("privacy").map({ () -> Self in
 
 #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
 ConstantAtomLiteral("invalidated").map({ () -> Self in
-if #available(iOS 17.0,visionOS 1.0,macOS 14.0,watchOS 10.0,tvOS 17.0, *) {
+if #available(iOS 17.0,tvOS 17.0,watchOS 10.0,macOS 14.0,visionOS 1.0, *) {
     return Self.invalidated
 } else { fatalError("'invalidated' is not available in this OS version") }
 })
@@ -18024,7 +18024,7 @@ ConstantAtomLiteral("minimum").map({ () -> Self in
 
 #if os(watchOS)
 ConstantAtomLiteral("navigationBar").map({ () -> Self in
-if #available(macOS 13.0,watchOS 9.0,iOS 16.0,tvOS 16.0, *) {
+if #available(tvOS 16.0,iOS 16.0,macOS 13.0,watchOS 9.0, *) {
     return Self.navigationBar
 } else { fatalError("'navigationBar' is not available in this OS version") }
 })
@@ -18045,7 +18045,7 @@ if #available(macOS 13.0,watchOS 9.0,iOS 16.0,tvOS 16.0, *) {
 /// * `.sizeChanges`
 /// * `.alignment`
 @_documentation(visibility: public)
-@available(tvOS 18.0,iOS 18.0,visionOS 2.0,watchOS 11.0,macOS 15.0, *)
+@available(iOS 18.0,tvOS 18.0,watchOS 11.0,macOS 15.0,visionOS 2.0, *)
 extension ScrollAnchorRole: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -18087,7 +18087,7 @@ ConstantAtomLiteral("alignment").map({ () -> Self in
 /// * `.always`
 /// * `.basedOnSize`
 @_documentation(visibility: public)
-@available(tvOS 16.4,macOS 13.3,watchOS 9.4,visionOS 1.0,iOS 16.4, *)
+@available(iOS 16.4,tvOS 16.4,watchOS 9.4,macOS 13.3,visionOS 1.0, *)
 extension ScrollBounceBehavior: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -18130,7 +18130,7 @@ ConstantAtomLiteral("basedOnSize").map({ () -> Self in
 /// * `.interactively`
 /// * `.never`
 @_documentation(visibility: public)
-@available(tvOS 16.0,macOS 13.0,watchOS 9.0,iOS 16.0, *)
+@available(iOS 16.0,tvOS 16.0,watchOS 9.0,macOS 13.0, *)
 extension ScrollDismissesKeyboardMode: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -18229,7 +18229,7 @@ ConstantAtomLiteral("never").map({ () -> Self in
 /// * `.enabled`
 /// * `.disabled`
 @_documentation(visibility: public)
-@available(tvOS 18.0,macOS 15.0,watchOS 11.0,visionOS 2.0,iOS 18.0, *)
+@available(iOS 18.0,tvOS 18.0,watchOS 11.0,macOS 15.0,visionOS 2.0, *)
 extension ScrollInputBehavior: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -18271,7 +18271,7 @@ ConstantAtomLiteral("disabled").map({ () -> Self in
 /// * `.onTextEntry`
 /// * `.onSearchPresentation`
 @_documentation(visibility: public)
-@available(tvOS 16.4,macOS 13.3,iOS 16.4,watchOS 9.4,visionOS 1.0, *)
+@available(macOS 13.3,watchOS 9.4,visionOS 1.0,iOS 16.4,tvOS 16.4, *)
 extension SearchScopeActivation: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -18355,7 +18355,7 @@ ConstantAtomLiteral("content").map({ () -> Self in
 /// * `.enabled`
 /// * `.disabled`
 @_documentation(visibility: public)
-@available(tvOS 17.0,visionOS 1.0,macOS 14.0,iOS 17.0,watchOS 10.0, *)
+@available(visionOS 1.0,tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0, *)
 extension SpringLoadingBehavior: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -18521,7 +18521,7 @@ ConstantAtomLiteral("search").map({ () -> Self in
 /// * `.upstream`
 /// * `.downstream`
 @_documentation(visibility: public)
-@available(tvOS 18.0,macOS 15.0,watchOS 11.0,visionOS 2.0,iOS 18.0, *)
+@available(iOS 18.0,tvOS 18.0,watchOS 11.0,macOS 15.0,visionOS 2.0, *)
 extension TextSelectionAffinity: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -18562,7 +18562,7 @@ ConstantAtomLiteral("downstream").map({ () -> Self in
 /// * `.sidebarToggle`
 /// * `.title`
 @_documentation(visibility: public)
-@available(tvOS 17.0,watchOS 10.0,visionOS 1.0,macOS 14.0,iOS 17.0, *)
+@available(iOS 17.0,tvOS 17.0,watchOS 10.0,macOS 14.0,visionOS 1.0, *)
 extension ToolbarDefaultItemKind: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -18576,7 +18576,7 @@ ConstantAtomLiteral("sidebarToggle").map({ () -> Self in
 #endif
 #if os(iOS) || os(macOS) || os(visionOS)
 ConstantAtomLiteral("title").map({ () -> Self in
-if #available(tvOS 17.0,watchOS 10.0,visionOS 2.0,macOS 15.0,iOS 18.0, *) {
+if #available(iOS 18.0,tvOS 17.0,watchOS 10.0,macOS 15.0,visionOS 2.0, *) {
     return Self.title
 } else { fatalError("'title' is not available in this OS version") }
 })
@@ -18612,21 +18612,21 @@ ConstantAtomLiteral("automatic").map({ () -> Self in
 
 #if os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
 ConstantAtomLiteral("navigationStack").map({ () -> Self in
-if #available(tvOS 16.0,watchOS 9.0,visionOS 1.0,macOS 13.0,iOS 16.0, *) {
+if #available(watchOS 9.0,iOS 16.0,tvOS 16.0,visionOS 1.0,macOS 13.0, *) {
     return Self.navigationStack
 } else { fatalError("'navigationStack' is not available in this OS version") }
 })
 #endif
 #if os(iOS) || os(visionOS)
 ConstantAtomLiteral("browser").map({ () -> Self in
-if #available(tvOS 16.0,watchOS 9.0,visionOS 1.0,macOS 13.0,iOS 16.0, *) {
+if #available(watchOS 9.0,iOS 16.0,tvOS 16.0,visionOS 1.0,macOS 13.0, *) {
     return Self.browser
 } else { fatalError("'browser' is not available in this OS version") }
 })
 #endif
 #if os(iOS) || os(macOS) || os(visionOS)
 ConstantAtomLiteral("editor").map({ () -> Self in
-if #available(tvOS 16.0,watchOS 9.0,visionOS 1.0,macOS 13.0,iOS 16.0, *) {
+if #available(watchOS 9.0,iOS 16.0,tvOS 16.0,visionOS 1.0,macOS 13.0, *) {
     return Self.editor
 } else { fatalError("'editor' is not available in this OS version") }
 })
@@ -18648,7 +18648,7 @@ if #available(tvOS 16.0,watchOS 9.0,visionOS 1.0,macOS 13.0,iOS 16.0, *) {
 /// * `.inlineLarge`
 /// * `.inline`
 @_documentation(visibility: public)
-@available(tvOS 17.0,iOS 17.0,visionOS 1.0,watchOS 10.0,macOS 14.0, *)
+@available(iOS 17.0,tvOS 17.0,watchOS 10.0,macOS 14.0,visionOS 1.0, *)
 extension ToolbarTitleDisplayMode: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -18754,7 +18754,7 @@ ConstantAtomLiteral("lastTextBaseline").map({ () -> Self in
 /// * `.up`
 /// * `.down`
 @_documentation(visibility: public)
-@available(iOS 18.0,tvOS 18.0,watchOS 11.0,visionOS 2.0,macOS 15.0, *)
+@available(watchOS 11.0,visionOS 2.0,macOS 15.0,iOS 18.0,tvOS 18.0, *)
 extension VerticalDirection: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -18907,7 +18907,7 @@ ConstantAtomLiteral("disabled").map({ () -> Self in
 /// * `.visible`
 /// * `.onHover`
 @_documentation(visibility: public)
-@available(tvOS 18.0,iOS 18.0,visionOS 2.0,watchOS 11.0,macOS 15.0, *)
+@available(macOS 15.0,watchOS 11.0,visionOS 2.0,iOS 18.0,tvOS 18.0, *)
 extension WindowToolbarFullScreenVisibility: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -18950,7 +18950,7 @@ ConstantAtomLiteral("onHover").map({ () -> Self in
 /// * `.limited`
 /// * `.disabled`
 @_documentation(visibility: public)
-@available(macOS 15.0,iOS 18.0, *)
+@available(iOS 18.0,macOS 15.0, *)
 extension WritingToolsBehavior: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {

--- a/Sources/LiveViewNative/_GeneratedModifiers.swift
+++ b/Sources/LiveViewNative/_GeneratedModifiers.swift
@@ -78,7 +78,7 @@ struct _accessibilityActionsModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 15.0,iOS 18.0,tvOS 18.0,visionOS 2.0,watchOS 11.0, *)
+    @available(macOS 15.0,watchOS 11.0,iOS 18.0,tvOS 18.0,visionOS 2.0, *)
     init(category: SwiftUI.AccessibilityActionCategory,content content: ViewReference=ViewReference(value: [])) {
         self.value = ._0(category: category, content: content)
         
@@ -98,7 +98,7 @@ struct _accessibilityActionsModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(category, content):
-            if #available(macOS 15.0,iOS 18.0,tvOS 18.0,visionOS 2.0,watchOS 11.0, *) {
+            if #available(macOS 15.0,watchOS 11.0,iOS 18.0,tvOS 18.0,visionOS 2.0, *) {
             let category = category as! SwiftUI.AccessibilityActionCategory
 let content = content as! ViewReference
             
@@ -634,7 +634,7 @@ struct _allowsWindowActivationEventsModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(visionOS 2.0,iOS 18.0,macOS 15.0, *)
+    @available(macOS 15.0,visionOS 2.0,iOS 18.0, *)
     init(_ value: AttributeReference<Swift.Bool?>? = .init(storage: .constant(true)) ) {
         self.value = ._0(value: value)
         
@@ -647,7 +647,7 @@ struct _allowsWindowActivationEventsModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(value):
-            if #available(visionOS 2.0,iOS 18.0,macOS 15.0, *) {
+            if #available(macOS 15.0,visionOS 2.0,iOS 18.0, *) {
             let value = value as? AttributeReference<Swift.Bool?>
             
             __content
@@ -1092,28 +1092,28 @@ struct _badgeModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(iOS 15.0,macOS 12.0,visionOS 1.0, *)
+    @available(visionOS 1.0,macOS 12.0,iOS 15.0, *)
     init(_ count: AttributeReference<Swift.Int>) {
         self.value = ._0(count: count)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(iOS 15.0,macOS 12.0,visionOS 1.0, *)
+    @available(macOS 12.0,visionOS 1.0,iOS 15.0, *)
     init(_ label: TextReference?) {
         self.value = ._1(label: label)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(iOS 15.0,macOS 12.0,visionOS 1.0, *)
+    @available(macOS 12.0,visionOS 1.0,iOS 15.0, *)
     init(_ key: SwiftUICore.LocalizedStringKey?) {
         self.value = ._2(key: key)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(iOS 15.0,macOS 12.0,visionOS 1.0, *)
+    @available(macOS 12.0,visionOS 1.0,iOS 15.0, *)
     init(_ label: AttributeReference<String>) {
         self.value = ._3(label: label)
         
@@ -1126,7 +1126,7 @@ struct _badgeModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(count):
-            if #available(iOS 15.0,macOS 12.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,macOS 12.0,iOS 15.0, *) {
             let count = count as! AttributeReference<Swift.Int>
             
             __content
@@ -1137,7 +1137,7 @@ struct _badgeModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._1(label):
-            if #available(iOS 15.0,macOS 12.0,visionOS 1.0, *) {
+            if #available(macOS 12.0,visionOS 1.0,iOS 15.0, *) {
             let label = label as? TextReference
             __content._observeTextReference(label, on: element, in: context) { __content in
             __content
@@ -1148,7 +1148,7 @@ struct _badgeModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._2(key):
-            if #available(iOS 15.0,macOS 12.0,visionOS 1.0, *) {
+            if #available(macOS 12.0,visionOS 1.0,iOS 15.0, *) {
             let key = key as? SwiftUICore.LocalizedStringKey
             
             __content
@@ -1159,7 +1159,7 @@ struct _badgeModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._3(label):
-            if #available(iOS 15.0,macOS 12.0,visionOS 1.0, *) {
+            if #available(macOS 12.0,visionOS 1.0,iOS 15.0, *) {
             let label = label as! AttributeReference<String>
             
             __content
@@ -1193,7 +1193,7 @@ struct _badgeProminenceModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(iOS 17.0,visionOS 1.0,macOS 14.0, *)
+    @available(visionOS 1.0,macOS 14.0,iOS 17.0, *)
     init(_ prominence: SwiftUI.BadgeProminence) {
         self.value = ._0(prominence: prominence)
         
@@ -1206,7 +1206,7 @@ struct _badgeProminenceModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(prominence):
-            if #available(iOS 17.0,visionOS 1.0,macOS 14.0, *) {
+            if #available(visionOS 1.0,macOS 14.0,iOS 17.0, *) {
             let prominence = prominence as! SwiftUI.BadgeProminence
             
             __content
@@ -1947,14 +1947,14 @@ struct _containerRelativeFrameModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 14.0,iOS 17.0,tvOS 17.0,visionOS 1.0,watchOS 10.0, *)
+    @available(tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0,visionOS 1.0, *)
     init(_ axes: SwiftUICore.Axis.Set,alignment: AttributeReference<SwiftUICore.Alignment> = .init(storage: .constant(.center)) ) {
         self.value = ._0(axes: axes, alignment: alignment)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 14.0,iOS 17.0,tvOS 17.0,visionOS 1.0,watchOS 10.0, *)
+    @available(tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0,visionOS 1.0, *)
     init(_ axes: SwiftUICore.Axis.Set,count: AttributeReference<Swift.Int>,span: AttributeReference<Swift.Int> = .init(storage: .constant(1)), spacing: AttributeReference<CoreFoundation.CGFloat>,alignment: AttributeReference<SwiftUICore.Alignment> = .init(storage: .constant(.center)) ) {
         self.value = ._1(axes: axes, count: count, span: span, spacing: spacing, alignment: alignment)
         
@@ -1967,7 +1967,7 @@ struct _containerRelativeFrameModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(axes, alignment):
-            if #available(macOS 14.0,iOS 17.0,tvOS 17.0,visionOS 1.0,watchOS 10.0, *) {
+            if #available(tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0,visionOS 1.0, *) {
             let axes = axes as! SwiftUICore.Axis.Set
 let alignment = alignment as! AttributeReference<SwiftUICore.Alignment>
             
@@ -1979,7 +1979,7 @@ let alignment = alignment as! AttributeReference<SwiftUICore.Alignment>
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(axes, count, span, spacing, alignment):
-            if #available(macOS 14.0,iOS 17.0,tvOS 17.0,visionOS 1.0,watchOS 10.0, *) {
+            if #available(tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0,visionOS 1.0, *) {
             let axes = axes as! SwiftUICore.Axis.Set
 let count = count as! AttributeReference<Swift.Int>
 let span = span as! AttributeReference<Swift.Int>
@@ -2074,21 +2074,21 @@ struct _contentMarginsModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 10.0,tvOS 17.0,iOS 17.0,visionOS 1.0,macOS 14.0, *)
+    @available(tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0,visionOS 1.0, *)
     init(_ edges: SwiftUICore.Edge.Set = .all, _ insets: SwiftUICore.EdgeInsets,for placement: SwiftUI.ContentMarginPlacement = .automatic ) {
         self.value = ._0(edges: edges, insets: insets, placement: placement)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 10.0,tvOS 17.0,iOS 17.0,visionOS 1.0,macOS 14.0, *)
+    @available(tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0,visionOS 1.0, *)
     init(_ edges: SwiftUICore.Edge.Set = .all, _ length: AttributeReference<CoreFoundation.CGFloat?>?,for placement: SwiftUI.ContentMarginPlacement = .automatic ) {
         self.value = ._1(edges: edges, length: length, placement: placement)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 10.0,tvOS 17.0,iOS 17.0,visionOS 1.0,macOS 14.0, *)
+    @available(tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0,visionOS 1.0, *)
     init(_ length: AttributeReference<CoreFoundation.CGFloat>,for placement: SwiftUI.ContentMarginPlacement = .automatic ) {
         self.value = ._2(length: length, placement: placement)
         
@@ -2101,7 +2101,7 @@ struct _contentMarginsModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(edges, insets, placement):
-            if #available(watchOS 10.0,tvOS 17.0,iOS 17.0,visionOS 1.0,macOS 14.0, *) {
+            if #available(tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0,visionOS 1.0, *) {
             let edges = edges as! SwiftUICore.Edge.Set 
 let insets = insets as! SwiftUICore.EdgeInsets
 let placement = placement as! SwiftUI.ContentMarginPlacement 
@@ -2114,7 +2114,7 @@ let placement = placement as! SwiftUI.ContentMarginPlacement
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(edges, length, placement):
-            if #available(watchOS 10.0,tvOS 17.0,iOS 17.0,visionOS 1.0,macOS 14.0, *) {
+            if #available(tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0,visionOS 1.0, *) {
             let edges = edges as! SwiftUICore.Edge.Set 
 let length = length as? AttributeReference<CoreFoundation.CGFloat?>
 let placement = placement as! SwiftUI.ContentMarginPlacement 
@@ -2127,7 +2127,7 @@ let placement = placement as! SwiftUI.ContentMarginPlacement
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._2(length, placement):
-            if #available(watchOS 10.0,tvOS 17.0,iOS 17.0,visionOS 1.0,macOS 14.0, *) {
+            if #available(tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0,visionOS 1.0, *) {
             let length = length as! AttributeReference<CoreFoundation.CGFloat>
 let placement = placement as! SwiftUI.ContentMarginPlacement 
             
@@ -2291,7 +2291,7 @@ struct _contextMenuModifier<R: RootRegistry>: ViewModifier {
     }
     
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS)
-    @available(tvOS 16.0,iOS 16.0,macOS 13.0,visionOS 1.0, *)
+    @available(macOS 13.0,iOS 16.0,tvOS 16.0,visionOS 1.0, *)
     init(menuItems: ViewReference=ViewReference(value: []),preview: ViewReference=ViewReference(value: [])) {
         self.value = ._1(menuItems: menuItems, preview: preview)
         
@@ -2315,7 +2315,7 @@ struct _contextMenuModifier<R: RootRegistry>: ViewModifier {
         
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS)
         case let ._1(menuItems, preview):
-            if #available(tvOS 16.0,iOS 16.0,macOS 13.0,visionOS 1.0, *) {
+            if #available(macOS 13.0,iOS 16.0,tvOS 16.0,visionOS 1.0, *) {
             let menuItems = menuItems as! ViewReference
 let preview = preview as! ViewReference
             
@@ -2397,7 +2397,7 @@ struct _controlGroupStyleModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS)
-    @available(visionOS 1.0,tvOS 17.0,iOS 15.0,macOS 12.0, *)
+    @available(tvOS 17.0,iOS 15.0,macOS 12.0,visionOS 1.0, *)
     init(_ style: AnyControlGroupStyle) {
         self.value = ._0(style: style)
         
@@ -2410,7 +2410,7 @@ struct _controlGroupStyleModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS)
         case let ._0(style):
-            if #available(visionOS 1.0,tvOS 17.0,iOS 15.0,macOS 12.0, *) {
+            if #available(tvOS 17.0,iOS 15.0,macOS 12.0,visionOS 1.0, *) {
             let style = style as! AnyControlGroupStyle
             
             __content
@@ -2444,7 +2444,7 @@ struct _controlSizeModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 9.0,iOS 15.0,visionOS 1.0,macOS 10.15, *)
+    @available(iOS 15.0,visionOS 1.0,macOS 10.15,watchOS 9.0, *)
     init(_ controlSize: SwiftUICore.ControlSize) {
         self.value = ._0(controlSize: controlSize)
         
@@ -2457,7 +2457,7 @@ struct _controlSizeModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
         case let ._0(controlSize):
-            if #available(watchOS 9.0,iOS 15.0,visionOS 1.0,macOS 10.15, *) {
+            if #available(iOS 15.0,visionOS 1.0,macOS 10.15,watchOS 9.0, *) {
             let controlSize = controlSize as! SwiftUICore.ControlSize
             
             __content
@@ -2491,7 +2491,7 @@ struct _coordinateSpaceModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0, *)
+    @available(watchOS 10.0,tvOS 17.0,macOS 14.0,iOS 17.0,visionOS 1.0, *)
     init(_ name: SwiftUICore.NamedCoordinateSpace) {
         self.value = ._0(name: name)
         
@@ -2504,7 +2504,7 @@ struct _coordinateSpaceModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(name):
-            if #available(visionOS 1.0,tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0, *) {
+            if #available(watchOS 10.0,tvOS 17.0,macOS 14.0,iOS 17.0,visionOS 1.0, *) {
             let name = name as! SwiftUICore.NamedCoordinateSpace
             
             __content
@@ -2538,7 +2538,7 @@ struct _datePickerStyleModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,iOS 13.0,watchOS 10.0,macOS 10.15, *)
+    @available(macOS 10.15,visionOS 1.0,iOS 13.0,watchOS 10.0, *)
     init(_ style: AnyDatePickerStyle) {
         self.value = ._0(style: style)
         
@@ -2551,7 +2551,7 @@ struct _datePickerStyleModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
         case let ._0(style):
-            if #available(visionOS 1.0,iOS 13.0,watchOS 10.0,macOS 10.15, *) {
+            if #available(macOS 10.15,visionOS 1.0,iOS 13.0,watchOS 10.0, *) {
             let style = style as! AnyDatePickerStyle
             
             __content
@@ -2632,7 +2632,7 @@ struct _defaultHoverEffectModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(tvOS) || os(visionOS)
-    @available(iOS 17.0,visionOS 1.0,tvOS 17.0, *)
+    @available(tvOS 17.0,visionOS 1.0,iOS 17.0, *)
     init(_ effect: SwiftUI.HoverEffect?) {
         self.value = ._0(effect: effect)
         
@@ -2645,7 +2645,7 @@ struct _defaultHoverEffectModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(tvOS) || os(visionOS)
         case let ._0(effect):
-            if #available(iOS 17.0,visionOS 1.0,tvOS 17.0, *) {
+            if #available(tvOS 17.0,visionOS 1.0,iOS 17.0, *) {
             let effect = effect as? SwiftUI.HoverEffect
             
             __content
@@ -2684,14 +2684,14 @@ struct _defaultScrollAnchorModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(tvOS 17.0,macOS 14.0,iOS 17.0,watchOS 10.0,visionOS 1.0, *)
+    @available(macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0,visionOS 1.0, *)
     init(_ anchor: AttributeReference<SwiftUICore.UnitPoint?>?) {
         self.value = ._0(anchor: anchor)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(tvOS 18.0,macOS 15.0,iOS 18.0,watchOS 11.0,visionOS 2.0, *)
+    @available(watchOS 11.0,tvOS 18.0,macOS 15.0,iOS 18.0,visionOS 2.0, *)
     init(_ anchor: AttributeReference<SwiftUICore.UnitPoint?>?,for role: SwiftUI.ScrollAnchorRole) {
         self.value = ._1(anchor: anchor, role: role)
         
@@ -2704,7 +2704,7 @@ struct _defaultScrollAnchorModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(anchor):
-            if #available(tvOS 17.0,macOS 14.0,iOS 17.0,watchOS 10.0,visionOS 1.0, *) {
+            if #available(macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0,visionOS 1.0, *) {
             let anchor = anchor as? AttributeReference<SwiftUICore.UnitPoint?>
             
             __content
@@ -2715,7 +2715,7 @@ struct _defaultScrollAnchorModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(anchor, role):
-            if #available(tvOS 18.0,macOS 15.0,iOS 18.0,watchOS 11.0,visionOS 2.0, *) {
+            if #available(watchOS 11.0,tvOS 18.0,macOS 15.0,iOS 18.0,visionOS 2.0, *) {
             let anchor = anchor as? AttributeReference<SwiftUICore.UnitPoint?>
 let role = role as! SwiftUI.ScrollAnchorRole
             
@@ -2750,7 +2750,7 @@ struct _defaultWheelPickerItemHeightModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,watchOS 6.0, *)
+    @available(watchOS 6.0,visionOS 1.0, *)
     init(_ height: AttributeReference<CoreFoundation.CGFloat>) {
         self.value = ._0(height: height)
         
@@ -2763,7 +2763,7 @@ struct _defaultWheelPickerItemHeightModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(visionOS) || os(watchOS)
         case let ._0(height):
-            if #available(visionOS 1.0,watchOS 6.0, *) {
+            if #available(watchOS 6.0,visionOS 1.0, *) {
             let height = height as! AttributeReference<CoreFoundation.CGFloat>
             
             __content
@@ -2906,28 +2906,28 @@ struct _dialogSuppressionToggleModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 10.0,tvOS 17.0,iOS 17.0,visionOS 1.0,macOS 14.0, *)
+    @available(tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0,visionOS 1.0, *)
     init(_ titleKey: SwiftUICore.LocalizedStringKey,isSuppressed: ChangeTracked<Swift.Bool>) {
         self.value = ._0(titleKey: titleKey)
         self.__0_isSuppressed = isSuppressed
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 10.0,tvOS 17.0,iOS 17.0,visionOS 1.0,macOS 14.0, *)
+    @available(tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0,visionOS 1.0, *)
     init(_ title: AttributeReference<String>,isSuppressed: ChangeTracked<Swift.Bool>) {
         self.value = ._1(title: title)
         self.__1_isSuppressed = isSuppressed
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 10.0,tvOS 17.0,iOS 17.0,visionOS 1.0,macOS 14.0, *)
+    @available(tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0,visionOS 1.0, *)
     init(_ label: TextReference,isSuppressed: ChangeTracked<Swift.Bool>) {
         self.value = ._2(label: label)
         self.__2_isSuppressed = isSuppressed
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 10.0,tvOS 17.0,iOS 17.0,visionOS 1.0,macOS 14.0, *)
+    @available(tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0,visionOS 1.0, *)
     init(isSuppressed: ChangeTracked<Swift.Bool>) {
         self.value = ._3
         self.__3_isSuppressed = isSuppressed
@@ -2940,7 +2940,7 @@ struct _dialogSuppressionToggleModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(titleKey):
-            if #available(watchOS 10.0,tvOS 17.0,iOS 17.0,visionOS 1.0,macOS 14.0, *) {
+            if #available(tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0,visionOS 1.0, *) {
             let titleKey = titleKey as! SwiftUICore.LocalizedStringKey
             
             __content
@@ -2951,7 +2951,7 @@ struct _dialogSuppressionToggleModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(title):
-            if #available(watchOS 10.0,tvOS 17.0,iOS 17.0,visionOS 1.0,macOS 14.0, *) {
+            if #available(tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0,visionOS 1.0, *) {
             let title = title as! AttributeReference<String>
             
             __content
@@ -2962,7 +2962,7 @@ struct _dialogSuppressionToggleModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._2(label):
-            if #available(watchOS 10.0,tvOS 17.0,iOS 17.0,visionOS 1.0,macOS 14.0, *) {
+            if #available(tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0,visionOS 1.0, *) {
             let label = label as! TextReference
             __content._observeTextReference(label, on: element, in: context) { __content in
             __content
@@ -2973,7 +2973,7 @@ struct _dialogSuppressionToggleModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case ._3:
-            if #available(watchOS 10.0,tvOS 17.0,iOS 17.0,visionOS 1.0,macOS 14.0, *) {
+            if #available(tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0,visionOS 1.0, *) {
             
             
             __content
@@ -3418,7 +3418,7 @@ struct _fileDialogCustomizationIDModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(iOS 17.0,macOS 14.0,visionOS 1.0, *)
+    @available(macOS 14.0,visionOS 1.0,iOS 17.0, *)
     init(_ id: AttributeReference<Swift.String>) {
         self.value = ._0(id: id)
         
@@ -3431,7 +3431,7 @@ struct _fileDialogCustomizationIDModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(id):
-            if #available(iOS 17.0,macOS 14.0,visionOS 1.0, *) {
+            if #available(macOS 14.0,visionOS 1.0,iOS 17.0, *) {
             let id = id as! AttributeReference<Swift.String>
             
             __content
@@ -3465,7 +3465,7 @@ struct _fileDialogImportsUnresolvedAliasesModifier<R: RootRegistry>: ViewModifie
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(iOS 17.0,macOS 14.0,visionOS 1.0, *)
+    @available(visionOS 1.0,macOS 14.0,iOS 17.0, *)
     init(_ imports: AttributeReference<Swift.Bool>) {
         self.value = ._0(imports: imports)
         
@@ -3478,7 +3478,7 @@ struct _fileDialogImportsUnresolvedAliasesModifier<R: RootRegistry>: ViewModifie
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(imports):
-            if #available(iOS 17.0,macOS 14.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,macOS 14.0,iOS 17.0, *) {
             let imports = imports as! AttributeReference<Swift.Bool>
             
             __content
@@ -3512,7 +3512,7 @@ struct _findDisabledModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(visionOS)
-    @available(iOS 16.0,visionOS 1.0, *)
+    @available(visionOS 1.0,iOS 16.0, *)
     init(_ isDisabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(isDisabled: isDisabled)
         
@@ -3525,7 +3525,7 @@ struct _findDisabledModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(visionOS)
         case let ._0(isDisabled):
-            if #available(iOS 16.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,iOS 16.0, *) {
             let isDisabled = isDisabled as! AttributeReference<Swift.Bool>
             
             __content
@@ -3559,7 +3559,7 @@ struct _findNavigatorModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(visionOS)
-    @available(iOS 16.0,visionOS 1.0, *)
+    @available(visionOS 1.0,iOS 16.0, *)
     init(isPresented: ChangeTracked<Swift.Bool>) {
         self.value = ._0
         self.__0_isPresented = isPresented
@@ -3572,7 +3572,7 @@ struct _findNavigatorModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(visionOS)
         case ._0:
-            if #available(iOS 16.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,iOS 16.0, *) {
             
             
             __content
@@ -3723,7 +3723,7 @@ struct _focusEffectDisabledModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 10.0,tvOS 17.0,visionOS 1.0,macOS 14.0,iOS 17.0, *)
+    @available(macOS 14.0,visionOS 1.0,tvOS 17.0,iOS 17.0,watchOS 10.0, *)
     init(_ disabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(disabled: disabled)
         
@@ -3736,7 +3736,7 @@ struct _focusEffectDisabledModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(disabled):
-            if #available(watchOS 10.0,tvOS 17.0,visionOS 1.0,macOS 14.0,iOS 17.0, *) {
+            if #available(macOS 14.0,visionOS 1.0,tvOS 17.0,iOS 17.0,watchOS 10.0, *) {
             let disabled = disabled as! AttributeReference<Swift.Bool>
             
             __content
@@ -3822,14 +3822,14 @@ struct _focusableModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 8.0,tvOS 15.0,iOS 17.0,visionOS 1.0,macOS 12.0, *)
+    @available(watchOS 8.0,iOS 17.0,visionOS 1.0,macOS 12.0,tvOS 15.0, *)
     init(_ isFocusable: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(isFocusable: isFocusable)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 10.0,tvOS 17.0,visionOS 1.0,macOS 14.0,iOS 17.0, *)
+    @available(macOS 14.0,visionOS 1.0,tvOS 17.0,iOS 17.0,watchOS 10.0, *)
     init(_ isFocusable: AttributeReference<Swift.Bool> = .init(storage: .constant(true)), interactions: SwiftUI.FocusInteractions) {
         self.value = ._1(isFocusable: isFocusable, interactions: interactions)
         
@@ -3842,7 +3842,7 @@ struct _focusableModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(isFocusable):
-            if #available(watchOS 8.0,tvOS 15.0,iOS 17.0,visionOS 1.0,macOS 12.0, *) {
+            if #available(watchOS 8.0,iOS 17.0,visionOS 1.0,macOS 12.0,tvOS 15.0, *) {
             let isFocusable = isFocusable as! AttributeReference<Swift.Bool>
             
             __content
@@ -3853,7 +3853,7 @@ struct _focusableModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(isFocusable, interactions):
-            if #available(watchOS 10.0,tvOS 17.0,visionOS 1.0,macOS 14.0,iOS 17.0, *) {
+            if #available(macOS 14.0,visionOS 1.0,tvOS 17.0,iOS 17.0,watchOS 10.0, *) {
             let isFocusable = isFocusable as! AttributeReference<Swift.Bool>
 let interactions = interactions as! SwiftUI.FocusInteractions
             
@@ -4078,7 +4078,7 @@ struct _fullScreenCoverModifier<R: RootRegistry>: ViewModifier {
 @Event private var _0_onDismiss__0: Event.EventHandler
 
     #if os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 7.0,tvOS 14.0,iOS 14.0,visionOS 1.0, *)
+    @available(watchOS 7.0,iOS 14.0,tvOS 14.0,visionOS 1.0, *)
     init(isPresented: ChangeTracked<Swift.Bool>,onDismiss onDismiss__0: Event=Event(), content: ViewReference=ViewReference(value: [])) {
         self.value = ._0(content: content)
         self.__0_isPresented = isPresented
@@ -4092,7 +4092,7 @@ self.__0_onDismiss__0 = onDismiss__0
             fatalError("unreachable")
         #if os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(content):
-            if #available(watchOS 7.0,tvOS 14.0,iOS 14.0,visionOS 1.0, *) {
+            if #available(watchOS 7.0,iOS 14.0,tvOS 14.0,visionOS 1.0, *) {
             let content = content as! ViewReference
             
             __content
@@ -4126,7 +4126,7 @@ struct _gaugeStyleModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 7.0,iOS 16.0,visionOS 1.0,macOS 13.0, *)
+    @available(watchOS 7.0,macOS 13.0,iOS 16.0,visionOS 1.0, *)
     init(_ style: AnyGaugeStyle) {
         self.value = ._0(style: style)
         
@@ -4139,7 +4139,7 @@ struct _gaugeStyleModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
         case let ._0(style):
-            if #available(watchOS 7.0,iOS 16.0,visionOS 1.0,macOS 13.0, *) {
+            if #available(watchOS 7.0,macOS 13.0,iOS 16.0,visionOS 1.0, *) {
             let style = style as! AnyGaugeStyle
             
             __content
@@ -4173,7 +4173,7 @@ struct _geometryGroupModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 14.0,tvOS 17.0,iOS 17.0,visionOS 1.0,watchOS 10.0, *)
+    @available(tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0,visionOS 1.0, *)
     init() {
         self.value = ._0
         
@@ -4186,7 +4186,7 @@ struct _geometryGroupModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case ._0:
-            if #available(macOS 14.0,tvOS 17.0,iOS 17.0,visionOS 1.0,watchOS 10.0, *) {
+            if #available(tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0,visionOS 1.0, *) {
             
             
             __content
@@ -4205,17 +4205,14 @@ struct _gestureModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS)
-        indirect case _0(representable: Any)
-        #endif
         
-        indirect case _1(gesture: _AnyGesture,mask: SwiftUICore.GestureMask = .all )
+        indirect case _0(gesture: _AnyGesture,mask: SwiftUICore.GestureMask = .all )
         
         
-        indirect case _2(gesture: _AnyGesture,isEnabled: AttributeReference<Swift.Bool>)
+        indirect case _1(gesture: _AnyGesture,isEnabled: AttributeReference<Swift.Bool>)
         
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-        indirect case _3(gesture: Any,name: Any,isEnabled: Any)
+        indirect case _2(gesture: Any,name: Any,isEnabled: Any)
         #endif
     }
 
@@ -4232,33 +4229,24 @@ struct _gestureModifier<R: RootRegistry>: ViewModifier {
 
 
 
-
-
-    #if os(iOS)
-    @available(iOS 18.0, *)
-    init(_ representable: AnyUIGestureRecognizerRepresentable) {
-        self.value = ._0(representable: representable)
-        
-    }
-    #endif
     
     
     init(_ gesture: _AnyGesture,including mask: SwiftUICore.GestureMask = .all ) {
-        self.value = ._1(gesture: gesture, mask: mask)
+        self.value = ._0(gesture: gesture, mask: mask)
         
     }
     
     
     
     init(_ gesture: _AnyGesture,isEnabled: AttributeReference<Swift.Bool>) {
-        self.value = ._2(gesture: gesture, isEnabled: isEnabled)
+        self.value = ._1(gesture: gesture, isEnabled: isEnabled)
         
     }
     
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 11.0,tvOS 18.0,iOS 18.0,visionOS 2.0,macOS 15.0, *)
+    @available(tvOS 18.0,watchOS 11.0,iOS 18.0,macOS 15.0,visionOS 2.0, *)
     init(_ gesture: _AnyGesture,name: AttributeReference<Swift.String>,isEnabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
-        self.value = ._3(gesture: gesture, name: name, isEnabled: isEnabled)
+        self.value = ._2(gesture: gesture, name: name, isEnabled: isEnabled)
         
     }
     #endif
@@ -4267,19 +4255,8 @@ struct _gestureModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS)
-        case let ._0(representable):
-            if #available(iOS 18.0, *) {
-            let representable = representable as! AnyUIGestureRecognizerRepresentable
-            
-            __content
-                .gesture(representable)
-            
-                
-            } else { __content }
-        #endif
         
-        case let ._1(gesture, mask):
+        case let ._0(gesture, mask):
             
             
             
@@ -4290,7 +4267,7 @@ struct _gestureModifier<R: RootRegistry>: ViewModifier {
             
         
         
-        case let ._2(gesture, isEnabled):
+        case let ._1(gesture, isEnabled):
             
             
             
@@ -4301,8 +4278,8 @@ struct _gestureModifier<R: RootRegistry>: ViewModifier {
             
         
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-        case let ._3(gesture, name, isEnabled):
-            if #available(watchOS 11.0,tvOS 18.0,iOS 18.0,visionOS 2.0,macOS 15.0, *) {
+        case let ._2(gesture, name, isEnabled):
+            if #available(tvOS 18.0,watchOS 11.0,iOS 18.0,macOS 15.0,visionOS 2.0, *) {
             let gesture = gesture as! _AnyGesture
 let name = name as! AttributeReference<Swift.String>
 let isEnabled = isEnabled as! AttributeReference<Swift.Bool>
@@ -4644,7 +4621,7 @@ struct _groupBoxStyleModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(visionOS 1.0,iOS 14.0,macOS 11.0, *)
+    @available(visionOS 1.0,macOS 11.0,iOS 14.0, *)
     init(_ style: AnyGroupBoxStyle) {
         self.value = ._0(style: style)
         
@@ -4657,7 +4634,7 @@ struct _groupBoxStyleModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(style):
-            if #available(visionOS 1.0,iOS 14.0,macOS 11.0, *) {
+            if #available(visionOS 1.0,macOS 11.0,iOS 14.0, *) {
             let style = style as! AnyGroupBoxStyle
             
             __content
@@ -4691,7 +4668,7 @@ struct _handGestureShortcutModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-    @available(watchOS 11.0,tvOS 18.0,iOS 18.0,macOS 15.0, *)
+    @available(watchOS 11.0,tvOS 18.0,macOS 15.0,iOS 18.0, *)
     init(_ shortcut: SwiftUI.HandGestureShortcut,isEnabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(shortcut: shortcut, isEnabled: isEnabled)
         
@@ -4704,7 +4681,7 @@ struct _handGestureShortcutModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
         case let ._0(shortcut, isEnabled):
-            if #available(watchOS 11.0,tvOS 18.0,iOS 18.0,macOS 15.0, *) {
+            if #available(watchOS 11.0,tvOS 18.0,macOS 15.0,iOS 18.0, *) {
             let shortcut = shortcut as! SwiftUI.HandGestureShortcut
 let isEnabled = isEnabled as! AttributeReference<Swift.Bool>
             
@@ -4997,7 +4974,7 @@ struct _highPriorityGestureModifier<R: RootRegistry>: ViewModifier {
     }
     
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 11.0,tvOS 18.0,iOS 18.0,visionOS 2.0,macOS 15.0, *)
+    @available(tvOS 18.0,watchOS 11.0,iOS 18.0,macOS 15.0,visionOS 2.0, *)
     init(_ gesture: _AnyGesture,name: AttributeReference<Swift.String>,isEnabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._2(gesture: gesture, name: name, isEnabled: isEnabled)
         
@@ -5032,7 +5009,7 @@ struct _highPriorityGestureModifier<R: RootRegistry>: ViewModifier {
         
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._2(gesture, name, isEnabled):
-            if #available(watchOS 11.0,tvOS 18.0,iOS 18.0,visionOS 2.0,macOS 15.0, *) {
+            if #available(tvOS 18.0,watchOS 11.0,iOS 18.0,macOS 15.0,visionOS 2.0, *) {
             let gesture = gesture as! _AnyGesture
 let name = name as! AttributeReference<Swift.String>
 let isEnabled = isEnabled as! AttributeReference<Swift.Bool>
@@ -5120,14 +5097,14 @@ struct _hoverEffectModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(tvOS) || os(visionOS)
-    @available(tvOS 16.0,iOS 13.4,visionOS 1.0, *)
+    @available(tvOS 16.0,visionOS 1.0,iOS 13.4, *)
     init(_ effect: SwiftUI.HoverEffect = .automatic ) {
         self.value = ._0(effect: effect)
         
     }
     #endif
     #if os(iOS) || os(tvOS) || os(visionOS)
-    @available(iOS 17.0,visionOS 1.0,tvOS 17.0, *)
+    @available(tvOS 17.0,visionOS 1.0,iOS 17.0, *)
     init(_ effect: SwiftUI.HoverEffect = .automatic, isEnabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._1(effect: effect, isEnabled: isEnabled)
         
@@ -5140,7 +5117,7 @@ struct _hoverEffectModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(tvOS) || os(visionOS)
         case let ._0(effect):
-            if #available(tvOS 16.0,iOS 13.4,visionOS 1.0, *) {
+            if #available(tvOS 16.0,visionOS 1.0,iOS 13.4, *) {
             let effect = effect as! SwiftUI.HoverEffect 
             
             __content
@@ -5151,7 +5128,7 @@ struct _hoverEffectModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(tvOS) || os(visionOS)
         case let ._1(effect, isEnabled):
-            if #available(iOS 17.0,visionOS 1.0,tvOS 17.0, *) {
+            if #available(tvOS 17.0,visionOS 1.0,iOS 17.0, *) {
             let effect = effect as! SwiftUI.HoverEffect 
 let isEnabled = isEnabled as! AttributeReference<Swift.Bool>
             
@@ -5186,7 +5163,7 @@ struct _hoverEffectDisabledModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(tvOS) || os(visionOS)
-    @available(iOS 17.0,visionOS 1.0,tvOS 17.0, *)
+    @available(tvOS 17.0,visionOS 1.0,iOS 17.0, *)
     init(_ disabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(disabled: disabled)
         
@@ -5199,7 +5176,7 @@ struct _hoverEffectDisabledModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(tvOS) || os(visionOS)
         case let ._0(disabled):
-            if #available(iOS 17.0,visionOS 1.0,tvOS 17.0, *) {
+            if #available(tvOS 17.0,visionOS 1.0,iOS 17.0, *) {
             let disabled = disabled as! AttributeReference<Swift.Bool>
             
             __content
@@ -5563,7 +5540,7 @@ struct _inspectorModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS)
-    @available(iOS 17.0,macOS 14.0, *)
+    @available(macOS 14.0,iOS 17.0, *)
     init(isPresented: ChangeTracked<Swift.Bool>,content: ViewReference=ViewReference(value: [])) {
         self.value = ._0(content: content)
         self.__0_isPresented = isPresented
@@ -5576,7 +5553,7 @@ struct _inspectorModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS)
         case let ._0(content):
-            if #available(iOS 17.0,macOS 14.0, *) {
+            if #available(macOS 14.0,iOS 17.0, *) {
             let content = content as! ViewReference
             
             __content
@@ -5615,14 +5592,14 @@ struct _inspectorColumnWidthModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS)
-    @available(iOS 17.0,macOS 14.0, *)
+    @available(macOS 14.0,iOS 17.0, *)
     init(min: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), ideal: AttributeReference<CoreFoundation.CGFloat>,max: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)) ) {
         self.value = ._0(min: min, ideal: ideal, max: max)
         
     }
     #endif
     #if os(iOS) || os(macOS)
-    @available(iOS 17.0,macOS 14.0, *)
+    @available(macOS 14.0,iOS 17.0, *)
     init(_ width: AttributeReference<CoreFoundation.CGFloat>) {
         self.value = ._1(width: width)
         
@@ -5635,7 +5612,7 @@ struct _inspectorColumnWidthModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS)
         case let ._0(min, ideal, max):
-            if #available(iOS 17.0,macOS 14.0, *) {
+            if #available(macOS 14.0,iOS 17.0, *) {
             let min = min as? AttributeReference<CoreFoundation.CGFloat?>
 let ideal = ideal as! AttributeReference<CoreFoundation.CGFloat>
 let max = max as? AttributeReference<CoreFoundation.CGFloat?>
@@ -5648,7 +5625,7 @@ let max = max as? AttributeReference<CoreFoundation.CGFloat?>
         #endif
         #if os(iOS) || os(macOS)
         case let ._1(width):
-            if #available(iOS 17.0,macOS 14.0, *) {
+            if #available(macOS 14.0,iOS 17.0, *) {
             let width = width as! AttributeReference<CoreFoundation.CGFloat>
             
             __content
@@ -5776,7 +5753,7 @@ struct _invalidatableContentModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 14.0,iOS 17.0,tvOS 17.0,visionOS 1.0,watchOS 10.0, *)
+    @available(tvOS 17.0,macOS 14.0,iOS 17.0,watchOS 10.0,visionOS 1.0, *)
     init(_ invalidatable: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(invalidatable: invalidatable)
         
@@ -5789,7 +5766,7 @@ struct _invalidatableContentModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(invalidatable):
-            if #available(macOS 14.0,iOS 17.0,tvOS 17.0,visionOS 1.0,watchOS 10.0, *) {
+            if #available(tvOS 17.0,macOS 14.0,iOS 17.0,watchOS 10.0,visionOS 1.0, *) {
             let invalidatable = invalidatable as! AttributeReference<Swift.Bool>
             
             __content
@@ -5838,28 +5815,28 @@ struct _keyboardShortcutModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(visionOS 1.0,iOS 14.0,macOS 11.0, *)
+    @available(macOS 11.0,visionOS 1.0,iOS 14.0, *)
     init(_ key: SwiftUI.KeyEquivalent,modifiers: SwiftUICore.EventModifiers = .command ) {
         self.value = ._0(key: key, modifiers: modifiers)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(visionOS 1.0,iOS 14.0,macOS 11.0, *)
+    @available(macOS 11.0,visionOS 1.0,iOS 14.0, *)
     init(_ shortcut: SwiftUI.KeyboardShortcut) {
         self.value = ._1(shortcut: shortcut)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(visionOS 1.0,iOS 15.4,macOS 12.3, *)
+    @available(macOS 12.3,visionOS 1.0,iOS 15.4, *)
     init(_ shortcut: SwiftUI.KeyboardShortcut?) {
         self.value = ._2(shortcut: shortcut)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(visionOS 1.0,iOS 15.0,macOS 12.0, *)
+    @available(macOS 12.0,visionOS 1.0,iOS 15.0, *)
     init(_ key: SwiftUI.KeyEquivalent,modifiers: SwiftUICore.EventModifiers = .command, localization: SwiftUI.KeyboardShortcut.Localization) {
         self.value = ._3(key: key, modifiers: modifiers, localization: localization)
         
@@ -5872,7 +5849,7 @@ struct _keyboardShortcutModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(key, modifiers):
-            if #available(visionOS 1.0,iOS 14.0,macOS 11.0, *) {
+            if #available(macOS 11.0,visionOS 1.0,iOS 14.0, *) {
             let key = key as! SwiftUI.KeyEquivalent
 let modifiers = modifiers as! SwiftUICore.EventModifiers 
             
@@ -5884,7 +5861,7 @@ let modifiers = modifiers as! SwiftUICore.EventModifiers
         #endif
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._1(shortcut):
-            if #available(visionOS 1.0,iOS 14.0,macOS 11.0, *) {
+            if #available(macOS 11.0,visionOS 1.0,iOS 14.0, *) {
             let shortcut = shortcut as! SwiftUI.KeyboardShortcut
             
             __content
@@ -5895,7 +5872,7 @@ let modifiers = modifiers as! SwiftUICore.EventModifiers
         #endif
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._2(shortcut):
-            if #available(visionOS 1.0,iOS 15.4,macOS 12.3, *) {
+            if #available(macOS 12.3,visionOS 1.0,iOS 15.4, *) {
             let shortcut = shortcut as? SwiftUI.KeyboardShortcut
             
             __content
@@ -5906,7 +5883,7 @@ let modifiers = modifiers as! SwiftUICore.EventModifiers
         #endif
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._3(key, modifiers, localization):
-            if #available(visionOS 1.0,iOS 15.0,macOS 12.0, *) {
+            if #available(macOS 12.0,visionOS 1.0,iOS 15.0, *) {
             let key = key as! SwiftUI.KeyEquivalent
 let modifiers = modifiers as! SwiftUICore.EventModifiers 
 let localization = localization as! SwiftUI.KeyboardShortcut.Localization
@@ -6130,7 +6107,7 @@ struct _labelsVisibilityModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 15.0,iOS 18.0,tvOS 18.0,watchOS 11.0,visionOS 2.0, *)
+    @available(tvOS 18.0,iOS 18.0,macOS 15.0,watchOS 11.0,visionOS 2.0, *)
     init(_ visibility: AttributeReference<SwiftUI.Visibility>) {
         self.value = ._0(visibility: visibility)
         
@@ -6143,7 +6120,7 @@ struct _labelsVisibilityModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(visibility):
-            if #available(macOS 15.0,iOS 18.0,tvOS 18.0,watchOS 11.0,visionOS 2.0, *) {
+            if #available(tvOS 18.0,iOS 18.0,macOS 15.0,watchOS 11.0,visionOS 2.0, *) {
             let visibility = visibility as! AttributeReference<SwiftUI.Visibility>
             
             __content
@@ -6668,7 +6645,7 @@ struct _listRowSeparatorModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(iOS 15.0,macOS 13.0,visionOS 1.0, *)
+    @available(visionOS 1.0,macOS 13.0,iOS 15.0, *)
     init(_ visibility: AttributeReference<SwiftUI.Visibility>,edges: SwiftUICore.VerticalEdge.Set = .all ) {
         self.value = ._0(visibility: visibility, edges: edges)
         
@@ -6681,7 +6658,7 @@ struct _listRowSeparatorModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(visibility, edges):
-            if #available(iOS 15.0,macOS 13.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,macOS 13.0,iOS 15.0, *) {
             let visibility = visibility as! AttributeReference<SwiftUI.Visibility>
 let edges = edges as! SwiftUICore.VerticalEdge.Set 
             
@@ -6716,7 +6693,7 @@ struct _listRowSeparatorTintModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(iOS 15.0,macOS 13.0,visionOS 1.0, *)
+    @available(visionOS 1.0,macOS 13.0,iOS 15.0, *)
     init(_ color: Color.Resolvable?,edges: SwiftUICore.VerticalEdge.Set = .all ) {
         self.value = ._0(color: color, edges: edges)
         
@@ -6729,7 +6706,7 @@ struct _listRowSeparatorTintModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(color, edges):
-            if #available(iOS 15.0,macOS 13.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,macOS 13.0,iOS 15.0, *) {
             let color = color as? Color.Resolvable
 let edges = edges as! SwiftUICore.VerticalEdge.Set 
             
@@ -6764,7 +6741,7 @@ struct _listRowSpacingModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(visionOS)
-    @available(iOS 15.0,visionOS 1.0, *)
+    @available(visionOS 1.0,iOS 15.0, *)
     init(_ spacing: AttributeReference<CoreFoundation.CGFloat?>?) {
         self.value = ._0(spacing: spacing)
         
@@ -6777,7 +6754,7 @@ struct _listRowSpacingModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(visionOS)
         case let ._0(spacing):
-            if #available(iOS 15.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,iOS 15.0, *) {
             let spacing = spacing as? AttributeReference<CoreFoundation.CGFloat?>
             
             __content
@@ -6811,7 +6788,7 @@ struct _listSectionSeparatorModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(iOS 15.0,macOS 13.0,visionOS 1.0, *)
+    @available(macOS 13.0,visionOS 1.0,iOS 15.0, *)
     init(_ visibility: AttributeReference<SwiftUI.Visibility>,edges: SwiftUICore.VerticalEdge.Set = .all ) {
         self.value = ._0(visibility: visibility, edges: edges)
         
@@ -6824,7 +6801,7 @@ struct _listSectionSeparatorModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(visibility, edges):
-            if #available(iOS 15.0,macOS 13.0,visionOS 1.0, *) {
+            if #available(macOS 13.0,visionOS 1.0,iOS 15.0, *) {
             let visibility = visibility as! AttributeReference<SwiftUI.Visibility>
 let edges = edges as! SwiftUICore.VerticalEdge.Set 
             
@@ -6859,7 +6836,7 @@ struct _listSectionSeparatorTintModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(iOS 15.0,macOS 13.0,visionOS 1.0, *)
+    @available(macOS 13.0,visionOS 1.0,iOS 15.0, *)
     init(_ color: Color.Resolvable?,edges: SwiftUICore.VerticalEdge.Set = .all ) {
         self.value = ._0(color: color, edges: edges)
         
@@ -6872,7 +6849,7 @@ struct _listSectionSeparatorTintModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(color, edges):
-            if #available(iOS 15.0,macOS 13.0,visionOS 1.0, *) {
+            if #available(macOS 13.0,visionOS 1.0,iOS 15.0, *) {
             let color = color as? Color.Resolvable
 let edges = edges as! SwiftUICore.VerticalEdge.Set 
             
@@ -6912,14 +6889,14 @@ struct _listSectionSpacingModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(visionOS) || os(watchOS)
-    @available(iOS 17.0,watchOS 10.0,visionOS 1.0, *)
+    @available(watchOS 10.0,visionOS 1.0,iOS 17.0, *)
     init(_ spacing: SwiftUI.ListSectionSpacing) {
         self.value = ._0(spacing: spacing)
         
     }
     #endif
     #if os(iOS) || os(visionOS) || os(watchOS)
-    @available(iOS 17.0,watchOS 10.0,visionOS 1.0, *)
+    @available(watchOS 10.0,visionOS 1.0,iOS 17.0, *)
     init(_ spacing: AttributeReference<CoreFoundation.CGFloat>) {
         self.value = ._1(spacing: spacing)
         
@@ -6932,7 +6909,7 @@ struct _listSectionSpacingModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(visionOS) || os(watchOS)
         case let ._0(spacing):
-            if #available(iOS 17.0,watchOS 10.0,visionOS 1.0, *) {
+            if #available(watchOS 10.0,visionOS 1.0,iOS 17.0, *) {
             let spacing = spacing as! SwiftUI.ListSectionSpacing
             
             __content
@@ -6943,7 +6920,7 @@ struct _listSectionSpacingModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(visionOS) || os(watchOS)
         case let ._1(spacing):
-            if #available(iOS 17.0,watchOS 10.0,visionOS 1.0, *) {
+            if #available(watchOS 10.0,visionOS 1.0,iOS 17.0, *) {
             let spacing = spacing as! AttributeReference<CoreFoundation.CGFloat>
             
             __content
@@ -7071,7 +7048,7 @@ struct _materialActiveAppearanceModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 15.0,tvOS 18.0,iOS 18.0,visionOS 2.0,watchOS 11.0, *)
+    @available(tvOS 18.0,iOS 18.0,macOS 15.0,watchOS 11.0,visionOS 2.0, *)
     init(_ appearance: SwiftUICore.MaterialActiveAppearance) {
         self.value = ._0(appearance: appearance)
         
@@ -7084,7 +7061,7 @@ struct _materialActiveAppearanceModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(appearance):
-            if #available(macOS 15.0,tvOS 18.0,iOS 18.0,visionOS 2.0,watchOS 11.0, *) {
+            if #available(tvOS 18.0,iOS 18.0,macOS 15.0,watchOS 11.0,visionOS 2.0, *) {
             let appearance = appearance as! SwiftUICore.MaterialActiveAppearance
             
             __content
@@ -7118,7 +7095,7 @@ struct _menuIndicatorModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS)
-    @available(tvOS 17.0,visionOS 1.0,iOS 15.0,macOS 12.0, *)
+    @available(macOS 12.0,visionOS 1.0,tvOS 17.0,iOS 15.0, *)
     init(_ visibility: AttributeReference<SwiftUI.Visibility>) {
         self.value = ._0(visibility: visibility)
         
@@ -7131,7 +7108,7 @@ struct _menuIndicatorModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS)
         case let ._0(visibility):
-            if #available(tvOS 17.0,visionOS 1.0,iOS 15.0,macOS 12.0, *) {
+            if #available(macOS 12.0,visionOS 1.0,tvOS 17.0,iOS 15.0, *) {
             let visibility = visibility as! AttributeReference<SwiftUI.Visibility>
             
             __content
@@ -7212,7 +7189,7 @@ struct _menuStyleModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS)
-    @available(macOS 11.0,visionOS 1.0,iOS 14.0,tvOS 17.0, *)
+    @available(macOS 11.0,iOS 14.0,tvOS 17.0,visionOS 1.0, *)
     init(_ style: AnyMenuStyle) {
         self.value = ._0(style: style)
         
@@ -7225,7 +7202,7 @@ struct _menuStyleModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS)
         case let ._0(style):
-            if #available(macOS 11.0,visionOS 1.0,iOS 14.0,tvOS 17.0, *) {
+            if #available(macOS 11.0,iOS 14.0,tvOS 17.0,visionOS 1.0, *) {
             let style = style as! AnyMenuStyle
             
             __content
@@ -7306,7 +7283,7 @@ struct _modifierKeyAlternateModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(macOS) || os(visionOS)
-    @available(visionOS 1.0,macOS 15.0, *)
+    @available(macOS 15.0,visionOS 1.0, *)
     init(_ modifiers: SwiftUICore.EventModifiers,_ alternate: ViewReference=ViewReference(value: [])) {
         self.value = ._0(modifiers: modifiers, alternate: alternate)
         
@@ -7319,7 +7296,7 @@ struct _modifierKeyAlternateModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(macOS) || os(visionOS)
         case let ._0(modifiers, alternate):
-            if #available(visionOS 1.0,macOS 15.0, *) {
+            if #available(macOS 15.0,visionOS 1.0, *) {
             let modifiers = modifiers as! SwiftUICore.EventModifiers
 let alternate = alternate as! ViewReference
             
@@ -7495,7 +7472,7 @@ struct _navigationBarTitleDisplayModeModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 8.0,iOS 14.0,visionOS 1.0, *)
+    @available(visionOS 1.0,watchOS 8.0,iOS 14.0, *)
     init(_ displayMode: SwiftUI.NavigationBarItem.TitleDisplayMode) {
         self.value = ._0(displayMode: displayMode)
         
@@ -7508,7 +7485,7 @@ struct _navigationBarTitleDisplayModeModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(visionOS) || os(watchOS)
         case let ._0(displayMode):
-            if #available(watchOS 8.0,iOS 14.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,watchOS 8.0,iOS 14.0, *) {
             let displayMode = displayMode as! SwiftUI.NavigationBarItem.TitleDisplayMode
             
             __content
@@ -7716,21 +7693,21 @@ struct _navigationSubtitleModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(macOS) || targetEnvironment(macCatalyst)
-    @available(macOS 11.0,macCatalyst 14.0, *)
+    @available(macCatalyst 14.0,macOS 11.0, *)
     init(_ subtitle: TextReference) {
         self.value = ._0(subtitle: subtitle)
         
     }
     #endif
     #if os(macOS) || targetEnvironment(macCatalyst)
-    @available(macOS 11.0,macCatalyst 14.0, *)
+    @available(macCatalyst 14.0,macOS 11.0, *)
     init(_ subtitleKey: SwiftUICore.LocalizedStringKey) {
         self.value = ._1(subtitleKey: subtitleKey)
         
     }
     #endif
     #if os(macOS) || targetEnvironment(macCatalyst)
-    @available(macOS 11.0,macCatalyst 14.0, *)
+    @available(macCatalyst 14.0,macOS 11.0, *)
     init(_ subtitle: AttributeReference<String>) {
         self.value = ._2(subtitle: subtitle)
         
@@ -7743,7 +7720,7 @@ struct _navigationSubtitleModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(macOS) || targetEnvironment(macCatalyst)
         case let ._0(subtitle):
-            if #available(macOS 11.0,macCatalyst 14.0, *) {
+            if #available(macCatalyst 14.0,macOS 11.0, *) {
             let subtitle = subtitle as! TextReference
             __content._observeTextReference(subtitle, on: element, in: context) { __content in
             __content
@@ -7754,7 +7731,7 @@ struct _navigationSubtitleModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(macOS) || targetEnvironment(macCatalyst)
         case let ._1(subtitleKey):
-            if #available(macOS 11.0,macCatalyst 14.0, *) {
+            if #available(macCatalyst 14.0,macOS 11.0, *) {
             let subtitleKey = subtitleKey as! SwiftUICore.LocalizedStringKey
             
             __content
@@ -7765,7 +7742,7 @@ struct _navigationSubtitleModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(macOS) || targetEnvironment(macCatalyst)
         case let ._2(subtitle):
-            if #available(macOS 11.0,macCatalyst 14.0, *) {
+            if #available(macCatalyst 14.0,macOS 11.0, *) {
             let subtitle = subtitle as! AttributeReference<String>
             
             __content
@@ -7840,7 +7817,7 @@ struct _navigationTitleModifier<R: RootRegistry>: ViewModifier {
     }
     
     #if os(watchOS)
-    @available(tvOS 14.0,macOS 11.0,iOS 14.0,watchOS 7.0, *)
+    @available(macOS 11.0,tvOS 14.0,watchOS 7.0,iOS 14.0, *)
     init(_ title: ViewReference=ViewReference(value: [])) {
         self.value = ._3(title: title)
         
@@ -7893,7 +7870,7 @@ struct _navigationTitleModifier<R: RootRegistry>: ViewModifier {
         
         #if os(watchOS)
         case let ._3(title):
-            if #available(tvOS 14.0,macOS 11.0,iOS 14.0,watchOS 7.0, *) {
+            if #available(macOS 11.0,tvOS 14.0,watchOS 7.0,iOS 14.0, *) {
             let title = title as! ViewReference
             
             __content
@@ -8219,7 +8196,7 @@ struct _onHoverModifier<R: RootRegistry>: ViewModifier {
 @Event private var _0_action__1: Event.EventHandler
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(visionOS 1.0,iOS 13.4,macOS 10.15, *)
+    @available(visionOS 1.0,macOS 10.15,iOS 13.4, *)
     init(perform action__1: Event) {
         self.value = ._0
         self.__0_action__1 = action__1
@@ -8232,7 +8209,7 @@ struct _onHoverModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case ._0:
-            if #available(visionOS 1.0,iOS 13.4,macOS 10.15, *) {
+            if #available(visionOS 1.0,macOS 10.15,iOS 13.4, *) {
             
             
             __content
@@ -8320,7 +8297,7 @@ struct _onLongPressGestureModifier<R: RootRegistry>: ViewModifier {
 @Event private var _1_onPressingChanged__1: Event.EventHandler
 
     #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 6.0,iOS 13.0,tvOS 14.0,visionOS 1.0,macOS 10.15, *)
+    @available(macOS 10.15,visionOS 1.0,tvOS 14.0,watchOS 6.0,iOS 13.0, *)
     init(minimumDuration: AttributeReference<Swift.Double> = .init(storage: .constant(0.5)), maximumDistance: AttributeReference<CoreFoundation.CGFloat> = .init(storage: .constant(10)), perform action__0: Event,onPressingChanged onPressingChanged__1: Event=Event() ) {
         self.value = ._0(minimumDuration: minimumDuration, maximumDistance: maximumDistance)
         self.__0_action__0 = action__0
@@ -8328,7 +8305,7 @@ self.__0_onPressingChanged__1 = onPressingChanged__1
     }
     #endif
     #if os(tvOS)
-    @available(watchOS 6.0,iOS 13.0,tvOS 14.0,macOS 10.15, *)
+    @available(watchOS 6.0,tvOS 14.0,macOS 10.15,iOS 13.0, *)
     init(minimumDuration: AttributeReference<Swift.Double> = .init(storage: .constant(0.5)), perform action__0: Event,onPressingChanged onPressingChanged__1: Event=Event() ) {
         self.value = ._1(minimumDuration: minimumDuration)
         self.__1_action__0 = action__0
@@ -8342,7 +8319,7 @@ self.__1_onPressingChanged__1 = onPressingChanged__1
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
         case let ._0(minimumDuration, maximumDistance):
-            if #available(watchOS 6.0,iOS 13.0,tvOS 14.0,visionOS 1.0,macOS 10.15, *) {
+            if #available(macOS 10.15,visionOS 1.0,tvOS 14.0,watchOS 6.0,iOS 13.0, *) {
             let minimumDuration = minimumDuration as! AttributeReference<Swift.Double>
 let maximumDistance = maximumDistance as! AttributeReference<CoreFoundation.CGFloat>
             
@@ -8354,7 +8331,7 @@ let maximumDistance = maximumDistance as! AttributeReference<CoreFoundation.CGFl
         #endif
         #if os(tvOS)
         case let ._1(minimumDuration):
-            if #available(watchOS 6.0,iOS 13.0,tvOS 14.0,macOS 10.15, *) {
+            if #available(watchOS 6.0,tvOS 14.0,macOS 10.15,iOS 13.0, *) {
             let minimumDuration = minimumDuration as! AttributeReference<Swift.Double>
             
             __content
@@ -8532,7 +8509,7 @@ struct _onPencilDoubleTapModifier<R: RootRegistry>: ViewModifier {
 @Event private var _0_action__1: Event.EventHandler
 
     #if os(iOS) || os(macOS)
-    @available(iOS 17.5,macOS 14.5, *)
+    @available(macOS 14.5,iOS 17.5, *)
     init(perform action__1: Event) {
         self.value = ._0
         self.__0_action__1 = action__1
@@ -8545,7 +8522,7 @@ struct _onPencilDoubleTapModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS)
         case ._0:
-            if #available(iOS 17.5,macOS 14.5, *) {
+            if #available(macOS 14.5,iOS 17.5, *) {
             
             
             __content
@@ -8579,7 +8556,7 @@ struct _onPencilSqueezeModifier<R: RootRegistry>: ViewModifier {
 @Event private var _0_action__1: Event.EventHandler
 
     #if os(iOS) || os(macOS)
-    @available(iOS 17.5,macOS 14.5, *)
+    @available(macOS 14.5,iOS 17.5, *)
     init(perform action__1: Event) {
         self.value = ._0
         self.__0_action__1 = action__1
@@ -8592,7 +8569,7 @@ struct _onPencilSqueezeModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS)
         case ._0:
-            if #available(iOS 17.5,macOS 14.5, *) {
+            if #available(macOS 14.5,iOS 17.5, *) {
             
             
             __content
@@ -8673,7 +8650,7 @@ struct _onScrollPhaseChangeModifier<R: RootRegistry>: ViewModifier {
 @Event private var _0_action__2: Event.EventHandler
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 2.0,tvOS 18.0,iOS 18.0,macOS 15.0,watchOS 11.0, *)
+    @available(watchOS 11.0,tvOS 18.0,macOS 15.0,iOS 18.0,visionOS 2.0, *)
     init(_ action__2: Event) {
         self.value = ._0
         self.__0_action__2 = action__2
@@ -8686,7 +8663,7 @@ struct _onScrollPhaseChangeModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case ._0:
-            if #available(visionOS 2.0,tvOS 18.0,iOS 18.0,macOS 15.0,watchOS 11.0, *) {
+            if #available(watchOS 11.0,tvOS 18.0,macOS 15.0,iOS 18.0,visionOS 2.0, *) {
             
             
             __content
@@ -8720,7 +8697,7 @@ struct _onScrollVisibilityChangeModifier<R: RootRegistry>: ViewModifier {
 @Event private var _0_action__1: Event.EventHandler
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(iOS 18.0,tvOS 18.0,visionOS 2.0,watchOS 11.0,macOS 15.0, *)
+    @available(watchOS 11.0,tvOS 18.0,macOS 15.0,iOS 18.0,visionOS 2.0, *)
     init(threshold: AttributeReference<Swift.Double> = .init(storage: .constant(0.5)), action action__1: Event) {
         self.value = ._0(threshold: threshold)
         self.__0_action__1 = action__1
@@ -8733,7 +8710,7 @@ struct _onScrollVisibilityChangeModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(threshold):
-            if #available(iOS 18.0,tvOS 18.0,visionOS 2.0,watchOS 11.0,macOS 15.0, *) {
+            if #available(watchOS 11.0,tvOS 18.0,macOS 15.0,iOS 18.0,visionOS 2.0, *) {
             let threshold = threshold as! AttributeReference<Swift.Double>
             
             __content
@@ -8772,7 +8749,7 @@ struct _onTapGestureModifier<R: RootRegistry>: ViewModifier {
 @Event private var _1_action__0: Event.EventHandler
 
     #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
-    @available(iOS 17.0,macOS 14.0,watchOS 10.0,visionOS 1.0, *)
+    @available(macOS 14.0,watchOS 10.0,visionOS 1.0,iOS 17.0, *)
     init(count: AttributeReference<Swift.Int> = .init(storage: .constant(1)), coordinateSpace: AnyCoordinateSpaceProtocol = .local, perform action__1: Event) {
         self.value = ._0(count: count, coordinateSpace: coordinateSpace)
         self.__0_action__1 = action__1
@@ -8792,7 +8769,7 @@ struct _onTapGestureModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
         case let ._0(count, coordinateSpace):
-            if #available(iOS 17.0,macOS 14.0,watchOS 10.0,visionOS 1.0, *) {
+            if #available(macOS 14.0,watchOS 10.0,visionOS 1.0,iOS 17.0, *) {
             let count = count as! AttributeReference<Swift.Int>
 let coordinateSpace = coordinateSpace as! AnyCoordinateSpaceProtocol 
             
@@ -9456,14 +9433,14 @@ struct _popoverModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(visionOS 1.0,iOS 13.0,macOS 10.15, *)
+    @available(macOS 10.15,visionOS 1.0,iOS 13.0, *)
     init(isPresented: ChangeTracked<Swift.Bool>,attachmentAnchor: SwiftUI.PopoverAttachmentAnchor = .rect(.bounds), arrowEdge: SwiftUICore.Edge = .top, content: ViewReference=ViewReference(value: [])) {
         self.value = ._0(attachmentAnchor: attachmentAnchor, arrowEdge: arrowEdge, content: content)
         self.__0_isPresented = isPresented
     }
     #endif
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(visionOS 2.0,iOS 18.0,macOS 15.0, *)
+    @available(visionOS 2.0,macOS 15.0,iOS 18.0, *)
     init(isPresented: ChangeTracked<Swift.Bool>,attachmentAnchor: SwiftUI.PopoverAttachmentAnchor = .rect(.bounds), content: ViewReference=ViewReference(value: [])) {
         self.value = ._1(attachmentAnchor: attachmentAnchor, content: content)
         self.__1_isPresented = isPresented
@@ -9476,7 +9453,7 @@ struct _popoverModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(attachmentAnchor, arrowEdge, content):
-            if #available(visionOS 1.0,iOS 13.0,macOS 10.15, *) {
+            if #available(macOS 10.15,visionOS 1.0,iOS 13.0, *) {
             let attachmentAnchor = attachmentAnchor as! SwiftUI.PopoverAttachmentAnchor 
 let arrowEdge = arrowEdge as! SwiftUICore.Edge 
 let content = content as! ViewReference
@@ -9489,7 +9466,7 @@ let content = content as! ViewReference
         #endif
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._1(attachmentAnchor, content):
-            if #available(visionOS 2.0,iOS 18.0,macOS 15.0, *) {
+            if #available(visionOS 2.0,macOS 15.0,iOS 18.0, *) {
             let attachmentAnchor = attachmentAnchor as! SwiftUI.PopoverAttachmentAnchor 
 let content = content as! ViewReference
             
@@ -9693,14 +9670,14 @@ struct _presentationBackgroundModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 9.4,tvOS 16.4,iOS 16.4,visionOS 1.0,macOS 13.3, *)
+    @available(watchOS 9.4,iOS 16.4,visionOS 1.0,macOS 13.3,tvOS 16.4, *)
     init(_ style: AnyShapeStyle.Resolvable) {
         self.value = ._0(style: style)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 9.4,tvOS 16.4,iOS 16.4,visionOS 1.0,macOS 13.3, *)
+    @available(macOS 13.3,iOS 16.4,watchOS 9.4,tvOS 16.4,visionOS 1.0, *)
     init(alignment: AttributeReference<SwiftUICore.Alignment> = .init(storage: .constant(.center)), content: ViewReference=ViewReference(value: [])) {
         self.value = ._1(alignment: alignment, content: content)
         
@@ -9713,7 +9690,7 @@ struct _presentationBackgroundModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(style):
-            if #available(watchOS 9.4,tvOS 16.4,iOS 16.4,visionOS 1.0,macOS 13.3, *) {
+            if #available(watchOS 9.4,iOS 16.4,visionOS 1.0,macOS 13.3,tvOS 16.4, *) {
             let style = style as! AnyShapeStyle.Resolvable
             
             __content
@@ -9724,7 +9701,7 @@ struct _presentationBackgroundModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(alignment, content):
-            if #available(watchOS 9.4,tvOS 16.4,iOS 16.4,visionOS 1.0,macOS 13.3, *) {
+            if #available(macOS 13.3,iOS 16.4,watchOS 9.4,tvOS 16.4,visionOS 1.0, *) {
             let alignment = alignment as! AttributeReference<SwiftUICore.Alignment>
 let content = content as! ViewReference
             
@@ -9759,7 +9736,7 @@ struct _presentationBackgroundInteractionModifier<R: RootRegistry>: ViewModifier
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(iOS 16.4,visionOS 1.0,macOS 13.3,tvOS 16.4,watchOS 9.4, *)
+    @available(macOS 13.3,iOS 16.4,watchOS 9.4,tvOS 16.4,visionOS 1.0, *)
     init(_ interaction: SwiftUI.PresentationBackgroundInteraction) {
         self.value = ._0(interaction: interaction)
         
@@ -9772,7 +9749,7 @@ struct _presentationBackgroundInteractionModifier<R: RootRegistry>: ViewModifier
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(interaction):
-            if #available(iOS 16.4,visionOS 1.0,macOS 13.3,tvOS 16.4,watchOS 9.4, *) {
+            if #available(macOS 13.3,iOS 16.4,watchOS 9.4,tvOS 16.4,visionOS 1.0, *) {
             let interaction = interaction as! SwiftUI.PresentationBackgroundInteraction
             
             __content
@@ -9811,14 +9788,14 @@ struct _presentationCompactAdaptationModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(iOS 16.4,visionOS 1.0,macOS 13.3,tvOS 16.4,watchOS 9.4, *)
+    @available(macOS 13.3,visionOS 1.0,tvOS 16.4,iOS 16.4,watchOS 9.4, *)
     init(_ adaptation: SwiftUI.PresentationAdaptation) {
         self.value = ._0(adaptation: adaptation)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(iOS 16.4,visionOS 1.0,macOS 13.3,tvOS 16.4,watchOS 9.4, *)
+    @available(macOS 13.3,visionOS 1.0,tvOS 16.4,iOS 16.4,watchOS 9.4, *)
     init(horizontal horizontalAdaptation: SwiftUI.PresentationAdaptation,vertical verticalAdaptation: SwiftUI.PresentationAdaptation) {
         self.value = ._1(horizontalAdaptation: horizontalAdaptation, verticalAdaptation: verticalAdaptation)
         
@@ -9831,7 +9808,7 @@ struct _presentationCompactAdaptationModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(adaptation):
-            if #available(iOS 16.4,visionOS 1.0,macOS 13.3,tvOS 16.4,watchOS 9.4, *) {
+            if #available(macOS 13.3,visionOS 1.0,tvOS 16.4,iOS 16.4,watchOS 9.4, *) {
             let adaptation = adaptation as! SwiftUI.PresentationAdaptation
             
             __content
@@ -9842,7 +9819,7 @@ struct _presentationCompactAdaptationModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(horizontalAdaptation, verticalAdaptation):
-            if #available(iOS 16.4,visionOS 1.0,macOS 13.3,tvOS 16.4,watchOS 9.4, *) {
+            if #available(macOS 13.3,visionOS 1.0,tvOS 16.4,iOS 16.4,watchOS 9.4, *) {
             let horizontalAdaptation = horizontalAdaptation as! SwiftUI.PresentationAdaptation
 let verticalAdaptation = verticalAdaptation as! SwiftUI.PresentationAdaptation
             
@@ -9877,7 +9854,7 @@ struct _presentationContentInteractionModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 9.4,tvOS 16.4,iOS 16.4,visionOS 1.0,macOS 13.3, *)
+    @available(macOS 13.3,visionOS 1.0,tvOS 16.4,watchOS 9.4,iOS 16.4, *)
     init(_ behavior: SwiftUI.PresentationContentInteraction) {
         self.value = ._0(behavior: behavior)
         
@@ -9890,7 +9867,7 @@ struct _presentationContentInteractionModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(behavior):
-            if #available(watchOS 9.4,tvOS 16.4,iOS 16.4,visionOS 1.0,macOS 13.3, *) {
+            if #available(macOS 13.3,visionOS 1.0,tvOS 16.4,watchOS 9.4,iOS 16.4, *) {
             let behavior = behavior as! SwiftUI.PresentationContentInteraction
             
             __content
@@ -9924,7 +9901,7 @@ struct _presentationCornerRadiusModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 13.3,iOS 16.4,tvOS 16.4,visionOS 1.0,watchOS 9.4, *)
+    @available(macOS 13.3,visionOS 1.0,tvOS 16.4,watchOS 9.4,iOS 16.4, *)
     init(_ cornerRadius: AttributeReference<CoreFoundation.CGFloat?>?) {
         self.value = ._0(cornerRadius: cornerRadius)
         
@@ -9937,7 +9914,7 @@ struct _presentationCornerRadiusModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(cornerRadius):
-            if #available(macOS 13.3,iOS 16.4,tvOS 16.4,visionOS 1.0,watchOS 9.4, *) {
+            if #available(macOS 13.3,visionOS 1.0,tvOS 16.4,watchOS 9.4,iOS 16.4, *) {
             let cornerRadius = cornerRadius as? AttributeReference<CoreFoundation.CGFloat?>
             
             __content
@@ -10018,7 +9995,7 @@ struct _presentationSizingModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(tvOS 18.0,macOS 15.0,iOS 18.0,visionOS 2.0,watchOS 11.0, *)
+    @available(macOS 15.0,visionOS 2.0,tvOS 18.0,iOS 18.0,watchOS 11.0, *)
     init(_ sizing: AnyPresentationSizing) {
         self.value = ._0(sizing: sizing)
         
@@ -10031,7 +10008,7 @@ struct _presentationSizingModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(sizing):
-            if #available(tvOS 18.0,macOS 15.0,iOS 18.0,visionOS 2.0,watchOS 11.0, *) {
+            if #available(macOS 15.0,visionOS 2.0,tvOS 18.0,iOS 18.0,watchOS 11.0, *) {
             let sizing = sizing as! AnyPresentationSizing
             
             __content
@@ -10394,7 +10371,7 @@ struct _replaceDisabledModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(visionOS)
-    @available(iOS 16.0,visionOS 1.0, *)
+    @available(visionOS 1.0,iOS 16.0, *)
     init(_ isDisabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(isDisabled: isDisabled)
         
@@ -10407,7 +10384,7 @@ struct _replaceDisabledModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(visionOS)
         case let ._0(isDisabled):
-            if #available(iOS 16.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,iOS 16.0, *) {
             let isDisabled = isDisabled as! AttributeReference<Swift.Bool>
             
             __content
@@ -10568,21 +10545,21 @@ struct _safeAreaPaddingModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 14.0,iOS 17.0,tvOS 17.0,visionOS 1.0,watchOS 10.0, *)
+    @available(macOS 14.0,visionOS 1.0,tvOS 17.0,iOS 17.0,watchOS 10.0, *)
     init(_ insets: SwiftUICore.EdgeInsets) {
         self.value = ._0(insets: insets)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 14.0,iOS 17.0,tvOS 17.0,visionOS 1.0,watchOS 10.0, *)
+    @available(tvOS 17.0,watchOS 10.0,iOS 17.0,visionOS 1.0,macOS 14.0, *)
     init(_ edges: SwiftUICore.Edge.Set = .all, _ length: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)) ) {
         self.value = ._1(edges: edges, length: length)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0,visionOS 1.0, *)
+    @available(tvOS 17.0,watchOS 10.0,iOS 17.0,visionOS 1.0,macOS 14.0, *)
     init(_ length: AttributeReference<CoreFoundation.CGFloat>) {
         self.value = ._2(length: length)
         
@@ -10595,7 +10572,7 @@ struct _safeAreaPaddingModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(insets):
-            if #available(macOS 14.0,iOS 17.0,tvOS 17.0,visionOS 1.0,watchOS 10.0, *) {
+            if #available(macOS 14.0,visionOS 1.0,tvOS 17.0,iOS 17.0,watchOS 10.0, *) {
             let insets = insets as! SwiftUICore.EdgeInsets
             
             __content
@@ -10606,7 +10583,7 @@ struct _safeAreaPaddingModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(edges, length):
-            if #available(macOS 14.0,iOS 17.0,tvOS 17.0,visionOS 1.0,watchOS 10.0, *) {
+            if #available(tvOS 17.0,watchOS 10.0,iOS 17.0,visionOS 1.0,macOS 14.0, *) {
             let edges = edges as! SwiftUICore.Edge.Set 
 let length = length as? AttributeReference<CoreFoundation.CGFloat?>
             
@@ -10618,7 +10595,7 @@ let length = length as? AttributeReference<CoreFoundation.CGFloat?>
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._2(length):
-            if #available(tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0,visionOS 1.0, *) {
+            if #available(tvOS 17.0,watchOS 10.0,iOS 17.0,visionOS 1.0,macOS 14.0, *) {
             let length = length as! AttributeReference<CoreFoundation.CGFloat>
             
             __content
@@ -11030,7 +11007,7 @@ struct _scrollBounceBehaviorModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,tvOS 16.4,iOS 16.4,macOS 13.3,watchOS 9.4, *)
+    @available(watchOS 9.4,tvOS 16.4,macOS 13.3,iOS 16.4,visionOS 1.0, *)
     init(_ behavior: SwiftUI.ScrollBounceBehavior,axes: SwiftUICore.Axis.Set = [.vertical] ) {
         self.value = ._0(behavior: behavior, axes: axes)
         
@@ -11043,7 +11020,7 @@ struct _scrollBounceBehaviorModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(behavior, axes):
-            if #available(visionOS 1.0,tvOS 16.4,iOS 16.4,macOS 13.3,watchOS 9.4, *) {
+            if #available(watchOS 9.4,tvOS 16.4,macOS 13.3,iOS 16.4,visionOS 1.0, *) {
             let behavior = behavior as! SwiftUI.ScrollBounceBehavior
 let axes = axes as! SwiftUICore.Axis.Set 
             
@@ -11078,7 +11055,7 @@ struct _scrollClipDisabledModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(tvOS 17.0,visionOS 1.0,iOS 17.0,watchOS 10.0,macOS 14.0, *)
+    @available(tvOS 17.0,macOS 14.0,iOS 17.0,watchOS 10.0,visionOS 1.0, *)
     init(_ disabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(disabled: disabled)
         
@@ -11091,7 +11068,7 @@ struct _scrollClipDisabledModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(disabled):
-            if #available(tvOS 17.0,visionOS 1.0,iOS 17.0,watchOS 10.0,macOS 14.0, *) {
+            if #available(tvOS 17.0,macOS 14.0,iOS 17.0,watchOS 10.0,visionOS 1.0, *) {
             let disabled = disabled as! AttributeReference<Swift.Bool>
             
             __content
@@ -11125,7 +11102,7 @@ struct _scrollContentBackgroundModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,iOS 16.0,macOS 13.0,watchOS 9.0, *)
+    @available(iOS 16.0,macOS 13.0,watchOS 9.0,visionOS 1.0, *)
     init(_ visibility: AttributeReference<SwiftUI.Visibility>) {
         self.value = ._0(visibility: visibility)
         
@@ -11138,7 +11115,7 @@ struct _scrollContentBackgroundModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
         case let ._0(visibility):
-            if #available(visionOS 1.0,iOS 16.0,macOS 13.0,watchOS 9.0, *) {
+            if #available(iOS 16.0,macOS 13.0,watchOS 9.0,visionOS 1.0, *) {
             let visibility = visibility as! AttributeReference<SwiftUI.Visibility>
             
             __content
@@ -11219,7 +11196,7 @@ struct _scrollDismissesKeyboardModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-    @available(tvOS 16.0,iOS 16.0,watchOS 9.0,macOS 13.0, *)
+    @available(watchOS 9.0,tvOS 16.0,macOS 13.0,iOS 16.0, *)
     init(_ mode: SwiftUI.ScrollDismissesKeyboardMode) {
         self.value = ._0(mode: mode)
         
@@ -11232,7 +11209,7 @@ struct _scrollDismissesKeyboardModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
         case let ._0(mode):
-            if #available(tvOS 16.0,iOS 16.0,watchOS 9.0,macOS 13.0, *) {
+            if #available(watchOS 9.0,tvOS 16.0,macOS 13.0,iOS 16.0, *) {
             let mode = mode as! SwiftUI.ScrollDismissesKeyboardMode
             
             __content
@@ -11318,14 +11295,14 @@ struct _scrollIndicatorsFlashModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(tvOS 17.0,macOS 14.0,iOS 17.0,watchOS 10.0,visionOS 1.0, *)
+    @available(tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0,visionOS 1.0, *)
     init(trigger value: AttributeReference<String>) {
         self.value = ._0(value: value)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(tvOS 17.0,macOS 14.0,iOS 17.0,watchOS 10.0,visionOS 1.0, *)
+    @available(tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0,visionOS 1.0, *)
     init(onAppear: AttributeReference<Swift.Bool>) {
         self.value = ._1(onAppear: onAppear)
         
@@ -11338,7 +11315,7 @@ struct _scrollIndicatorsFlashModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(value):
-            if #available(tvOS 17.0,macOS 14.0,iOS 17.0,watchOS 10.0,visionOS 1.0, *) {
+            if #available(tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0,visionOS 1.0, *) {
             let value = value as! AttributeReference<String>
             
             __content
@@ -11349,59 +11326,11 @@ struct _scrollIndicatorsFlashModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(onAppear):
-            if #available(tvOS 17.0,macOS 14.0,iOS 17.0,watchOS 10.0,visionOS 1.0, *) {
+            if #available(tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0,visionOS 1.0, *) {
             let onAppear = onAppear as! AttributeReference<Swift.Bool>
             
             __content
                 .scrollIndicatorsFlash(onAppear: onAppear.resolve(on: element, in: context))
-            
-                
-            } else { __content }
-        #endif
-        }
-    }
-}
-@_documentation(visibility: public)
-@ParseableExpression
-struct _scrollInputBehaviorModifier<R: RootRegistry>: ViewModifier {
-    static var name: String { "scrollInputBehavior" }
-
-    enum Value {
-        case _never
-        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-        indirect case _0(behavior: Any,input: Any)
-        #endif
-    }
-
-    let value: Value
-
-    
-    
-    
-
-
-
-
-    #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 2.0,tvOS 18.0,iOS 18.0,macOS 15.0,watchOS 11.0, *)
-    init(_ behavior: SwiftUI.ScrollInputBehavior,for input: SwiftUI.ScrollInputKind) {
-        self.value = ._0(behavior: behavior, input: input)
-        
-    }
-    #endif
-
-    func body(content __content: Content) -> some View {
-        switch value {
-        case ._never:
-            fatalError("unreachable")
-        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-        case let ._0(behavior, input):
-            if #available(visionOS 2.0,tvOS 18.0,iOS 18.0,macOS 15.0,watchOS 11.0, *) {
-            let behavior = behavior as! SwiftUI.ScrollInputBehavior
-let input = input as! SwiftUI.ScrollInputKind
-            
-            __content
-                .scrollInputBehavior(behavior, for: input)
             
                 
             } else { __content }
@@ -11431,7 +11360,7 @@ struct _scrollPositionModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(iOS 17.0,visionOS 1.0,macOS 14.0,tvOS 17.0,watchOS 10.0, *)
+    @available(tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0,visionOS 1.0, *)
     init(id: ChangeTracked<String?>,anchor: AttributeReference<SwiftUICore.UnitPoint?>? = .init(storage: .constant(nil)) ) {
         self.value = ._0(anchor: anchor)
         self.__0_id = id
@@ -11444,7 +11373,7 @@ struct _scrollPositionModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(anchor):
-            if #available(iOS 17.0,visionOS 1.0,macOS 14.0,tvOS 17.0,watchOS 10.0, *) {
+            if #available(tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0,visionOS 1.0, *) {
             let anchor = anchor as? AttributeReference<SwiftUICore.UnitPoint?>
             
             __content
@@ -11478,7 +11407,7 @@ struct _scrollTargetBehaviorModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(tvOS 17.0,visionOS 1.0,iOS 17.0,watchOS 10.0,macOS 14.0, *)
+    @available(watchOS 10.0,tvOS 17.0,macOS 14.0,iOS 17.0,visionOS 1.0, *)
     init(_ behavior: AnyScrollTargetBehavior) {
         self.value = ._0(behavior: behavior)
         
@@ -11491,7 +11420,7 @@ struct _scrollTargetBehaviorModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(behavior):
-            if #available(tvOS 17.0,visionOS 1.0,iOS 17.0,watchOS 10.0,macOS 14.0, *) {
+            if #available(watchOS 10.0,tvOS 17.0,macOS 14.0,iOS 17.0,visionOS 1.0, *) {
             let behavior = behavior as! AnyScrollTargetBehavior
             
             __content
@@ -11525,7 +11454,7 @@ struct _scrollTargetLayoutModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 14.0,iOS 17.0,tvOS 17.0,visionOS 1.0,watchOS 10.0, *)
+    @available(macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0,visionOS 1.0, *)
     init(isEnabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(isEnabled: isEnabled)
         
@@ -11538,7 +11467,7 @@ struct _scrollTargetLayoutModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(isEnabled):
-            if #available(macOS 14.0,iOS 17.0,tvOS 17.0,visionOS 1.0,watchOS 10.0, *) {
+            if #available(macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0,visionOS 1.0, *) {
             let isEnabled = isEnabled as! AttributeReference<Swift.Bool>
             
             __content
@@ -11619,7 +11548,7 @@ struct _searchPresentationToolbarBehaviorModifier<R: RootRegistry>: ViewModifier
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 14.1,iOS 17.1,tvOS 17.1,watchOS 10.1,visionOS 1.0, *)
+    @available(watchOS 10.1,iOS 17.1,visionOS 1.0,macOS 14.1,tvOS 17.1, *)
     init(_ behavior: SwiftUI.SearchPresentationToolbarBehavior) {
         self.value = ._0(behavior: behavior)
         
@@ -11632,7 +11561,7 @@ struct _searchPresentationToolbarBehaviorModifier<R: RootRegistry>: ViewModifier
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(behavior):
-            if #available(macOS 14.1,iOS 17.1,tvOS 17.1,watchOS 10.1,visionOS 1.0, *) {
+            if #available(watchOS 10.1,iOS 17.1,visionOS 1.0,macOS 14.1,tvOS 17.1, *) {
             let behavior = behavior as! SwiftUI.SearchPresentationToolbarBehavior
             
             __content
@@ -11907,7 +11836,7 @@ struct _sectionActionsModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(visionOS 2.0,iOS 18.0,macOS 15.0, *)
+    @available(visionOS 2.0,macOS 15.0,iOS 18.0, *)
     init(content: ViewReference=ViewReference(value: [])) {
         self.value = ._0(content: content)
         
@@ -11920,7 +11849,7 @@ struct _sectionActionsModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(content):
-            if #available(visionOS 2.0,iOS 18.0,macOS 15.0, *) {
+            if #available(visionOS 2.0,macOS 15.0,iOS 18.0, *) {
             let content = content as! ViewReference
             
             __content
@@ -11954,7 +11883,7 @@ struct _selectionDisabledModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 10.0,tvOS 17.0,iOS 17.0,visionOS 1.0,macOS 14.0, *)
+    @available(visionOS 1.0,tvOS 17.0,macOS 14.0,iOS 17.0,watchOS 10.0, *)
     init(_ isDisabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(isDisabled: isDisabled)
         
@@ -11967,7 +11896,7 @@ struct _selectionDisabledModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(isDisabled):
-            if #available(watchOS 10.0,tvOS 17.0,iOS 17.0,visionOS 1.0,macOS 14.0, *) {
+            if #available(visionOS 1.0,tvOS 17.0,macOS 14.0,iOS 17.0,watchOS 10.0, *) {
             let isDisabled = isDisabled as! AttributeReference<Swift.Bool>
             
             __content
@@ -12120,7 +12049,7 @@ struct _simultaneousGestureModifier<R: RootRegistry>: ViewModifier {
     }
     
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 11.0,tvOS 18.0,iOS 18.0,visionOS 2.0,macOS 15.0, *)
+    @available(tvOS 18.0,watchOS 11.0,iOS 18.0,macOS 15.0,visionOS 2.0, *)
     init(_ gesture: _AnyGesture,name: AttributeReference<Swift.String>,isEnabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._2(gesture: gesture, name: name, isEnabled: isEnabled)
         
@@ -12155,7 +12084,7 @@ struct _simultaneousGestureModifier<R: RootRegistry>: ViewModifier {
         
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._2(gesture, name, isEnabled):
-            if #available(watchOS 11.0,tvOS 18.0,iOS 18.0,visionOS 2.0,macOS 15.0, *) {
+            if #available(tvOS 18.0,watchOS 11.0,iOS 18.0,macOS 15.0,visionOS 2.0, *) {
             let gesture = gesture as! _AnyGesture
 let name = name as! AttributeReference<Swift.String>
 let isEnabled = isEnabled as! AttributeReference<Swift.Bool>
@@ -12379,7 +12308,7 @@ struct _statusBarHiddenModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(visionOS)
-    @available(iOS 13.0,visionOS 1.0, *)
+    @available(visionOS 1.0,iOS 13.0, *)
     init(_ hidden: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(hidden: hidden)
         
@@ -12392,7 +12321,7 @@ struct _statusBarHiddenModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(visionOS)
         case let ._0(hidden):
-            if #available(iOS 13.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,iOS 13.0, *) {
             let hidden = hidden as! AttributeReference<Swift.Bool>
             
             __content
@@ -12567,7 +12496,7 @@ struct _swipeActionsModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,iOS 15.0,macOS 12.0,watchOS 8.0, *)
+    @available(macOS 12.0,visionOS 1.0,watchOS 8.0,iOS 15.0, *)
     init(edge: SwiftUICore.HorizontalEdge = .trailing, allowsFullSwipe: AttributeReference<Swift.Bool> = .init(storage: .constant(true)), content: ViewReference=ViewReference(value: [])) {
         self.value = ._0(edge: edge, allowsFullSwipe: allowsFullSwipe, content: content)
         
@@ -12580,7 +12509,7 @@ struct _swipeActionsModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
         case let ._0(edge, allowsFullSwipe, content):
-            if #available(visionOS 1.0,iOS 15.0,macOS 12.0,watchOS 8.0, *) {
+            if #available(macOS 12.0,visionOS 1.0,watchOS 8.0,iOS 15.0, *) {
             let edge = edge as! SwiftUICore.HorizontalEdge 
 let allowsFullSwipe = allowsFullSwipe as! AttributeReference<Swift.Bool>
 let content = content as! ViewReference
@@ -12621,14 +12550,14 @@ struct _symbolEffectModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 14.0,iOS 17.0,tvOS 17.0,visionOS 1.0,watchOS 10.0, *)
+    @available(visionOS 1.0,iOS 17.0,macOS 14.0,watchOS 10.0,tvOS 17.0, *)
     init(_ effect: AnyIndefiniteSymbolEffect,options: Symbols.SymbolEffectOptions = .default, isActive: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(effect: effect, options: options, isActive: isActive)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 14.0,iOS 17.0,tvOS 17.0,visionOS 1.0,watchOS 10.0, *)
+    @available(macOS 14.0,watchOS 10.0,visionOS 1.0,tvOS 17.0,iOS 17.0, *)
     init(_ effect: AnyDiscreteSymbolEffect,options: Symbols.SymbolEffectOptions = .default, value: AttributeReference<String>) {
         self.value = ._1(effect: effect, options: options, value: value)
         
@@ -12641,7 +12570,7 @@ struct _symbolEffectModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(effect, options, isActive):
-            if #available(macOS 14.0,iOS 17.0,tvOS 17.0,visionOS 1.0,watchOS 10.0, *) {
+            if #available(visionOS 1.0,iOS 17.0,macOS 14.0,watchOS 10.0,tvOS 17.0, *) {
             let effect = effect as! AnyIndefiniteSymbolEffect
 let options = options as! Symbols.SymbolEffectOptions 
 let isActive = isActive as! AttributeReference<Swift.Bool>
@@ -12654,7 +12583,7 @@ let isActive = isActive as! AttributeReference<Swift.Bool>
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(effect, options, value):
-            if #available(macOS 14.0,iOS 17.0,tvOS 17.0,visionOS 1.0,watchOS 10.0, *) {
+            if #available(macOS 14.0,watchOS 10.0,visionOS 1.0,tvOS 17.0,iOS 17.0, *) {
             let effect = effect as! AnyDiscreteSymbolEffect
 let options = options as! Symbols.SymbolEffectOptions 
 let value = value as! AttributeReference<String>
@@ -12690,7 +12619,7 @@ struct _symbolEffectsRemovedModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 10.0,tvOS 17.0,iOS 17.0,visionOS 1.0,macOS 14.0, *)
+    @available(macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0,visionOS 1.0, *)
     init(_ isEnabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(isEnabled: isEnabled)
         
@@ -12703,7 +12632,7 @@ struct _symbolEffectsRemovedModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(isEnabled):
-            if #available(watchOS 10.0,tvOS 17.0,iOS 17.0,visionOS 1.0,macOS 14.0, *) {
+            if #available(macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0,visionOS 1.0, *) {
             let isEnabled = isEnabled as! AttributeReference<Swift.Bool>
             
             __content
@@ -12831,7 +12760,7 @@ struct _tabViewSidebarBottomBarModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(iOS 18.0,macOS 15.0,visionOS 2.0, *)
+    @available(macOS 15.0,visionOS 2.0,iOS 18.0, *)
     init(content: ViewReference=ViewReference(value: [])) {
         self.value = ._0(content: content)
         
@@ -12844,7 +12773,7 @@ struct _tabViewSidebarBottomBarModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(content):
-            if #available(iOS 18.0,macOS 15.0,visionOS 2.0, *) {
+            if #available(macOS 15.0,visionOS 2.0,iOS 18.0, *) {
             let content = content as! ViewReference
             
             __content
@@ -12878,7 +12807,7 @@ struct _tabViewSidebarFooterModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(iOS 18.0,macOS 15.0,visionOS 2.0, *)
+    @available(macOS 15.0,visionOS 2.0,iOS 18.0, *)
     init(content: ViewReference=ViewReference(value: [])) {
         self.value = ._0(content: content)
         
@@ -12891,7 +12820,7 @@ struct _tabViewSidebarFooterModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(content):
-            if #available(iOS 18.0,macOS 15.0,visionOS 2.0, *) {
+            if #available(macOS 15.0,visionOS 2.0,iOS 18.0, *) {
             let content = content as! ViewReference
             
             __content
@@ -12925,7 +12854,7 @@ struct _tabViewSidebarHeaderModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(iOS 18.0,macOS 15.0,visionOS 2.0, *)
+    @available(visionOS 2.0,macOS 15.0,iOS 18.0, *)
     init(content: ViewReference=ViewReference(value: [])) {
         self.value = ._0(content: content)
         
@@ -12938,7 +12867,7 @@ struct _tabViewSidebarHeaderModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(content):
-            if #available(iOS 18.0,macOS 15.0,visionOS 2.0, *) {
+            if #available(visionOS 2.0,macOS 15.0,iOS 18.0, *) {
             let content = content as! ViewReference
             
             __content
@@ -13113,7 +13042,7 @@ struct _textContentTypeModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(tvOS) || os(visionOS)
-    @available(visionOS 1.0,iOS 13.0,tvOS 13.0, *)
+    @available(tvOS 13.0,visionOS 1.0,iOS 13.0, *)
     init(_ textContentType: UIKit.UITextContentType?) {
         self.value = ._0(textContentType: textContentType)
         
@@ -13126,7 +13055,7 @@ struct _textContentTypeModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(tvOS) || os(visionOS)
         case let ._0(textContentType):
-            if #available(visionOS 1.0,iOS 13.0,tvOS 13.0, *) {
+            if #available(tvOS 13.0,visionOS 1.0,iOS 13.0, *) {
             let textContentType = textContentType as? UIKit.UITextContentType
             
             __content
@@ -13254,7 +13183,7 @@ struct _textInputAutocapitalizationModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(iOS 15.0,tvOS 15.0,visionOS 1.0,watchOS 8.0, *)
+    @available(tvOS 15.0,iOS 15.0,watchOS 8.0,visionOS 1.0, *)
     init(_ autocapitalization: SwiftUI.TextInputAutocapitalization?) {
         self.value = ._0(autocapitalization: autocapitalization)
         
@@ -13267,7 +13196,7 @@ struct _textInputAutocapitalizationModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(autocapitalization):
-            if #available(iOS 15.0,tvOS 15.0,visionOS 1.0,watchOS 8.0, *) {
+            if #available(tvOS 15.0,iOS 15.0,watchOS 8.0,visionOS 1.0, *) {
             let autocapitalization = autocapitalization as? SwiftUI.TextInputAutocapitalization
             
             __content
@@ -13395,7 +13324,7 @@ struct _textSelectionModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(iOS 15.0,macOS 12.0,visionOS 1.0, *)
+    @available(visionOS 1.0,macOS 12.0,iOS 15.0, *)
     init(_ selectability: AnyTextSelectability) {
         self.value = ._0(selectability: selectability)
         
@@ -13408,7 +13337,7 @@ struct _textSelectionModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(selectability):
-            if #available(iOS 15.0,macOS 12.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,macOS 12.0,iOS 15.0, *) {
             let selectability = selectability as! AnyTextSelectability
             
             __content
@@ -13442,7 +13371,7 @@ struct _textSelectionAffinityModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(iOS 18.0,visionOS 2.0,macOS 15.0,tvOS 18.0,watchOS 11.0, *)
+    @available(watchOS 11.0,iOS 18.0,visionOS 2.0,macOS 15.0,tvOS 18.0, *)
     init(_ affinity: SwiftUI.TextSelectionAffinity) {
         self.value = ._0(affinity: affinity)
         
@@ -13455,7 +13384,7 @@ struct _textSelectionAffinityModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(affinity):
-            if #available(iOS 18.0,visionOS 2.0,macOS 15.0,tvOS 18.0,watchOS 11.0, *) {
+            if #available(watchOS 11.0,iOS 18.0,visionOS 2.0,macOS 15.0,tvOS 18.0, *) {
             let affinity = affinity as! SwiftUI.TextSelectionAffinity
             
             __content
@@ -13616,7 +13545,7 @@ struct _toolbarModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(iOS 17.0,visionOS 1.0,macOS 14.0,tvOS 17.0,watchOS 10.0, *)
+    @available(macOS 14.0,iOS 17.0,watchOS 10.0,tvOS 17.0,visionOS 1.0, *)
     init(removing defaultItemKind: SwiftUI.ToolbarDefaultItemKind?) {
         self.value = ._0(defaultItemKind: defaultItemKind)
         
@@ -13643,7 +13572,7 @@ struct _toolbarModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(defaultItemKind):
-            if #available(iOS 17.0,visionOS 1.0,macOS 14.0,tvOS 17.0,watchOS 10.0, *) {
+            if #available(macOS 14.0,iOS 17.0,watchOS 10.0,tvOS 17.0,visionOS 1.0, *) {
             let defaultItemKind = defaultItemKind as? SwiftUI.ToolbarDefaultItemKind
             
             __content
@@ -13746,7 +13675,7 @@ struct _toolbarBackgroundVisibilityModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(tvOS 18.0,visionOS 2.0,iOS 18.0,watchOS 11.0,macOS 15.0, *)
+    @available(macOS 15.0,visionOS 2.0,tvOS 18.0,iOS 18.0,watchOS 11.0, *)
     init(_ visibility: AttributeReference<SwiftUI.Visibility>,for bars: SwiftUI.ToolbarPlacement) {
         self.value = ._0(visibility: visibility, bars: bars)
         
@@ -13759,7 +13688,7 @@ struct _toolbarBackgroundVisibilityModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(visibility, bars):
-            if #available(tvOS 18.0,visionOS 2.0,iOS 18.0,watchOS 11.0,macOS 15.0, *) {
+            if #available(macOS 15.0,visionOS 2.0,tvOS 18.0,iOS 18.0,watchOS 11.0, *) {
             let visibility = visibility as! AttributeReference<SwiftUI.Visibility>
 let bars = bars as! SwiftUI.ToolbarPlacement
             
@@ -13935,7 +13864,7 @@ struct _toolbarTitleDisplayModeModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0,visionOS 1.0, *)
+    @available(macOS 14.0,visionOS 1.0,tvOS 17.0,iOS 17.0,watchOS 10.0, *)
     init(_ mode: SwiftUI.ToolbarTitleDisplayMode) {
         self.value = ._0(mode: mode)
         
@@ -13948,7 +13877,7 @@ struct _toolbarTitleDisplayModeModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(mode):
-            if #available(macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0,visionOS 1.0, *) {
+            if #available(macOS 14.0,visionOS 1.0,tvOS 17.0,iOS 17.0,watchOS 10.0, *) {
             let mode = mode as! SwiftUI.ToolbarTitleDisplayMode
             
             __content
@@ -14029,7 +13958,7 @@ struct _toolbarVisibilityModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 11.0,tvOS 18.0,iOS 18.0,visionOS 2.0,macOS 15.0, *)
+    @available(tvOS 18.0,macOS 15.0,iOS 18.0,watchOS 11.0,visionOS 2.0, *)
     init(_ visibility: AttributeReference<SwiftUI.Visibility>,for bars: SwiftUI.ToolbarPlacement) {
         self.value = ._0(visibility: visibility, bars: bars)
         
@@ -14042,7 +13971,7 @@ struct _toolbarVisibilityModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(visibility, bars):
-            if #available(watchOS 11.0,tvOS 18.0,iOS 18.0,visionOS 2.0,macOS 15.0, *) {
+            if #available(tvOS 18.0,macOS 15.0,iOS 18.0,watchOS 11.0,visionOS 2.0, *) {
             let visibility = visibility as! AttributeReference<SwiftUI.Visibility>
 let bars = bars as! SwiftUI.ToolbarPlacement
             
@@ -14688,7 +14617,7 @@ struct _windowToolbarFullScreenVisibilityModifier<R: RootRegistry>: ViewModifier
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 11.0,tvOS 18.0,iOS 18.0,visionOS 2.0,macOS 15.0, *)
+    @available(tvOS 18.0,macOS 15.0,iOS 18.0,watchOS 11.0,visionOS 2.0, *)
     init(_ visibility: SwiftUI.WindowToolbarFullScreenVisibility) {
         self.value = ._0(visibility: visibility)
         
@@ -14701,7 +14630,7 @@ struct _windowToolbarFullScreenVisibilityModifier<R: RootRegistry>: ViewModifier
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(visibility):
-            if #available(watchOS 11.0,tvOS 18.0,iOS 18.0,visionOS 2.0,macOS 15.0, *) {
+            if #available(tvOS 18.0,macOS 15.0,iOS 18.0,watchOS 11.0,visionOS 2.0, *) {
             let visibility = visibility as! SwiftUI.WindowToolbarFullScreenVisibility
             
             __content
@@ -15483,10 +15412,10 @@ indirect case scrollDisabled(_scrollDisabledModifier<R>)
 indirect case scrollDismissesKeyboard(_scrollDismissesKeyboardModifier<R>)
 indirect case scrollIndicators(_scrollIndicatorsModifier<R>)
 indirect case scrollIndicatorsFlash(_scrollIndicatorsFlashModifier<R>)
-indirect case scrollInputBehavior(_scrollInputBehaviorModifier<R>)
 indirect case scrollPosition(_scrollPositionModifier<R>)
 indirect case scrollTargetBehavior(_scrollTargetBehaviorModifier<R>)
 indirect case scrollTargetLayout(_scrollTargetLayoutModifier<R>)
+indirect case searchDictationBehavior(_searchDictationBehaviorModifier<R>)
         
         func body(content: Content) -> some View {
             switch self {
@@ -15510,13 +15439,13 @@ case let .scrollIndicators(modifier):
     content.modifier(modifier)
 case let .scrollIndicatorsFlash(modifier):
     content.modifier(modifier)
-case let .scrollInputBehavior(modifier):
-    content.modifier(modifier)
 case let .scrollPosition(modifier):
     content.modifier(modifier)
 case let .scrollTargetBehavior(modifier):
     content.modifier(modifier)
 case let .scrollTargetLayout(modifier):
+    content.modifier(modifier)
+case let .searchDictationBehavior(modifier):
     content.modifier(modifier)
             }
         }
@@ -15524,8 +15453,7 @@ case let .scrollTargetLayout(modifier):
 }
 extension BuiltinRegistry {
     enum _BuiltinModifierChunk14: ViewModifier {
-        indirect case searchDictationBehavior(_searchDictationBehaviorModifier<R>)
-indirect case searchPresentationToolbarBehavior(_searchPresentationToolbarBehaviorModifier<R>)
+        indirect case searchPresentationToolbarBehavior(_searchPresentationToolbarBehaviorModifier<R>)
 indirect case searchSuggestions(_searchSuggestionsModifier<R>)
 indirect case searchable(_searchableModifier<R>)
 indirect case sectionActions(_sectionActionsModifier<R>)
@@ -15538,12 +15466,11 @@ indirect case speechAlwaysIncludesPunctuation(_speechAlwaysIncludesPunctuationMo
 indirect case speechAnnouncementsQueued(_speechAnnouncementsQueuedModifier<R>)
 indirect case speechSpellsOutCharacters(_speechSpellsOutCharactersModifier<R>)
 indirect case statusBarHidden(_statusBarHiddenModifier<R>)
+indirect case submitLabel(_submitLabelModifier<R>)
         
         func body(content: Content) -> some View {
             switch self {
-            case let .searchDictationBehavior(modifier):
-    content.modifier(modifier)
-case let .searchPresentationToolbarBehavior(modifier):
+            case let .searchPresentationToolbarBehavior(modifier):
     content.modifier(modifier)
 case let .searchSuggestions(modifier):
     content.modifier(modifier)
@@ -15569,14 +15496,15 @@ case let .speechSpellsOutCharacters(modifier):
     content.modifier(modifier)
 case let .statusBarHidden(modifier):
     content.modifier(modifier)
+case let .submitLabel(modifier):
+    content.modifier(modifier)
             }
         }
     }
 }
 extension BuiltinRegistry {
     enum _BuiltinModifierChunk15: ViewModifier {
-        indirect case submitLabel(_submitLabelModifier<R>)
-indirect case submitScope(_submitScopeModifier<R>)
+        indirect case submitScope(_submitScopeModifier<R>)
 indirect case supportedVolumeViewpoints(_supportedVolumeViewpointsModifier<R>)
 indirect case swipeActions(_swipeActionsModifier<R>)
 indirect case symbolEffect(_symbolEffectModifier<R>)
@@ -15589,12 +15517,11 @@ indirect case tabViewSidebarHeader(_tabViewSidebarHeaderModifier<R>)
 indirect case tabViewStyle(_tabViewStyleModifier<R>)
 indirect case tableStyle(_tableStyleModifier<R>)
 indirect case textCase(_textCaseModifier<R>)
+indirect case textContentType(_textContentTypeModifier<R>)
         
         func body(content: Content) -> some View {
             switch self {
-            case let .submitLabel(modifier):
-    content.modifier(modifier)
-case let .submitScope(modifier):
+            case let .submitScope(modifier):
     content.modifier(modifier)
 case let .supportedVolumeViewpoints(modifier):
     content.modifier(modifier)
@@ -15620,14 +15547,15 @@ case let .tableStyle(modifier):
     content.modifier(modifier)
 case let .textCase(modifier):
     content.modifier(modifier)
+case let .textContentType(modifier):
+    content.modifier(modifier)
             }
         }
     }
 }
 extension BuiltinRegistry {
     enum _BuiltinModifierChunk16: ViewModifier {
-        indirect case textContentType(_textContentTypeModifier<R>)
-indirect case textEditorStyle(_textEditorStyleModifier<R>)
+        indirect case textEditorStyle(_textEditorStyleModifier<R>)
 indirect case textFieldStyle(_textFieldStyleModifier<R>)
 indirect case textInputAutocapitalization(_textInputAutocapitalizationModifier<R>)
 indirect case textInputCompletion(_textInputCompletionModifier<R>)
@@ -15640,12 +15568,11 @@ indirect case toolbar(_toolbarModifier<R>)
 indirect case toolbarBackground(_toolbarBackgroundModifier<R>)
 indirect case toolbarBackgroundVisibility(_toolbarBackgroundVisibilityModifier<R>)
 indirect case toolbarColorScheme(_toolbarColorSchemeModifier<R>)
+indirect case toolbarItemHidden(_toolbarItemHiddenModifier<R>)
         
         func body(content: Content) -> some View {
             switch self {
-            case let .textContentType(modifier):
-    content.modifier(modifier)
-case let .textEditorStyle(modifier):
+            case let .textEditorStyle(modifier):
     content.modifier(modifier)
 case let .textFieldStyle(modifier):
     content.modifier(modifier)
@@ -15671,14 +15598,15 @@ case let .toolbarBackgroundVisibility(modifier):
     content.modifier(modifier)
 case let .toolbarColorScheme(modifier):
     content.modifier(modifier)
+case let .toolbarItemHidden(modifier):
+    content.modifier(modifier)
             }
         }
     }
 }
 extension BuiltinRegistry {
     enum _BuiltinModifierChunk17: ViewModifier {
-        indirect case toolbarItemHidden(_toolbarItemHiddenModifier<R>)
-indirect case toolbarRole(_toolbarRoleModifier<R>)
+        indirect case toolbarRole(_toolbarRoleModifier<R>)
 indirect case toolbarTitleDisplayMode(_toolbarTitleDisplayModeModifier<R>)
 indirect case toolbarTitleMenu(_toolbarTitleMenuModifier<R>)
 indirect case toolbarVisibility(_toolbarVisibilityModifier<R>)
@@ -15691,12 +15619,11 @@ indirect case truncationMode(_truncationModeModifier<R>)
 indirect case unredacted(_unredactedModifier<R>)
 indirect case upperLimbVisibility(_upperLimbVisibilityModifier<R>)
 indirect case volumeBaseplateVisibility(_volumeBaseplateVisibilityModifier<R>)
+indirect case windowDismissBehavior(_windowDismissBehaviorModifier<R>)
         
         func body(content: Content) -> some View {
             switch self {
-            case let .toolbarItemHidden(modifier):
-    content.modifier(modifier)
-case let .toolbarRole(modifier):
+            case let .toolbarRole(modifier):
     content.modifier(modifier)
 case let .toolbarTitleDisplayMode(modifier):
     content.modifier(modifier)
@@ -15722,14 +15649,15 @@ case let .upperLimbVisibility(modifier):
     content.modifier(modifier)
 case let .volumeBaseplateVisibility(modifier):
     content.modifier(modifier)
+case let .windowDismissBehavior(modifier):
+    content.modifier(modifier)
             }
         }
     }
 }
 extension BuiltinRegistry {
     enum _BuiltinModifierChunk18: ViewModifier {
-        indirect case windowDismissBehavior(_windowDismissBehaviorModifier<R>)
-indirect case windowFullScreenBehavior(_windowFullScreenBehaviorModifier<R>)
+        indirect case windowFullScreenBehavior(_windowFullScreenBehaviorModifier<R>)
 indirect case windowMinimizeBehavior(_windowMinimizeBehaviorModifier<R>)
 indirect case windowResizeBehavior(_windowResizeBehaviorModifier<R>)
 indirect case windowToolbarFullScreenVisibility(_windowToolbarFullScreenVisibilityModifier<R>)
@@ -15738,9 +15666,7 @@ indirect case zIndex(_zIndexModifier<R>)
         
         func body(content: Content) -> some View {
             switch self {
-            case let .windowDismissBehavior(modifier):
-    content.modifier(modifier)
-case let .windowFullScreenBehavior(modifier):
+            case let .windowFullScreenBehavior(modifier):
     content.modifier(modifier)
 case let .windowMinimizeBehavior(modifier):
     content.modifier(modifier)
@@ -15777,18 +15703,18 @@ indirect case chunk15(_BuiltinModifierChunk15)
 indirect case chunk16(_BuiltinModifierChunk16)
 indirect case chunk17(_BuiltinModifierChunk17)
 indirect case chunk18(_BuiltinModifierChunk18)
-        indirect case _PresentationDetentsModifier(LiveViewNative._PresentationDetentsModifier)
+        indirect case _MaskModifier(LiveViewNative._MaskModifier<R>)
 indirect case _Rotation3DEffectModifier(LiveViewNative._Rotation3DEffectModifier<R>)
-indirect case _SearchScopesModifier(LiveViewNative._SearchScopesModifier<R>)
-indirect case _MaskModifier(LiveViewNative._MaskModifier<R>)
-indirect case _MatchedGeometryEffectModifier(LiveViewNative._MatchedGeometryEffectModifier<R>)
 indirect case _FocusScopeModifier(LiveViewNative._FocusScopeModifier<R>)
-indirect case _PrefersDefaultFocusModifier(LiveViewNative._PrefersDefaultFocusModifier<R>)
-indirect case _NavigationTransitionModifier(LiveViewNative._NavigationTransitionModifier<R>)
 indirect case _OnSubmitModifier(LiveViewNative._OnSubmitModifier)
-indirect case _MatchedTransitionSourceModifier(LiveViewNative._MatchedTransitionSourceModifier<R>)
+indirect case _NavigationTransitionModifier(LiveViewNative._NavigationTransitionModifier<R>)
 indirect case _SearchCompletionModifier(LiveViewNative._SearchCompletionModifier<R>)
+indirect case _MatchedGeometryEffectModifier(LiveViewNative._MatchedGeometryEffectModifier<R>)
+indirect case _MatchedTransitionSourceModifier(LiveViewNative._MatchedTransitionSourceModifier<R>)
 indirect case _PerspectiveRotationEffectModifier(LiveViewNative._PerspectiveRotationEffectModifier<R>)
+indirect case _SearchScopesModifier(LiveViewNative._SearchScopesModifier<R>)
+indirect case _PrefersDefaultFocusModifier(LiveViewNative._PrefersDefaultFocusModifier<R>)
+indirect case _PresentationDetentsModifier(LiveViewNative._PresentationDetentsModifier)
         indirect case _customRegistryModifier(R.CustomModifier)
         indirect case _anyTextModifier(_AnyTextModifier<R>)
         indirect case _anyImageModifier(_AnyImageModifier<R>)
@@ -15835,29 +15761,29 @@ case let .chunk17(chunk):
     content.modifier(chunk)
 case let .chunk18(chunk):
     content.modifier(chunk)
-            case let ._PresentationDetentsModifier(modifier):
+            case let ._MaskModifier(modifier):
     content.modifier(modifier)
 case let ._Rotation3DEffectModifier(modifier):
     content.modifier(modifier)
-case let ._SearchScopesModifier(modifier):
-    content.modifier(modifier)
-case let ._MaskModifier(modifier):
-    content.modifier(modifier)
-case let ._MatchedGeometryEffectModifier(modifier):
-    content.modifier(modifier)
 case let ._FocusScopeModifier(modifier):
-    content.modifier(modifier)
-case let ._PrefersDefaultFocusModifier(modifier):
-    content.modifier(modifier)
-case let ._NavigationTransitionModifier(modifier):
     content.modifier(modifier)
 case let ._OnSubmitModifier(modifier):
     content.modifier(modifier)
-case let ._MatchedTransitionSourceModifier(modifier):
+case let ._NavigationTransitionModifier(modifier):
     content.modifier(modifier)
 case let ._SearchCompletionModifier(modifier):
     content.modifier(modifier)
+case let ._MatchedGeometryEffectModifier(modifier):
+    content.modifier(modifier)
+case let ._MatchedTransitionSourceModifier(modifier):
+    content.modifier(modifier)
 case let ._PerspectiveRotationEffectModifier(modifier):
+    content.modifier(modifier)
+case let ._SearchScopesModifier(modifier):
+    content.modifier(modifier)
+case let ._PrefersDefaultFocusModifier(modifier):
+    content.modifier(modifier)
+case let ._PresentationDetentsModifier(modifier):
     content.modifier(modifier)
             case let ._customRegistryModifier(modifier):
                 content.modifier(modifier)
@@ -16076,11 +16002,10 @@ _scrollDisabledModifier<R>.name: _scrollDisabledModifier<R>.parser(in: context).
 _scrollDismissesKeyboardModifier<R>.name: _scrollDismissesKeyboardModifier<R>.parser(in: context).map({ Output.chunk13(.scrollDismissesKeyboard($0)) }).eraseToAnyParser(),
 _scrollIndicatorsModifier<R>.name: _scrollIndicatorsModifier<R>.parser(in: context).map({ Output.chunk13(.scrollIndicators($0)) }).eraseToAnyParser(),
 _scrollIndicatorsFlashModifier<R>.name: _scrollIndicatorsFlashModifier<R>.parser(in: context).map({ Output.chunk13(.scrollIndicatorsFlash($0)) }).eraseToAnyParser(),
-_scrollInputBehaviorModifier<R>.name: _scrollInputBehaviorModifier<R>.parser(in: context).map({ Output.chunk13(.scrollInputBehavior($0)) }).eraseToAnyParser(),
 _scrollPositionModifier<R>.name: _scrollPositionModifier<R>.parser(in: context).map({ Output.chunk13(.scrollPosition($0)) }).eraseToAnyParser(),
 _scrollTargetBehaviorModifier<R>.name: _scrollTargetBehaviorModifier<R>.parser(in: context).map({ Output.chunk13(.scrollTargetBehavior($0)) }).eraseToAnyParser(),
 _scrollTargetLayoutModifier<R>.name: _scrollTargetLayoutModifier<R>.parser(in: context).map({ Output.chunk13(.scrollTargetLayout($0)) }).eraseToAnyParser(),
-_searchDictationBehaviorModifier<R>.name: _searchDictationBehaviorModifier<R>.parser(in: context).map({ Output.chunk14(.searchDictationBehavior($0)) }).eraseToAnyParser(),
+_searchDictationBehaviorModifier<R>.name: _searchDictationBehaviorModifier<R>.parser(in: context).map({ Output.chunk13(.searchDictationBehavior($0)) }).eraseToAnyParser(),
 _searchPresentationToolbarBehaviorModifier<R>.name: _searchPresentationToolbarBehaviorModifier<R>.parser(in: context).map({ Output.chunk14(.searchPresentationToolbarBehavior($0)) }).eraseToAnyParser(),
 _searchSuggestionsModifier<R>.name: _searchSuggestionsModifier<R>.parser(in: context).map({ Output.chunk14(.searchSuggestions($0)) }).eraseToAnyParser(),
 _searchableModifier<R>.name: _searchableModifier<R>.parser(in: context).map({ Output.chunk14(.searchable($0)) }).eraseToAnyParser(),
@@ -16094,7 +16019,7 @@ _speechAlwaysIncludesPunctuationModifier<R>.name: _speechAlwaysIncludesPunctuati
 _speechAnnouncementsQueuedModifier<R>.name: _speechAnnouncementsQueuedModifier<R>.parser(in: context).map({ Output.chunk14(.speechAnnouncementsQueued($0)) }).eraseToAnyParser(),
 _speechSpellsOutCharactersModifier<R>.name: _speechSpellsOutCharactersModifier<R>.parser(in: context).map({ Output.chunk14(.speechSpellsOutCharacters($0)) }).eraseToAnyParser(),
 _statusBarHiddenModifier<R>.name: _statusBarHiddenModifier<R>.parser(in: context).map({ Output.chunk14(.statusBarHidden($0)) }).eraseToAnyParser(),
-_submitLabelModifier<R>.name: _submitLabelModifier<R>.parser(in: context).map({ Output.chunk15(.submitLabel($0)) }).eraseToAnyParser(),
+_submitLabelModifier<R>.name: _submitLabelModifier<R>.parser(in: context).map({ Output.chunk14(.submitLabel($0)) }).eraseToAnyParser(),
 _submitScopeModifier<R>.name: _submitScopeModifier<R>.parser(in: context).map({ Output.chunk15(.submitScope($0)) }).eraseToAnyParser(),
 _supportedVolumeViewpointsModifier<R>.name: _supportedVolumeViewpointsModifier<R>.parser(in: context).map({ Output.chunk15(.supportedVolumeViewpoints($0)) }).eraseToAnyParser(),
 _swipeActionsModifier<R>.name: _swipeActionsModifier<R>.parser(in: context).map({ Output.chunk15(.swipeActions($0)) }).eraseToAnyParser(),
@@ -16108,7 +16033,7 @@ _tabViewSidebarHeaderModifier<R>.name: _tabViewSidebarHeaderModifier<R>.parser(i
 _tabViewStyleModifier<R>.name: _tabViewStyleModifier<R>.parser(in: context).map({ Output.chunk15(.tabViewStyle($0)) }).eraseToAnyParser(),
 _tableStyleModifier<R>.name: _tableStyleModifier<R>.parser(in: context).map({ Output.chunk15(.tableStyle($0)) }).eraseToAnyParser(),
 _textCaseModifier<R>.name: _textCaseModifier<R>.parser(in: context).map({ Output.chunk15(.textCase($0)) }).eraseToAnyParser(),
-_textContentTypeModifier<R>.name: _textContentTypeModifier<R>.parser(in: context).map({ Output.chunk16(.textContentType($0)) }).eraseToAnyParser(),
+_textContentTypeModifier<R>.name: _textContentTypeModifier<R>.parser(in: context).map({ Output.chunk15(.textContentType($0)) }).eraseToAnyParser(),
 _textEditorStyleModifier<R>.name: _textEditorStyleModifier<R>.parser(in: context).map({ Output.chunk16(.textEditorStyle($0)) }).eraseToAnyParser(),
 _textFieldStyleModifier<R>.name: _textFieldStyleModifier<R>.parser(in: context).map({ Output.chunk16(.textFieldStyle($0)) }).eraseToAnyParser(),
 _textInputAutocapitalizationModifier<R>.name: _textInputAutocapitalizationModifier<R>.parser(in: context).map({ Output.chunk16(.textInputAutocapitalization($0)) }).eraseToAnyParser(),
@@ -16122,7 +16047,7 @@ _toolbarModifier<R>.name: _toolbarModifier<R>.parser(in: context).map({ Output.c
 _toolbarBackgroundModifier<R>.name: _toolbarBackgroundModifier<R>.parser(in: context).map({ Output.chunk16(.toolbarBackground($0)) }).eraseToAnyParser(),
 _toolbarBackgroundVisibilityModifier<R>.name: _toolbarBackgroundVisibilityModifier<R>.parser(in: context).map({ Output.chunk16(.toolbarBackgroundVisibility($0)) }).eraseToAnyParser(),
 _toolbarColorSchemeModifier<R>.name: _toolbarColorSchemeModifier<R>.parser(in: context).map({ Output.chunk16(.toolbarColorScheme($0)) }).eraseToAnyParser(),
-_toolbarItemHiddenModifier<R>.name: _toolbarItemHiddenModifier<R>.parser(in: context).map({ Output.chunk17(.toolbarItemHidden($0)) }).eraseToAnyParser(),
+_toolbarItemHiddenModifier<R>.name: _toolbarItemHiddenModifier<R>.parser(in: context).map({ Output.chunk16(.toolbarItemHidden($0)) }).eraseToAnyParser(),
 _toolbarRoleModifier<R>.name: _toolbarRoleModifier<R>.parser(in: context).map({ Output.chunk17(.toolbarRole($0)) }).eraseToAnyParser(),
 _toolbarTitleDisplayModeModifier<R>.name: _toolbarTitleDisplayModeModifier<R>.parser(in: context).map({ Output.chunk17(.toolbarTitleDisplayMode($0)) }).eraseToAnyParser(),
 _toolbarTitleMenuModifier<R>.name: _toolbarTitleMenuModifier<R>.parser(in: context).map({ Output.chunk17(.toolbarTitleMenu($0)) }).eraseToAnyParser(),
@@ -16136,25 +16061,25 @@ _truncationModeModifier<R>.name: _truncationModeModifier<R>.parser(in: context).
 _unredactedModifier<R>.name: _unredactedModifier<R>.parser(in: context).map({ Output.chunk17(.unredacted($0)) }).eraseToAnyParser(),
 _upperLimbVisibilityModifier<R>.name: _upperLimbVisibilityModifier<R>.parser(in: context).map({ Output.chunk17(.upperLimbVisibility($0)) }).eraseToAnyParser(),
 _volumeBaseplateVisibilityModifier<R>.name: _volumeBaseplateVisibilityModifier<R>.parser(in: context).map({ Output.chunk17(.volumeBaseplateVisibility($0)) }).eraseToAnyParser(),
-_windowDismissBehaviorModifier<R>.name: _windowDismissBehaviorModifier<R>.parser(in: context).map({ Output.chunk18(.windowDismissBehavior($0)) }).eraseToAnyParser(),
+_windowDismissBehaviorModifier<R>.name: _windowDismissBehaviorModifier<R>.parser(in: context).map({ Output.chunk17(.windowDismissBehavior($0)) }).eraseToAnyParser(),
 _windowFullScreenBehaviorModifier<R>.name: _windowFullScreenBehaviorModifier<R>.parser(in: context).map({ Output.chunk18(.windowFullScreenBehavior($0)) }).eraseToAnyParser(),
 _windowMinimizeBehaviorModifier<R>.name: _windowMinimizeBehaviorModifier<R>.parser(in: context).map({ Output.chunk18(.windowMinimizeBehavior($0)) }).eraseToAnyParser(),
 _windowResizeBehaviorModifier<R>.name: _windowResizeBehaviorModifier<R>.parser(in: context).map({ Output.chunk18(.windowResizeBehavior($0)) }).eraseToAnyParser(),
 _windowToolbarFullScreenVisibilityModifier<R>.name: _windowToolbarFullScreenVisibilityModifier<R>.parser(in: context).map({ Output.chunk18(.windowToolbarFullScreenVisibility($0)) }).eraseToAnyParser(),
 _writingToolsBehaviorModifier<R>.name: _writingToolsBehaviorModifier<R>.parser(in: context).map({ Output.chunk18(.writingToolsBehavior($0)) }).eraseToAnyParser(),
 _zIndexModifier<R>.name: _zIndexModifier<R>.parser(in: context).map({ Output.chunk18(.zIndex($0)) }).eraseToAnyParser(),
-                    LiveViewNative._PresentationDetentsModifier.name: LiveViewNative._PresentationDetentsModifier.parser(in: context).map(Output._PresentationDetentsModifier).eraseToAnyParser(),
+                    LiveViewNative._MaskModifier<R>.name: LiveViewNative._MaskModifier<R>.parser(in: context).map(Output._MaskModifier).eraseToAnyParser(),
 LiveViewNative._Rotation3DEffectModifier<R>.name: LiveViewNative._Rotation3DEffectModifier<R>.parser(in: context).map(Output._Rotation3DEffectModifier).eraseToAnyParser(),
-LiveViewNative._SearchScopesModifier<R>.name: LiveViewNative._SearchScopesModifier<R>.parser(in: context).map(Output._SearchScopesModifier).eraseToAnyParser(),
-LiveViewNative._MaskModifier<R>.name: LiveViewNative._MaskModifier<R>.parser(in: context).map(Output._MaskModifier).eraseToAnyParser(),
-LiveViewNative._MatchedGeometryEffectModifier<R>.name: LiveViewNative._MatchedGeometryEffectModifier<R>.parser(in: context).map(Output._MatchedGeometryEffectModifier).eraseToAnyParser(),
 LiveViewNative._FocusScopeModifier<R>.name: LiveViewNative._FocusScopeModifier<R>.parser(in: context).map(Output._FocusScopeModifier).eraseToAnyParser(),
-LiveViewNative._PrefersDefaultFocusModifier<R>.name: LiveViewNative._PrefersDefaultFocusModifier<R>.parser(in: context).map(Output._PrefersDefaultFocusModifier).eraseToAnyParser(),
-LiveViewNative._NavigationTransitionModifier<R>.name: LiveViewNative._NavigationTransitionModifier<R>.parser(in: context).map(Output._NavigationTransitionModifier).eraseToAnyParser(),
 LiveViewNative._OnSubmitModifier.name: LiveViewNative._OnSubmitModifier.parser(in: context).map(Output._OnSubmitModifier).eraseToAnyParser(),
-LiveViewNative._MatchedTransitionSourceModifier<R>.name: LiveViewNative._MatchedTransitionSourceModifier<R>.parser(in: context).map(Output._MatchedTransitionSourceModifier).eraseToAnyParser(),
+LiveViewNative._NavigationTransitionModifier<R>.name: LiveViewNative._NavigationTransitionModifier<R>.parser(in: context).map(Output._NavigationTransitionModifier).eraseToAnyParser(),
 LiveViewNative._SearchCompletionModifier<R>.name: LiveViewNative._SearchCompletionModifier<R>.parser(in: context).map(Output._SearchCompletionModifier).eraseToAnyParser(),
+LiveViewNative._MatchedGeometryEffectModifier<R>.name: LiveViewNative._MatchedGeometryEffectModifier<R>.parser(in: context).map(Output._MatchedGeometryEffectModifier).eraseToAnyParser(),
+LiveViewNative._MatchedTransitionSourceModifier<R>.name: LiveViewNative._MatchedTransitionSourceModifier<R>.parser(in: context).map(Output._MatchedTransitionSourceModifier).eraseToAnyParser(),
 LiveViewNative._PerspectiveRotationEffectModifier<R>.name: LiveViewNative._PerspectiveRotationEffectModifier<R>.parser(in: context).map(Output._PerspectiveRotationEffectModifier).eraseToAnyParser(),
+LiveViewNative._SearchScopesModifier<R>.name: LiveViewNative._SearchScopesModifier<R>.parser(in: context).map(Output._SearchScopesModifier).eraseToAnyParser(),
+LiveViewNative._PrefersDefaultFocusModifier<R>.name: LiveViewNative._PrefersDefaultFocusModifier<R>.parser(in: context).map(Output._PrefersDefaultFocusModifier).eraseToAnyParser(),
+LiveViewNative._PresentationDetentsModifier.name: LiveViewNative._PresentationDetentsModifier.parser(in: context).map(Output._PresentationDetentsModifier).eraseToAnyParser(),
                 ]
 
                 let deprecations = [
@@ -16350,7 +16275,7 @@ ConstantAtomLiteral("content").map({ () -> Self in
 /// * `.tabBar`
 /// * `.sidebar`
 @_documentation(visibility: public)
-@available(iOS 18.0,tvOS 18.0,macOS 15.0,visionOS 2.0,watchOS 11.0, *)
+@available(tvOS 18.0,watchOS 11.0,visionOS 2.0,macOS 15.0,iOS 18.0, *)
 extension AdaptableTabBarPlacement: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -16696,7 +16621,7 @@ ConstantAtomLiteral("plusLighter").map({ () -> Self in
 /// * `.enabled`
 /// * `.disabled`
 @_documentation(visibility: public)
-@available(macOS 14.0,tvOS 17.0,iOS 17.0,watchOS 10.0,visionOS 1.0, *)
+@available(iOS 17.0,visionOS 1.0,macOS 14.0,watchOS 10.0,tvOS 17.0, *)
 extension ButtonRepeatBehavior: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -16815,35 +16740,35 @@ ConstantAtomLiteral("dark").map({ () -> Self in
 /// * `.navigationSplitView`
 /// * `.window`
 @_documentation(visibility: public)
-@available(watchOS 10.0,tvOS 17.0,iOS 17.0,visionOS 1.0,macOS 14.0, *)
+@available(macOS 14.0,watchOS 10.0,tvOS 17.0,visionOS 1.0,iOS 17.0, *)
 extension ContainerBackgroundPlacement: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             #if os(watchOS)
 ConstantAtomLiteral("tabView").map({ () -> Self in
-if #available(watchOS 10.0,tvOS 17.0,iOS 17.0,macOS 14.0, *) {
+if #available(macOS 14.0,watchOS 10.0,tvOS 17.0,iOS 17.0, *) {
     return Self.tabView
 } else { fatalError("'tabView' is not available in this OS version") }
 })
 #endif
 #if os(iOS) || os(watchOS)
 ConstantAtomLiteral("navigation").map({ () -> Self in
-if #available(watchOS 10.0,tvOS 17.0,iOS 18.0,macOS 14.0, *) {
+if #available(macOS 14.0,watchOS 10.0,tvOS 17.0,iOS 18.0, *) {
     return Self.navigation
 } else { fatalError("'navigation' is not available in this OS version") }
 })
 #endif
 #if os(iOS) || os(watchOS)
 ConstantAtomLiteral("navigationSplitView").map({ () -> Self in
-if #available(watchOS 11.0,tvOS 17.0,iOS 18.0,macOS 14.0, *) {
+if #available(macOS 14.0,watchOS 11.0,tvOS 17.0,iOS 18.0, *) {
     return Self.navigationSplitView
 } else { fatalError("'navigationSplitView' is not available in this OS version") }
 })
 #endif
 #if os(macOS)
 ConstantAtomLiteral("window").map({ () -> Self in
-if #available(watchOS 10.0,tvOS 17.0,iOS 17.0,macOS 15.0, *) {
+if #available(macOS 15.0,watchOS 10.0,tvOS 17.0,iOS 17.0, *) {
     return Self.window
 } else { fatalError("'window' is not available in this OS version") }
 })
@@ -16864,7 +16789,7 @@ if #available(watchOS 10.0,tvOS 17.0,iOS 17.0,macOS 15.0, *) {
 /// * `.scrollContent`
 /// * `.scrollIndicators`
 @_documentation(visibility: public)
-@available(macOS 14.0,iOS 17.0,tvOS 17.0,visionOS 1.0,watchOS 10.0, *)
+@available(macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0,visionOS 1.0, *)
 extension ContentMarginPlacement: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -16923,35 +16848,35 @@ ConstantAtomLiteral("interaction").map({ () -> Self in
 
 #if os(iOS) || os(macOS) || os(visionOS)
 ConstantAtomLiteral("dragPreview").map({ () -> Self in
-if #available(tvOS 15.0,iOS 15.0,macOS 12.0,watchOS 8.0,visionOS 1.0, *) {
+if #available(tvOS 15.0,macOS 12.0,watchOS 8.0,visionOS 1.0,iOS 15.0, *) {
     return Self.dragPreview
 } else { fatalError("'dragPreview' is not available in this OS version") }
 })
 #endif
 #if os(iOS) || os(tvOS) || os(visionOS)
 ConstantAtomLiteral("contextMenuPreview").map({ () -> Self in
-if #available(tvOS 17.0,iOS 15.0,macOS 12.0,watchOS 8.0,visionOS 1.0, *) {
+if #available(tvOS 17.0,macOS 12.0,watchOS 8.0,visionOS 1.0,iOS 15.0, *) {
     return Self.contextMenuPreview
 } else { fatalError("'contextMenuPreview' is not available in this OS version") }
 })
 #endif
 #if os(iOS) || os(tvOS) || os(visionOS)
 ConstantAtomLiteral("hoverEffect").map({ () -> Self in
-if #available(tvOS 18.0,iOS 15.0,macOS 12.0,watchOS 8.0,visionOS 1.0, *) {
+if #available(tvOS 18.0,macOS 12.0,watchOS 8.0,visionOS 1.0,iOS 15.0, *) {
     return Self.hoverEffect
 } else { fatalError("'hoverEffect' is not available in this OS version") }
 })
 #endif
 #if os(macOS) || os(watchOS)
 ConstantAtomLiteral("focusEffect").map({ () -> Self in
-if #available(tvOS 15.0,iOS 15.0,macOS 12.0,watchOS 8.0, *) {
+if #available(tvOS 15.0,macOS 12.0,watchOS 8.0,iOS 15.0, *) {
     return Self.focusEffect
 } else { fatalError("'focusEffect' is not available in this OS version") }
 })
 #endif
 #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
 ConstantAtomLiteral("accessibility").map({ () -> Self in
-if #available(visionOS 1.0,watchOS 10.0,tvOS 17.0,macOS 14.0,iOS 17.0, *) {
+if #available(macOS 14.0,visionOS 1.0,watchOS 10.0,tvOS 17.0,iOS 17.0, *) {
     return Self.accessibility
 } else { fatalError("'accessibility' is not available in this OS version") }
 })
@@ -16974,7 +16899,7 @@ if #available(visionOS 1.0,watchOS 10.0,tvOS 17.0,macOS 14.0,iOS 17.0, *) {
 /// * `.large`
 /// * `.extraLarge`
 @_documentation(visibility: public)
-@available(iOS 15.0,macOS 10.15,visionOS 1.0,watchOS 9.0, *)
+@available(iOS 15.0,visionOS 1.0,macOS 10.15,watchOS 9.0, *)
 extension ControlSize: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -17002,14 +16927,14 @@ ConstantAtomLiteral("regular").map({ () -> Self in
 #endif
 #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
 ConstantAtomLiteral("large").map({ () -> Self in
-if #available(iOS 15.0,macOS 11.0,visionOS 1.0,watchOS 9.0, *) {
+if #available(iOS 15.0,visionOS 1.0,macOS 11.0,watchOS 9.0, *) {
     return Self.large
 } else { fatalError("'large' is not available in this OS version") }
 })
 #endif
 #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
 ConstantAtomLiteral("extraLarge").map({ () -> Self in
-if #available(iOS 17.0,macOS 14.0,visionOS 1.0,watchOS 10.0, *) {
+if #available(iOS 17.0,visionOS 1.0,macOS 14.0,watchOS 10.0, *) {
     return Self.extraLarge
 } else { fatalError("'extraLarge' is not available in this OS version") }
 })
@@ -17064,7 +16989,7 @@ ConstantAtomLiteral("userInitiated").map({ () -> Self in
 /// * `.critical`
 /// * `.standard`
 @_documentation(visibility: public)
-@available(macOS 13.0,iOS 17.0,tvOS 17.0,visionOS 1.0,watchOS 10.0, *)
+@available(tvOS 17.0,watchOS 10.0,visionOS 1.0,macOS 13.0,iOS 17.0, *)
 extension DialogSeverity: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -17085,7 +17010,7 @@ ConstantAtomLiteral("critical").map({ () -> Self in
 #endif
 #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
 ConstantAtomLiteral("standard").map({ () -> Self in
-if #available(macOS 14.0,iOS 17.0,tvOS 17.0,visionOS 1.0,watchOS 10.0, *) {
+if #available(tvOS 17.0,watchOS 10.0,visionOS 1.0,macOS 14.0,iOS 17.0, *) {
     return Self.standard
 } else { fatalError("'standard' is not available in this OS version") }
 })
@@ -17256,7 +17181,7 @@ ConstantAtomLiteral("all").map({ () -> Self in
 /// * `.includeHiddenFiles`
 /// * `.displayFileExtensions`
 @_documentation(visibility: public)
-@available(visionOS 1.0,iOS 17.0,macOS 14.0, *)
+@available(macOS 14.0,visionOS 1.0,iOS 17.0, *)
 extension FileDialogBrowserOptions: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -17298,7 +17223,7 @@ ConstantAtomLiteral("displayFileExtensions").map({ () -> Self in
 /// * `.edit`
 /// * `.automatic`
 @_documentation(visibility: public)
-@available(macOS 14.0,tvOS 17.0,iOS 17.0,watchOS 10.0,visionOS 1.0, *)
+@available(iOS 17.0,visionOS 1.0,macOS 14.0,watchOS 10.0,tvOS 17.0, *)
 extension FocusInteractions: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -17550,7 +17475,7 @@ ConstantAtomLiteral("never").map({ () -> Self in
 /// * `.center`
 /// * `.trailing`
 @_documentation(visibility: public)
-@available(iOS 16.0,macOS 13.0,visionOS 1.0, *)
+@available(macOS 13.0,visionOS 1.0,iOS 16.0, *)
 extension HorizontalAlignment: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -17605,7 +17530,7 @@ ConstantAtomLiteral("trailing").map({ () -> Self in
 /// * `.leading`
 /// * `.trailing`
 @_documentation(visibility: public)
-@available(tvOS 18.0,iOS 18.0,macOS 15.0,watchOS 11.0,visionOS 2.0, *)
+@available(iOS 18.0,tvOS 18.0,watchOS 11.0,visionOS 2.0,macOS 15.0, *)
 extension HorizontalDirection: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -17674,7 +17599,7 @@ ConstantAtomLiteral("trailing").map({ () -> Self in
 /// * `.highlight`
 /// * `.lift`
 @_documentation(visibility: public)
-@available(tvOS 16.0,iOS 13.4,visionOS 1.0, *)
+@available(tvOS 16.0,visionOS 1.0,iOS 13.4, *)
 extension HoverEffect: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -17688,7 +17613,7 @@ ConstantAtomLiteral("automatic").map({ () -> Self in
 #endif
 #if os(iOS) || os(tvOS) || os(visionOS)
 ConstantAtomLiteral("highlight").map({ () -> Self in
-if #available(tvOS 17.0,iOS 13.4,visionOS 1.0, *) {
+if #available(tvOS 17.0,visionOS 1.0,iOS 13.4, *) {
     return Self.highlight
 } else { fatalError("'highlight' is not available in this OS version") }
 })
@@ -17715,7 +17640,7 @@ ConstantAtomLiteral("lift").map({ () -> Self in
 /// * `.defaultAction`
 /// * `.cancelAction`
 @_documentation(visibility: public)
-@available(iOS 14.0,visionOS 1.0,macOS 11.0, *)
+@available(macOS 11.0,visionOS 1.0,iOS 14.0, *)
 extension KeyboardShortcut: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -17806,7 +17731,7 @@ ConstantAtomLiteral("automatic").map({ () -> Self in
 
 #if os(iOS) || os(visionOS)
 ConstantAtomLiteral("priority").map({ () -> Self in
-if #available(watchOS 9.0,visionOS 1.0,macOS 13.0,iOS 16.0,tvOS 16.0, *) {
+if #available(tvOS 16.0,macOS 13.0,iOS 16.0,watchOS 9.0,visionOS 1.0, *) {
     return Self.priority
 } else { fatalError("'priority' is not available in this OS version") }
 })
@@ -17836,7 +17761,7 @@ ConstantAtomLiteral("fixed").map({ () -> Self in
 /// * `.sheet`
 /// * `.fullScreenCover`
 @_documentation(visibility: public)
-@available(visionOS 1.0,tvOS 16.4,watchOS 9.4,iOS 16.4,macOS 13.3, *)
+@available(watchOS 9.4,visionOS 1.0,tvOS 16.4,iOS 16.4,macOS 13.3, *)
 extension PresentationAdaptation: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -17892,7 +17817,7 @@ ConstantAtomLiteral("fullScreenCover").map({ () -> Self in
 /// * `.resizes`
 /// * `.scrolls`
 @_documentation(visibility: public)
-@available(macOS 13.3,tvOS 16.4,iOS 16.4,watchOS 9.4,visionOS 1.0, *)
+@available(iOS 16.4,visionOS 1.0,macOS 13.3,watchOS 9.4,tvOS 16.4, *)
 extension PresentationContentInteraction: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -17989,7 +17914,7 @@ ConstantAtomLiteral("privacy").map({ () -> Self in
 
 #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
 ConstantAtomLiteral("invalidated").map({ () -> Self in
-if #available(tvOS 17.0,iOS 17.0,macOS 14.0,visionOS 1.0,watchOS 10.0, *) {
+if #available(iOS 17.0,visionOS 1.0,macOS 14.0,watchOS 10.0,tvOS 17.0, *) {
     return Self.invalidated
 } else { fatalError("'invalidated' is not available in this OS version") }
 })
@@ -18099,7 +18024,7 @@ ConstantAtomLiteral("minimum").map({ () -> Self in
 
 #if os(watchOS)
 ConstantAtomLiteral("navigationBar").map({ () -> Self in
-if #available(tvOS 16.0,iOS 16.0,macOS 13.0,watchOS 9.0, *) {
+if #available(macOS 13.0,watchOS 9.0,iOS 16.0,tvOS 16.0, *) {
     return Self.navigationBar
 } else { fatalError("'navigationBar' is not available in this OS version") }
 })
@@ -18120,7 +18045,7 @@ if #available(tvOS 16.0,iOS 16.0,macOS 13.0,watchOS 9.0, *) {
 /// * `.sizeChanges`
 /// * `.alignment`
 @_documentation(visibility: public)
-@available(watchOS 11.0,tvOS 18.0,iOS 18.0,visionOS 2.0,macOS 15.0, *)
+@available(tvOS 18.0,iOS 18.0,visionOS 2.0,watchOS 11.0,macOS 15.0, *)
 extension ScrollAnchorRole: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -18162,7 +18087,7 @@ ConstantAtomLiteral("alignment").map({ () -> Self in
 /// * `.always`
 /// * `.basedOnSize`
 @_documentation(visibility: public)
-@available(watchOS 9.4,tvOS 16.4,iOS 16.4,visionOS 1.0,macOS 13.3, *)
+@available(tvOS 16.4,macOS 13.3,watchOS 9.4,visionOS 1.0,iOS 16.4, *)
 extension ScrollBounceBehavior: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -18205,7 +18130,7 @@ ConstantAtomLiteral("basedOnSize").map({ () -> Self in
 /// * `.interactively`
 /// * `.never`
 @_documentation(visibility: public)
-@available(watchOS 9.0,tvOS 16.0,iOS 16.0,macOS 13.0, *)
+@available(tvOS 16.0,macOS 13.0,watchOS 9.0,iOS 16.0, *)
 extension ScrollDismissesKeyboardMode: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -18297,6 +18222,48 @@ ConstantAtomLiteral("never").map({ () -> Self in
 }
 
 #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+/// See [`SwiftUI.ScrollInputBehavior`](https://developer.apple.com/documentation/swiftui/ScrollInputBehavior) for more details.
+///
+/// Possible values:
+/// * `.automatic`
+/// * `.enabled`
+/// * `.disabled`
+@_documentation(visibility: public)
+@available(tvOS 18.0,macOS 15.0,watchOS 11.0,visionOS 2.0,iOS 18.0, *)
+extension ScrollInputBehavior: ParseableModifierValue {
+    public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
+        ImplicitStaticMember {
+            OneOf {
+            #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+ConstantAtomLiteral("automatic").map({ () -> Self in
+
+    return Self.automatic
+
+})
+#endif
+#if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+ConstantAtomLiteral("enabled").map({ () -> Self in
+
+    return Self.enabled
+
+})
+#endif
+#if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+ConstantAtomLiteral("disabled").map({ () -> Self in
+
+    return Self.disabled
+
+})
+#endif
+                AtomLiteral().fail(outputType: ScrollInputBehavior.self) {
+                    ModifierParseError(error: .unknownArgument($0), metadata: context.metadata)
+                }
+            }
+        }
+    }
+}
+#endif
+#if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
 /// See [`SwiftUI.SearchScopeActivation`](https://developer.apple.com/documentation/swiftui/SearchScopeActivation) for more details.
 ///
 /// Possible values:
@@ -18304,7 +18271,7 @@ ConstantAtomLiteral("never").map({ () -> Self in
 /// * `.onTextEntry`
 /// * `.onSearchPresentation`
 @_documentation(visibility: public)
-@available(iOS 16.4,tvOS 16.4,visionOS 1.0,watchOS 9.4,macOS 13.3, *)
+@available(tvOS 16.4,macOS 13.3,iOS 16.4,watchOS 9.4,visionOS 1.0, *)
 extension SearchScopeActivation: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -18388,7 +18355,7 @@ ConstantAtomLiteral("content").map({ () -> Self in
 /// * `.enabled`
 /// * `.disabled`
 @_documentation(visibility: public)
-@available(watchOS 10.0,visionOS 1.0,macOS 14.0,iOS 17.0,tvOS 17.0, *)
+@available(tvOS 17.0,visionOS 1.0,macOS 14.0,iOS 17.0,watchOS 10.0, *)
 extension SpringLoadingBehavior: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -18554,7 +18521,7 @@ ConstantAtomLiteral("search").map({ () -> Self in
 /// * `.upstream`
 /// * `.downstream`
 @_documentation(visibility: public)
-@available(macOS 15.0,iOS 18.0,tvOS 18.0,visionOS 2.0,watchOS 11.0, *)
+@available(tvOS 18.0,macOS 15.0,watchOS 11.0,visionOS 2.0,iOS 18.0, *)
 extension TextSelectionAffinity: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -18595,7 +18562,7 @@ ConstantAtomLiteral("downstream").map({ () -> Self in
 /// * `.sidebarToggle`
 /// * `.title`
 @_documentation(visibility: public)
-@available(macOS 14.0,iOS 17.0,tvOS 17.0,visionOS 1.0,watchOS 10.0, *)
+@available(tvOS 17.0,watchOS 10.0,visionOS 1.0,macOS 14.0,iOS 17.0, *)
 extension ToolbarDefaultItemKind: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -18609,7 +18576,7 @@ ConstantAtomLiteral("sidebarToggle").map({ () -> Self in
 #endif
 #if os(iOS) || os(macOS) || os(visionOS)
 ConstantAtomLiteral("title").map({ () -> Self in
-if #available(macOS 15.0,iOS 18.0,tvOS 17.0,visionOS 2.0,watchOS 10.0, *) {
+if #available(tvOS 17.0,watchOS 10.0,visionOS 2.0,macOS 15.0,iOS 18.0, *) {
     return Self.title
 } else { fatalError("'title' is not available in this OS version") }
 })
@@ -18645,21 +18612,21 @@ ConstantAtomLiteral("automatic").map({ () -> Self in
 
 #if os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
 ConstantAtomLiteral("navigationStack").map({ () -> Self in
-if #available(macOS 13.0,iOS 16.0,tvOS 16.0,visionOS 1.0,watchOS 9.0, *) {
+if #available(tvOS 16.0,watchOS 9.0,visionOS 1.0,macOS 13.0,iOS 16.0, *) {
     return Self.navigationStack
 } else { fatalError("'navigationStack' is not available in this OS version") }
 })
 #endif
 #if os(iOS) || os(visionOS)
 ConstantAtomLiteral("browser").map({ () -> Self in
-if #available(macOS 13.0,iOS 16.0,tvOS 16.0,visionOS 1.0,watchOS 9.0, *) {
+if #available(tvOS 16.0,watchOS 9.0,visionOS 1.0,macOS 13.0,iOS 16.0, *) {
     return Self.browser
 } else { fatalError("'browser' is not available in this OS version") }
 })
 #endif
 #if os(iOS) || os(macOS) || os(visionOS)
 ConstantAtomLiteral("editor").map({ () -> Self in
-if #available(macOS 13.0,iOS 16.0,tvOS 16.0,visionOS 1.0,watchOS 9.0, *) {
+if #available(tvOS 16.0,watchOS 9.0,visionOS 1.0,macOS 13.0,iOS 16.0, *) {
     return Self.editor
 } else { fatalError("'editor' is not available in this OS version") }
 })
@@ -18681,7 +18648,7 @@ if #available(macOS 13.0,iOS 16.0,tvOS 16.0,visionOS 1.0,watchOS 9.0, *) {
 /// * `.inlineLarge`
 /// * `.inline`
 @_documentation(visibility: public)
-@available(macOS 14.0,iOS 17.0,tvOS 17.0,visionOS 1.0,watchOS 10.0, *)
+@available(tvOS 17.0,iOS 17.0,visionOS 1.0,watchOS 10.0,macOS 14.0, *)
 extension ToolbarTitleDisplayMode: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -18787,7 +18754,7 @@ ConstantAtomLiteral("lastTextBaseline").map({ () -> Self in
 /// * `.up`
 /// * `.down`
 @_documentation(visibility: public)
-@available(tvOS 18.0,iOS 18.0,macOS 15.0,watchOS 11.0,visionOS 2.0, *)
+@available(iOS 18.0,tvOS 18.0,watchOS 11.0,visionOS 2.0,macOS 15.0, *)
 extension VerticalDirection: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -18925,6 +18892,98 @@ ConstantAtomLiteral("disabled").map({ () -> Self in
 })
 #endif
                 AtomLiteral().fail(outputType: WindowInteractionBehavior.self) {
+                    ModifierParseError(error: .unknownArgument($0), metadata: context.metadata)
+                }
+            }
+        }
+    }
+}
+#endif
+#if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+/// See [`SwiftUI.WindowToolbarFullScreenVisibility`](https://developer.apple.com/documentation/swiftui/WindowToolbarFullScreenVisibility) for more details.
+///
+/// Possible values:
+/// * `.automatic`
+/// * `.visible`
+/// * `.onHover`
+@_documentation(visibility: public)
+@available(tvOS 18.0,iOS 18.0,visionOS 2.0,watchOS 11.0,macOS 15.0, *)
+extension WindowToolbarFullScreenVisibility: ParseableModifierValue {
+    public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
+        ImplicitStaticMember {
+            OneOf {
+            #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+ConstantAtomLiteral("automatic").map({ () -> Self in
+
+    return Self.automatic
+
+})
+#endif
+#if os(macOS)
+ConstantAtomLiteral("visible").map({ () -> Self in
+
+    return Self.visible
+
+})
+#endif
+#if os(macOS)
+ConstantAtomLiteral("onHover").map({ () -> Self in
+
+    return Self.onHover
+
+})
+#endif
+                AtomLiteral().fail(outputType: WindowToolbarFullScreenVisibility.self) {
+                    ModifierParseError(error: .unknownArgument($0), metadata: context.metadata)
+                }
+            }
+        }
+    }
+}
+#endif
+#if os(iOS) || os(macOS)
+/// See [`SwiftUI.WritingToolsBehavior`](https://developer.apple.com/documentation/swiftui/WritingToolsBehavior) for more details.
+///
+/// Possible values:
+/// * `.automatic`
+/// * `.complete`
+/// * `.limited`
+/// * `.disabled`
+@_documentation(visibility: public)
+@available(macOS 15.0,iOS 18.0, *)
+extension WritingToolsBehavior: ParseableModifierValue {
+    public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
+        ImplicitStaticMember {
+            OneOf {
+            #if os(iOS) || os(macOS)
+ConstantAtomLiteral("automatic").map({ () -> Self in
+
+    return Self.automatic
+
+})
+#endif
+#if os(iOS) || os(macOS)
+ConstantAtomLiteral("complete").map({ () -> Self in
+
+    return Self.complete
+
+})
+#endif
+#if os(iOS) || os(macOS)
+ConstantAtomLiteral("limited").map({ () -> Self in
+
+    return Self.limited
+
+})
+#endif
+#if os(iOS) || os(macOS)
+ConstantAtomLiteral("disabled").map({ () -> Self in
+
+    return Self.disabled
+
+})
+#endif
+                AtomLiteral().fail(outputType: WritingToolsBehavior.self) {
                     ModifierParseError(error: .unknownArgument($0), metadata: context.metadata)
                 }
             }

--- a/Sources/LiveViewNative/_GeneratedModifiers.swift
+++ b/Sources/LiveViewNative/_GeneratedModifiers.swift
@@ -1,4 +1,4 @@
-// File generated with `swift run ModifierGenerator source "/Applications/Xcode.app/Contents/Developer/Platforms/XROS.platform/Developer/SDKs/XROS.sdk/System/Library/Frameworks/SwiftUI.framework/Modules/SwiftUI.swiftmodule/arm64-apple-xros.swiftinterface" > Sources/LiveViewNative/_GeneratedModifiers.swift`
+// File generated with `swift run ModifierGenerator source "/Applications/Xcode.app/Contents/Developer/Platforms/XROS.platform/Developer/SDKs/XROS.sdk/System/Library/Frameworks/SwiftUI.framework/Modules/SwiftUI.swiftmodule/arm64e-apple-xros.swiftinterface" "/Applications/Xcode.app/Contents/Developer/Platforms/XROS.platform/Developer/SDKs/XROS.sdk/System/Library/Frameworks/SwiftUICore.framework/Modules/SwiftUICore.swiftmodule/arm64e-apple-xros.swiftinterface" > Sources/LiveViewNative/_GeneratedModifiers.swift`
 
 import SwiftUI
 import Symbols
@@ -58,8 +58,11 @@ struct _accessibilityActionsModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+        indirect case _0(category: Any,content: Any)
+        #endif
         
-        indirect case _0(content: ViewReference=ViewReference(value: []))
+        indirect case _1(content: ViewReference=ViewReference(value: []))
         
     }
 
@@ -72,10 +75,19 @@ struct _accessibilityActionsModifier<R: RootRegistry>: ViewModifier {
 
 
 
+
+
+    #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+    @available(tvOS 18.0,iOS 18.0,macOS 15.0,visionOS 2.0,watchOS 11.0, *)
+    init(category: SwiftUI.AccessibilityActionCategory,content content: ViewReference=ViewReference(value: [])) {
+        self.value = ._0(category: category, content: content)
+        
+    }
+    #endif
     
     
     init(_ content: ViewReference=ViewReference(value: [])) {
-        self.value = ._0(content: content)
+        self.value = ._1(content: content)
         
     }
     
@@ -84,8 +96,20 @@ struct _accessibilityActionsModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+        case let ._0(category, content):
+            if #available(tvOS 18.0,iOS 18.0,macOS 15.0,visionOS 2.0,watchOS 11.0, *) {
+            let category = category as! SwiftUI.AccessibilityActionCategory
+let content = content as! ViewReference
+            
+            __content
+                .accessibilityActions(category: category, { content.resolve(on: element, in: context) })
+            
+                
+            } else { __content }
+        #endif
         
-        case let ._0(content):
+        case let ._1(content):
             
             
             
@@ -317,7 +341,7 @@ struct _alertModifier<R: RootRegistry>: ViewModifier {
     enum Value {
         case _never
         
-        indirect case _0(titleKey: SwiftUI.LocalizedStringKey,actions: ViewReference=ViewReference(value: []))
+        indirect case _0(titleKey: SwiftUICore.LocalizedStringKey,actions: ViewReference=ViewReference(value: []))
         
         
         indirect case _1(title: AttributeReference<String>,actions: ViewReference=ViewReference(value: []))
@@ -326,7 +350,7 @@ struct _alertModifier<R: RootRegistry>: ViewModifier {
         indirect case _2(title: TextReference,actions: ViewReference=ViewReference(value: []))
         
         
-        indirect case _3(titleKey: SwiftUI.LocalizedStringKey,actions: ViewReference=ViewReference(value: []),message: ViewReference=ViewReference(value: []))
+        indirect case _3(titleKey: SwiftUICore.LocalizedStringKey,actions: ViewReference=ViewReference(value: []),message: ViewReference=ViewReference(value: []))
         
         
         indirect case _4(title: AttributeReference<String>,actions: ViewReference=ViewReference(value: []),message: ViewReference=ViewReference(value: []))
@@ -362,7 +386,7 @@ struct _alertModifier<R: RootRegistry>: ViewModifier {
 
     
     
-    init(_ titleKey: SwiftUI.LocalizedStringKey,isPresented: ChangeTracked<Swift.Bool>,actions: ViewReference=ViewReference(value: [])) {
+    init(_ titleKey: SwiftUICore.LocalizedStringKey,isPresented: ChangeTracked<Swift.Bool>,actions: ViewReference=ViewReference(value: [])) {
         self.value = ._0(titleKey: titleKey, actions: actions)
         self.__0_isPresented = isPresented
     }
@@ -383,7 +407,7 @@ struct _alertModifier<R: RootRegistry>: ViewModifier {
     
     
     
-    init(_ titleKey: SwiftUI.LocalizedStringKey,isPresented: ChangeTracked<Swift.Bool>,actions: ViewReference=ViewReference(value: []),message: ViewReference=ViewReference(value: [])) {
+    init(_ titleKey: SwiftUICore.LocalizedStringKey,isPresented: ChangeTracked<Swift.Bool>,actions: ViewReference=ViewReference(value: []),message: ViewReference=ViewReference(value: [])) {
         self.value = ._3(titleKey: titleKey, actions: actions, message: message)
         self.__3_isPresented = isPresented
     }
@@ -590,13 +614,60 @@ struct _allowsTighteningModifier<R: RootRegistry>: ViewModifier {
 }
 @_documentation(visibility: public)
 @ParseableExpression
+struct _allowsWindowActivationEventsModifier<R: RootRegistry>: ViewModifier {
+    static var name: String { "allowsWindowActivationEvents" }
+
+    enum Value {
+        case _never
+        #if os(iOS) || os(macOS) || os(visionOS)
+        indirect case _0(value: Any?)
+        #endif
+    }
+
+    let value: Value
+
+    @ObservedElement private var element
+    @LiveContext<R> private var context
+    
+
+
+
+
+    #if os(iOS) || os(macOS) || os(visionOS)
+    @available(visionOS 2.0,macOS 15.0,iOS 18.0, *)
+    init(_ value: AttributeReference<Swift.Bool?>? = .init(storage: .constant(true)) ) {
+        self.value = ._0(value: value)
+        
+    }
+    #endif
+
+    func body(content __content: Content) -> some View {
+        switch value {
+        case ._never:
+            fatalError("unreachable")
+        #if os(iOS) || os(macOS) || os(visionOS)
+        case let ._0(value):
+            if #available(visionOS 2.0,macOS 15.0,iOS 18.0, *) {
+            let value = value as? AttributeReference<Swift.Bool?>
+            
+            __content
+                .allowsWindowActivationEvents(value?.resolve(on: element, in: context))
+            
+                
+            } else { __content }
+        #endif
+        }
+    }
+}
+@_documentation(visibility: public)
+@ParseableExpression
 struct _animationModifier<R: RootRegistry>: ViewModifier {
     static var name: String { "animation" }
 
     enum Value {
         case _never
         
-        indirect case _0(animation: SwiftUI.Animation?,value: AttributeReference<String>)
+        indirect case _0(animation: SwiftUICore.Animation?,value: AttributeReference<String>)
         
     }
 
@@ -611,7 +682,7 @@ struct _animationModifier<R: RootRegistry>: ViewModifier {
 
     
     
-    init(_ animation: SwiftUI.Animation?,value: AttributeReference<String>) {
+    init(_ animation: SwiftUICore.Animation?,value: AttributeReference<String>) {
         self.value = ._0(animation: animation, value: value)
         
     }
@@ -643,10 +714,10 @@ struct _aspectRatioModifier<R: RootRegistry>: ViewModifier {
     enum Value {
         case _never
         
-        indirect case _0(aspectRatio: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), contentMode: SwiftUI.ContentMode)
+        indirect case _0(aspectRatio: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), contentMode: SwiftUICore.ContentMode)
         
         
-        indirect case _1(aspectRatio: CoreFoundation.CGSize,contentMode: SwiftUI.ContentMode)
+        indirect case _1(aspectRatio: CoreFoundation.CGSize,contentMode: SwiftUICore.ContentMode)
         
     }
 
@@ -663,14 +734,14 @@ struct _aspectRatioModifier<R: RootRegistry>: ViewModifier {
 
     
     
-    init(_ aspectRatio: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), contentMode: SwiftUI.ContentMode) {
+    init(_ aspectRatio: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), contentMode: SwiftUICore.ContentMode) {
         self.value = ._0(aspectRatio: aspectRatio, contentMode: contentMode)
         
     }
     
     
     
-    init(_ aspectRatio: CoreFoundation.CGSize,contentMode: SwiftUI.ContentMode) {
+    init(_ aspectRatio: CoreFoundation.CGSize,contentMode: SwiftUICore.ContentMode) {
         self.value = ._1(aspectRatio: aspectRatio, contentMode: contentMode)
         
     }
@@ -760,25 +831,25 @@ struct _backgroundModifier<R: RootRegistry>: ViewModifier {
     enum Value {
         case _never
         
-        indirect case _0(alignment: AttributeReference<SwiftUI.Alignment> = .init(storage: .constant(.center)), content: ViewReference=ViewReference(value: []))
+        indirect case _0(alignment: AttributeReference<SwiftUICore.Alignment> = .init(storage: .constant(.center)), content: ViewReference=ViewReference(value: []))
         
         
-        indirect case _1(edges: SwiftUI.Edge.Set = .all )
+        indirect case _1(edges: SwiftUICore.Edge.Set = .all )
         
         
-        indirect case _2(style: AnyShapeStyle.Resolvable,edges: SwiftUI.Edge.Set = .all )
+        indirect case _2(style: AnyShapeStyle.Resolvable,edges: SwiftUICore.Edge.Set = .all )
         
         
-        indirect case _3(shape: AnyShape,fillStyle: SwiftUI.FillStyle = FillStyle() )
+        indirect case _3(shape: AnyShape,fillStyle: SwiftUICore.FillStyle = FillStyle() )
         
         
-        indirect case _4(style: AnyShapeStyle.Resolvable,shape: AnyShape,fillStyle: SwiftUI.FillStyle = FillStyle() )
+        indirect case _4(style: AnyShapeStyle.Resolvable,shape: AnyShape,fillStyle: SwiftUICore.FillStyle = FillStyle() )
         
         
-        indirect case _5(shape: AnyInsettableShape,fillStyle: SwiftUI.FillStyle = FillStyle() )
+        indirect case _5(shape: AnyInsettableShape,fillStyle: SwiftUICore.FillStyle = FillStyle() )
         
         
-        indirect case _6(style: AnyShapeStyle.Resolvable,shape: AnyInsettableShape,fillStyle: SwiftUI.FillStyle = FillStyle() )
+        indirect case _6(style: AnyShapeStyle.Resolvable,shape: AnyInsettableShape,fillStyle: SwiftUICore.FillStyle = FillStyle() )
         
     }
 
@@ -805,49 +876,49 @@ struct _backgroundModifier<R: RootRegistry>: ViewModifier {
 
     
     
-    init(alignment: AttributeReference<SwiftUI.Alignment> = .init(storage: .constant(.center)), content: ViewReference=ViewReference(value: [])) {
+    init(alignment: AttributeReference<SwiftUICore.Alignment> = .init(storage: .constant(.center)), content: ViewReference=ViewReference(value: [])) {
         self.value = ._0(alignment: alignment, content: content)
         
     }
     
     
     
-    init(ignoresSafeAreaEdges edges: SwiftUI.Edge.Set = .all ) {
+    init(ignoresSafeAreaEdges edges: SwiftUICore.Edge.Set = .all ) {
         self.value = ._1(edges: edges)
         
     }
     
     
     
-    init(_ style: AnyShapeStyle.Resolvable,ignoresSafeAreaEdges edges: SwiftUI.Edge.Set = .all ) {
+    init(_ style: AnyShapeStyle.Resolvable,ignoresSafeAreaEdges edges: SwiftUICore.Edge.Set = .all ) {
         self.value = ._2(style: style, edges: edges)
         
     }
     
     
     
-    init(in shape: AnyShape,fillStyle: SwiftUI.FillStyle = FillStyle() ) {
+    init(in shape: AnyShape,fillStyle: SwiftUICore.FillStyle = FillStyle() ) {
         self.value = ._3(shape: shape, fillStyle: fillStyle)
         
     }
     
     
     
-    init(_ style: AnyShapeStyle.Resolvable,in shape: AnyShape,fillStyle: SwiftUI.FillStyle = FillStyle() ) {
+    init(_ style: AnyShapeStyle.Resolvable,in shape: AnyShape,fillStyle: SwiftUICore.FillStyle = FillStyle() ) {
         self.value = ._4(style: style, shape: shape, fillStyle: fillStyle)
         
     }
     
     
     
-    init(in shape: AnyInsettableShape,fillStyle: SwiftUI.FillStyle = FillStyle() ) {
+    init(in shape: AnyInsettableShape,fillStyle: SwiftUICore.FillStyle = FillStyle() ) {
         self.value = ._5(shape: shape, fillStyle: fillStyle)
         
     }
     
     
     
-    init(_ style: AnyShapeStyle.Resolvable,in shape: AnyInsettableShape,fillStyle: SwiftUI.FillStyle = FillStyle() ) {
+    init(_ style: AnyShapeStyle.Resolvable,in shape: AnyInsettableShape,fillStyle: SwiftUICore.FillStyle = FillStyle() ) {
         self.value = ._6(style: style, shape: shape, fillStyle: fillStyle)
         
     }
@@ -1036,13 +1107,13 @@ struct _badgeModifier<R: RootRegistry>: ViewModifier {
     #endif
     #if os(iOS) || os(macOS) || os(visionOS)
     @available(macOS 12.0,visionOS 1.0,iOS 15.0, *)
-    init(_ key: SwiftUI.LocalizedStringKey?) {
+    init(_ key: SwiftUICore.LocalizedStringKey?) {
         self.value = ._2(key: key)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 12.0,visionOS 1.0,iOS 15.0, *)
+    @available(macOS 12.0,iOS 15.0,visionOS 1.0, *)
     init(_ label: AttributeReference<String>) {
         self.value = ._3(label: label)
         
@@ -1078,7 +1149,7 @@ struct _badgeModifier<R: RootRegistry>: ViewModifier {
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._2(key):
             if #available(macOS 12.0,visionOS 1.0,iOS 15.0, *) {
-            let key = key as? SwiftUI.LocalizedStringKey
+            let key = key as? SwiftUICore.LocalizedStringKey
             
             __content
                 .badge(key)
@@ -1088,7 +1159,7 @@ struct _badgeModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._3(label):
-            if #available(macOS 12.0,visionOS 1.0,iOS 15.0, *) {
+            if #available(macOS 12.0,iOS 15.0,visionOS 1.0, *) {
             let label = label as! AttributeReference<String>
             
             __content
@@ -1155,7 +1226,7 @@ struct _blendModeModifier<R: RootRegistry>: ViewModifier {
     enum Value {
         case _never
         
-        indirect case _0(blendMode: SwiftUI.BlendMode)
+        indirect case _0(blendMode: SwiftUICore.BlendMode)
         
     }
 
@@ -1170,7 +1241,7 @@ struct _blendModeModifier<R: RootRegistry>: ViewModifier {
 
     
     
-    init(_ blendMode: SwiftUI.BlendMode) {
+    init(_ blendMode: SwiftUICore.BlendMode) {
         self.value = ._0(blendMode: blendMode)
         
     }
@@ -1460,7 +1531,7 @@ struct _clipShapeModifier<R: RootRegistry>: ViewModifier {
     enum Value {
         case _never
         
-        indirect case _0(shape: AnyShape,style: SwiftUI.FillStyle = FillStyle() )
+        indirect case _0(shape: AnyShape,style: SwiftUICore.FillStyle = FillStyle() )
         
     }
 
@@ -1475,7 +1546,7 @@ struct _clipShapeModifier<R: RootRegistry>: ViewModifier {
 
     
     
-    init(_ shape: AnyShape,style: SwiftUI.FillStyle = FillStyle() ) {
+    init(_ shape: AnyShape,style: SwiftUICore.FillStyle = FillStyle() ) {
         self.value = ._0(shape: shape, style: style)
         
     }
@@ -1695,7 +1766,7 @@ struct _confirmationDialogModifier<R: RootRegistry>: ViewModifier {
     enum Value {
         case _never
         
-        indirect case _0(titleKey: SwiftUI.LocalizedStringKey,titleVisibility: AttributeReference<SwiftUI.Visibility> = .init(storage: .constant(.automatic)), actions: ViewReference=ViewReference(value: []))
+        indirect case _0(titleKey: SwiftUICore.LocalizedStringKey,titleVisibility: AttributeReference<SwiftUI.Visibility> = .init(storage: .constant(.automatic)), actions: ViewReference=ViewReference(value: []))
         
         
         indirect case _1(title: AttributeReference<String>,titleVisibility: AttributeReference<SwiftUI.Visibility> = .init(storage: .constant(.automatic)), actions: ViewReference=ViewReference(value: []))
@@ -1704,7 +1775,7 @@ struct _confirmationDialogModifier<R: RootRegistry>: ViewModifier {
         indirect case _2(title: TextReference,titleVisibility: AttributeReference<SwiftUI.Visibility> = .init(storage: .constant(.automatic)), actions: ViewReference=ViewReference(value: []))
         
         
-        indirect case _3(titleKey: SwiftUI.LocalizedStringKey,titleVisibility: AttributeReference<SwiftUI.Visibility> = .init(storage: .constant(.automatic)), actions: ViewReference=ViewReference(value: []),message: ViewReference=ViewReference(value: []))
+        indirect case _3(titleKey: SwiftUICore.LocalizedStringKey,titleVisibility: AttributeReference<SwiftUI.Visibility> = .init(storage: .constant(.automatic)), actions: ViewReference=ViewReference(value: []),message: ViewReference=ViewReference(value: []))
         
         
         indirect case _4(title: AttributeReference<String>,titleVisibility: AttributeReference<SwiftUI.Visibility> = .init(storage: .constant(.automatic)), actions: ViewReference=ViewReference(value: []),message: ViewReference=ViewReference(value: []))
@@ -1735,7 +1806,7 @@ struct _confirmationDialogModifier<R: RootRegistry>: ViewModifier {
 
     
     
-    init(_ titleKey: SwiftUI.LocalizedStringKey,isPresented: ChangeTracked<Swift.Bool>,titleVisibility: AttributeReference<SwiftUI.Visibility> = .init(storage: .constant(.automatic)), actions: ViewReference=ViewReference(value: [])) {
+    init(_ titleKey: SwiftUICore.LocalizedStringKey,isPresented: ChangeTracked<Swift.Bool>,titleVisibility: AttributeReference<SwiftUI.Visibility> = .init(storage: .constant(.automatic)), actions: ViewReference=ViewReference(value: [])) {
         self.value = ._0(titleKey: titleKey, titleVisibility: titleVisibility, actions: actions)
         self.__0_isPresented = isPresented
     }
@@ -1756,7 +1827,7 @@ struct _confirmationDialogModifier<R: RootRegistry>: ViewModifier {
     
     
     
-    init(_ titleKey: SwiftUI.LocalizedStringKey,isPresented: ChangeTracked<Swift.Bool>,titleVisibility: AttributeReference<SwiftUI.Visibility> = .init(storage: .constant(.automatic)), actions: ViewReference=ViewReference(value: []),message: ViewReference=ViewReference(value: [])) {
+    init(_ titleKey: SwiftUICore.LocalizedStringKey,isPresented: ChangeTracked<Swift.Bool>,titleVisibility: AttributeReference<SwiftUI.Visibility> = .init(storage: .constant(.automatic)), actions: ViewReference=ViewReference(value: []),message: ViewReference=ViewReference(value: [])) {
         self.value = ._3(titleKey: titleKey, titleVisibility: titleVisibility, actions: actions, message: message)
         self.__3_isPresented = isPresented
     }
@@ -1876,15 +1947,15 @@ struct _containerRelativeFrameModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,macOS 14.0,watchOS 10.0,tvOS 17.0,iOS 17.0, *)
-    init(_ axes: SwiftUI.Axis.Set,alignment: AttributeReference<SwiftUI.Alignment> = .init(storage: .constant(.center)) ) {
+    @available(watchOS 10.0,iOS 17.0,tvOS 17.0,macOS 14.0,visionOS 1.0, *)
+    init(_ axes: SwiftUICore.Axis.Set,alignment: AttributeReference<SwiftUICore.Alignment> = .init(storage: .constant(.center)) ) {
         self.value = ._0(axes: axes, alignment: alignment)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,macOS 14.0,watchOS 10.0,tvOS 17.0,iOS 17.0, *)
-    init(_ axes: SwiftUI.Axis.Set,count: AttributeReference<Swift.Int>,span: AttributeReference<Swift.Int> = .init(storage: .constant(1)), spacing: AttributeReference<CoreFoundation.CGFloat>,alignment: AttributeReference<SwiftUI.Alignment> = .init(storage: .constant(.center)) ) {
+    @available(tvOS 17.0,watchOS 10.0,macOS 14.0,iOS 17.0,visionOS 1.0, *)
+    init(_ axes: SwiftUICore.Axis.Set,count: AttributeReference<Swift.Int>,span: AttributeReference<Swift.Int> = .init(storage: .constant(1)), spacing: AttributeReference<CoreFoundation.CGFloat>,alignment: AttributeReference<SwiftUICore.Alignment> = .init(storage: .constant(.center)) ) {
         self.value = ._1(axes: axes, count: count, span: span, spacing: spacing, alignment: alignment)
         
     }
@@ -1896,9 +1967,9 @@ struct _containerRelativeFrameModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(axes, alignment):
-            if #available(visionOS 1.0,macOS 14.0,watchOS 10.0,tvOS 17.0,iOS 17.0, *) {
-            let axes = axes as! SwiftUI.Axis.Set
-let alignment = alignment as! AttributeReference<SwiftUI.Alignment>
+            if #available(watchOS 10.0,iOS 17.0,tvOS 17.0,macOS 14.0,visionOS 1.0, *) {
+            let axes = axes as! SwiftUICore.Axis.Set
+let alignment = alignment as! AttributeReference<SwiftUICore.Alignment>
             
             __content
                 .containerRelativeFrame(axes, alignment: alignment.resolve(on: element, in: context))
@@ -1908,12 +1979,12 @@ let alignment = alignment as! AttributeReference<SwiftUI.Alignment>
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(axes, count, span, spacing, alignment):
-            if #available(visionOS 1.0,macOS 14.0,watchOS 10.0,tvOS 17.0,iOS 17.0, *) {
-            let axes = axes as! SwiftUI.Axis.Set
+            if #available(tvOS 17.0,watchOS 10.0,macOS 14.0,iOS 17.0,visionOS 1.0, *) {
+            let axes = axes as! SwiftUICore.Axis.Set
 let count = count as! AttributeReference<Swift.Int>
 let span = span as! AttributeReference<Swift.Int>
 let spacing = spacing as! AttributeReference<CoreFoundation.CGFloat>
-let alignment = alignment as! AttributeReference<SwiftUI.Alignment>
+let alignment = alignment as! AttributeReference<SwiftUICore.Alignment>
             
             __content
                 .containerRelativeFrame(axes, count: count.resolve(on: element, in: context), span: span.resolve(on: element, in: context), spacing: spacing.resolve(on: element, in: context), alignment: alignment.resolve(on: element, in: context))
@@ -2003,21 +2074,21 @@ struct _contentMarginsModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 10.0,macOS 14.0,visionOS 1.0,iOS 17.0,tvOS 17.0, *)
-    init(_ edges: SwiftUI.Edge.Set = .all, _ insets: SwiftUI.EdgeInsets,for placement: SwiftUI.ContentMarginPlacement = .automatic ) {
+    @available(visionOS 1.0,tvOS 17.0,watchOS 10.0,macOS 14.0,iOS 17.0, *)
+    init(_ edges: SwiftUICore.Edge.Set = .all, _ insets: SwiftUICore.EdgeInsets,for placement: SwiftUI.ContentMarginPlacement = .automatic ) {
         self.value = ._0(edges: edges, insets: insets, placement: placement)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 10.0,macOS 14.0,visionOS 1.0,iOS 17.0,tvOS 17.0, *)
-    init(_ edges: SwiftUI.Edge.Set = .all, _ length: AttributeReference<CoreFoundation.CGFloat?>?,for placement: SwiftUI.ContentMarginPlacement = .automatic ) {
+    @available(visionOS 1.0,tvOS 17.0,watchOS 10.0,macOS 14.0,iOS 17.0, *)
+    init(_ edges: SwiftUICore.Edge.Set = .all, _ length: AttributeReference<CoreFoundation.CGFloat?>?,for placement: SwiftUI.ContentMarginPlacement = .automatic ) {
         self.value = ._1(edges: edges, length: length, placement: placement)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 10.0,macOS 14.0,visionOS 1.0,iOS 17.0,tvOS 17.0, *)
+    @available(visionOS 1.0,tvOS 17.0,watchOS 10.0,macOS 14.0,iOS 17.0, *)
     init(_ length: AttributeReference<CoreFoundation.CGFloat>,for placement: SwiftUI.ContentMarginPlacement = .automatic ) {
         self.value = ._2(length: length, placement: placement)
         
@@ -2030,9 +2101,9 @@ struct _contentMarginsModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(edges, insets, placement):
-            if #available(watchOS 10.0,macOS 14.0,visionOS 1.0,iOS 17.0,tvOS 17.0, *) {
-            let edges = edges as! SwiftUI.Edge.Set 
-let insets = insets as! SwiftUI.EdgeInsets
+            if #available(visionOS 1.0,tvOS 17.0,watchOS 10.0,macOS 14.0,iOS 17.0, *) {
+            let edges = edges as! SwiftUICore.Edge.Set 
+let insets = insets as! SwiftUICore.EdgeInsets
 let placement = placement as! SwiftUI.ContentMarginPlacement 
             
             __content
@@ -2043,8 +2114,8 @@ let placement = placement as! SwiftUI.ContentMarginPlacement
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(edges, length, placement):
-            if #available(watchOS 10.0,macOS 14.0,visionOS 1.0,iOS 17.0,tvOS 17.0, *) {
-            let edges = edges as! SwiftUI.Edge.Set 
+            if #available(visionOS 1.0,tvOS 17.0,watchOS 10.0,macOS 14.0,iOS 17.0, *) {
+            let edges = edges as! SwiftUICore.Edge.Set 
 let length = length as? AttributeReference<CoreFoundation.CGFloat?>
 let placement = placement as! SwiftUI.ContentMarginPlacement 
             
@@ -2056,7 +2127,7 @@ let placement = placement as! SwiftUI.ContentMarginPlacement
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._2(length, placement):
-            if #available(watchOS 10.0,macOS 14.0,visionOS 1.0,iOS 17.0,tvOS 17.0, *) {
+            if #available(visionOS 1.0,tvOS 17.0,watchOS 10.0,macOS 14.0,iOS 17.0, *) {
             let length = length as! AttributeReference<CoreFoundation.CGFloat>
 let placement = placement as! SwiftUI.ContentMarginPlacement 
             
@@ -2077,10 +2148,10 @@ struct _contentShapeModifier<R: RootRegistry>: ViewModifier {
     enum Value {
         case _never
         
-        indirect case _0(shape: AnyShape,eoFill: AttributeReference<Swift.Bool> = .init(storage: .constant(false)) )
+        indirect case _0(kind: SwiftUICore.ContentShapeKinds,shape: AnyShape,eoFill: AttributeReference<Swift.Bool> = .init(storage: .constant(false)) )
         
         
-        indirect case _1(kind: SwiftUI.ContentShapeKinds,shape: AnyShape,eoFill: AttributeReference<Swift.Bool> = .init(storage: .constant(false)) )
+        indirect case _1(shape: AnyShape,eoFill: AttributeReference<Swift.Bool> = .init(storage: .constant(false)) )
         
     }
 
@@ -2097,15 +2168,15 @@ struct _contentShapeModifier<R: RootRegistry>: ViewModifier {
 
     
     
-    init(_ shape: AnyShape,eoFill: AttributeReference<Swift.Bool> = .init(storage: .constant(false)) ) {
-        self.value = ._0(shape: shape, eoFill: eoFill)
+    init(_ kind: SwiftUICore.ContentShapeKinds,_ shape: AnyShape,eoFill: AttributeReference<Swift.Bool> = .init(storage: .constant(false)) ) {
+        self.value = ._0(kind: kind, shape: shape, eoFill: eoFill)
         
     }
     
     
     
-    init(_ kind: SwiftUI.ContentShapeKinds,_ shape: AnyShape,eoFill: AttributeReference<Swift.Bool> = .init(storage: .constant(false)) ) {
-        self.value = ._1(kind: kind, shape: shape, eoFill: eoFill)
+    init(_ shape: AnyShape,eoFill: AttributeReference<Swift.Bool> = .init(storage: .constant(false)) ) {
+        self.value = ._1(shape: shape, eoFill: eoFill)
         
     }
     
@@ -2115,23 +2186,23 @@ struct _contentShapeModifier<R: RootRegistry>: ViewModifier {
         case ._never:
             fatalError("unreachable")
         
-        case let ._0(shape, eoFill):
-            
-            
-            
-            __content
-                .contentShape(shape, eoFill: eoFill.resolve(on: element, in: context))
-            
-                
-            
-        
-        
-        case let ._1(kind, shape, eoFill):
+        case let ._0(kind, shape, eoFill):
             
             
             
             __content
                 .contentShape(kind, shape, eoFill: eoFill.resolve(on: element, in: context))
+            
+                
+            
+        
+        
+        case let ._1(shape, eoFill):
+            
+            
+            
+            __content
+                .contentShape(shape, eoFill: eoFill.resolve(on: element, in: context))
             
                 
             
@@ -2147,7 +2218,7 @@ struct _contentTransitionModifier<R: RootRegistry>: ViewModifier {
     enum Value {
         case _never
         
-        indirect case _0(transition: SwiftUI.ContentTransition)
+        indirect case _0(transition: SwiftUICore.ContentTransition)
         
     }
 
@@ -2162,7 +2233,7 @@ struct _contentTransitionModifier<R: RootRegistry>: ViewModifier {
 
     
     
-    init(_ transition: SwiftUI.ContentTransition) {
+    init(_ transition: SwiftUICore.ContentTransition) {
         self.value = ._0(transition: transition)
         
     }
@@ -2220,7 +2291,7 @@ struct _contextMenuModifier<R: RootRegistry>: ViewModifier {
     }
     
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS)
-    @available(iOS 16.0,tvOS 16.0,macOS 13.0,visionOS 1.0, *)
+    @available(visionOS 1.0,macOS 13.0,iOS 16.0,tvOS 16.0, *)
     init(menuItems: ViewReference=ViewReference(value: []),preview: ViewReference=ViewReference(value: [])) {
         self.value = ._1(menuItems: menuItems, preview: preview)
         
@@ -2244,7 +2315,7 @@ struct _contextMenuModifier<R: RootRegistry>: ViewModifier {
         
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS)
         case let ._1(menuItems, preview):
-            if #available(iOS 16.0,tvOS 16.0,macOS 13.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,macOS 13.0,iOS 16.0,tvOS 16.0, *) {
             let menuItems = menuItems as! ViewReference
 let preview = preview as! ViewReference
             
@@ -2326,7 +2397,7 @@ struct _controlGroupStyleModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS)
-    @available(macOS 12.0,iOS 15.0,visionOS 1.0,tvOS 17.0, *)
+    @available(macOS 12.0,iOS 15.0,tvOS 17.0,visionOS 1.0, *)
     init(_ style: AnyControlGroupStyle) {
         self.value = ._0(style: style)
         
@@ -2339,7 +2410,7 @@ struct _controlGroupStyleModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS)
         case let ._0(style):
-            if #available(macOS 12.0,iOS 15.0,visionOS 1.0,tvOS 17.0, *) {
+            if #available(macOS 12.0,iOS 15.0,tvOS 17.0,visionOS 1.0, *) {
             let style = style as! AnyControlGroupStyle
             
             __content
@@ -2373,8 +2444,8 @@ struct _controlSizeModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
-    @available(iOS 15.0,watchOS 9.0,macOS 10.15,visionOS 1.0, *)
-    init(_ controlSize: SwiftUI.ControlSize) {
+    @available(macOS 10.15,watchOS 9.0,iOS 15.0,visionOS 1.0, *)
+    init(_ controlSize: SwiftUICore.ControlSize) {
         self.value = ._0(controlSize: controlSize)
         
     }
@@ -2386,8 +2457,8 @@ struct _controlSizeModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
         case let ._0(controlSize):
-            if #available(iOS 15.0,watchOS 9.0,macOS 10.15,visionOS 1.0, *) {
-            let controlSize = controlSize as! SwiftUI.ControlSize
+            if #available(macOS 10.15,watchOS 9.0,iOS 15.0,visionOS 1.0, *) {
+            let controlSize = controlSize as! SwiftUICore.ControlSize
             
             __content
                 .controlSize(controlSize)
@@ -2420,8 +2491,8 @@ struct _coordinateSpaceModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 10.0,macOS 14.0,visionOS 1.0,iOS 17.0,tvOS 17.0, *)
-    init(_ name: SwiftUI.NamedCoordinateSpace) {
+    @available(visionOS 1.0,macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0, *)
+    init(_ name: SwiftUICore.NamedCoordinateSpace) {
         self.value = ._0(name: name)
         
     }
@@ -2433,8 +2504,8 @@ struct _coordinateSpaceModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(name):
-            if #available(watchOS 10.0,macOS 14.0,visionOS 1.0,iOS 17.0,tvOS 17.0, *) {
-            let name = name as! SwiftUI.NamedCoordinateSpace
+            if #available(visionOS 1.0,macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0, *) {
+            let name = name as! SwiftUICore.NamedCoordinateSpace
             
             __content
                 .coordinateSpace(name)
@@ -2467,7 +2538,7 @@ struct _datePickerStyleModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
-    @available(macOS 10.15,iOS 13.0,visionOS 1.0,watchOS 10.0, *)
+    @available(macOS 10.15,watchOS 10.0,iOS 13.0,visionOS 1.0, *)
     init(_ style: AnyDatePickerStyle) {
         self.value = ._0(style: style)
         
@@ -2480,11 +2551,58 @@ struct _datePickerStyleModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
         case let ._0(style):
-            if #available(macOS 10.15,iOS 13.0,visionOS 1.0,watchOS 10.0, *) {
+            if #available(macOS 10.15,watchOS 10.0,iOS 13.0,visionOS 1.0, *) {
             let style = style as! AnyDatePickerStyle
             
             __content
                 .datePickerStyle(style)
+            
+                
+            } else { __content }
+        #endif
+        }
+    }
+}
+@_documentation(visibility: public)
+@ParseableExpression
+struct _defaultAdaptableTabBarPlacementModifier<R: RootRegistry>: ViewModifier {
+    static var name: String { "defaultAdaptableTabBarPlacement" }
+
+    enum Value {
+        case _never
+        #if os(iOS)
+        indirect case _0(defaultPlacement: Any)
+        #endif
+    }
+
+    let value: Value
+
+    
+    
+    
+
+
+
+
+    #if os(iOS)
+    @available(iOS 18.0, *)
+    init(_ defaultPlacement: SwiftUI.AdaptableTabBarPlacement = .automatic ) {
+        self.value = ._0(defaultPlacement: defaultPlacement)
+        
+    }
+    #endif
+
+    func body(content __content: Content) -> some View {
+        switch value {
+        case ._never:
+            fatalError("unreachable")
+        #if os(iOS)
+        case let ._0(defaultPlacement):
+            if #available(iOS 18.0, *) {
+            let defaultPlacement = defaultPlacement as! SwiftUI.AdaptableTabBarPlacement 
+            
+            __content
+                .defaultAdaptableTabBarPlacement(defaultPlacement)
             
                 
             } else { __content }
@@ -2514,7 +2632,7 @@ struct _defaultHoverEffectModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(tvOS) || os(visionOS)
-    @available(tvOS 17.0,visionOS 1.0,iOS 17.0, *)
+    @available(tvOS 17.0,iOS 17.0,visionOS 1.0, *)
     init(_ effect: SwiftUI.HoverEffect?) {
         self.value = ._0(effect: effect)
         
@@ -2527,7 +2645,7 @@ struct _defaultHoverEffectModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(tvOS) || os(visionOS)
         case let ._0(effect):
-            if #available(tvOS 17.0,visionOS 1.0,iOS 17.0, *) {
+            if #available(tvOS 17.0,iOS 17.0,visionOS 1.0, *) {
             let effect = effect as? SwiftUI.HoverEffect
             
             __content
@@ -2549,6 +2667,9 @@ struct _defaultScrollAnchorModifier<R: RootRegistry>: ViewModifier {
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         indirect case _0(anchor: Any?)
         #endif
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+        indirect case _1(anchor: Any?,role: Any)
+        #endif
     }
 
     let value: Value
@@ -2560,10 +2681,19 @@ struct _defaultScrollAnchorModifier<R: RootRegistry>: ViewModifier {
 
 
 
+
+
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(tvOS 17.0,iOS 17.0,watchOS 10.0,visionOS 1.0,macOS 14.0, *)
-    init(_ anchor: AttributeReference<SwiftUI.UnitPoint?>?) {
+    @available(macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0,visionOS 1.0, *)
+    init(_ anchor: AttributeReference<SwiftUICore.UnitPoint?>?) {
         self.value = ._0(anchor: anchor)
+        
+    }
+    #endif
+    #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+    @available(macOS 15.0,watchOS 11.0,iOS 18.0,tvOS 18.0,visionOS 2.0, *)
+    init(_ anchor: AttributeReference<SwiftUICore.UnitPoint?>?,for role: SwiftUI.ScrollAnchorRole) {
+        self.value = ._1(anchor: anchor, role: role)
         
     }
     #endif
@@ -2574,11 +2704,23 @@ struct _defaultScrollAnchorModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(anchor):
-            if #available(tvOS 17.0,iOS 17.0,watchOS 10.0,visionOS 1.0,macOS 14.0, *) {
-            let anchor = anchor as? AttributeReference<SwiftUI.UnitPoint?>
+            if #available(macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0,visionOS 1.0, *) {
+            let anchor = anchor as? AttributeReference<SwiftUICore.UnitPoint?>
             
             __content
                 .defaultScrollAnchor(anchor?.resolve(on: element, in: context))
+            
+                
+            } else { __content }
+        #endif
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+        case let ._1(anchor, role):
+            if #available(macOS 15.0,watchOS 11.0,iOS 18.0,tvOS 18.0,visionOS 2.0, *) {
+            let anchor = anchor as? AttributeReference<SwiftUICore.UnitPoint?>
+let role = role as! SwiftUI.ScrollAnchorRole
+            
+            __content
+                .defaultScrollAnchor(anchor?.resolve(on: element, in: context), for: role)
             
                 
             } else { __content }
@@ -2608,7 +2750,7 @@ struct _defaultWheelPickerItemHeightModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,watchOS 6.0, *)
+    @available(watchOS 6.0,visionOS 1.0, *)
     init(_ height: AttributeReference<CoreFoundation.CGFloat>) {
         self.value = ._0(height: height)
         
@@ -2621,7 +2763,7 @@ struct _defaultWheelPickerItemHeightModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(visionOS) || os(watchOS)
         case let ._0(height):
-            if #available(visionOS 1.0,watchOS 6.0, *) {
+            if #available(watchOS 6.0,visionOS 1.0, *) {
             let height = height as! AttributeReference<CoreFoundation.CGFloat>
             
             __content
@@ -2656,7 +2798,7 @@ struct _defersSystemGesturesModifier<R: RootRegistry>: ViewModifier {
 
     #if os(iOS)
     @available(iOS 16.0, *)
-    init(on edges: SwiftUI.Edge.Set) {
+    init(on edges: SwiftUICore.Edge.Set) {
         self.value = ._0(edges: edges)
         
     }
@@ -2669,7 +2811,7 @@ struct _defersSystemGesturesModifier<R: RootRegistry>: ViewModifier {
         #if os(iOS)
         case let ._0(edges):
             if #available(iOS 16.0, *) {
-            let edges = edges as! SwiftUI.Edge.Set
+            let edges = edges as! SwiftUICore.Edge.Set
             
             __content
                 .defersSystemGestures(on: edges)
@@ -2764,28 +2906,28 @@ struct _dialogSuppressionToggleModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0, *)
-    init(_ titleKey: SwiftUI.LocalizedStringKey,isSuppressed: ChangeTracked<Swift.Bool>) {
+    @available(visionOS 1.0,tvOS 17.0,watchOS 10.0,macOS 14.0,iOS 17.0, *)
+    init(_ titleKey: SwiftUICore.LocalizedStringKey,isSuppressed: ChangeTracked<Swift.Bool>) {
         self.value = ._0(titleKey: titleKey)
         self.__0_isSuppressed = isSuppressed
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0, *)
+    @available(visionOS 1.0,tvOS 17.0,watchOS 10.0,macOS 14.0,iOS 17.0, *)
     init(_ title: AttributeReference<String>,isSuppressed: ChangeTracked<Swift.Bool>) {
         self.value = ._1(title: title)
         self.__1_isSuppressed = isSuppressed
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0, *)
+    @available(visionOS 1.0,tvOS 17.0,watchOS 10.0,macOS 14.0,iOS 17.0, *)
     init(_ label: TextReference,isSuppressed: ChangeTracked<Swift.Bool>) {
         self.value = ._2(label: label)
         self.__2_isSuppressed = isSuppressed
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0, *)
+    @available(visionOS 1.0,tvOS 17.0,watchOS 10.0,macOS 14.0,iOS 17.0, *)
     init(isSuppressed: ChangeTracked<Swift.Bool>) {
         self.value = ._3
         self.__3_isSuppressed = isSuppressed
@@ -2798,8 +2940,8 @@ struct _dialogSuppressionToggleModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(titleKey):
-            if #available(visionOS 1.0,tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0, *) {
-            let titleKey = titleKey as! SwiftUI.LocalizedStringKey
+            if #available(visionOS 1.0,tvOS 17.0,watchOS 10.0,macOS 14.0,iOS 17.0, *) {
+            let titleKey = titleKey as! SwiftUICore.LocalizedStringKey
             
             __content
                 .dialogSuppressionToggle(titleKey, isSuppressed: __0_isSuppressed.projectedValue)
@@ -2809,7 +2951,7 @@ struct _dialogSuppressionToggleModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(title):
-            if #available(visionOS 1.0,tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0, *) {
+            if #available(visionOS 1.0,tvOS 17.0,watchOS 10.0,macOS 14.0,iOS 17.0, *) {
             let title = title as! AttributeReference<String>
             
             __content
@@ -2820,7 +2962,7 @@ struct _dialogSuppressionToggleModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._2(label):
-            if #available(visionOS 1.0,tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0, *) {
+            if #available(visionOS 1.0,tvOS 17.0,watchOS 10.0,macOS 14.0,iOS 17.0, *) {
             let label = label as! TextReference
             __content._observeTextReference(label, on: element, in: context) { __content in
             __content
@@ -2831,7 +2973,7 @@ struct _dialogSuppressionToggleModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case ._3:
-            if #available(visionOS 1.0,tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0, *) {
+            if #available(visionOS 1.0,tvOS 17.0,watchOS 10.0,macOS 14.0,iOS 17.0, *) {
             
             
             __content
@@ -2962,13 +3104,190 @@ struct _disabledModifier<R: RootRegistry>: ViewModifier {
 }
 @_documentation(visibility: public)
 @ParseableExpression
+struct _dismissalConfirmationDialogModifier<R: RootRegistry>: ViewModifier {
+    static var name: String { "dismissalConfirmationDialog" }
+
+    enum Value {
+        case _never
+        #if os(macOS)
+        indirect case _0(titleKey: Any,shouldPresent: Any,actions: Any)
+        #endif
+        #if os(macOS)
+        indirect case _1(title: Any,shouldPresent: Any,actions: Any)
+        #endif
+        #if os(macOS)
+        indirect case _2(title: Any,shouldPresent: Any,actions: Any)
+        #endif
+        #if os(macOS)
+        indirect case _3(titleKey: Any,shouldPresent: Any,actions: Any,message: Any)
+        #endif
+        #if os(macOS)
+        indirect case _4(title: Any,shouldPresent: Any,actions: Any,message: Any)
+        #endif
+        #if os(macOS)
+        indirect case _5(title: Any,shouldPresent: Any,actions: Any,message: Any)
+        #endif
+    }
+
+    let value: Value
+
+    @ObservedElement private var element
+    @LiveContext<R> private var context
+    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+    #if os(macOS)
+    @available(macOS 15.0, *)
+    init(_ titleKey: SwiftUICore.LocalizedStringKey,shouldPresent: AttributeReference<Swift.Bool>,actions: ViewReference=ViewReference(value: [])) {
+        self.value = ._0(titleKey: titleKey, shouldPresent: shouldPresent, actions: actions)
+        
+    }
+    #endif
+    #if os(macOS)
+    @available(macOS 15.0, *)
+    init(_ title: AttributeReference<String>,shouldPresent: AttributeReference<Swift.Bool>,actions: ViewReference=ViewReference(value: [])) {
+        self.value = ._1(title: title, shouldPresent: shouldPresent, actions: actions)
+        
+    }
+    #endif
+    #if os(macOS)
+    @available(macOS 15.0, *)
+    init(_ title: TextReference,shouldPresent: AttributeReference<Swift.Bool>,actions: ViewReference=ViewReference(value: [])) {
+        self.value = ._2(title: title, shouldPresent: shouldPresent, actions: actions)
+        
+    }
+    #endif
+    #if os(macOS)
+    @available(macOS 15.0, *)
+    init(_ titleKey: SwiftUICore.LocalizedStringKey,shouldPresent: AttributeReference<Swift.Bool>,actions: ViewReference=ViewReference(value: []),message: ViewReference=ViewReference(value: [])) {
+        self.value = ._3(titleKey: titleKey, shouldPresent: shouldPresent, actions: actions, message: message)
+        
+    }
+    #endif
+    #if os(macOS)
+    @available(macOS 15.0, *)
+    init(_ title: AttributeReference<String>,shouldPresent: AttributeReference<Swift.Bool>,actions: ViewReference=ViewReference(value: []),message: ViewReference=ViewReference(value: [])) {
+        self.value = ._4(title: title, shouldPresent: shouldPresent, actions: actions, message: message)
+        
+    }
+    #endif
+    #if os(macOS)
+    @available(macOS 15.0, *)
+    init(_ title: TextReference,shouldPresent: AttributeReference<Swift.Bool>,actions: ViewReference=ViewReference(value: []),message: ViewReference=ViewReference(value: [])) {
+        self.value = ._5(title: title, shouldPresent: shouldPresent, actions: actions, message: message)
+        
+    }
+    #endif
+
+    func body(content __content: Content) -> some View {
+        switch value {
+        case ._never:
+            fatalError("unreachable")
+        #if os(macOS)
+        case let ._0(titleKey, shouldPresent, actions):
+            if #available(macOS 15.0, *) {
+            let titleKey = titleKey as! SwiftUICore.LocalizedStringKey
+let shouldPresent = shouldPresent as! AttributeReference<Swift.Bool>
+let actions = actions as! ViewReference
+            
+            __content
+                .dismissalConfirmationDialog(titleKey, shouldPresent: shouldPresent.resolve(on: element, in: context), actions: { actions.resolve(on: element, in: context) })
+            
+                
+            } else { __content }
+        #endif
+        #if os(macOS)
+        case let ._1(title, shouldPresent, actions):
+            if #available(macOS 15.0, *) {
+            let title = title as! AttributeReference<String>
+let shouldPresent = shouldPresent as! AttributeReference<Swift.Bool>
+let actions = actions as! ViewReference
+            
+            __content
+                .dismissalConfirmationDialog(title.resolve(on: element, in: context), shouldPresent: shouldPresent.resolve(on: element, in: context), actions: { actions.resolve(on: element, in: context) })
+            
+                
+            } else { __content }
+        #endif
+        #if os(macOS)
+        case let ._2(title, shouldPresent, actions):
+            if #available(macOS 15.0, *) {
+            let title = title as! TextReference
+let shouldPresent = shouldPresent as! AttributeReference<Swift.Bool>
+let actions = actions as! ViewReference
+            __content._observeTextReference(title, on: element, in: context) { __content in
+            __content
+                .dismissalConfirmationDialog(title.resolve(on: element, in: context), shouldPresent: shouldPresent.resolve(on: element, in: context), actions: { actions.resolve(on: element, in: context) })
+            }
+                
+            } else { __content }
+        #endif
+        #if os(macOS)
+        case let ._3(titleKey, shouldPresent, actions, message):
+            if #available(macOS 15.0, *) {
+            let titleKey = titleKey as! SwiftUICore.LocalizedStringKey
+let shouldPresent = shouldPresent as! AttributeReference<Swift.Bool>
+let actions = actions as! ViewReference
+let message = message as! ViewReference
+            
+            __content
+                .dismissalConfirmationDialog(titleKey, shouldPresent: shouldPresent.resolve(on: element, in: context), actions: { actions.resolve(on: element, in: context) }, message: { message.resolve(on: element, in: context) })
+            
+                
+            } else { __content }
+        #endif
+        #if os(macOS)
+        case let ._4(title, shouldPresent, actions, message):
+            if #available(macOS 15.0, *) {
+            let title = title as! AttributeReference<String>
+let shouldPresent = shouldPresent as! AttributeReference<Swift.Bool>
+let actions = actions as! ViewReference
+let message = message as! ViewReference
+            
+            __content
+                .dismissalConfirmationDialog(title.resolve(on: element, in: context), shouldPresent: shouldPresent.resolve(on: element, in: context), actions: { actions.resolve(on: element, in: context) }, message: { message.resolve(on: element, in: context) })
+            
+                
+            } else { __content }
+        #endif
+        #if os(macOS)
+        case let ._5(title, shouldPresent, actions, message):
+            if #available(macOS 15.0, *) {
+            let title = title as! TextReference
+let shouldPresent = shouldPresent as! AttributeReference<Swift.Bool>
+let actions = actions as! ViewReference
+let message = message as! ViewReference
+            __content._observeTextReference(title, on: element, in: context) { __content in
+            __content
+                .dismissalConfirmationDialog(title.resolve(on: element, in: context), shouldPresent: shouldPresent.resolve(on: element, in: context), actions: { actions.resolve(on: element, in: context) }, message: { message.resolve(on: element, in: context) })
+            }
+                
+            } else { __content }
+        #endif
+        }
+    }
+}
+@_documentation(visibility: public)
+@ParseableExpression
 struct _drawingGroupModifier<R: RootRegistry>: ViewModifier {
     static var name: String { "drawingGroup" }
 
     enum Value {
         case _never
         
-        indirect case _0(opaque: AttributeReference<Swift.Bool> = .init(storage: .constant(false)), colorMode: SwiftUI.ColorRenderingMode = .nonLinear )
+        indirect case _0(opaque: AttributeReference<Swift.Bool> = .init(storage: .constant(false)), colorMode: SwiftUICore.ColorRenderingMode = .nonLinear )
         
     }
 
@@ -2983,7 +3302,7 @@ struct _drawingGroupModifier<R: RootRegistry>: ViewModifier {
 
     
     
-    init(opaque: AttributeReference<Swift.Bool> = .init(storage: .constant(false)), colorMode: SwiftUI.ColorRenderingMode = .nonLinear ) {
+    init(opaque: AttributeReference<Swift.Bool> = .init(storage: .constant(false)), colorMode: SwiftUICore.ColorRenderingMode = .nonLinear ) {
         self.value = ._0(opaque: opaque, colorMode: colorMode)
         
     }
@@ -3015,10 +3334,10 @@ struct _dynamicTypeSizeModifier<R: RootRegistry>: ViewModifier {
     enum Value {
         case _never
         
-        indirect case _0(size: SwiftUI.DynamicTypeSize)
+        indirect case _0(size: SwiftUICore.DynamicTypeSize)
         
         
-        indirect case _1(range: ParseableRangeExpression<SwiftUI.DynamicTypeSize>)
+        indirect case _1(range: ParseableRangeExpression<SwiftUICore.DynamicTypeSize>)
         
     }
 
@@ -3035,14 +3354,14 @@ struct _dynamicTypeSizeModifier<R: RootRegistry>: ViewModifier {
 
     
     
-    init(_ size: SwiftUI.DynamicTypeSize) {
+    init(_ size: SwiftUICore.DynamicTypeSize) {
         self.value = ._0(size: size)
         
     }
     
     
     
-    init(_ range: ParseableRangeExpression<SwiftUI.DynamicTypeSize>) {
+    init(_ range: ParseableRangeExpression<SwiftUICore.DynamicTypeSize>) {
         self.value = ._1(range: range)
         
     }
@@ -3404,7 +3723,7 @@ struct _focusEffectDisabledModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 10.0,visionOS 1.0,tvOS 17.0,macOS 14.0,iOS 17.0, *)
+    @available(macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0,visionOS 1.0, *)
     init(_ disabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(disabled: disabled)
         
@@ -3417,7 +3736,7 @@ struct _focusEffectDisabledModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(disabled):
-            if #available(watchOS 10.0,visionOS 1.0,tvOS 17.0,macOS 14.0,iOS 17.0, *) {
+            if #available(macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0,visionOS 1.0, *) {
             let disabled = disabled as! AttributeReference<Swift.Bool>
             
             __content
@@ -3451,7 +3770,7 @@ struct _focusSectionModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(macOS) || os(tvOS)
-    @available(tvOS 15.0,macOS 13.0, *)
+    @available(macOS 13.0,tvOS 15.0, *)
     init() {
         self.value = ._0
         
@@ -3464,7 +3783,7 @@ struct _focusSectionModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(macOS) || os(tvOS)
         case ._0:
-            if #available(tvOS 15.0,macOS 13.0, *) {
+            if #available(macOS 13.0,tvOS 15.0, *) {
             
             
             __content
@@ -3503,14 +3822,14 @@ struct _focusableModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 8.0,visionOS 1.0,tvOS 15.0,macOS 12.0,iOS 17.0, *)
+    @available(iOS 17.0,watchOS 8.0,tvOS 15.0,visionOS 1.0,macOS 12.0, *)
     init(_ isFocusable: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(isFocusable: isFocusable)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 10.0,visionOS 1.0,tvOS 17.0,macOS 14.0,iOS 17.0, *)
+    @available(macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0,visionOS 1.0, *)
     init(_ isFocusable: AttributeReference<Swift.Bool> = .init(storage: .constant(true)), interactions: SwiftUI.FocusInteractions) {
         self.value = ._1(isFocusable: isFocusable, interactions: interactions)
         
@@ -3523,7 +3842,7 @@ struct _focusableModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(isFocusable):
-            if #available(watchOS 8.0,visionOS 1.0,tvOS 15.0,macOS 12.0,iOS 17.0, *) {
+            if #available(iOS 17.0,watchOS 8.0,tvOS 15.0,visionOS 1.0,macOS 12.0, *) {
             let isFocusable = isFocusable as! AttributeReference<Swift.Bool>
             
             __content
@@ -3534,7 +3853,7 @@ struct _focusableModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(isFocusable, interactions):
-            if #available(watchOS 10.0,visionOS 1.0,tvOS 17.0,macOS 14.0,iOS 17.0, *) {
+            if #available(macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0,visionOS 1.0, *) {
             let isFocusable = isFocusable as! AttributeReference<Swift.Bool>
 let interactions = interactions as! SwiftUI.FocusInteractions
             
@@ -3608,13 +3927,13 @@ struct _frameModifier<R: RootRegistry>: ViewModifier {
         indirect case _1(minDepth: Any?, idealDepth: Any?, maxDepth: Any?, alignment: Any)
         #endif
         
-        indirect case _2(width: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), height: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), alignment: AttributeReference<SwiftUI.Alignment> = .init(storage: .constant(.center)) )
+        indirect case _2(width: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), height: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), alignment: AttributeReference<SwiftUICore.Alignment> = .init(storage: .constant(.center)) )
         
         
          case _3
         
         
-        indirect case _4(minWidth: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), idealWidth: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), maxWidth: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), minHeight: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), idealHeight: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), maxHeight: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), alignment: AttributeReference<SwiftUI.Alignment> = .init(storage: .constant(.center)) )
+        indirect case _4(minWidth: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), idealWidth: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), maxWidth: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), minHeight: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), idealHeight: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), maxHeight: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), alignment: AttributeReference<SwiftUICore.Alignment> = .init(storage: .constant(.center)) )
         
     }
 
@@ -3637,21 +3956,21 @@ struct _frameModifier<R: RootRegistry>: ViewModifier {
 
     #if os(visionOS)
     @available(visionOS 1.0, *)
-    init(depth: AttributeReference<CoreFoundation.CGFloat?>?,alignment: SwiftUI.DepthAlignment = .center ) {
+    init(depth: AttributeReference<CoreFoundation.CGFloat?>?,alignment: SwiftUICore.DepthAlignment = .center ) {
         self.value = ._0(depth: depth, alignment: alignment)
         
     }
     #endif
     #if os(visionOS)
     @available(visionOS 1.0, *)
-    init(minDepth: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), idealDepth: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), maxDepth: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), alignment: SwiftUI.DepthAlignment = .center ) {
+    init(minDepth: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), idealDepth: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), maxDepth: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), alignment: SwiftUICore.DepthAlignment = .center ) {
         self.value = ._1(minDepth: minDepth, idealDepth: idealDepth, maxDepth: maxDepth, alignment: alignment)
         
     }
     #endif
     
     
-    init(width: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), height: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), alignment: AttributeReference<SwiftUI.Alignment> = .init(storage: .constant(.center)) ) {
+    init(width: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), height: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), alignment: AttributeReference<SwiftUICore.Alignment> = .init(storage: .constant(.center)) ) {
         self.value = ._2(width: width, height: height, alignment: alignment)
         
     }
@@ -3665,7 +3984,7 @@ struct _frameModifier<R: RootRegistry>: ViewModifier {
     
     
     
-    init(minWidth: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), idealWidth: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), maxWidth: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), minHeight: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), idealHeight: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), maxHeight: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), alignment: AttributeReference<SwiftUI.Alignment> = .init(storage: .constant(.center)) ) {
+    init(minWidth: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), idealWidth: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), maxWidth: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), minHeight: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), idealHeight: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), maxHeight: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), alignment: AttributeReference<SwiftUICore.Alignment> = .init(storage: .constant(.center)) ) {
         self.value = ._4(minWidth: minWidth, idealWidth: idealWidth, maxWidth: maxWidth, minHeight: minHeight, idealHeight: idealHeight, maxHeight: maxHeight, alignment: alignment)
         
     }
@@ -3679,7 +3998,7 @@ struct _frameModifier<R: RootRegistry>: ViewModifier {
         case let ._0(depth, alignment):
             if #available(visionOS 1.0, *) {
             let depth = depth as? AttributeReference<CoreFoundation.CGFloat?>
-let alignment = alignment as! SwiftUI.DepthAlignment 
+let alignment = alignment as! SwiftUICore.DepthAlignment 
             
             __content
                 .frame(depth: depth?.resolve(on: element, in: context), alignment: alignment)
@@ -3693,7 +4012,7 @@ let alignment = alignment as! SwiftUI.DepthAlignment
             let minDepth = minDepth as? AttributeReference<CoreFoundation.CGFloat?>
 let idealDepth = idealDepth as? AttributeReference<CoreFoundation.CGFloat?>
 let maxDepth = maxDepth as? AttributeReference<CoreFoundation.CGFloat?>
-let alignment = alignment as! SwiftUI.DepthAlignment 
+let alignment = alignment as! SwiftUICore.DepthAlignment 
             
             __content
                 .frame(minDepth: minDepth?.resolve(on: element, in: context), idealDepth: idealDepth?.resolve(on: element, in: context), maxDepth: maxDepth?.resolve(on: element, in: context), alignment: alignment)
@@ -3759,7 +4078,7 @@ struct _fullScreenCoverModifier<R: RootRegistry>: ViewModifier {
 @Event private var _0_onDismiss__0: Event.EventHandler
 
     #if os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(iOS 14.0,watchOS 7.0,tvOS 14.0,visionOS 1.0, *)
+    @available(tvOS 14.0,watchOS 7.0,iOS 14.0,visionOS 1.0, *)
     init(isPresented: ChangeTracked<Swift.Bool>,onDismiss onDismiss__0: Event=Event(), content: ViewReference=ViewReference(value: [])) {
         self.value = ._0(content: content)
         self.__0_isPresented = isPresented
@@ -3773,7 +4092,7 @@ self.__0_onDismiss__0 = onDismiss__0
             fatalError("unreachable")
         #if os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(content):
-            if #available(iOS 14.0,watchOS 7.0,tvOS 14.0,visionOS 1.0, *) {
+            if #available(tvOS 14.0,watchOS 7.0,iOS 14.0,visionOS 1.0, *) {
             let content = content as! ViewReference
             
             __content
@@ -3807,7 +4126,7 @@ struct _gaugeStyleModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
-    @available(macOS 13.0,iOS 16.0,visionOS 1.0,watchOS 7.0, *)
+    @available(visionOS 1.0,watchOS 7.0,macOS 13.0,iOS 16.0, *)
     init(_ style: AnyGaugeStyle) {
         self.value = ._0(style: style)
         
@@ -3820,7 +4139,7 @@ struct _gaugeStyleModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
         case let ._0(style):
-            if #available(macOS 13.0,iOS 16.0,visionOS 1.0,watchOS 7.0, *) {
+            if #available(visionOS 1.0,watchOS 7.0,macOS 13.0,iOS 16.0, *) {
             let style = style as! AnyGaugeStyle
             
             __content
@@ -3854,7 +4173,7 @@ struct _geometryGroupModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(iOS 17.0,watchOS 10.0,tvOS 17.0,macOS 14.0,visionOS 1.0, *)
+    @available(watchOS 10.0,macOS 14.0,visionOS 1.0,tvOS 17.0,iOS 17.0, *)
     init() {
         self.value = ._0
         
@@ -3867,7 +4186,7 @@ struct _geometryGroupModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case ._0:
-            if #available(iOS 17.0,watchOS 10.0,tvOS 17.0,macOS 14.0,visionOS 1.0, *) {
+            if #available(watchOS 10.0,macOS 14.0,visionOS 1.0,tvOS 17.0,iOS 17.0, *) {
             
             
             __content
@@ -3886,9 +4205,18 @@ struct _gestureModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
+        #if os(iOS)
+        indirect case _0(representable: Any)
+        #endif
         
-        indirect case _0(gesture: _AnyGesture,mask: SwiftUI.GestureMask = .all )
+        indirect case _1(gesture: _AnyGesture,mask: SwiftUICore.GestureMask = .all )
         
+        
+        indirect case _2(gesture: _AnyGesture,isEnabled: AttributeReference<Swift.Bool>)
+        
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+        indirect case _3(gesture: Any,name: Any,isEnabled: Any)
+        #endif
     }
 
     let value: Value
@@ -3900,20 +4228,58 @@ struct _gestureModifier<R: RootRegistry>: ViewModifier {
 
 
 
+
+
+
+
+
+
+    #if os(iOS)
+    @available(iOS 18.0, *)
+    init(_ representable: AnyUIGestureRecognizerRepresentable) {
+        self.value = ._0(representable: representable)
+        
+    }
+    #endif
     
     
-    init(_ gesture: _AnyGesture,including mask: SwiftUI.GestureMask = .all ) {
-        self.value = ._0(gesture: gesture, mask: mask)
+    init(_ gesture: _AnyGesture,including mask: SwiftUICore.GestureMask = .all ) {
+        self.value = ._1(gesture: gesture, mask: mask)
         
     }
     
+    
+    
+    init(_ gesture: _AnyGesture,isEnabled: AttributeReference<Swift.Bool>) {
+        self.value = ._2(gesture: gesture, isEnabled: isEnabled)
+        
+    }
+    
+    #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+    @available(visionOS 2.0,tvOS 18.0,iOS 18.0,macOS 15.0,watchOS 11.0, *)
+    init(_ gesture: _AnyGesture,name: AttributeReference<Swift.String>,isEnabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
+        self.value = ._3(gesture: gesture, name: name, isEnabled: isEnabled)
+        
+    }
+    #endif
 
     func body(content __content: Content) -> some View {
         switch value {
         case ._never:
             fatalError("unreachable")
+        #if os(iOS)
+        case let ._0(representable):
+            if #available(iOS 18.0, *) {
+            let representable = representable as! AnyUIGestureRecognizerRepresentable
+            
+            __content
+                .gesture(representable)
+            
+                
+            } else { __content }
+        #endif
         
-        case let ._0(gesture, mask):
+        case let ._1(gesture, mask):
             
             
             
@@ -3923,6 +4289,30 @@ struct _gestureModifier<R: RootRegistry>: ViewModifier {
                 .environment(\.gestureState, _gestureState)
             
         
+        
+        case let ._2(gesture, isEnabled):
+            
+            
+            
+            __content
+                .gesture(gesture.resolve(on: element, in: context.withGestureState(_gestureState)), isEnabled: isEnabled.resolve(on: element, in: context))
+            
+                .environment(\.gestureState, _gestureState)
+            
+        
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+        case let ._3(gesture, name, isEnabled):
+            if #available(visionOS 2.0,tvOS 18.0,iOS 18.0,macOS 15.0,watchOS 11.0, *) {
+            let gesture = gesture as! _AnyGesture
+let name = name as! AttributeReference<Swift.String>
+let isEnabled = isEnabled as! AttributeReference<Swift.Bool>
+            
+            __content
+                .gesture(gesture.resolve(on: element, in: context.withGestureState(_gestureState)), name: name.resolve(on: element, in: context), isEnabled: isEnabled.resolve(on: element, in: context))
+            
+                .environment(\.gestureState, _gestureState)
+            } else { __content }
+        #endif
         }
     }
 }
@@ -4052,7 +4442,7 @@ struct _gridCellAnchorModifier<R: RootRegistry>: ViewModifier {
     enum Value {
         case _never
         
-        indirect case _0(anchor: AttributeReference<SwiftUI.UnitPoint>)
+        indirect case _0(anchor: AttributeReference<SwiftUICore.UnitPoint>)
         
     }
 
@@ -4067,7 +4457,7 @@ struct _gridCellAnchorModifier<R: RootRegistry>: ViewModifier {
 
     
     
-    init(_ anchor: AttributeReference<SwiftUI.UnitPoint>) {
+    init(_ anchor: AttributeReference<SwiftUICore.UnitPoint>) {
         self.value = ._0(anchor: anchor)
         
     }
@@ -4146,7 +4536,7 @@ struct _gridCellUnsizedAxesModifier<R: RootRegistry>: ViewModifier {
     enum Value {
         case _never
         
-        indirect case _0(axes: SwiftUI.Axis.Set)
+        indirect case _0(axes: SwiftUICore.Axis.Set)
         
     }
 
@@ -4161,7 +4551,7 @@ struct _gridCellUnsizedAxesModifier<R: RootRegistry>: ViewModifier {
 
     
     
-    init(_ axes: SwiftUI.Axis.Set) {
+    init(_ axes: SwiftUICore.Axis.Set) {
         self.value = ._0(axes: axes)
         
     }
@@ -4193,7 +4583,7 @@ struct _gridColumnAlignmentModifier<R: RootRegistry>: ViewModifier {
     enum Value {
         case _never
         
-        indirect case _0(guide: AttributeReference<SwiftUI.HorizontalAlignment>)
+        indirect case _0(guide: AttributeReference<SwiftUICore.HorizontalAlignment>)
         
     }
 
@@ -4208,7 +4598,7 @@ struct _gridColumnAlignmentModifier<R: RootRegistry>: ViewModifier {
 
     
     
-    init(_ guide: AttributeReference<SwiftUI.HorizontalAlignment>) {
+    init(_ guide: AttributeReference<SwiftUICore.HorizontalAlignment>) {
         self.value = ._0(guide: guide)
         
     }
@@ -4254,7 +4644,7 @@ struct _groupBoxStyleModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 11.0,visionOS 1.0,iOS 14.0, *)
+    @available(visionOS 1.0,iOS 14.0,macOS 11.0, *)
     init(_ style: AnyGroupBoxStyle) {
         self.value = ._0(style: style)
         
@@ -4267,11 +4657,106 @@ struct _groupBoxStyleModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(style):
-            if #available(macOS 11.0,visionOS 1.0,iOS 14.0, *) {
+            if #available(visionOS 1.0,iOS 14.0,macOS 11.0, *) {
             let style = style as! AnyGroupBoxStyle
             
             __content
                 .groupBoxStyle(style)
+            
+                
+            } else { __content }
+        #endif
+        }
+    }
+}
+@_documentation(visibility: public)
+@ParseableExpression
+struct _handGestureShortcutModifier<R: RootRegistry>: ViewModifier {
+    static var name: String { "handGestureShortcut" }
+
+    enum Value {
+        case _never
+        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+        indirect case _0(shortcut: Any,isEnabled: Any)
+        #endif
+    }
+
+    let value: Value
+
+    @ObservedElement private var element
+    @LiveContext<R> private var context
+    
+
+
+
+
+    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+    @available(tvOS 18.0,watchOS 11.0,macOS 15.0,iOS 18.0, *)
+    init(_ shortcut: SwiftUI.HandGestureShortcut,isEnabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
+        self.value = ._0(shortcut: shortcut, isEnabled: isEnabled)
+        
+    }
+    #endif
+
+    func body(content __content: Content) -> some View {
+        switch value {
+        case ._never:
+            fatalError("unreachable")
+        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+        case let ._0(shortcut, isEnabled):
+            if #available(tvOS 18.0,watchOS 11.0,macOS 15.0,iOS 18.0, *) {
+            let shortcut = shortcut as! SwiftUI.HandGestureShortcut
+let isEnabled = isEnabled as! AttributeReference<Swift.Bool>
+            
+            __content
+                .handGestureShortcut(shortcut, isEnabled: isEnabled.resolve(on: element, in: context))
+            
+                
+            } else { __content }
+        #endif
+        }
+    }
+}
+@_documentation(visibility: public)
+@ParseableExpression
+struct _handPointerBehaviorModifier<R: RootRegistry>: ViewModifier {
+    static var name: String { "handPointerBehavior" }
+
+    enum Value {
+        case _never
+        #if os(visionOS)
+        indirect case _0(behavior: Any?)
+        #endif
+    }
+
+    let value: Value
+
+    
+    
+    
+
+
+
+
+    #if os(visionOS)
+    @available(visionOS 2.0, *)
+    init(_ behavior: SwiftUI.HandPointerBehavior?) {
+        self.value = ._0(behavior: behavior)
+        
+    }
+    #endif
+
+    func body(content __content: Content) -> some View {
+        switch value {
+        case ._never:
+            fatalError("unreachable")
+        #if os(visionOS)
+        case let ._0(behavior):
+            if #available(visionOS 2.0, *) {
+            let behavior = behavior as? SwiftUI.HandPointerBehavior
+            
+            __content
+                .handPointerBehavior(behavior)
             
                 
             } else { __content }
@@ -4287,7 +4772,7 @@ struct _headerProminenceModifier<R: RootRegistry>: ViewModifier {
     enum Value {
         case _never
         
-        indirect case _0(prominence: SwiftUI.Prominence)
+        indirect case _0(prominence: SwiftUICore.Prominence)
         
     }
 
@@ -4302,7 +4787,7 @@ struct _headerProminenceModifier<R: RootRegistry>: ViewModifier {
 
     
     
-    init(_ prominence: SwiftUI.Prominence) {
+    init(_ prominence: SwiftUICore.Prominence) {
         self.value = ._0(prominence: prominence)
         
     }
@@ -4334,7 +4819,7 @@ struct _helpModifier<R: RootRegistry>: ViewModifier {
     enum Value {
         case _never
         
-        indirect case _0(textKey: SwiftUI.LocalizedStringKey)
+        indirect case _0(textKey: SwiftUICore.LocalizedStringKey)
         
         
         indirect case _1(text: TextReference)
@@ -4359,7 +4844,7 @@ struct _helpModifier<R: RootRegistry>: ViewModifier {
 
     
     
-    init(_ textKey: SwiftUI.LocalizedStringKey) {
+    init(_ textKey: SwiftUICore.LocalizedStringKey) {
         self.value = ._0(textKey: textKey)
         
     }
@@ -4474,8 +4959,14 @@ struct _highPriorityGestureModifier<R: RootRegistry>: ViewModifier {
     enum Value {
         case _never
         
-        indirect case _0(gesture: _AnyGesture,mask: SwiftUI.GestureMask = .all )
+        indirect case _0(gesture: _AnyGesture,mask: SwiftUICore.GestureMask = .all )
         
+        
+        indirect case _1(gesture: _AnyGesture,isEnabled: AttributeReference<Swift.Bool>)
+        
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+        indirect case _2(gesture: Any,name: Any,isEnabled: Any)
+        #endif
     }
 
     let value: Value
@@ -4487,13 +4978,31 @@ struct _highPriorityGestureModifier<R: RootRegistry>: ViewModifier {
 
 
 
+
+
+
+
     
     
-    init(_ gesture: _AnyGesture,including mask: SwiftUI.GestureMask = .all ) {
+    init(_ gesture: _AnyGesture,including mask: SwiftUICore.GestureMask = .all ) {
         self.value = ._0(gesture: gesture, mask: mask)
         
     }
     
+    
+    
+    init(_ gesture: _AnyGesture,isEnabled: AttributeReference<Swift.Bool>) {
+        self.value = ._1(gesture: gesture, isEnabled: isEnabled)
+        
+    }
+    
+    #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+    @available(visionOS 2.0,tvOS 18.0,iOS 18.0,macOS 15.0,watchOS 11.0, *)
+    init(_ gesture: _AnyGesture,name: AttributeReference<Swift.String>,isEnabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
+        self.value = ._2(gesture: gesture, name: name, isEnabled: isEnabled)
+        
+    }
+    #endif
 
     func body(content __content: Content) -> some View {
         switch value {
@@ -4510,6 +5019,30 @@ struct _highPriorityGestureModifier<R: RootRegistry>: ViewModifier {
                 .environment(\.gestureState, _gestureState)
             
         
+        
+        case let ._1(gesture, isEnabled):
+            
+            
+            
+            __content
+                .highPriorityGesture(gesture.resolve(on: element, in: context.withGestureState(_gestureState)), isEnabled: isEnabled.resolve(on: element, in: context))
+            
+                .environment(\.gestureState, _gestureState)
+            
+        
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+        case let ._2(gesture, name, isEnabled):
+            if #available(visionOS 2.0,tvOS 18.0,iOS 18.0,macOS 15.0,watchOS 11.0, *) {
+            let gesture = gesture as! _AnyGesture
+let name = name as! AttributeReference<Swift.String>
+let isEnabled = isEnabled as! AttributeReference<Swift.Bool>
+            
+            __content
+                .highPriorityGesture(gesture.resolve(on: element, in: context.withGestureState(_gestureState)), name: name.resolve(on: element, in: context), isEnabled: isEnabled.resolve(on: element, in: context))
+            
+                .environment(\.gestureState, _gestureState)
+            } else { __content }
+        #endif
         }
     }
 }
@@ -4587,14 +5120,14 @@ struct _hoverEffectModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(tvOS) || os(visionOS)
-    @available(tvOS 16.0,visionOS 1.0,iOS 13.4, *)
+    @available(tvOS 16.0,iOS 13.4,visionOS 1.0, *)
     init(_ effect: SwiftUI.HoverEffect = .automatic ) {
         self.value = ._0(effect: effect)
         
     }
     #endif
     #if os(iOS) || os(tvOS) || os(visionOS)
-    @available(tvOS 17.0,visionOS 1.0,iOS 17.0, *)
+    @available(tvOS 17.0,iOS 17.0,visionOS 1.0, *)
     init(_ effect: SwiftUI.HoverEffect = .automatic, isEnabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._1(effect: effect, isEnabled: isEnabled)
         
@@ -4607,7 +5140,7 @@ struct _hoverEffectModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(tvOS) || os(visionOS)
         case let ._0(effect):
-            if #available(tvOS 16.0,visionOS 1.0,iOS 13.4, *) {
+            if #available(tvOS 16.0,iOS 13.4,visionOS 1.0, *) {
             let effect = effect as! SwiftUI.HoverEffect 
             
             __content
@@ -4618,7 +5151,7 @@ struct _hoverEffectModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(tvOS) || os(visionOS)
         case let ._1(effect, isEnabled):
-            if #available(tvOS 17.0,visionOS 1.0,iOS 17.0, *) {
+            if #available(tvOS 17.0,iOS 17.0,visionOS 1.0, *) {
             let effect = effect as! SwiftUI.HoverEffect 
 let isEnabled = isEnabled as! AttributeReference<Swift.Bool>
             
@@ -4653,7 +5186,7 @@ struct _hoverEffectDisabledModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(tvOS) || os(visionOS)
-    @available(tvOS 17.0,visionOS 1.0,iOS 17.0, *)
+    @available(visionOS 1.0,tvOS 17.0,iOS 17.0, *)
     init(_ disabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(disabled: disabled)
         
@@ -4666,11 +5199,106 @@ struct _hoverEffectDisabledModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(tvOS) || os(visionOS)
         case let ._0(disabled):
-            if #available(tvOS 17.0,visionOS 1.0,iOS 17.0, *) {
+            if #available(visionOS 1.0,tvOS 17.0,iOS 17.0, *) {
             let disabled = disabled as! AttributeReference<Swift.Bool>
             
             __content
                 .hoverEffectDisabled(disabled.resolve(on: element, in: context))
+            
+                
+            } else { __content }
+        #endif
+        }
+    }
+}
+@_documentation(visibility: public)
+@ParseableExpression
+struct _hoverEffectGroupModifier<R: RootRegistry>: ViewModifier {
+    static var name: String { "hoverEffectGroup" }
+
+    enum Value {
+        case _never
+        #if os(visionOS)
+        indirect case _0(id: Any?, namespace: Any,behavior: Any)
+        #endif
+        #if os(visionOS)
+        indirect case _1(group: Any?)
+        #endif
+        #if os(visionOS)
+         case _2
+        #endif
+    }
+
+    let value: Value
+
+    @ObservedElement private var element
+    @LiveContext<R> private var context
+    
+
+
+
+
+
+
+
+
+    #if os(visionOS)
+    @available(visionOS 2.0, *)
+    init(id: AttributeReference<Swift.String?>? = .init(storage: .constant(nil)), in namespace: SwiftUICore.Namespace.ID,behavior: SwiftUI.HoverEffectGroup.Behavior = .activatesGroup ) {
+        self.value = ._0(id: id, namespace: namespace, behavior: behavior)
+        
+    }
+    #endif
+    #if os(visionOS)
+    @available(visionOS 2.0, *)
+    init(_ group: SwiftUI.HoverEffectGroup?) {
+        self.value = ._1(group: group)
+        
+    }
+    #endif
+    #if os(visionOS)
+    @available(visionOS 2.0, *)
+    init() {
+        self.value = ._2
+        
+    }
+    #endif
+
+    func body(content __content: Content) -> some View {
+        switch value {
+        case ._never:
+            fatalError("unreachable")
+        #if os(visionOS)
+        case let ._0(id, namespace, behavior):
+            if #available(visionOS 2.0, *) {
+            let id = id as? AttributeReference<Swift.String?>
+let namespace = namespace as! SwiftUICore.Namespace.ID
+let behavior = behavior as! SwiftUI.HoverEffectGroup.Behavior 
+            
+            __content
+                .hoverEffectGroup(id: id?.resolve(on: element, in: context), in: namespace, behavior: behavior)
+            
+                
+            } else { __content }
+        #endif
+        #if os(visionOS)
+        case let ._1(group):
+            if #available(visionOS 2.0, *) {
+            let group = group as? SwiftUI.HoverEffectGroup
+            
+            __content
+                .hoverEffectGroup(group)
+            
+                
+            } else { __content }
+        #endif
+        #if os(visionOS)
+        case ._2:
+            if #available(visionOS 2.0, *) {
+            
+            
+            __content
+                .hoverEffectGroup()
             
                 
             } else { __content }
@@ -4686,7 +5314,7 @@ struct _hueRotationModifier<R: RootRegistry>: ViewModifier {
     enum Value {
         case _never
         
-        indirect case _0(angle: AttributeReference<SwiftUI.Angle>)
+        indirect case _0(angle: AttributeReference<SwiftUICore.Angle>)
         
     }
 
@@ -4701,7 +5329,7 @@ struct _hueRotationModifier<R: RootRegistry>: ViewModifier {
 
     
     
-    init(_ angle: AttributeReference<SwiftUI.Angle>) {
+    init(_ angle: AttributeReference<SwiftUICore.Angle>) {
         self.value = ._0(angle: angle)
         
     }
@@ -4733,7 +5361,7 @@ struct _ignoresSafeAreaModifier<R: RootRegistry>: ViewModifier {
     enum Value {
         case _never
         
-        indirect case _0(regions: SwiftUI.SafeAreaRegions = .all, edges: SwiftUI.Edge.Set = .all )
+        indirect case _0(regions: SwiftUICore.SafeAreaRegions = .all, edges: SwiftUICore.Edge.Set = .all )
         
     }
 
@@ -4748,7 +5376,7 @@ struct _ignoresSafeAreaModifier<R: RootRegistry>: ViewModifier {
 
     
     
-    init(_ regions: SwiftUI.SafeAreaRegions = .all, edges: SwiftUI.Edge.Set = .all ) {
+    init(_ regions: SwiftUICore.SafeAreaRegions = .all, edges: SwiftUICore.Edge.Set = .all ) {
         self.value = ._0(regions: regions, edges: edges)
         
     }
@@ -4780,7 +5408,7 @@ struct _imageScaleModifier<R: RootRegistry>: ViewModifier {
     enum Value {
         case _never
         
-        indirect case _0(scale: SwiftUI.Image.Scale)
+        indirect case _0(scale: SwiftUICore.Image.Scale)
         
     }
 
@@ -4795,7 +5423,7 @@ struct _imageScaleModifier<R: RootRegistry>: ViewModifier {
 
     
     
-    init(_ scale: SwiftUI.Image.Scale) {
+    init(_ scale: SwiftUICore.Image.Scale) {
         self.value = ._0(scale: scale)
         
     }
@@ -4821,6 +5449,53 @@ struct _imageScaleModifier<R: RootRegistry>: ViewModifier {
 }
 @_documentation(visibility: public)
 @ParseableExpression
+struct _immersiveEnvironmentPickerModifier<R: RootRegistry>: ViewModifier {
+    static var name: String { "immersiveEnvironmentPicker" }
+
+    enum Value {
+        case _never
+        #if os(visionOS)
+        indirect case _0(content: Any)
+        #endif
+    }
+
+    let value: Value
+
+    @ObservedElement private var element
+    @LiveContext<R> private var context
+    
+
+
+
+
+    #if os(visionOS)
+    @available(visionOS 2.0, *)
+    init(content: ViewReference=ViewReference(value: [])) {
+        self.value = ._0(content: content)
+        
+    }
+    #endif
+
+    func body(content __content: Content) -> some View {
+        switch value {
+        case ._never:
+            fatalError("unreachable")
+        #if os(visionOS)
+        case let ._0(content):
+            if #available(visionOS 2.0, *) {
+            let content = content as! ViewReference
+            
+            __content
+                .immersiveEnvironmentPicker(content: { content.resolve(on: element, in: context) })
+            
+                
+            } else { __content }
+        #endif
+        }
+    }
+}
+@_documentation(visibility: public)
+@ParseableExpression
 struct _indexViewStyleModifier<R: RootRegistry>: ViewModifier {
     static var name: String { "indexViewStyle" }
 
@@ -4841,7 +5516,7 @@ struct _indexViewStyleModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,watchOS 8.0,tvOS 14.0,iOS 14.0, *)
+    @available(watchOS 8.0,iOS 14.0,tvOS 14.0,visionOS 1.0, *)
     init(_ style: AnyIndexViewStyle) {
         self.value = ._0(style: style)
         
@@ -4854,7 +5529,7 @@ struct _indexViewStyleModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(style):
-            if #available(visionOS 1.0,watchOS 8.0,tvOS 14.0,iOS 14.0, *) {
+            if #available(watchOS 8.0,iOS 14.0,tvOS 14.0,visionOS 1.0, *) {
             let style = style as! AnyIndexViewStyle
             
             __content
@@ -5101,7 +5776,7 @@ struct _invalidatableContentModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(iOS 17.0,watchOS 10.0,tvOS 17.0,macOS 14.0,visionOS 1.0, *)
+    @available(tvOS 17.0,watchOS 10.0,macOS 14.0,iOS 17.0,visionOS 1.0, *)
     init(_ invalidatable: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(invalidatable: invalidatable)
         
@@ -5114,7 +5789,7 @@ struct _invalidatableContentModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(invalidatable):
-            if #available(iOS 17.0,watchOS 10.0,tvOS 17.0,macOS 14.0,visionOS 1.0, *) {
+            if #available(tvOS 17.0,watchOS 10.0,macOS 14.0,iOS 17.0,visionOS 1.0, *) {
             let invalidatable = invalidatable as! AttributeReference<Swift.Bool>
             
             __content
@@ -5163,21 +5838,21 @@ struct _keyboardShortcutModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 11.0,visionOS 1.0,iOS 14.0, *)
-    init(_ key: SwiftUI.KeyEquivalent,modifiers: SwiftUI.EventModifiers = .command ) {
+    @available(macOS 11.0,iOS 14.0,visionOS 1.0, *)
+    init(_ key: SwiftUI.KeyEquivalent,modifiers: SwiftUICore.EventModifiers = .command ) {
         self.value = ._0(key: key, modifiers: modifiers)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 11.0,visionOS 1.0,iOS 14.0, *)
+    @available(macOS 11.0,iOS 14.0,visionOS 1.0, *)
     init(_ shortcut: SwiftUI.KeyboardShortcut) {
         self.value = ._1(shortcut: shortcut)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 12.3,visionOS 1.0,iOS 15.4, *)
+    @available(macOS 12.3,iOS 15.4,visionOS 1.0, *)
     init(_ shortcut: SwiftUI.KeyboardShortcut?) {
         self.value = ._2(shortcut: shortcut)
         
@@ -5185,7 +5860,7 @@ struct _keyboardShortcutModifier<R: RootRegistry>: ViewModifier {
     #endif
     #if os(iOS) || os(macOS) || os(visionOS)
     @available(macOS 12.0,visionOS 1.0,iOS 15.0, *)
-    init(_ key: SwiftUI.KeyEquivalent,modifiers: SwiftUI.EventModifiers = .command, localization: SwiftUI.KeyboardShortcut.Localization) {
+    init(_ key: SwiftUI.KeyEquivalent,modifiers: SwiftUICore.EventModifiers = .command, localization: SwiftUI.KeyboardShortcut.Localization) {
         self.value = ._3(key: key, modifiers: modifiers, localization: localization)
         
     }
@@ -5197,9 +5872,9 @@ struct _keyboardShortcutModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(key, modifiers):
-            if #available(macOS 11.0,visionOS 1.0,iOS 14.0, *) {
+            if #available(macOS 11.0,iOS 14.0,visionOS 1.0, *) {
             let key = key as! SwiftUI.KeyEquivalent
-let modifiers = modifiers as! SwiftUI.EventModifiers 
+let modifiers = modifiers as! SwiftUICore.EventModifiers 
             
             __content
                 .keyboardShortcut(key, modifiers: modifiers)
@@ -5209,7 +5884,7 @@ let modifiers = modifiers as! SwiftUI.EventModifiers
         #endif
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._1(shortcut):
-            if #available(macOS 11.0,visionOS 1.0,iOS 14.0, *) {
+            if #available(macOS 11.0,iOS 14.0,visionOS 1.0, *) {
             let shortcut = shortcut as! SwiftUI.KeyboardShortcut
             
             __content
@@ -5220,7 +5895,7 @@ let modifiers = modifiers as! SwiftUI.EventModifiers
         #endif
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._2(shortcut):
-            if #available(macOS 12.3,visionOS 1.0,iOS 15.4, *) {
+            if #available(macOS 12.3,iOS 15.4,visionOS 1.0, *) {
             let shortcut = shortcut as? SwiftUI.KeyboardShortcut
             
             __content
@@ -5233,7 +5908,7 @@ let modifiers = modifiers as! SwiftUI.EventModifiers
         case let ._3(key, modifiers, localization):
             if #available(macOS 12.0,visionOS 1.0,iOS 15.0, *) {
             let key = key as! SwiftUI.KeyEquivalent
-let modifiers = modifiers as! SwiftUI.EventModifiers 
+let modifiers = modifiers as! SwiftUICore.EventModifiers 
 let localization = localization as! SwiftUI.KeyboardShortcut.Localization
             
             __content
@@ -5267,7 +5942,7 @@ struct _keyboardTypeModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(tvOS) || os(visionOS)
-    @available(tvOS 13.0,visionOS 1.0,iOS 13.0, *)
+    @available(tvOS 13.0,iOS 13.0,visionOS 1.0, *)
     init(_ type: UIKit.UIKeyboardType) {
         self.value = ._0(type: type)
         
@@ -5280,7 +5955,7 @@ struct _keyboardTypeModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(tvOS) || os(visionOS)
         case let ._0(type):
-            if #available(tvOS 13.0,visionOS 1.0,iOS 13.0, *) {
+            if #available(tvOS 13.0,iOS 13.0,visionOS 1.0, *) {
             let type = type as! UIKit.UIKeyboardType
             
             __content
@@ -5430,6 +6105,53 @@ struct _labelsHiddenModifier<R: RootRegistry>: ViewModifier {
                 
             
         
+        }
+    }
+}
+@_documentation(visibility: public)
+@ParseableExpression
+struct _labelsVisibilityModifier<R: RootRegistry>: ViewModifier {
+    static var name: String { "labelsVisibility" }
+
+    enum Value {
+        case _never
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+        indirect case _0(visibility: Any)
+        #endif
+    }
+
+    let value: Value
+
+    @ObservedElement private var element
+    @LiveContext<R> private var context
+    
+
+
+
+
+    #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+    @available(visionOS 2.0,tvOS 18.0,watchOS 11.0,macOS 15.0,iOS 18.0, *)
+    init(_ visibility: AttributeReference<SwiftUI.Visibility>) {
+        self.value = ._0(visibility: visibility)
+        
+    }
+    #endif
+
+    func body(content __content: Content) -> some View {
+        switch value {
+        case ._never:
+            fatalError("unreachable")
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+        case let ._0(visibility):
+            if #available(visionOS 2.0,tvOS 18.0,watchOS 11.0,macOS 15.0,iOS 18.0, *) {
+            let visibility = visibility as! AttributeReference<SwiftUI.Visibility>
+            
+            __content
+                .labelsVisibility(visibility.resolve(on: element, in: context))
+            
+                
+            } else { __content }
+        #endif
         }
     }
 }
@@ -5885,7 +6607,7 @@ struct _listRowInsetsModifier<R: RootRegistry>: ViewModifier {
     enum Value {
         case _never
         
-        indirect case _0(insets: SwiftUI.EdgeInsets?)
+        indirect case _0(insets: SwiftUICore.EdgeInsets?)
         
     }
 
@@ -5900,7 +6622,7 @@ struct _listRowInsetsModifier<R: RootRegistry>: ViewModifier {
 
     
     
-    init(_ insets: SwiftUI.EdgeInsets?) {
+    init(_ insets: SwiftUICore.EdgeInsets?) {
         self.value = ._0(insets: insets)
         
     }
@@ -5947,7 +6669,7 @@ struct _listRowSeparatorModifier<R: RootRegistry>: ViewModifier {
 
     #if os(iOS) || os(macOS) || os(visionOS)
     @available(macOS 13.0,visionOS 1.0,iOS 15.0, *)
-    init(_ visibility: AttributeReference<SwiftUI.Visibility>,edges: SwiftUI.VerticalEdge.Set = .all ) {
+    init(_ visibility: AttributeReference<SwiftUI.Visibility>,edges: SwiftUICore.VerticalEdge.Set = .all ) {
         self.value = ._0(visibility: visibility, edges: edges)
         
     }
@@ -5961,7 +6683,7 @@ struct _listRowSeparatorModifier<R: RootRegistry>: ViewModifier {
         case let ._0(visibility, edges):
             if #available(macOS 13.0,visionOS 1.0,iOS 15.0, *) {
             let visibility = visibility as! AttributeReference<SwiftUI.Visibility>
-let edges = edges as! SwiftUI.VerticalEdge.Set 
+let edges = edges as! SwiftUICore.VerticalEdge.Set 
             
             __content
                 .listRowSeparator(visibility.resolve(on: element, in: context), edges: edges)
@@ -5995,7 +6717,7 @@ struct _listRowSeparatorTintModifier<R: RootRegistry>: ViewModifier {
 
     #if os(iOS) || os(macOS) || os(visionOS)
     @available(macOS 13.0,visionOS 1.0,iOS 15.0, *)
-    init(_ color: Color.Resolvable?,edges: SwiftUI.VerticalEdge.Set = .all ) {
+    init(_ color: Color.Resolvable?,edges: SwiftUICore.VerticalEdge.Set = .all ) {
         self.value = ._0(color: color, edges: edges)
         
     }
@@ -6009,7 +6731,7 @@ struct _listRowSeparatorTintModifier<R: RootRegistry>: ViewModifier {
         case let ._0(color, edges):
             if #available(macOS 13.0,visionOS 1.0,iOS 15.0, *) {
             let color = color as? Color.Resolvable
-let edges = edges as! SwiftUI.VerticalEdge.Set 
+let edges = edges as! SwiftUICore.VerticalEdge.Set 
             
             __content
                 .listRowSeparatorTint(color?.resolve(on: element, in: context), edges: edges)
@@ -6042,7 +6764,7 @@ struct _listRowSpacingModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(visionOS)
-    @available(visionOS 1.0,iOS 15.0, *)
+    @available(iOS 15.0,visionOS 1.0, *)
     init(_ spacing: AttributeReference<CoreFoundation.CGFloat?>?) {
         self.value = ._0(spacing: spacing)
         
@@ -6055,7 +6777,7 @@ struct _listRowSpacingModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(visionOS)
         case let ._0(spacing):
-            if #available(visionOS 1.0,iOS 15.0, *) {
+            if #available(iOS 15.0,visionOS 1.0, *) {
             let spacing = spacing as? AttributeReference<CoreFoundation.CGFloat?>
             
             __content
@@ -6090,7 +6812,7 @@ struct _listSectionSeparatorModifier<R: RootRegistry>: ViewModifier {
 
     #if os(iOS) || os(macOS) || os(visionOS)
     @available(macOS 13.0,visionOS 1.0,iOS 15.0, *)
-    init(_ visibility: AttributeReference<SwiftUI.Visibility>,edges: SwiftUI.VerticalEdge.Set = .all ) {
+    init(_ visibility: AttributeReference<SwiftUI.Visibility>,edges: SwiftUICore.VerticalEdge.Set = .all ) {
         self.value = ._0(visibility: visibility, edges: edges)
         
     }
@@ -6104,7 +6826,7 @@ struct _listSectionSeparatorModifier<R: RootRegistry>: ViewModifier {
         case let ._0(visibility, edges):
             if #available(macOS 13.0,visionOS 1.0,iOS 15.0, *) {
             let visibility = visibility as! AttributeReference<SwiftUI.Visibility>
-let edges = edges as! SwiftUI.VerticalEdge.Set 
+let edges = edges as! SwiftUICore.VerticalEdge.Set 
             
             __content
                 .listSectionSeparator(visibility.resolve(on: element, in: context), edges: edges)
@@ -6138,7 +6860,7 @@ struct _listSectionSeparatorTintModifier<R: RootRegistry>: ViewModifier {
 
     #if os(iOS) || os(macOS) || os(visionOS)
     @available(macOS 13.0,visionOS 1.0,iOS 15.0, *)
-    init(_ color: Color.Resolvable?,edges: SwiftUI.VerticalEdge.Set = .all ) {
+    init(_ color: Color.Resolvable?,edges: SwiftUICore.VerticalEdge.Set = .all ) {
         self.value = ._0(color: color, edges: edges)
         
     }
@@ -6152,7 +6874,7 @@ struct _listSectionSeparatorTintModifier<R: RootRegistry>: ViewModifier {
         case let ._0(color, edges):
             if #available(macOS 13.0,visionOS 1.0,iOS 15.0, *) {
             let color = color as? Color.Resolvable
-let edges = edges as! SwiftUI.VerticalEdge.Set 
+let edges = edges as! SwiftUICore.VerticalEdge.Set 
             
             __content
                 .listSectionSeparatorTint(color?.resolve(on: element, in: context), edges: edges)
@@ -6190,14 +6912,14 @@ struct _listSectionSpacingModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 10.0,visionOS 1.0,iOS 17.0, *)
+    @available(iOS 17.0,watchOS 10.0,visionOS 1.0, *)
     init(_ spacing: SwiftUI.ListSectionSpacing) {
         self.value = ._0(spacing: spacing)
         
     }
     #endif
     #if os(iOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 10.0,visionOS 1.0,iOS 17.0, *)
+    @available(iOS 17.0,watchOS 10.0,visionOS 1.0, *)
     init(_ spacing: AttributeReference<CoreFoundation.CGFloat>) {
         self.value = ._1(spacing: spacing)
         
@@ -6210,7 +6932,7 @@ struct _listSectionSpacingModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(visionOS) || os(watchOS)
         case let ._0(spacing):
-            if #available(watchOS 10.0,visionOS 1.0,iOS 17.0, *) {
+            if #available(iOS 17.0,watchOS 10.0,visionOS 1.0, *) {
             let spacing = spacing as! SwiftUI.ListSectionSpacing
             
             __content
@@ -6221,7 +6943,7 @@ struct _listSectionSpacingModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(visionOS) || os(watchOS)
         case let ._1(spacing):
-            if #available(watchOS 10.0,visionOS 1.0,iOS 17.0, *) {
+            if #available(iOS 17.0,watchOS 10.0,visionOS 1.0, *) {
             let spacing = spacing as! AttributeReference<CoreFoundation.CGFloat>
             
             __content
@@ -6329,6 +7051,53 @@ struct _luminanceToAlphaModifier<R: RootRegistry>: ViewModifier {
 }
 @_documentation(visibility: public)
 @ParseableExpression
+struct _materialActiveAppearanceModifier<R: RootRegistry>: ViewModifier {
+    static var name: String { "materialActiveAppearance" }
+
+    enum Value {
+        case _never
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+        indirect case _0(appearance: Any)
+        #endif
+    }
+
+    let value: Value
+
+    
+    
+    
+
+
+
+
+    #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+    @available(iOS 18.0,watchOS 11.0,tvOS 18.0,visionOS 2.0,macOS 15.0, *)
+    init(_ appearance: SwiftUICore.MaterialActiveAppearance) {
+        self.value = ._0(appearance: appearance)
+        
+    }
+    #endif
+
+    func body(content __content: Content) -> some View {
+        switch value {
+        case ._never:
+            fatalError("unreachable")
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+        case let ._0(appearance):
+            if #available(iOS 18.0,watchOS 11.0,tvOS 18.0,visionOS 2.0,macOS 15.0, *) {
+            let appearance = appearance as! SwiftUICore.MaterialActiveAppearance
+            
+            __content
+                .materialActiveAppearance(appearance)
+            
+                
+            } else { __content }
+        #endif
+        }
+    }
+}
+@_documentation(visibility: public)
+@ParseableExpression
 struct _menuIndicatorModifier<R: RootRegistry>: ViewModifier {
     static var name: String { "menuIndicator" }
 
@@ -6349,7 +7118,7 @@ struct _menuIndicatorModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS)
-    @available(iOS 15.0,tvOS 17.0,macOS 12.0,visionOS 1.0, *)
+    @available(tvOS 17.0,macOS 12.0,visionOS 1.0,iOS 15.0, *)
     init(_ visibility: AttributeReference<SwiftUI.Visibility>) {
         self.value = ._0(visibility: visibility)
         
@@ -6362,7 +7131,7 @@ struct _menuIndicatorModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS)
         case let ._0(visibility):
-            if #available(iOS 15.0,tvOS 17.0,macOS 12.0,visionOS 1.0, *) {
+            if #available(tvOS 17.0,macOS 12.0,visionOS 1.0,iOS 15.0, *) {
             let visibility = visibility as! AttributeReference<SwiftUI.Visibility>
             
             __content
@@ -6443,7 +7212,7 @@ struct _menuStyleModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS)
-    @available(iOS 14.0,tvOS 17.0,macOS 11.0,visionOS 1.0, *)
+    @available(visionOS 1.0,macOS 11.0,iOS 14.0,tvOS 17.0, *)
     init(_ style: AnyMenuStyle) {
         self.value = ._0(style: style)
         
@@ -6456,7 +7225,7 @@ struct _menuStyleModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS)
         case let ._0(style):
-            if #available(iOS 14.0,tvOS 17.0,macOS 11.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,macOS 11.0,iOS 14.0,tvOS 17.0, *) {
             let style = style as! AnyMenuStyle
             
             __content
@@ -6517,6 +7286,54 @@ struct _minimumScaleFactorModifier<R: RootRegistry>: ViewModifier {
 }
 @_documentation(visibility: public)
 @ParseableExpression
+struct _modifierKeyAlternateModifier<R: RootRegistry>: ViewModifier {
+    static var name: String { "modifierKeyAlternate" }
+
+    enum Value {
+        case _never
+        #if os(macOS) || os(visionOS)
+        indirect case _0(modifiers: Any,alternate: Any)
+        #endif
+    }
+
+    let value: Value
+
+    @ObservedElement private var element
+    @LiveContext<R> private var context
+    
+
+
+
+
+    #if os(macOS) || os(visionOS)
+    @available(macOS 15.0,visionOS 1.0, *)
+    init(_ modifiers: SwiftUICore.EventModifiers,_ alternate: ViewReference=ViewReference(value: [])) {
+        self.value = ._0(modifiers: modifiers, alternate: alternate)
+        
+    }
+    #endif
+
+    func body(content __content: Content) -> some View {
+        switch value {
+        case ._never:
+            fatalError("unreachable")
+        #if os(macOS) || os(visionOS)
+        case let ._0(modifiers, alternate):
+            if #available(macOS 15.0,visionOS 1.0, *) {
+            let modifiers = modifiers as! SwiftUICore.EventModifiers
+let alternate = alternate as! ViewReference
+            
+            __content
+                .modifierKeyAlternate(modifiers, { alternate.resolve(on: element, in: context) })
+            
+                
+            } else { __content }
+        #endif
+        }
+    }
+}
+@_documentation(visibility: public)
+@ParseableExpression
 struct _moveDisabledModifier<R: RootRegistry>: ViewModifier {
     static var name: String { "moveDisabled" }
 
@@ -6570,7 +7387,7 @@ struct _multilineTextAlignmentModifier<R: RootRegistry>: ViewModifier {
     enum Value {
         case _never
         
-        indirect case _0(alignment: SwiftUI.TextAlignment)
+        indirect case _0(alignment: SwiftUICore.TextAlignment)
         
     }
 
@@ -6585,7 +7402,7 @@ struct _multilineTextAlignmentModifier<R: RootRegistry>: ViewModifier {
 
     
     
-    init(_ alignment: SwiftUI.TextAlignment) {
+    init(_ alignment: SwiftUICore.TextAlignment) {
         self.value = ._0(alignment: alignment)
         
     }
@@ -6678,7 +7495,7 @@ struct _navigationBarTitleDisplayModeModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 8.0,visionOS 1.0,iOS 14.0, *)
+    @available(watchOS 8.0,iOS 14.0,visionOS 1.0, *)
     init(_ displayMode: SwiftUI.NavigationBarItem.TitleDisplayMode) {
         self.value = ._0(displayMode: displayMode)
         
@@ -6691,7 +7508,7 @@ struct _navigationBarTitleDisplayModeModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(visionOS) || os(watchOS)
         case let ._0(displayMode):
-            if #available(watchOS 8.0,visionOS 1.0,iOS 14.0, *) {
+            if #available(watchOS 8.0,iOS 14.0,visionOS 1.0, *) {
             let displayMode = displayMode as! SwiftUI.NavigationBarItem.TitleDisplayMode
             
             __content
@@ -6907,7 +7724,7 @@ struct _navigationSubtitleModifier<R: RootRegistry>: ViewModifier {
     #endif
     #if os(macOS) || targetEnvironment(macCatalyst)
     @available(macCatalyst 14.0,macOS 11.0, *)
-    init(_ subtitleKey: SwiftUI.LocalizedStringKey) {
+    init(_ subtitleKey: SwiftUICore.LocalizedStringKey) {
         self.value = ._1(subtitleKey: subtitleKey)
         
     }
@@ -6938,7 +7755,7 @@ struct _navigationSubtitleModifier<R: RootRegistry>: ViewModifier {
         #if os(macOS) || targetEnvironment(macCatalyst)
         case let ._1(subtitleKey):
             if #available(macCatalyst 14.0,macOS 11.0, *) {
-            let subtitleKey = subtitleKey as! SwiftUI.LocalizedStringKey
+            let subtitleKey = subtitleKey as! SwiftUICore.LocalizedStringKey
             
             __content
                 .navigationSubtitle(subtitleKey)
@@ -6971,7 +7788,7 @@ struct _navigationTitleModifier<R: RootRegistry>: ViewModifier {
         indirect case _0(title: TextReference)
         
         
-        indirect case _1(titleKey: SwiftUI.LocalizedStringKey)
+        indirect case _1(titleKey: SwiftUICore.LocalizedStringKey)
         
         
         indirect case _2(title: AttributeReference<String>)
@@ -7010,7 +7827,7 @@ struct _navigationTitleModifier<R: RootRegistry>: ViewModifier {
     
     
     
-    init(_ titleKey: SwiftUI.LocalizedStringKey) {
+    init(_ titleKey: SwiftUICore.LocalizedStringKey) {
         self.value = ._1(titleKey: titleKey)
         
     }
@@ -7023,7 +7840,7 @@ struct _navigationTitleModifier<R: RootRegistry>: ViewModifier {
     }
     
     #if os(watchOS)
-    @available(watchOS 7.0,macOS 11.0,iOS 14.0,tvOS 14.0, *)
+    @available(iOS 14.0,tvOS 14.0,watchOS 7.0,macOS 11.0, *)
     init(_ title: ViewReference=ViewReference(value: [])) {
         self.value = ._3(title: title)
         
@@ -7076,7 +7893,7 @@ struct _navigationTitleModifier<R: RootRegistry>: ViewModifier {
         
         #if os(watchOS)
         case let ._3(title):
-            if #available(watchOS 7.0,macOS 11.0,iOS 14.0,tvOS 14.0, *) {
+            if #available(iOS 14.0,tvOS 14.0,watchOS 7.0,macOS 11.0, *) {
             let title = title as! ViewReference
             
             __content
@@ -7106,15 +7923,15 @@ struct _offsetModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        
-        indirect case _0(offset: CoreFoundation.CGSize)
-        
-        
-        indirect case _1(x: AttributeReference<CoreFoundation.CGFloat> = .init(storage: .constant(0)), y: AttributeReference<CoreFoundation.CGFloat> = .init(storage: .constant(0)) )
-        
         #if os(visionOS)
-        indirect case _2(z: Any)
+        indirect case _0(z: Any)
         #endif
+        
+        indirect case _1(offset: CoreFoundation.CGSize)
+        
+        
+        indirect case _2(x: AttributeReference<CoreFoundation.CGFloat> = .init(storage: .constant(0)), y: AttributeReference<CoreFoundation.CGFloat> = .init(storage: .constant(0)) )
+        
     }
 
     let value: Value
@@ -7130,34 +7947,45 @@ struct _offsetModifier<R: RootRegistry>: ViewModifier {
 
 
 
+    #if os(visionOS)
+    @available(visionOS 1.0, *)
+    init(z: AttributeReference<CoreFoundation.CGFloat>) {
+        self.value = ._0(z: z)
+        
+    }
+    #endif
     
     
     init(_ offset: CoreFoundation.CGSize) {
-        self.value = ._0(offset: offset)
+        self.value = ._1(offset: offset)
         
     }
     
     
     
     init(x: AttributeReference<CoreFoundation.CGFloat> = .init(storage: .constant(0)), y: AttributeReference<CoreFoundation.CGFloat> = .init(storage: .constant(0)) ) {
-        self.value = ._1(x: x, y: y)
+        self.value = ._2(x: x, y: y)
         
     }
     
-    #if os(visionOS)
-    @available(visionOS 1.0, *)
-    init(z: AttributeReference<CoreFoundation.CGFloat>) {
-        self.value = ._2(z: z)
-        
-    }
-    #endif
 
     func body(content __content: Content) -> some View {
         switch value {
         case ._never:
             fatalError("unreachable")
+        #if os(visionOS)
+        case let ._0(z):
+            if #available(visionOS 1.0, *) {
+            let z = z as! AttributeReference<CoreFoundation.CGFloat>
+            
+            __content
+                .offset(z: z.resolve(on: element, in: context))
+            
+                
+            } else { __content }
+        #endif
         
-        case let ._0(offset):
+        case let ._1(offset):
             
             
             
@@ -7168,7 +7996,7 @@ struct _offsetModifier<R: RootRegistry>: ViewModifier {
             
         
         
-        case let ._1(x, y):
+        case let ._2(x, y):
             
             
             
@@ -7178,17 +8006,6 @@ struct _offsetModifier<R: RootRegistry>: ViewModifier {
                 
             
         
-        #if os(visionOS)
-        case let ._2(z):
-            if #available(visionOS 1.0, *) {
-            let z = z as! AttributeReference<CoreFoundation.CGFloat>
-            
-            __content
-                .offset(z: z.resolve(on: element, in: context))
-            
-                
-            } else { __content }
-        #endif
         }
     }
 }
@@ -7355,7 +8172,7 @@ struct _onExitCommandModifier<R: RootRegistry>: ViewModifier {
 @Event private var _0_action__0: Event.EventHandler
 
     #if os(macOS) || os(tvOS)
-    @available(tvOS 13.0,macOS 10.15, *)
+    @available(macOS 10.15,tvOS 13.0, *)
     init(perform action__0: Event=Event()) {
         self.value = ._0
         self.__0_action__0 = action__0
@@ -7368,7 +8185,7 @@ struct _onExitCommandModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(macOS) || os(tvOS)
         case ._0:
-            if #available(tvOS 13.0,macOS 10.15, *) {
+            if #available(macOS 10.15,tvOS 13.0, *) {
             
             
             __content
@@ -7429,6 +8246,53 @@ struct _onHoverModifier<R: RootRegistry>: ViewModifier {
 }
 @_documentation(visibility: public)
 @ParseableExpression
+struct _onImmersionChangeModifier<R: RootRegistry>: ViewModifier {
+    static var name: String { "onImmersionChange" }
+
+    enum Value {
+        case _never
+        #if os(visionOS)
+        indirect case _0(initial: Any)
+        #endif
+    }
+
+    let value: Value
+
+    @ObservedElement private var element
+    @LiveContext<R> private var context
+    
+
+
+@Event private var _0_action__2: Event.EventHandler
+
+    #if os(visionOS)
+    @available(visionOS 2.0, *)
+    init(initial: AttributeReference<Swift.Bool> = .init(storage: .constant(true)), action action__2: Event) {
+        self.value = ._0(initial: initial)
+        self.__0_action__2 = action__2
+    }
+    #endif
+
+    func body(content __content: Content) -> some View {
+        switch value {
+        case ._never:
+            fatalError("unreachable")
+        #if os(visionOS)
+        case let ._0(initial):
+            if #available(visionOS 2.0, *) {
+            let initial = initial as! AttributeReference<Swift.Bool>
+            
+            __content
+                .onImmersionChange(initial: initial.resolve(on: element, in: context), { __0_action__2.wrappedValue(value: [$0, $1]) })
+            
+                
+            } else { __content }
+        #endif
+        }
+    }
+}
+@_documentation(visibility: public)
+@ParseableExpression
 struct _onLongPressGestureModifier<R: RootRegistry>: ViewModifier {
     static var name: String { "onLongPressGesture" }
 
@@ -7456,7 +8320,7 @@ struct _onLongPressGestureModifier<R: RootRegistry>: ViewModifier {
 @Event private var _1_onPressingChanged__1: Event.EventHandler
 
     #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 6.0,iOS 13.0,visionOS 1.0,macOS 10.15,tvOS 14.0, *)
+    @available(visionOS 1.0,macOS 10.15,iOS 13.0,tvOS 14.0,watchOS 6.0, *)
     init(minimumDuration: AttributeReference<Swift.Double> = .init(storage: .constant(0.5)), maximumDistance: AttributeReference<CoreFoundation.CGFloat> = .init(storage: .constant(10)), perform action__0: Event,onPressingChanged onPressingChanged__1: Event=Event() ) {
         self.value = ._0(minimumDuration: minimumDuration, maximumDistance: maximumDistance)
         self.__0_action__0 = action__0
@@ -7464,7 +8328,7 @@ self.__0_onPressingChanged__1 = onPressingChanged__1
     }
     #endif
     #if os(tvOS)
-    @available(watchOS 6.0,iOS 13.0,macOS 10.15,tvOS 14.0, *)
+    @available(macOS 10.15,iOS 13.0,tvOS 14.0,watchOS 6.0, *)
     init(minimumDuration: AttributeReference<Swift.Double> = .init(storage: .constant(0.5)), perform action__0: Event,onPressingChanged onPressingChanged__1: Event=Event() ) {
         self.value = ._1(minimumDuration: minimumDuration)
         self.__1_action__0 = action__0
@@ -7478,7 +8342,7 @@ self.__1_onPressingChanged__1 = onPressingChanged__1
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
         case let ._0(minimumDuration, maximumDistance):
-            if #available(watchOS 6.0,iOS 13.0,visionOS 1.0,macOS 10.15,tvOS 14.0, *) {
+            if #available(visionOS 1.0,macOS 10.15,iOS 13.0,tvOS 14.0,watchOS 6.0, *) {
             let minimumDuration = minimumDuration as! AttributeReference<Swift.Double>
 let maximumDistance = maximumDistance as! AttributeReference<CoreFoundation.CGFloat>
             
@@ -7490,7 +8354,7 @@ let maximumDistance = maximumDistance as! AttributeReference<CoreFoundation.CGFl
         #endif
         #if os(tvOS)
         case let ._1(minimumDuration):
-            if #available(watchOS 6.0,iOS 13.0,macOS 10.15,tvOS 14.0, *) {
+            if #available(macOS 10.15,iOS 13.0,tvOS 14.0,watchOS 6.0, *) {
             let minimumDuration = minimumDuration as! AttributeReference<Swift.Double>
             
             __content
@@ -7553,6 +8417,54 @@ self.__0_onTouchingChanged__1 = onTouchingChanged__1
 }
 @_documentation(visibility: public)
 @ParseableExpression
+struct _onModifierKeysChangedModifier<R: RootRegistry>: ViewModifier {
+    static var name: String { "onModifierKeysChanged" }
+
+    enum Value {
+        case _never
+        #if os(macOS) || os(visionOS)
+        indirect case _0(mask: Any, initial: Any)
+        #endif
+    }
+
+    let value: Value
+
+    @ObservedElement private var element
+    @LiveContext<R> private var context
+    
+
+
+@Event private var _0_action__2: Event.EventHandler
+
+    #if os(macOS) || os(visionOS)
+    @available(macOS 15.0,visionOS 1.0, *)
+    init(mask: SwiftUICore.EventModifiers = .all, initial: AttributeReference<Swift.Bool> = .init(storage: .constant(true)), action action__2: Event) {
+        self.value = ._0(mask: mask, initial: initial)
+        self.__0_action__2 = action__2
+    }
+    #endif
+
+    func body(content __content: Content) -> some View {
+        switch value {
+        case ._never:
+            fatalError("unreachable")
+        #if os(macOS) || os(visionOS)
+        case let ._0(mask, initial):
+            if #available(macOS 15.0,visionOS 1.0, *) {
+            let mask = mask as! SwiftUICore.EventModifiers 
+let initial = initial as! AttributeReference<Swift.Bool>
+            
+            __content
+                .onModifierKeysChanged(mask: mask, initial: initial.resolve(on: element, in: context), { __0_action__2.wrappedValue(value: [$0, $1]) })
+            
+                
+            } else { __content }
+        #endif
+        }
+    }
+}
+@_documentation(visibility: public)
+@ParseableExpression
 struct _onMoveCommandModifier<R: RootRegistry>: ViewModifier {
     static var name: String { "onMoveCommand" }
 
@@ -7573,7 +8485,7 @@ struct _onMoveCommandModifier<R: RootRegistry>: ViewModifier {
 @Event private var _0_action__1: Event.EventHandler
 
     #if os(macOS) || os(tvOS)
-    @available(tvOS 13.0,macOS 10.15, *)
+    @available(macOS 10.15,tvOS 13.0, *)
     init(perform action__1: Event=Event()) {
         self.value = ._0
         self.__0_action__1 = action__1
@@ -7586,11 +8498,105 @@ struct _onMoveCommandModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(macOS) || os(tvOS)
         case ._0:
-            if #available(tvOS 13.0,macOS 10.15, *) {
+            if #available(macOS 10.15,tvOS 13.0, *) {
             
             
             __content
                 .onMoveCommand(perform: { __0_action__1.wrappedValue(value: $0) })
+            
+                
+            } else { __content }
+        #endif
+        }
+    }
+}
+@_documentation(visibility: public)
+@ParseableExpression
+struct _onPencilDoubleTapModifier<R: RootRegistry>: ViewModifier {
+    static var name: String { "onPencilDoubleTap" }
+
+    enum Value {
+        case _never
+        #if os(iOS) || os(macOS)
+         case _0
+        #endif
+    }
+
+    let value: Value
+
+    
+    
+    
+
+
+@Event private var _0_action__1: Event.EventHandler
+
+    #if os(iOS) || os(macOS)
+    @available(macOS 14.5,iOS 17.5, *)
+    init(perform action__1: Event) {
+        self.value = ._0
+        self.__0_action__1 = action__1
+    }
+    #endif
+
+    func body(content __content: Content) -> some View {
+        switch value {
+        case ._never:
+            fatalError("unreachable")
+        #if os(iOS) || os(macOS)
+        case ._0:
+            if #available(macOS 14.5,iOS 17.5, *) {
+            
+            
+            __content
+                .onPencilDoubleTap(perform: { __0_action__1.wrappedValue(value: $0) })
+            
+                
+            } else { __content }
+        #endif
+        }
+    }
+}
+@_documentation(visibility: public)
+@ParseableExpression
+struct _onPencilSqueezeModifier<R: RootRegistry>: ViewModifier {
+    static var name: String { "onPencilSqueeze" }
+
+    enum Value {
+        case _never
+        #if os(iOS) || os(macOS)
+         case _0
+        #endif
+    }
+
+    let value: Value
+
+    
+    
+    
+
+
+@Event private var _0_action__1: Event.EventHandler
+
+    #if os(iOS) || os(macOS)
+    @available(iOS 17.5,macOS 14.5, *)
+    init(perform action__1: Event) {
+        self.value = ._0
+        self.__0_action__1 = action__1
+    }
+    #endif
+
+    func body(content __content: Content) -> some View {
+        switch value {
+        case ._never:
+            fatalError("unreachable")
+        #if os(iOS) || os(macOS)
+        case ._0:
+            if #available(iOS 17.5,macOS 14.5, *) {
+            
+            
+            __content
+                .onPencilSqueeze(perform: { __0_action__1.wrappedValue(value: $0) })
             
                 
             } else { __content }
@@ -7647,16 +8653,60 @@ struct _onPlayPauseCommandModifier<R: RootRegistry>: ViewModifier {
 }
 @_documentation(visibility: public)
 @ParseableExpression
-struct _onTapGestureModifier<R: RootRegistry>: ViewModifier {
-    static var name: String { "onTapGesture" }
+struct _onScrollPhaseChangeModifier<R: RootRegistry>: ViewModifier {
+    static var name: String { "onScrollPhaseChange" }
 
     enum Value {
         case _never
-        
-        indirect case _0(count: AttributeReference<Swift.Int> = .init(storage: .constant(1)))
-        
-        #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
-        indirect case _1(count: Any, coordinateSpace: Any)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+         case _0
+        #endif
+    }
+
+    let value: Value
+
+    
+    
+    
+
+
+@Event private var _0_action__2: Event.EventHandler
+
+    #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+    @available(visionOS 2.0,macOS 15.0,iOS 18.0,tvOS 18.0,watchOS 11.0, *)
+    init(_ action__2: Event) {
+        self.value = ._0
+        self.__0_action__2 = action__2
+    }
+    #endif
+
+    func body(content __content: Content) -> some View {
+        switch value {
+        case ._never:
+            fatalError("unreachable")
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+        case ._0:
+            if #available(visionOS 2.0,macOS 15.0,iOS 18.0,tvOS 18.0,watchOS 11.0, *) {
+            
+            
+            __content
+                .onScrollPhaseChange({ __0_action__2.wrappedValue(value: [$0, $1]) })
+            
+                
+            } else { __content }
+        #endif
+        }
+    }
+}
+@_documentation(visibility: public)
+@ParseableExpression
+struct _onScrollVisibilityChangeModifier<R: RootRegistry>: ViewModifier {
+    static var name: String { "onScrollVisibilityChange" }
+
+    enum Value {
+        case _never
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+        indirect case _0(threshold: Any)
         #endif
     }
 
@@ -7667,22 +8717,13 @@ struct _onTapGestureModifier<R: RootRegistry>: ViewModifier {
     
 
 
-@Event private var _0_action__0: Event.EventHandler
+@Event private var _0_action__1: Event.EventHandler
 
-@Event private var _1_action__1: Event.EventHandler
-
-    
-    
-    init(count: AttributeReference<Swift.Int> = .init(storage: .constant(1)), perform action__0: Event) {
-        self.value = ._0(count: count)
-        self.__0_action__0 = action__0
-    }
-    
-    #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,macOS 14.0,watchOS 10.0,iOS 17.0, *)
-    init(count: AttributeReference<Swift.Int> = .init(storage: .constant(1)), coordinateSpace: AnyCoordinateSpaceProtocol = .local, perform action__1: Event) {
-        self.value = ._1(count: count, coordinateSpace: coordinateSpace)
-        self.__1_action__1 = action__1
+    #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+    @available(visionOS 2.0,tvOS 18.0,watchOS 11.0,macOS 15.0,iOS 18.0, *)
+    init(threshold: AttributeReference<Swift.Double> = .init(storage: .constant(0.5)), action action__1: Event) {
+        self.value = ._0(threshold: threshold)
+        self.__0_action__1 = action__1
     }
     #endif
 
@@ -7690,25 +8731,132 @@ struct _onTapGestureModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        
-        case let ._0(count):
-            
-            
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+        case let ._0(threshold):
+            if #available(visionOS 2.0,tvOS 18.0,watchOS 11.0,macOS 15.0,iOS 18.0, *) {
+            let threshold = threshold as! AttributeReference<Swift.Double>
             
             __content
-                .onTapGesture(count: count.resolve(on: element, in: context), perform: { __0_action__0.wrappedValue() })
+                .onScrollVisibilityChange(threshold: threshold.resolve(on: element, in: context), { __0_action__1.wrappedValue(value: $0) })
             
                 
-            
-        
+            } else { __content }
+        #endif
+        }
+    }
+}
+@_documentation(visibility: public)
+@ParseableExpression
+struct _onTapGestureModifier<R: RootRegistry>: ViewModifier {
+    static var name: String { "onTapGesture" }
+
+    enum Value {
+        case _never
         #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
-        case let ._1(count, coordinateSpace):
-            if #available(visionOS 1.0,macOS 14.0,watchOS 10.0,iOS 17.0, *) {
+        indirect case _0(count: Any, coordinateSpace: Any)
+        #endif
+        
+        indirect case _1(count: AttributeReference<Swift.Int> = .init(storage: .constant(1)))
+        
+    }
+
+    let value: Value
+
+    @ObservedElement private var element
+    @LiveContext<R> private var context
+    
+
+
+@Event private var _0_action__1: Event.EventHandler
+
+@Event private var _1_action__0: Event.EventHandler
+
+    #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
+    @available(macOS 14.0,watchOS 10.0,iOS 17.0,visionOS 1.0, *)
+    init(count: AttributeReference<Swift.Int> = .init(storage: .constant(1)), coordinateSpace: AnyCoordinateSpaceProtocol = .local, perform action__1: Event) {
+        self.value = ._0(count: count, coordinateSpace: coordinateSpace)
+        self.__0_action__1 = action__1
+    }
+    #endif
+    
+    
+    init(count: AttributeReference<Swift.Int> = .init(storage: .constant(1)), perform action__0: Event) {
+        self.value = ._1(count: count)
+        self.__1_action__0 = action__0
+    }
+    
+
+    func body(content __content: Content) -> some View {
+        switch value {
+        case ._never:
+            fatalError("unreachable")
+        #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
+        case let ._0(count, coordinateSpace):
+            if #available(macOS 14.0,watchOS 10.0,iOS 17.0,visionOS 1.0, *) {
             let count = count as! AttributeReference<Swift.Int>
 let coordinateSpace = coordinateSpace as! AnyCoordinateSpaceProtocol 
             
             __content
-                .onTapGesture(count: count.resolve(on: element, in: context), coordinateSpace: coordinateSpace, perform: { __1_action__1.wrappedValue(value: $0) })
+                .onTapGesture(count: count.resolve(on: element, in: context), coordinateSpace: coordinateSpace, perform: { __0_action__1.wrappedValue(value: $0) })
+            
+                
+            } else { __content }
+        #endif
+        
+        case let ._1(count):
+            
+            
+            
+            __content
+                .onTapGesture(count: count.resolve(on: element, in: context), perform: { __1_action__0.wrappedValue() })
+            
+                
+            
+        
+        }
+    }
+}
+@_documentation(visibility: public)
+@ParseableExpression
+struct _onVolumeViewpointChangeModifier<R: RootRegistry>: ViewModifier {
+    static var name: String { "onVolumeViewpointChange" }
+
+    enum Value {
+        case _never
+        #if os(visionOS)
+        indirect case _0(updateStrategy: Any, initial: Any)
+        #endif
+    }
+
+    let value: Value
+
+    @ObservedElement private var element
+    @LiveContext<R> private var context
+    
+
+
+@Event private var _0_action__2: Event.EventHandler
+
+    #if os(visionOS)
+    @available(visionOS 2.0, *)
+    init(updateStrategy: SwiftUI.VolumeViewpointUpdateStrategy = .supported, initial: AttributeReference<Swift.Bool> = .init(storage: .constant(true)), action action__2: Event) {
+        self.value = ._0(updateStrategy: updateStrategy, initial: initial)
+        self.__0_action__2 = action__2
+    }
+    #endif
+
+    func body(content __content: Content) -> some View {
+        switch value {
+        case ._never:
+            fatalError("unreachable")
+        #if os(visionOS)
+        case let ._0(updateStrategy, initial):
+            if #available(visionOS 2.0, *) {
+            let updateStrategy = updateStrategy as! SwiftUI.VolumeViewpointUpdateStrategy 
+let initial = initial as! AttributeReference<Swift.Bool>
+            
+            __content
+                .onVolumeViewpointChange(updateStrategy: updateStrategy, initial: initial.resolve(on: element, in: context), { __0_action__2.wrappedValue(value: [$0, $1]) })
             
                 
             } else { __content }
@@ -7786,7 +8934,7 @@ struct _ornamentModifier<R: RootRegistry>: ViewModifier {
 
     #if os(visionOS)
     @available(visionOS 1.0, *)
-    init(visibility: AttributeReference<SwiftUI.Visibility> = .init(storage: .constant(.automatic)), attachmentAnchor: SwiftUI.OrnamentAttachmentAnchor,contentAlignment: AttributeReference<SwiftUI.Alignment> = .init(storage: .constant(.center)), ornament: ViewReference=ViewReference(value: [])) {
+    init(visibility: AttributeReference<SwiftUI.Visibility> = .init(storage: .constant(.automatic)), attachmentAnchor: SwiftUI.OrnamentAttachmentAnchor,contentAlignment: AttributeReference<SwiftUICore.Alignment> = .init(storage: .constant(.center)), ornament: ViewReference=ViewReference(value: [])) {
         self.value = ._0(visibility: visibility, attachmentAnchor: attachmentAnchor, contentAlignment: contentAlignment, ornament: ornament)
         
     }
@@ -7801,7 +8949,7 @@ struct _ornamentModifier<R: RootRegistry>: ViewModifier {
             if #available(visionOS 1.0, *) {
             let visibility = visibility as! AttributeReference<SwiftUI.Visibility>
 let attachmentAnchor = attachmentAnchor as! SwiftUI.OrnamentAttachmentAnchor
-let contentAlignment = contentAlignment as! AttributeReference<SwiftUI.Alignment>
+let contentAlignment = contentAlignment as! AttributeReference<SwiftUICore.Alignment>
 let ornament = ornament as! ViewReference
             
             __content
@@ -7821,13 +8969,13 @@ struct _overlayModifier<R: RootRegistry>: ViewModifier {
     enum Value {
         case _never
         
-        indirect case _0(alignment: AttributeReference<SwiftUI.Alignment> = .init(storage: .constant(.center)), content: ViewReference=ViewReference(value: []))
+        indirect case _0(alignment: AttributeReference<SwiftUICore.Alignment> = .init(storage: .constant(.center)), content: ViewReference=ViewReference(value: []))
         
         
-        indirect case _1(style: AnyShapeStyle.Resolvable,edges: SwiftUI.Edge.Set = .all )
+        indirect case _1(style: AnyShapeStyle.Resolvable,edges: SwiftUICore.Edge.Set = .all )
         
         
-        indirect case _2(style: AnyShapeStyle.Resolvable,shape: AnyShape,fillStyle: SwiftUI.FillStyle = FillStyle() )
+        indirect case _2(style: AnyShapeStyle.Resolvable,shape: AnyShape,fillStyle: SwiftUICore.FillStyle = FillStyle() )
         
     }
 
@@ -7846,21 +8994,21 @@ struct _overlayModifier<R: RootRegistry>: ViewModifier {
 
     
     
-    init(alignment: AttributeReference<SwiftUI.Alignment> = .init(storage: .constant(.center)), content: ViewReference=ViewReference(value: [])) {
+    init(alignment: AttributeReference<SwiftUICore.Alignment> = .init(storage: .constant(.center)), content: ViewReference=ViewReference(value: [])) {
         self.value = ._0(alignment: alignment, content: content)
         
     }
     
     
     
-    init(_ style: AnyShapeStyle.Resolvable,ignoresSafeAreaEdges edges: SwiftUI.Edge.Set = .all ) {
+    init(_ style: AnyShapeStyle.Resolvable,ignoresSafeAreaEdges edges: SwiftUICore.Edge.Set = .all ) {
         self.value = ._1(style: style, edges: edges)
         
     }
     
     
     
-    init(_ style: AnyShapeStyle.Resolvable,in shape: AnyShape,fillStyle: SwiftUI.FillStyle = FillStyle() ) {
+    init(_ style: AnyShapeStyle.Resolvable,in shape: AnyShape,fillStyle: SwiftUICore.FillStyle = FillStyle() ) {
         self.value = ._2(style: style, shape: shape, fillStyle: fillStyle)
         
     }
@@ -7914,10 +9062,10 @@ struct _paddingModifier<R: RootRegistry>: ViewModifier {
     enum Value {
         case _never
         
-        indirect case _0(insets: SwiftUI.EdgeInsets)
+        indirect case _0(insets: SwiftUICore.EdgeInsets)
         
         
-        indirect case _1(edges: SwiftUI.Edge.Set = .all, length: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)) )
+        indirect case _1(edges: SwiftUICore.Edge.Set = .all, length: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)) )
         
         
         indirect case _2(length: AttributeReference<CoreFoundation.CGFloat>)
@@ -7939,14 +9087,14 @@ struct _paddingModifier<R: RootRegistry>: ViewModifier {
 
     
     
-    init(_ insets: SwiftUI.EdgeInsets) {
+    init(_ insets: SwiftUICore.EdgeInsets) {
         self.value = ._0(insets: insets)
         
     }
     
     
     
-    init(_ edges: SwiftUI.Edge.Set = .all, _ length: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)) ) {
+    init(_ edges: SwiftUICore.Edge.Set = .all, _ length: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)) ) {
         self.value = ._1(edges: edges, length: length)
         
     }
@@ -8032,14 +9180,14 @@ struct _padding3DModifier<R: RootRegistry>: ViewModifier {
 
     #if os(visionOS)
     @available(visionOS 1.0, *)
-    init(_ insets: SwiftUI.EdgeInsets3D) {
+    init(_ insets: SwiftUICore.EdgeInsets3D) {
         self.value = ._0(insets: insets)
         
     }
     #endif
     #if os(visionOS)
     @available(visionOS 1.0, *)
-    init(_ edges: SwiftUI.Edge3D.Set = .all, _ length: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)) ) {
+    init(_ edges: SwiftUICore.Edge3D.Set = .all, _ length: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)) ) {
         self.value = ._1(edges: edges, length: length)
         
     }
@@ -8059,7 +9207,7 @@ struct _padding3DModifier<R: RootRegistry>: ViewModifier {
         #if os(visionOS)
         case let ._0(insets):
             if #available(visionOS 1.0, *) {
-            let insets = insets as! SwiftUI.EdgeInsets3D
+            let insets = insets as! SwiftUICore.EdgeInsets3D
             
             __content
                 .padding3D(insets)
@@ -8070,7 +9218,7 @@ struct _padding3DModifier<R: RootRegistry>: ViewModifier {
         #if os(visionOS)
         case let ._1(edges, length):
             if #available(visionOS 1.0, *) {
-            let edges = edges as! SwiftUI.Edge3D.Set 
+            let edges = edges as! SwiftUICore.Edge3D.Set 
 let length = length as? AttributeReference<CoreFoundation.CGFloat?>
             
             __content
@@ -8189,6 +9337,100 @@ struct _pickerStyleModifier<R: RootRegistry>: ViewModifier {
 }
 @_documentation(visibility: public)
 @ParseableExpression
+struct _pointerStyleModifier<R: RootRegistry>: ViewModifier {
+    static var name: String { "pointerStyle" }
+
+    enum Value {
+        case _never
+        #if os(macOS) || os(visionOS)
+        indirect case _0(style: Any?)
+        #endif
+    }
+
+    let value: Value
+
+    
+    
+    
+
+
+
+
+    #if os(macOS) || os(visionOS)
+    @available(macOS 15.0,visionOS 2.0, *)
+    init(_ style: SwiftUI.PointerStyle?) {
+        self.value = ._0(style: style)
+        
+    }
+    #endif
+
+    func body(content __content: Content) -> some View {
+        switch value {
+        case ._never:
+            fatalError("unreachable")
+        #if os(macOS) || os(visionOS)
+        case let ._0(style):
+            if #available(macOS 15.0,visionOS 2.0, *) {
+            let style = style as? SwiftUI.PointerStyle
+            
+            __content
+                .pointerStyle(style)
+            
+                
+            } else { __content }
+        #endif
+        }
+    }
+}
+@_documentation(visibility: public)
+@ParseableExpression
+struct _pointerVisibilityModifier<R: RootRegistry>: ViewModifier {
+    static var name: String { "pointerVisibility" }
+
+    enum Value {
+        case _never
+        #if os(macOS)
+        indirect case _0(visibility: Any)
+        #endif
+    }
+
+    let value: Value
+
+    @ObservedElement private var element
+    @LiveContext<R> private var context
+    
+
+
+
+
+    #if os(macOS)
+    @available(macOS 15.0, *)
+    init(_ visibility: AttributeReference<SwiftUI.Visibility>) {
+        self.value = ._0(visibility: visibility)
+        
+    }
+    #endif
+
+    func body(content __content: Content) -> some View {
+        switch value {
+        case ._never:
+            fatalError("unreachable")
+        #if os(macOS)
+        case let ._0(visibility):
+            if #available(macOS 15.0, *) {
+            let visibility = visibility as! AttributeReference<SwiftUI.Visibility>
+            
+            __content
+                .pointerVisibility(visibility.resolve(on: element, in: context))
+            
+                
+            } else { __content }
+        #endif
+        }
+    }
+}
+@_documentation(visibility: public)
+@ParseableExpression
 struct _popoverModifier<R: RootRegistry>: ViewModifier {
     static var name: String { "popover" }
 
@@ -8196,6 +9438,9 @@ struct _popoverModifier<R: RootRegistry>: ViewModifier {
         case _never
         #if os(iOS) || os(macOS) || os(visionOS)
         indirect case _0(attachmentAnchor: Any, arrowEdge: Any, content: Any)
+        #endif
+        #if os(iOS) || os(macOS) || os(visionOS)
+        indirect case _1(attachmentAnchor: Any, content: Any)
         #endif
     }
 
@@ -8207,12 +9452,21 @@ struct _popoverModifier<R: RootRegistry>: ViewModifier {
 
 @ChangeTracked private var _0_isPresented: Swift.Bool
 
+@ChangeTracked private var _1_isPresented: Swift.Bool
+
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 10.15,visionOS 1.0,iOS 13.0, *)
-    init(isPresented: ChangeTracked<Swift.Bool>,attachmentAnchor: SwiftUI.PopoverAttachmentAnchor = .rect(.bounds), arrowEdge: SwiftUI.Edge = .top, content: ViewReference=ViewReference(value: [])) {
+    @available(macOS 10.15,iOS 13.0,visionOS 1.0, *)
+    init(isPresented: ChangeTracked<Swift.Bool>,attachmentAnchor: SwiftUI.PopoverAttachmentAnchor = .rect(.bounds), arrowEdge: SwiftUICore.Edge = .top, content: ViewReference=ViewReference(value: [])) {
         self.value = ._0(attachmentAnchor: attachmentAnchor, arrowEdge: arrowEdge, content: content)
         self.__0_isPresented = isPresented
+    }
+    #endif
+    #if os(iOS) || os(macOS) || os(visionOS)
+    @available(macOS 15.0,iOS 18.0,visionOS 2.0, *)
+    init(isPresented: ChangeTracked<Swift.Bool>,attachmentAnchor: SwiftUI.PopoverAttachmentAnchor = .rect(.bounds), content: ViewReference=ViewReference(value: [])) {
+        self.value = ._1(attachmentAnchor: attachmentAnchor, content: content)
+        self.__1_isPresented = isPresented
     }
     #endif
 
@@ -8222,13 +9476,25 @@ struct _popoverModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(attachmentAnchor, arrowEdge, content):
-            if #available(macOS 10.15,visionOS 1.0,iOS 13.0, *) {
+            if #available(macOS 10.15,iOS 13.0,visionOS 1.0, *) {
             let attachmentAnchor = attachmentAnchor as! SwiftUI.PopoverAttachmentAnchor 
-let arrowEdge = arrowEdge as! SwiftUI.Edge 
+let arrowEdge = arrowEdge as! SwiftUICore.Edge 
 let content = content as! ViewReference
             
             __content
                 .popover(isPresented: __0_isPresented.projectedValue, attachmentAnchor: attachmentAnchor, arrowEdge: arrowEdge, content: { content.resolve(on: element, in: context) })
+            
+                
+            } else { __content }
+        #endif
+        #if os(iOS) || os(macOS) || os(visionOS)
+        case let ._1(attachmentAnchor, content):
+            if #available(macOS 15.0,iOS 18.0,visionOS 2.0, *) {
+            let attachmentAnchor = attachmentAnchor as! SwiftUI.PopoverAttachmentAnchor 
+let content = content as! ViewReference
+            
+            __content
+                .popover(isPresented: __1_isPresented.projectedValue, attachmentAnchor: attachmentAnchor, content: { content.resolve(on: element, in: context) })
             
                 
             } else { __content }
@@ -8314,7 +9580,7 @@ struct _preferredColorSchemeModifier<R: RootRegistry>: ViewModifier {
     enum Value {
         case _never
         
-        indirect case _0(colorScheme: AttributeReference<SwiftUI.ColorScheme?>?)
+        indirect case _0(colorScheme: AttributeReference<SwiftUICore.ColorScheme?>?)
         
     }
 
@@ -8329,7 +9595,7 @@ struct _preferredColorSchemeModifier<R: RootRegistry>: ViewModifier {
 
     
     
-    init(_ colorScheme: AttributeReference<SwiftUI.ColorScheme?>?) {
+    init(_ colorScheme: AttributeReference<SwiftUICore.ColorScheme?>?) {
         self.value = ._0(colorScheme: colorScheme)
         
     }
@@ -8427,15 +9693,15 @@ struct _presentationBackgroundModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 9.4,visionOS 1.0,tvOS 16.4,macOS 13.3,iOS 16.4, *)
+    @available(watchOS 9.4,macOS 13.3,visionOS 1.0,tvOS 16.4,iOS 16.4, *)
     init(_ style: AnyShapeStyle.Resolvable) {
         self.value = ._0(style: style)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 9.4,visionOS 1.0,tvOS 16.4,macOS 13.3,iOS 16.4, *)
-    init(alignment: AttributeReference<SwiftUI.Alignment> = .init(storage: .constant(.center)), content: ViewReference=ViewReference(value: [])) {
+    @available(watchOS 9.4,macOS 13.3,visionOS 1.0,tvOS 16.4,iOS 16.4, *)
+    init(alignment: AttributeReference<SwiftUICore.Alignment> = .init(storage: .constant(.center)), content: ViewReference=ViewReference(value: [])) {
         self.value = ._1(alignment: alignment, content: content)
         
     }
@@ -8447,7 +9713,7 @@ struct _presentationBackgroundModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(style):
-            if #available(watchOS 9.4,visionOS 1.0,tvOS 16.4,macOS 13.3,iOS 16.4, *) {
+            if #available(watchOS 9.4,macOS 13.3,visionOS 1.0,tvOS 16.4,iOS 16.4, *) {
             let style = style as! AnyShapeStyle.Resolvable
             
             __content
@@ -8458,8 +9724,8 @@ struct _presentationBackgroundModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(alignment, content):
-            if #available(watchOS 9.4,visionOS 1.0,tvOS 16.4,macOS 13.3,iOS 16.4, *) {
-            let alignment = alignment as! AttributeReference<SwiftUI.Alignment>
+            if #available(watchOS 9.4,macOS 13.3,visionOS 1.0,tvOS 16.4,iOS 16.4, *) {
+            let alignment = alignment as! AttributeReference<SwiftUICore.Alignment>
 let content = content as! ViewReference
             
             __content
@@ -8493,7 +9759,7 @@ struct _presentationBackgroundInteractionModifier<R: RootRegistry>: ViewModifier
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,watchOS 9.4,macOS 13.3,tvOS 16.4,iOS 16.4, *)
+    @available(watchOS 9.4,macOS 13.3,visionOS 1.0,tvOS 16.4,iOS 16.4, *)
     init(_ interaction: SwiftUI.PresentationBackgroundInteraction) {
         self.value = ._0(interaction: interaction)
         
@@ -8506,7 +9772,7 @@ struct _presentationBackgroundInteractionModifier<R: RootRegistry>: ViewModifier
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(interaction):
-            if #available(visionOS 1.0,watchOS 9.4,macOS 13.3,tvOS 16.4,iOS 16.4, *) {
+            if #available(watchOS 9.4,macOS 13.3,visionOS 1.0,tvOS 16.4,iOS 16.4, *) {
             let interaction = interaction as! SwiftUI.PresentationBackgroundInteraction
             
             __content
@@ -8545,14 +9811,14 @@ struct _presentationCompactAdaptationModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,watchOS 9.4,macOS 13.3,tvOS 16.4,iOS 16.4, *)
+    @available(watchOS 9.4,macOS 13.3,visionOS 1.0,tvOS 16.4,iOS 16.4, *)
     init(_ adaptation: SwiftUI.PresentationAdaptation) {
         self.value = ._0(adaptation: adaptation)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,watchOS 9.4,macOS 13.3,tvOS 16.4,iOS 16.4, *)
+    @available(watchOS 9.4,macOS 13.3,visionOS 1.0,tvOS 16.4,iOS 16.4, *)
     init(horizontal horizontalAdaptation: SwiftUI.PresentationAdaptation,vertical verticalAdaptation: SwiftUI.PresentationAdaptation) {
         self.value = ._1(horizontalAdaptation: horizontalAdaptation, verticalAdaptation: verticalAdaptation)
         
@@ -8565,7 +9831,7 @@ struct _presentationCompactAdaptationModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(adaptation):
-            if #available(visionOS 1.0,watchOS 9.4,macOS 13.3,tvOS 16.4,iOS 16.4, *) {
+            if #available(watchOS 9.4,macOS 13.3,visionOS 1.0,tvOS 16.4,iOS 16.4, *) {
             let adaptation = adaptation as! SwiftUI.PresentationAdaptation
             
             __content
@@ -8576,7 +9842,7 @@ struct _presentationCompactAdaptationModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(horizontalAdaptation, verticalAdaptation):
-            if #available(visionOS 1.0,watchOS 9.4,macOS 13.3,tvOS 16.4,iOS 16.4, *) {
+            if #available(watchOS 9.4,macOS 13.3,visionOS 1.0,tvOS 16.4,iOS 16.4, *) {
             let horizontalAdaptation = horizontalAdaptation as! SwiftUI.PresentationAdaptation
 let verticalAdaptation = verticalAdaptation as! SwiftUI.PresentationAdaptation
             
@@ -8611,7 +9877,7 @@ struct _presentationContentInteractionModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,watchOS 9.4,macOS 13.3,tvOS 16.4,iOS 16.4, *)
+    @available(visionOS 1.0,tvOS 16.4,watchOS 9.4,macOS 13.3,iOS 16.4, *)
     init(_ behavior: SwiftUI.PresentationContentInteraction) {
         self.value = ._0(behavior: behavior)
         
@@ -8624,7 +9890,7 @@ struct _presentationContentInteractionModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(behavior):
-            if #available(visionOS 1.0,watchOS 9.4,macOS 13.3,tvOS 16.4,iOS 16.4, *) {
+            if #available(visionOS 1.0,tvOS 16.4,watchOS 9.4,macOS 13.3,iOS 16.4, *) {
             let behavior = behavior as! SwiftUI.PresentationContentInteraction
             
             __content
@@ -8658,7 +9924,7 @@ struct _presentationCornerRadiusModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,watchOS 9.4,macOS 13.3,tvOS 16.4,iOS 16.4, *)
+    @available(iOS 16.4,watchOS 9.4,tvOS 16.4,visionOS 1.0,macOS 13.3, *)
     init(_ cornerRadius: AttributeReference<CoreFoundation.CGFloat?>?) {
         self.value = ._0(cornerRadius: cornerRadius)
         
@@ -8671,7 +9937,7 @@ struct _presentationCornerRadiusModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(cornerRadius):
-            if #available(visionOS 1.0,watchOS 9.4,macOS 13.3,tvOS 16.4,iOS 16.4, *) {
+            if #available(iOS 16.4,watchOS 9.4,tvOS 16.4,visionOS 1.0,macOS 13.3, *) {
             let cornerRadius = cornerRadius as? AttributeReference<CoreFoundation.CGFloat?>
             
             __content
@@ -8727,6 +9993,53 @@ struct _presentationDragIndicatorModifier<R: RootRegistry>: ViewModifier {
                 
             
         
+        }
+    }
+}
+@_documentation(visibility: public)
+@ParseableExpression
+struct _presentationSizingModifier<R: RootRegistry>: ViewModifier {
+    static var name: String { "presentationSizing" }
+
+    enum Value {
+        case _never
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+        indirect case _0(sizing: Any)
+        #endif
+    }
+
+    let value: Value
+
+    
+    
+    
+
+
+
+
+    #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+    @available(tvOS 18.0,macOS 15.0,watchOS 11.0,visionOS 2.0,iOS 18.0, *)
+    init(_ sizing: AnyPresentationSizing) {
+        self.value = ._0(sizing: sizing)
+        
+    }
+    #endif
+
+    func body(content __content: Content) -> some View {
+        switch value {
+        case ._never:
+            fatalError("unreachable")
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+        case let ._0(sizing):
+            if #available(tvOS 18.0,macOS 15.0,watchOS 11.0,visionOS 2.0,iOS 18.0, *) {
+            let sizing = sizing as! AnyPresentationSizing
+            
+            __content
+                .presentationSizing(sizing)
+            
+                
+            } else { __content }
+        #endif
         }
     }
 }
@@ -8879,7 +10192,7 @@ struct _projectionEffectModifier<R: RootRegistry>: ViewModifier {
     enum Value {
         case _never
         
-        indirect case _0(transform: SwiftUI.ProjectionTransform)
+        indirect case _0(transform: SwiftUICore.ProjectionTransform)
         
     }
 
@@ -8894,7 +10207,7 @@ struct _projectionEffectModifier<R: RootRegistry>: ViewModifier {
 
     
     
-    init(_ transform: SwiftUI.ProjectionTransform) {
+    init(_ transform: SwiftUICore.ProjectionTransform) {
         self.value = ._0(transform: transform)
         
     }
@@ -8926,7 +10239,7 @@ struct _redactedModifier<R: RootRegistry>: ViewModifier {
     enum Value {
         case _never
         
-        indirect case _0(reason: SwiftUI.RedactionReasons)
+        indirect case _0(reason: SwiftUICore.RedactionReasons)
         
     }
 
@@ -8941,7 +10254,7 @@ struct _redactedModifier<R: RootRegistry>: ViewModifier {
 
     
     
-    init(reason: SwiftUI.RedactionReasons) {
+    init(reason: SwiftUICore.RedactionReasons) {
         self.value = ._0(reason: reason)
         
     }
@@ -9114,7 +10427,7 @@ struct _rotationEffectModifier<R: RootRegistry>: ViewModifier {
     enum Value {
         case _never
         
-        indirect case _0(angle: AttributeReference<SwiftUI.Angle>,anchor: AttributeReference<SwiftUI.UnitPoint> = .init(storage: .constant(.center)) )
+        indirect case _0(angle: AttributeReference<SwiftUICore.Angle>,anchor: AttributeReference<SwiftUICore.UnitPoint> = .init(storage: .constant(.center)) )
         
     }
 
@@ -9129,7 +10442,7 @@ struct _rotationEffectModifier<R: RootRegistry>: ViewModifier {
 
     
     
-    init(_ angle: AttributeReference<SwiftUI.Angle>,anchor: AttributeReference<SwiftUI.UnitPoint> = .init(storage: .constant(.center)) ) {
+    init(_ angle: AttributeReference<SwiftUICore.Angle>,anchor: AttributeReference<SwiftUICore.UnitPoint> = .init(storage: .constant(.center)) ) {
         self.value = ._0(angle: angle, anchor: anchor)
         
     }
@@ -9161,10 +10474,10 @@ struct _safeAreaInsetModifier<R: RootRegistry>: ViewModifier {
     enum Value {
         case _never
         
-        indirect case _0(edge: SwiftUI.VerticalEdge,alignment: AttributeReference<SwiftUI.HorizontalAlignment> = .init(storage: .constant(.center)), spacing: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), content: ViewReference=ViewReference(value: []))
+        indirect case _0(edge: SwiftUICore.VerticalEdge,alignment: AttributeReference<SwiftUICore.HorizontalAlignment> = .init(storage: .constant(.center)), spacing: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), content: ViewReference=ViewReference(value: []))
         
         
-        indirect case _1(edge: SwiftUI.HorizontalEdge,alignment: AttributeReference<SwiftUI.VerticalAlignment> = .init(storage: .constant(.center)), spacing: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), content: ViewReference=ViewReference(value: []))
+        indirect case _1(edge: SwiftUICore.HorizontalEdge,alignment: AttributeReference<SwiftUICore.VerticalAlignment> = .init(storage: .constant(.center)), spacing: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), content: ViewReference=ViewReference(value: []))
         
     }
 
@@ -9181,14 +10494,14 @@ struct _safeAreaInsetModifier<R: RootRegistry>: ViewModifier {
 
     
     
-    init(edge: SwiftUI.VerticalEdge,alignment: AttributeReference<SwiftUI.HorizontalAlignment> = .init(storage: .constant(.center)), spacing: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), content: ViewReference=ViewReference(value: [])) {
+    init(edge: SwiftUICore.VerticalEdge,alignment: AttributeReference<SwiftUICore.HorizontalAlignment> = .init(storage: .constant(.center)), spacing: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), content: ViewReference=ViewReference(value: [])) {
         self.value = ._0(edge: edge, alignment: alignment, spacing: spacing, content: content)
         
     }
     
     
     
-    init(edge: SwiftUI.HorizontalEdge,alignment: AttributeReference<SwiftUI.VerticalAlignment> = .init(storage: .constant(.center)), spacing: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), content: ViewReference=ViewReference(value: [])) {
+    init(edge: SwiftUICore.HorizontalEdge,alignment: AttributeReference<SwiftUICore.VerticalAlignment> = .init(storage: .constant(.center)), spacing: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), content: ViewReference=ViewReference(value: [])) {
         self.value = ._1(edge: edge, alignment: alignment, spacing: spacing, content: content)
         
     }
@@ -9255,21 +10568,21 @@ struct _safeAreaPaddingModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0, *)
-    init(_ insets: SwiftUI.EdgeInsets) {
+    @available(tvOS 17.0,macOS 14.0,watchOS 10.0,visionOS 1.0,iOS 17.0, *)
+    init(_ insets: SwiftUICore.EdgeInsets) {
         self.value = ._0(insets: insets)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0, *)
-    init(_ edges: SwiftUI.Edge.Set = .all, _ length: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)) ) {
+    @available(tvOS 17.0,macOS 14.0,watchOS 10.0,visionOS 1.0,iOS 17.0, *)
+    init(_ edges: SwiftUICore.Edge.Set = .all, _ length: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)) ) {
         self.value = ._1(edges: edges, length: length)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0, *)
+    @available(tvOS 17.0,macOS 14.0,watchOS 10.0,visionOS 1.0,iOS 17.0, *)
     init(_ length: AttributeReference<CoreFoundation.CGFloat>) {
         self.value = ._2(length: length)
         
@@ -9282,8 +10595,8 @@ struct _safeAreaPaddingModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(insets):
-            if #available(visionOS 1.0,tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0, *) {
-            let insets = insets as! SwiftUI.EdgeInsets
+            if #available(tvOS 17.0,macOS 14.0,watchOS 10.0,visionOS 1.0,iOS 17.0, *) {
+            let insets = insets as! SwiftUICore.EdgeInsets
             
             __content
                 .safeAreaPadding(insets)
@@ -9293,8 +10606,8 @@ struct _safeAreaPaddingModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(edges, length):
-            if #available(visionOS 1.0,tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0, *) {
-            let edges = edges as! SwiftUI.Edge.Set 
+            if #available(tvOS 17.0,macOS 14.0,watchOS 10.0,visionOS 1.0,iOS 17.0, *) {
+            let edges = edges as! SwiftUICore.Edge.Set 
 let length = length as? AttributeReference<CoreFoundation.CGFloat?>
             
             __content
@@ -9305,7 +10618,7 @@ let length = length as? AttributeReference<CoreFoundation.CGFloat?>
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._2(length):
-            if #available(visionOS 1.0,tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0, *) {
+            if #available(tvOS 17.0,macOS 14.0,watchOS 10.0,visionOS 1.0,iOS 17.0, *) {
             let length = length as! AttributeReference<CoreFoundation.CGFloat>
             
             __content
@@ -9371,24 +10684,24 @@ struct _scaleEffectModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        
-        indirect case _0(scale: CoreFoundation.CGSize,anchor: AttributeReference<SwiftUI.UnitPoint> = .init(storage: .constant(.center)) )
-        
-        
-        indirect case _1(s: AttributeReference<CoreFoundation.CGFloat>,anchor: AttributeReference<SwiftUI.UnitPoint> = .init(storage: .constant(.center)) )
-        
-        
-        indirect case _2(x: AttributeReference<CoreFoundation.CGFloat> = .init(storage: .constant(1.0)), y: AttributeReference<CoreFoundation.CGFloat> = .init(storage: .constant(1.0)), anchor: AttributeReference<SwiftUI.UnitPoint> = .init(storage: .constant(.center)) )
-        
         #if os(visionOS)
-        indirect case _3(scale: Any,anchor: Any)
+        indirect case _0(scale: Any,anchor: Any)
         #endif
         #if os(visionOS)
-        indirect case _4(s: Any,anchor: Any)
+        indirect case _1(s: Any,anchor: Any)
         #endif
         #if os(visionOS)
-        indirect case _5(x: Any, y: Any, z: Any, anchor: Any)
+        indirect case _2(x: Any, y: Any, z: Any, anchor: Any)
         #endif
+        
+        indirect case _3(scale: CoreFoundation.CGSize,anchor: AttributeReference<SwiftUICore.UnitPoint> = .init(storage: .constant(.center)) )
+        
+        
+        indirect case _4(s: AttributeReference<CoreFoundation.CGFloat>,anchor: AttributeReference<SwiftUICore.UnitPoint> = .init(storage: .constant(.center)) )
+        
+        
+        indirect case _5(x: AttributeReference<CoreFoundation.CGFloat> = .init(storage: .constant(1.0)), y: AttributeReference<CoreFoundation.CGFloat> = .init(storage: .constant(1.0)), anchor: AttributeReference<SwiftUICore.UnitPoint> = .init(storage: .constant(.center)) )
+        
     }
 
     let value: Value
@@ -9410,55 +10723,93 @@ struct _scaleEffectModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    
-    
-    init(_ scale: CoreFoundation.CGSize,anchor: AttributeReference<SwiftUI.UnitPoint> = .init(storage: .constant(.center)) ) {
+    #if os(visionOS)
+    @available(visionOS 1.0, *)
+    init(_ scale: Spatial.Size3D,anchor: SwiftUICore.UnitPoint3D = .center ) {
         self.value = ._0(scale: scale, anchor: anchor)
         
     }
-    
-    
-    
-    init(_ s: AttributeReference<CoreFoundation.CGFloat>,anchor: AttributeReference<SwiftUI.UnitPoint> = .init(storage: .constant(.center)) ) {
+    #endif
+    #if os(visionOS)
+    @available(visionOS 1.0, *)
+    init(_ s: AttributeReference<CoreFoundation.CGFloat>,anchor: SwiftUICore.UnitPoint3D = .center ) {
         self.value = ._1(s: s, anchor: anchor)
         
     }
-    
-    
-    
-    init(x: AttributeReference<CoreFoundation.CGFloat> = .init(storage: .constant(1.0)), y: AttributeReference<CoreFoundation.CGFloat> = .init(storage: .constant(1.0)), anchor: AttributeReference<SwiftUI.UnitPoint> = .init(storage: .constant(.center)) ) {
-        self.value = ._2(x: x, y: y, anchor: anchor)
-        
-    }
-    
+    #endif
     #if os(visionOS)
     @available(visionOS 1.0, *)
-    init(_ scale: Spatial.Size3D,anchor: SwiftUI.UnitPoint3D = .center ) {
+    init(x: AttributeReference<CoreFoundation.CGFloat> = .init(storage: .constant(1.0)), y: AttributeReference<CoreFoundation.CGFloat> = .init(storage: .constant(1.0)), z: AttributeReference<CoreFoundation.CGFloat> = .init(storage: .constant(1.0)), anchor: SwiftUICore.UnitPoint3D = .center ) {
+        self.value = ._2(x: x, y: y, z: z, anchor: anchor)
+        
+    }
+    #endif
+    
+    
+    init(_ scale: CoreFoundation.CGSize,anchor: AttributeReference<SwiftUICore.UnitPoint> = .init(storage: .constant(.center)) ) {
         self.value = ._3(scale: scale, anchor: anchor)
         
     }
-    #endif
-    #if os(visionOS)
-    @available(visionOS 1.0, *)
-    init(_ s: AttributeReference<CoreFoundation.CGFloat>,anchor: SwiftUI.UnitPoint3D = .center ) {
+    
+    
+    
+    init(_ s: AttributeReference<CoreFoundation.CGFloat>,anchor: AttributeReference<SwiftUICore.UnitPoint> = .init(storage: .constant(.center)) ) {
         self.value = ._4(s: s, anchor: anchor)
         
     }
-    #endif
-    #if os(visionOS)
-    @available(visionOS 1.0, *)
-    init(x: AttributeReference<CoreFoundation.CGFloat> = .init(storage: .constant(1.0)), y: AttributeReference<CoreFoundation.CGFloat> = .init(storage: .constant(1.0)), z: AttributeReference<CoreFoundation.CGFloat> = .init(storage: .constant(1.0)), anchor: SwiftUI.UnitPoint3D = .center ) {
-        self.value = ._5(x: x, y: y, z: z, anchor: anchor)
+    
+    
+    
+    init(x: AttributeReference<CoreFoundation.CGFloat> = .init(storage: .constant(1.0)), y: AttributeReference<CoreFoundation.CGFloat> = .init(storage: .constant(1.0)), anchor: AttributeReference<SwiftUICore.UnitPoint> = .init(storage: .constant(.center)) ) {
+        self.value = ._5(x: x, y: y, anchor: anchor)
         
     }
-    #endif
+    
 
     func body(content __content: Content) -> some View {
         switch value {
         case ._never:
             fatalError("unreachable")
-        
+        #if os(visionOS)
         case let ._0(scale, anchor):
+            if #available(visionOS 1.0, *) {
+            let scale = scale as! Spatial.Size3D
+let anchor = anchor as! SwiftUICore.UnitPoint3D 
+            
+            __content
+                .scaleEffect(scale, anchor: anchor)
+            
+                
+            } else { __content }
+        #endif
+        #if os(visionOS)
+        case let ._1(s, anchor):
+            if #available(visionOS 1.0, *) {
+            let s = s as! AttributeReference<CoreFoundation.CGFloat>
+let anchor = anchor as! SwiftUICore.UnitPoint3D 
+            
+            __content
+                .scaleEffect(s.resolve(on: element, in: context), anchor: anchor)
+            
+                
+            } else { __content }
+        #endif
+        #if os(visionOS)
+        case let ._2(x, y, z, anchor):
+            if #available(visionOS 1.0, *) {
+            let x = x as! AttributeReference<CoreFoundation.CGFloat>
+let y = y as! AttributeReference<CoreFoundation.CGFloat>
+let z = z as! AttributeReference<CoreFoundation.CGFloat>
+let anchor = anchor as! SwiftUICore.UnitPoint3D 
+            
+            __content
+                .scaleEffect(x: x.resolve(on: element, in: context), y: y.resolve(on: element, in: context), z: z.resolve(on: element, in: context), anchor: anchor)
+            
+                
+            } else { __content }
+        #endif
+        
+        case let ._3(scale, anchor):
             
             
             
@@ -9469,7 +10820,7 @@ struct _scaleEffectModifier<R: RootRegistry>: ViewModifier {
             
         
         
-        case let ._1(s, anchor):
+        case let ._4(s, anchor):
             
             
             
@@ -9480,7 +10831,7 @@ struct _scaleEffectModifier<R: RootRegistry>: ViewModifier {
             
         
         
-        case let ._2(x, y, anchor):
+        case let ._5(x, y, anchor):
             
             
             
@@ -9490,44 +10841,6 @@ struct _scaleEffectModifier<R: RootRegistry>: ViewModifier {
                 
             
         
-        #if os(visionOS)
-        case let ._3(scale, anchor):
-            if #available(visionOS 1.0, *) {
-            let scale = scale as! Spatial.Size3D
-let anchor = anchor as! SwiftUI.UnitPoint3D 
-            
-            __content
-                .scaleEffect(scale, anchor: anchor)
-            
-                
-            } else { __content }
-        #endif
-        #if os(visionOS)
-        case let ._4(s, anchor):
-            if #available(visionOS 1.0, *) {
-            let s = s as! AttributeReference<CoreFoundation.CGFloat>
-let anchor = anchor as! SwiftUI.UnitPoint3D 
-            
-            __content
-                .scaleEffect(s.resolve(on: element, in: context), anchor: anchor)
-            
-                
-            } else { __content }
-        #endif
-        #if os(visionOS)
-        case let ._5(x, y, z, anchor):
-            if #available(visionOS 1.0, *) {
-            let x = x as! AttributeReference<CoreFoundation.CGFloat>
-let y = y as! AttributeReference<CoreFoundation.CGFloat>
-let z = z as! AttributeReference<CoreFoundation.CGFloat>
-let anchor = anchor as! SwiftUI.UnitPoint3D 
-            
-            __content
-                .scaleEffect(x: x.resolve(on: element, in: context), y: y.resolve(on: element, in: context), z: z.resolve(on: element, in: context), anchor: anchor)
-            
-                
-            } else { __content }
-        #endif
         }
     }
 }
@@ -9633,10 +10946,10 @@ struct _scenePaddingModifier<R: RootRegistry>: ViewModifier {
     enum Value {
         case _never
         
-        indirect case _0(edges: SwiftUI.Edge.Set = .all )
+        indirect case _0(edges: SwiftUICore.Edge.Set = .all )
         
         
-        indirect case _1(padding: SwiftUI.ScenePadding,edges: SwiftUI.Edge.Set = .all )
+        indirect case _1(padding: SwiftUI.ScenePadding,edges: SwiftUICore.Edge.Set = .all )
         
     }
 
@@ -9653,14 +10966,14 @@ struct _scenePaddingModifier<R: RootRegistry>: ViewModifier {
 
     
     
-    init(_ edges: SwiftUI.Edge.Set = .all ) {
+    init(_ edges: SwiftUICore.Edge.Set = .all ) {
         self.value = ._0(edges: edges)
         
     }
     
     
     
-    init(_ padding: SwiftUI.ScenePadding,edges: SwiftUI.Edge.Set = .all ) {
+    init(_ padding: SwiftUI.ScenePadding,edges: SwiftUICore.Edge.Set = .all ) {
         self.value = ._1(padding: padding, edges: edges)
         
     }
@@ -9717,8 +11030,8 @@ struct _scrollBounceBehaviorModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(iOS 16.4,tvOS 16.4,watchOS 9.4,visionOS 1.0,macOS 13.3, *)
-    init(_ behavior: SwiftUI.ScrollBounceBehavior,axes: SwiftUI.Axis.Set = [.vertical] ) {
+    @available(iOS 16.4,tvOS 16.4,watchOS 9.4,macOS 13.3,visionOS 1.0, *)
+    init(_ behavior: SwiftUI.ScrollBounceBehavior,axes: SwiftUICore.Axis.Set = [.vertical] ) {
         self.value = ._0(behavior: behavior, axes: axes)
         
     }
@@ -9730,9 +11043,9 @@ struct _scrollBounceBehaviorModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(behavior, axes):
-            if #available(iOS 16.4,tvOS 16.4,watchOS 9.4,visionOS 1.0,macOS 13.3, *) {
+            if #available(iOS 16.4,tvOS 16.4,watchOS 9.4,macOS 13.3,visionOS 1.0, *) {
             let behavior = behavior as! SwiftUI.ScrollBounceBehavior
-let axes = axes as! SwiftUI.Axis.Set 
+let axes = axes as! SwiftUICore.Axis.Set 
             
             __content
                 .scrollBounceBehavior(behavior, axes: axes)
@@ -9765,7 +11078,7 @@ struct _scrollClipDisabledModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(tvOS 17.0,iOS 17.0,watchOS 10.0,visionOS 1.0,macOS 14.0, *)
+    @available(macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0,visionOS 1.0, *)
     init(_ disabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(disabled: disabled)
         
@@ -9778,7 +11091,7 @@ struct _scrollClipDisabledModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(disabled):
-            if #available(tvOS 17.0,iOS 17.0,watchOS 10.0,visionOS 1.0,macOS 14.0, *) {
+            if #available(macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0,visionOS 1.0, *) {
             let disabled = disabled as! AttributeReference<Swift.Bool>
             
             __content
@@ -9812,7 +11125,7 @@ struct _scrollContentBackgroundModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
-    @available(macOS 13.0,iOS 16.0,visionOS 1.0,watchOS 9.0, *)
+    @available(visionOS 1.0,macOS 13.0,iOS 16.0,watchOS 9.0, *)
     init(_ visibility: AttributeReference<SwiftUI.Visibility>) {
         self.value = ._0(visibility: visibility)
         
@@ -9825,7 +11138,7 @@ struct _scrollContentBackgroundModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
         case let ._0(visibility):
-            if #available(macOS 13.0,iOS 16.0,visionOS 1.0,watchOS 9.0, *) {
+            if #available(visionOS 1.0,macOS 13.0,iOS 16.0,watchOS 9.0, *) {
             let visibility = visibility as! AttributeReference<SwiftUI.Visibility>
             
             __content
@@ -9906,7 +11219,7 @@ struct _scrollDismissesKeyboardModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-    @available(watchOS 9.0,macOS 13.0,iOS 16.0,tvOS 16.0, *)
+    @available(macOS 13.0,watchOS 9.0,iOS 16.0,tvOS 16.0, *)
     init(_ mode: SwiftUI.ScrollDismissesKeyboardMode) {
         self.value = ._0(mode: mode)
         
@@ -9919,7 +11232,7 @@ struct _scrollDismissesKeyboardModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
         case let ._0(mode):
-            if #available(watchOS 9.0,macOS 13.0,iOS 16.0,tvOS 16.0, *) {
+            if #available(macOS 13.0,watchOS 9.0,iOS 16.0,tvOS 16.0, *) {
             let mode = mode as! SwiftUI.ScrollDismissesKeyboardMode
             
             __content
@@ -9939,7 +11252,7 @@ struct _scrollIndicatorsModifier<R: RootRegistry>: ViewModifier {
     enum Value {
         case _never
         
-        indirect case _0(visibility: SwiftUI.ScrollIndicatorVisibility,axes: SwiftUI.Axis.Set = [.vertical, .horizontal] )
+        indirect case _0(visibility: SwiftUI.ScrollIndicatorVisibility,axes: SwiftUICore.Axis.Set = [.vertical, .horizontal] )
         
     }
 
@@ -9954,7 +11267,7 @@ struct _scrollIndicatorsModifier<R: RootRegistry>: ViewModifier {
 
     
     
-    init(_ visibility: SwiftUI.ScrollIndicatorVisibility,axes: SwiftUI.Axis.Set = [.vertical, .horizontal] ) {
+    init(_ visibility: SwiftUI.ScrollIndicatorVisibility,axes: SwiftUICore.Axis.Set = [.vertical, .horizontal] ) {
         self.value = ._0(visibility: visibility, axes: axes)
         
     }
@@ -10005,14 +11318,14 @@ struct _scrollIndicatorsFlashModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 10.0,macOS 14.0,visionOS 1.0,iOS 17.0,tvOS 17.0, *)
+    @available(visionOS 1.0,macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0, *)
     init(trigger value: AttributeReference<String>) {
         self.value = ._0(value: value)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 10.0,macOS 14.0,visionOS 1.0,iOS 17.0,tvOS 17.0, *)
+    @available(iOS 17.0,tvOS 17.0,watchOS 10.0,macOS 14.0,visionOS 1.0, *)
     init(onAppear: AttributeReference<Swift.Bool>) {
         self.value = ._1(onAppear: onAppear)
         
@@ -10025,7 +11338,7 @@ struct _scrollIndicatorsFlashModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(value):
-            if #available(watchOS 10.0,macOS 14.0,visionOS 1.0,iOS 17.0,tvOS 17.0, *) {
+            if #available(visionOS 1.0,macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0, *) {
             let value = value as! AttributeReference<String>
             
             __content
@@ -10036,11 +11349,59 @@ struct _scrollIndicatorsFlashModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(onAppear):
-            if #available(watchOS 10.0,macOS 14.0,visionOS 1.0,iOS 17.0,tvOS 17.0, *) {
+            if #available(iOS 17.0,tvOS 17.0,watchOS 10.0,macOS 14.0,visionOS 1.0, *) {
             let onAppear = onAppear as! AttributeReference<Swift.Bool>
             
             __content
                 .scrollIndicatorsFlash(onAppear: onAppear.resolve(on: element, in: context))
+            
+                
+            } else { __content }
+        #endif
+        }
+    }
+}
+@_documentation(visibility: public)
+@ParseableExpression
+struct _scrollInputBehaviorModifier<R: RootRegistry>: ViewModifier {
+    static var name: String { "scrollInputBehavior" }
+
+    enum Value {
+        case _never
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+        indirect case _0(behavior: Any,input: Any)
+        #endif
+    }
+
+    let value: Value
+
+    
+    
+    
+
+
+
+
+    #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+    @available(iOS 18.0,tvOS 18.0,watchOS 11.0,macOS 15.0,visionOS 2.0, *)
+    init(_ behavior: SwiftUI.ScrollInputBehavior,for input: SwiftUI.ScrollInputKind) {
+        self.value = ._0(behavior: behavior, input: input)
+        
+    }
+    #endif
+
+    func body(content __content: Content) -> some View {
+        switch value {
+        case ._never:
+            fatalError("unreachable")
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+        case let ._0(behavior, input):
+            if #available(iOS 18.0,tvOS 18.0,watchOS 11.0,macOS 15.0,visionOS 2.0, *) {
+            let behavior = behavior as! SwiftUI.ScrollInputBehavior
+let input = input as! SwiftUI.ScrollInputKind
+            
+            __content
+                .scrollInputBehavior(behavior, for: input)
             
                 
             } else { __content }
@@ -10070,8 +11431,8 @@ struct _scrollPositionModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,macOS 14.0,watchOS 10.0,tvOS 17.0,iOS 17.0, *)
-    init(id: ChangeTracked<String?>,anchor: AttributeReference<SwiftUI.UnitPoint?>? = .init(storage: .constant(nil)) ) {
+    @available(visionOS 1.0,tvOS 17.0,watchOS 10.0,macOS 14.0,iOS 17.0, *)
+    init(id: ChangeTracked<String?>,anchor: AttributeReference<SwiftUICore.UnitPoint?>? = .init(storage: .constant(nil)) ) {
         self.value = ._0(anchor: anchor)
         self.__0_id = id
     }
@@ -10083,8 +11444,8 @@ struct _scrollPositionModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(anchor):
-            if #available(visionOS 1.0,macOS 14.0,watchOS 10.0,tvOS 17.0,iOS 17.0, *) {
-            let anchor = anchor as? AttributeReference<SwiftUI.UnitPoint?>
+            if #available(visionOS 1.0,tvOS 17.0,watchOS 10.0,macOS 14.0,iOS 17.0, *) {
+            let anchor = anchor as? AttributeReference<SwiftUICore.UnitPoint?>
             
             __content
                 .scrollPosition(id: __0_id.projectedValue, anchor: anchor?.resolve(on: element, in: context))
@@ -10117,7 +11478,7 @@ struct _scrollTargetBehaviorModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(iOS 17.0,tvOS 17.0,watchOS 10.0,visionOS 1.0,macOS 14.0, *)
+    @available(watchOS 10.0,iOS 17.0,tvOS 17.0,macOS 14.0,visionOS 1.0, *)
     init(_ behavior: AnyScrollTargetBehavior) {
         self.value = ._0(behavior: behavior)
         
@@ -10130,7 +11491,7 @@ struct _scrollTargetBehaviorModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(behavior):
-            if #available(iOS 17.0,tvOS 17.0,watchOS 10.0,visionOS 1.0,macOS 14.0, *) {
+            if #available(watchOS 10.0,iOS 17.0,tvOS 17.0,macOS 14.0,visionOS 1.0, *) {
             let behavior = behavior as! AnyScrollTargetBehavior
             
             __content
@@ -10164,7 +11525,7 @@ struct _scrollTargetLayoutModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 10.0,macOS 14.0,visionOS 1.0,iOS 17.0,tvOS 17.0, *)
+    @available(watchOS 10.0,iOS 17.0,tvOS 17.0,macOS 14.0,visionOS 1.0, *)
     init(isEnabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(isEnabled: isEnabled)
         
@@ -10177,7 +11538,7 @@ struct _scrollTargetLayoutModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(isEnabled):
-            if #available(watchOS 10.0,macOS 14.0,visionOS 1.0,iOS 17.0,tvOS 17.0, *) {
+            if #available(watchOS 10.0,iOS 17.0,tvOS 17.0,macOS 14.0,visionOS 1.0, *) {
             let isEnabled = isEnabled as! AttributeReference<Swift.Bool>
             
             __content
@@ -10258,7 +11619,7 @@ struct _searchPresentationToolbarBehaviorModifier<R: RootRegistry>: ViewModifier
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(iOS 17.1,watchOS 10.1,tvOS 17.1,macOS 14.1,visionOS 1.0, *)
+    @available(macOS 14.1,watchOS 10.1,iOS 17.1,tvOS 17.1,visionOS 1.0, *)
     init(_ behavior: SwiftUI.SearchPresentationToolbarBehavior) {
         self.value = ._0(behavior: behavior)
         
@@ -10271,7 +11632,7 @@ struct _searchPresentationToolbarBehaviorModifier<R: RootRegistry>: ViewModifier
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(behavior):
-            if #available(iOS 17.1,watchOS 10.1,tvOS 17.1,macOS 14.1,visionOS 1.0, *) {
+            if #available(macOS 14.1,watchOS 10.1,iOS 17.1,tvOS 17.1,visionOS 1.0, *) {
             let behavior = behavior as! SwiftUI.SearchPresentationToolbarBehavior
             
             __content
@@ -10364,7 +11725,7 @@ struct _searchableModifier<R: RootRegistry>: ViewModifier {
         indirect case _0(placement: SwiftUI.SearchFieldPlacement = .automatic, prompt: TextReference? = nil )
         
         
-        indirect case _1(placement: SwiftUI.SearchFieldPlacement = .automatic, prompt: SwiftUI.LocalizedStringKey)
+        indirect case _1(placement: SwiftUI.SearchFieldPlacement = .automatic, prompt: SwiftUICore.LocalizedStringKey)
         
         
         indirect case _2(placement: SwiftUI.SearchFieldPlacement = .automatic, prompt: AttributeReference<String>)
@@ -10411,7 +11772,7 @@ struct _searchableModifier<R: RootRegistry>: ViewModifier {
     
     
     
-    init(text: ChangeTracked<Swift.String>,placement: SwiftUI.SearchFieldPlacement = .automatic, prompt: SwiftUI.LocalizedStringKey) {
+    init(text: ChangeTracked<Swift.String>,placement: SwiftUI.SearchFieldPlacement = .automatic, prompt: SwiftUICore.LocalizedStringKey) {
         self.value = ._1(placement: placement, prompt: prompt)
         self.__1_text = text
     }
@@ -10424,7 +11785,7 @@ struct _searchableModifier<R: RootRegistry>: ViewModifier {
     }
     
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 14.0,visionOS 1.0,iOS 17.0, *)
+    @available(iOS 17.0,macOS 14.0,visionOS 1.0, *)
     init(text: ChangeTracked<Swift.String>,isPresented: ChangeTracked<Swift.Bool>,placement: SwiftUI.SearchFieldPlacement = .automatic, prompt: TextReference? = nil ) {
         self.value = ._3(placement: placement, prompt: prompt)
         self.__3_text = text
@@ -10432,15 +11793,15 @@ self.__3_isPresented = isPresented
     }
     #endif
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 14.0,visionOS 1.0,iOS 17.0, *)
-    init(text: ChangeTracked<Swift.String>,isPresented: ChangeTracked<Swift.Bool>,placement: SwiftUI.SearchFieldPlacement = .automatic, prompt: SwiftUI.LocalizedStringKey) {
+    @available(iOS 17.0,macOS 14.0,visionOS 1.0, *)
+    init(text: ChangeTracked<Swift.String>,isPresented: ChangeTracked<Swift.Bool>,placement: SwiftUI.SearchFieldPlacement = .automatic, prompt: SwiftUICore.LocalizedStringKey) {
         self.value = ._4(placement: placement, prompt: prompt)
         self.__4_text = text
 self.__4_isPresented = isPresented
     }
     #endif
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 14.0,visionOS 1.0,iOS 17.0, *)
+    @available(iOS 17.0,macOS 14.0,visionOS 1.0, *)
     init(text: ChangeTracked<Swift.String>,isPresented: ChangeTracked<Swift.Bool>,placement: SwiftUI.SearchFieldPlacement = .automatic, prompt: AttributeReference<String>) {
         self.value = ._5(placement: placement, prompt: prompt)
         self.__5_text = text
@@ -10487,7 +11848,7 @@ self.__5_isPresented = isPresented
         
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._3(placement, prompt):
-            if #available(macOS 14.0,visionOS 1.0,iOS 17.0, *) {
+            if #available(iOS 17.0,macOS 14.0,visionOS 1.0, *) {
             let placement = placement as! SwiftUI.SearchFieldPlacement 
 let prompt = prompt as? TextReference
             __content._observeTextReference(prompt, on: element, in: context) { __content in
@@ -10499,9 +11860,9 @@ let prompt = prompt as? TextReference
         #endif
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._4(placement, prompt):
-            if #available(macOS 14.0,visionOS 1.0,iOS 17.0, *) {
+            if #available(iOS 17.0,macOS 14.0,visionOS 1.0, *) {
             let placement = placement as! SwiftUI.SearchFieldPlacement 
-let prompt = prompt as! SwiftUI.LocalizedStringKey
+let prompt = prompt as! SwiftUICore.LocalizedStringKey
             
             __content
                 .searchable(text: __4_text.projectedValue, isPresented: __4_isPresented.projectedValue, placement: placement, prompt: prompt)
@@ -10511,12 +11872,59 @@ let prompt = prompt as! SwiftUI.LocalizedStringKey
         #endif
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._5(placement, prompt):
-            if #available(macOS 14.0,visionOS 1.0,iOS 17.0, *) {
+            if #available(iOS 17.0,macOS 14.0,visionOS 1.0, *) {
             let placement = placement as! SwiftUI.SearchFieldPlacement 
 let prompt = prompt as! AttributeReference<String>
             
             __content
                 .searchable(text: __5_text.projectedValue, isPresented: __5_isPresented.projectedValue, placement: placement, prompt: prompt.resolve(on: element, in: context))
+            
+                
+            } else { __content }
+        #endif
+        }
+    }
+}
+@_documentation(visibility: public)
+@ParseableExpression
+struct _sectionActionsModifier<R: RootRegistry>: ViewModifier {
+    static var name: String { "sectionActions" }
+
+    enum Value {
+        case _never
+        #if os(iOS) || os(macOS) || os(visionOS)
+        indirect case _0(content: Any)
+        #endif
+    }
+
+    let value: Value
+
+    @ObservedElement private var element
+    @LiveContext<R> private var context
+    
+
+
+
+
+    #if os(iOS) || os(macOS) || os(visionOS)
+    @available(macOS 15.0,visionOS 2.0,iOS 18.0, *)
+    init(content: ViewReference=ViewReference(value: [])) {
+        self.value = ._0(content: content)
+        
+    }
+    #endif
+
+    func body(content __content: Content) -> some View {
+        switch value {
+        case ._never:
+            fatalError("unreachable")
+        #if os(iOS) || os(macOS) || os(visionOS)
+        case let ._0(content):
+            if #available(macOS 15.0,visionOS 2.0,iOS 18.0, *) {
+            let content = content as! ViewReference
+            
+            __content
+                .sectionActions(content: { content.resolve(on: element, in: context) })
             
                 
             } else { __content }
@@ -10546,7 +11954,7 @@ struct _selectionDisabledModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(iOS 17.0,watchOS 10.0,tvOS 17.0,macOS 14.0,visionOS 1.0, *)
+    @available(visionOS 1.0,macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0, *)
     init(_ isDisabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(isDisabled: isDisabled)
         
@@ -10559,7 +11967,7 @@ struct _selectionDisabledModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(isDisabled):
-            if #available(iOS 17.0,watchOS 10.0,tvOS 17.0,macOS 14.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0, *) {
             let isDisabled = isDisabled as! AttributeReference<Swift.Bool>
             
             __content
@@ -10674,8 +12082,14 @@ struct _simultaneousGestureModifier<R: RootRegistry>: ViewModifier {
     enum Value {
         case _never
         
-        indirect case _0(gesture: _AnyGesture,mask: SwiftUI.GestureMask = .all )
+        indirect case _0(gesture: _AnyGesture,mask: SwiftUICore.GestureMask = .all )
         
+        
+        indirect case _1(gesture: _AnyGesture,isEnabled: AttributeReference<Swift.Bool>)
+        
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+        indirect case _2(gesture: Any,name: Any,isEnabled: Any)
+        #endif
     }
 
     let value: Value
@@ -10687,13 +12101,31 @@ struct _simultaneousGestureModifier<R: RootRegistry>: ViewModifier {
 
 
 
+
+
+
+
     
     
-    init(_ gesture: _AnyGesture,including mask: SwiftUI.GestureMask = .all ) {
+    init(_ gesture: _AnyGesture,including mask: SwiftUICore.GestureMask = .all ) {
         self.value = ._0(gesture: gesture, mask: mask)
         
     }
     
+    
+    
+    init(_ gesture: _AnyGesture,isEnabled: AttributeReference<Swift.Bool>) {
+        self.value = ._1(gesture: gesture, isEnabled: isEnabled)
+        
+    }
+    
+    #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+    @available(visionOS 2.0,tvOS 18.0,iOS 18.0,macOS 15.0,watchOS 11.0, *)
+    init(_ gesture: _AnyGesture,name: AttributeReference<Swift.String>,isEnabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
+        self.value = ._2(gesture: gesture, name: name, isEnabled: isEnabled)
+        
+    }
+    #endif
 
     func body(content __content: Content) -> some View {
         switch value {
@@ -10710,6 +12142,30 @@ struct _simultaneousGestureModifier<R: RootRegistry>: ViewModifier {
                 .environment(\.gestureState, _gestureState)
             
         
+        
+        case let ._1(gesture, isEnabled):
+            
+            
+            
+            __content
+                .simultaneousGesture(gesture.resolve(on: element, in: context.withGestureState(_gestureState)), isEnabled: isEnabled.resolve(on: element, in: context))
+            
+                .environment(\.gestureState, _gestureState)
+            
+        
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+        case let ._2(gesture, name, isEnabled):
+            if #available(visionOS 2.0,tvOS 18.0,iOS 18.0,macOS 15.0,watchOS 11.0, *) {
+            let gesture = gesture as! _AnyGesture
+let name = name as! AttributeReference<Swift.String>
+let isEnabled = isEnabled as! AttributeReference<Swift.Bool>
+            
+            __content
+                .simultaneousGesture(gesture.resolve(on: element, in: context.withGestureState(_gestureState)), name: name.resolve(on: element, in: context), isEnabled: isEnabled.resolve(on: element, in: context))
+            
+                .environment(\.gestureState, _gestureState)
+            } else { __content }
+        #endif
         }
     }
 }
@@ -11044,6 +12500,53 @@ struct _submitScopeModifier<R: RootRegistry>: ViewModifier {
 }
 @_documentation(visibility: public)
 @ParseableExpression
+struct _supportedVolumeViewpointsModifier<R: RootRegistry>: ViewModifier {
+    static var name: String { "supportedVolumeViewpoints" }
+
+    enum Value {
+        case _never
+        #if os(visionOS)
+        indirect case _0(viewpoints: Any)
+        #endif
+    }
+
+    let value: Value
+
+    
+    
+    
+
+
+
+
+    #if os(visionOS)
+    @available(visionOS 2.0, *)
+    init(_ viewpoints: SwiftUI.SquareAzimuth.Set) {
+        self.value = ._0(viewpoints: viewpoints)
+        
+    }
+    #endif
+
+    func body(content __content: Content) -> some View {
+        switch value {
+        case ._never:
+            fatalError("unreachable")
+        #if os(visionOS)
+        case let ._0(viewpoints):
+            if #available(visionOS 2.0, *) {
+            let viewpoints = viewpoints as! SwiftUI.SquareAzimuth.Set
+            
+            __content
+                .supportedVolumeViewpoints(viewpoints)
+            
+                
+            } else { __content }
+        #endif
+        }
+    }
+}
+@_documentation(visibility: public)
+@ParseableExpression
 struct _swipeActionsModifier<R: RootRegistry>: ViewModifier {
     static var name: String { "swipeActions" }
 
@@ -11064,8 +12567,8 @@ struct _swipeActionsModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 8.0,iOS 15.0,visionOS 1.0,macOS 12.0, *)
-    init(edge: SwiftUI.HorizontalEdge = .trailing, allowsFullSwipe: AttributeReference<Swift.Bool> = .init(storage: .constant(true)), content: ViewReference=ViewReference(value: [])) {
+    @available(macOS 12.0,watchOS 8.0,iOS 15.0,visionOS 1.0, *)
+    init(edge: SwiftUICore.HorizontalEdge = .trailing, allowsFullSwipe: AttributeReference<Swift.Bool> = .init(storage: .constant(true)), content: ViewReference=ViewReference(value: [])) {
         self.value = ._0(edge: edge, allowsFullSwipe: allowsFullSwipe, content: content)
         
     }
@@ -11077,8 +12580,8 @@ struct _swipeActionsModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
         case let ._0(edge, allowsFullSwipe, content):
-            if #available(watchOS 8.0,iOS 15.0,visionOS 1.0,macOS 12.0, *) {
-            let edge = edge as! SwiftUI.HorizontalEdge 
+            if #available(macOS 12.0,watchOS 8.0,iOS 15.0,visionOS 1.0, *) {
+            let edge = edge as! SwiftUICore.HorizontalEdge 
 let allowsFullSwipe = allowsFullSwipe as! AttributeReference<Swift.Bool>
 let content = content as! ViewReference
             
@@ -11118,14 +12621,14 @@ struct _symbolEffectModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,macOS 14.0,watchOS 10.0,tvOS 17.0,iOS 17.0, *)
+    @available(watchOS 10.0,iOS 17.0,tvOS 17.0,macOS 14.0,visionOS 1.0, *)
     init(_ effect: AnyIndefiniteSymbolEffect,options: Symbols.SymbolEffectOptions = .default, isActive: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(effect: effect, options: options, isActive: isActive)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,macOS 14.0,watchOS 10.0,tvOS 17.0,iOS 17.0, *)
+    @available(watchOS 10.0,iOS 17.0,tvOS 17.0,macOS 14.0,visionOS 1.0, *)
     init(_ effect: AnyDiscreteSymbolEffect,options: Symbols.SymbolEffectOptions = .default, value: AttributeReference<String>) {
         self.value = ._1(effect: effect, options: options, value: value)
         
@@ -11138,7 +12641,7 @@ struct _symbolEffectModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(effect, options, isActive):
-            if #available(visionOS 1.0,macOS 14.0,watchOS 10.0,tvOS 17.0,iOS 17.0, *) {
+            if #available(watchOS 10.0,iOS 17.0,tvOS 17.0,macOS 14.0,visionOS 1.0, *) {
             let effect = effect as! AnyIndefiniteSymbolEffect
 let options = options as! Symbols.SymbolEffectOptions 
 let isActive = isActive as! AttributeReference<Swift.Bool>
@@ -11151,7 +12654,7 @@ let isActive = isActive as! AttributeReference<Swift.Bool>
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(effect, options, value):
-            if #available(visionOS 1.0,macOS 14.0,watchOS 10.0,tvOS 17.0,iOS 17.0, *) {
+            if #available(watchOS 10.0,iOS 17.0,tvOS 17.0,macOS 14.0,visionOS 1.0, *) {
             let effect = effect as! AnyDiscreteSymbolEffect
 let options = options as! Symbols.SymbolEffectOptions 
 let value = value as! AttributeReference<String>
@@ -11187,7 +12690,7 @@ struct _symbolEffectsRemovedModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(iOS 17.0,watchOS 10.0,tvOS 17.0,macOS 14.0,visionOS 1.0, *)
+    @available(visionOS 1.0,macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0, *)
     init(_ isEnabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(isEnabled: isEnabled)
         
@@ -11200,7 +12703,7 @@ struct _symbolEffectsRemovedModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(isEnabled):
-            if #available(iOS 17.0,watchOS 10.0,tvOS 17.0,macOS 14.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0, *) {
             let isEnabled = isEnabled as! AttributeReference<Swift.Bool>
             
             __content
@@ -11220,7 +12723,7 @@ struct _symbolRenderingModeModifier<R: RootRegistry>: ViewModifier {
     enum Value {
         case _never
         
-        indirect case _0(mode: SwiftUI.SymbolRenderingMode?)
+        indirect case _0(mode: SwiftUICore.SymbolRenderingMode?)
         
     }
 
@@ -11235,7 +12738,7 @@ struct _symbolRenderingModeModifier<R: RootRegistry>: ViewModifier {
 
     
     
-    init(_ mode: SwiftUI.SymbolRenderingMode?) {
+    init(_ mode: SwiftUICore.SymbolRenderingMode?) {
         self.value = ._0(mode: mode)
         
     }
@@ -11267,7 +12770,7 @@ struct _symbolVariantModifier<R: RootRegistry>: ViewModifier {
     enum Value {
         case _never
         
-        indirect case _0(variant: SwiftUI.SymbolVariants)
+        indirect case _0(variant: SwiftUICore.SymbolVariants)
         
     }
 
@@ -11282,7 +12785,7 @@ struct _symbolVariantModifier<R: RootRegistry>: ViewModifier {
 
     
     
-    init(_ variant: SwiftUI.SymbolVariants) {
+    init(_ variant: SwiftUICore.SymbolVariants) {
         self.value = ._0(variant: variant)
         
     }
@@ -11308,14 +12811,14 @@ struct _symbolVariantModifier<R: RootRegistry>: ViewModifier {
 }
 @_documentation(visibility: public)
 @ParseableExpression
-struct _tabItemModifier<R: RootRegistry>: ViewModifier {
-    static var name: String { "tabItem" }
+struct _tabViewSidebarBottomBarModifier<R: RootRegistry>: ViewModifier {
+    static var name: String { "tabViewSidebarBottomBar" }
 
     enum Value {
         case _never
-        
-        indirect case _0(label: ViewReference=ViewReference(value: []))
-        
+        #if os(iOS) || os(macOS) || os(visionOS)
+        indirect case _0(content: Any)
+        #endif
     }
 
     let value: Value
@@ -11327,29 +12830,123 @@ struct _tabItemModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    
-    
-    init(_ label: ViewReference=ViewReference(value: [])) {
-        self.value = ._0(label: label)
+    #if os(iOS) || os(macOS) || os(visionOS)
+    @available(macOS 15.0,visionOS 2.0,iOS 18.0, *)
+    init(content: ViewReference=ViewReference(value: [])) {
+        self.value = ._0(content: content)
         
     }
-    
+    #endif
 
     func body(content __content: Content) -> some View {
         switch value {
         case ._never:
             fatalError("unreachable")
-        
-        case let ._0(label):
-            
-            
+        #if os(iOS) || os(macOS) || os(visionOS)
+        case let ._0(content):
+            if #available(macOS 15.0,visionOS 2.0,iOS 18.0, *) {
+            let content = content as! ViewReference
             
             __content
-                .tabItem({ label.resolve(on: element, in: context) })
+                .tabViewSidebarBottomBar(content: { content.resolve(on: element, in: context) })
             
                 
-            
+            } else { __content }
+        #endif
+        }
+    }
+}
+@_documentation(visibility: public)
+@ParseableExpression
+struct _tabViewSidebarFooterModifier<R: RootRegistry>: ViewModifier {
+    static var name: String { "tabViewSidebarFooter" }
+
+    enum Value {
+        case _never
+        #if os(iOS) || os(macOS) || os(visionOS)
+        indirect case _0(content: Any)
+        #endif
+    }
+
+    let value: Value
+
+    @ObservedElement private var element
+    @LiveContext<R> private var context
+    
+
+
+
+
+    #if os(iOS) || os(macOS) || os(visionOS)
+    @available(macOS 15.0,visionOS 2.0,iOS 18.0, *)
+    init(content: ViewReference=ViewReference(value: [])) {
+        self.value = ._0(content: content)
         
+    }
+    #endif
+
+    func body(content __content: Content) -> some View {
+        switch value {
+        case ._never:
+            fatalError("unreachable")
+        #if os(iOS) || os(macOS) || os(visionOS)
+        case let ._0(content):
+            if #available(macOS 15.0,visionOS 2.0,iOS 18.0, *) {
+            let content = content as! ViewReference
+            
+            __content
+                .tabViewSidebarFooter(content: { content.resolve(on: element, in: context) })
+            
+                
+            } else { __content }
+        #endif
+        }
+    }
+}
+@_documentation(visibility: public)
+@ParseableExpression
+struct _tabViewSidebarHeaderModifier<R: RootRegistry>: ViewModifier {
+    static var name: String { "tabViewSidebarHeader" }
+
+    enum Value {
+        case _never
+        #if os(iOS) || os(macOS) || os(visionOS)
+        indirect case _0(content: Any)
+        #endif
+    }
+
+    let value: Value
+
+    @ObservedElement private var element
+    @LiveContext<R> private var context
+    
+
+
+
+
+    #if os(iOS) || os(macOS) || os(visionOS)
+    @available(macOS 15.0,visionOS 2.0,iOS 18.0, *)
+    init(content: ViewReference=ViewReference(value: [])) {
+        self.value = ._0(content: content)
+        
+    }
+    #endif
+
+    func body(content __content: Content) -> some View {
+        switch value {
+        case ._never:
+            fatalError("unreachable")
+        #if os(iOS) || os(macOS) || os(visionOS)
+        case let ._0(content):
+            if #available(macOS 15.0,visionOS 2.0,iOS 18.0, *) {
+            let content = content as! ViewReference
+            
+            __content
+                .tabViewSidebarHeader(content: { content.resolve(on: element, in: context) })
+            
+                
+            } else { __content }
+        #endif
         }
     }
 }
@@ -11422,7 +13019,7 @@ struct _tableStyleModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 12.0,visionOS 1.0,iOS 16.0, *)
+    @available(iOS 16.0,macOS 12.0,visionOS 1.0, *)
     init(_ style: AnyTableStyle) {
         self.value = ._0(style: style)
         
@@ -11435,7 +13032,7 @@ struct _tableStyleModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(style):
-            if #available(macOS 12.0,visionOS 1.0,iOS 16.0, *) {
+            if #available(iOS 16.0,macOS 12.0,visionOS 1.0, *) {
             let style = style as! AnyTableStyle
             
             __content
@@ -11455,7 +13052,7 @@ struct _textCaseModifier<R: RootRegistry>: ViewModifier {
     enum Value {
         case _never
         
-        indirect case _0(textCase: SwiftUI.Text.Case?)
+        indirect case _0(textCase: SwiftUICore.Text.Case?)
         
     }
 
@@ -11470,7 +13067,7 @@ struct _textCaseModifier<R: RootRegistry>: ViewModifier {
 
     
     
-    init(_ textCase: SwiftUI.Text.Case?) {
+    init(_ textCase: SwiftUICore.Text.Case?) {
         self.value = ._0(textCase: textCase)
         
     }
@@ -11563,7 +13160,7 @@ struct _textEditorStyleModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 14.0,visionOS 1.0,iOS 17.0, *)
+    @available(visionOS 1.0,iOS 17.0,macOS 14.0, *)
     init(_ style: AnyTextEditorStyle) {
         self.value = ._0(style: style)
         
@@ -11576,7 +13173,7 @@ struct _textEditorStyleModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(style):
-            if #available(macOS 14.0,visionOS 1.0,iOS 17.0, *) {
+            if #available(visionOS 1.0,iOS 17.0,macOS 14.0, *) {
             let style = style as! AnyTextEditorStyle
             
             __content
@@ -11657,7 +13254,7 @@ struct _textInputAutocapitalizationModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,watchOS 8.0,tvOS 15.0,iOS 15.0, *)
+    @available(tvOS 15.0,watchOS 8.0,visionOS 1.0,iOS 15.0, *)
     init(_ autocapitalization: SwiftUI.TextInputAutocapitalization?) {
         self.value = ._0(autocapitalization: autocapitalization)
         
@@ -11670,11 +13267,105 @@ struct _textInputAutocapitalizationModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(autocapitalization):
-            if #available(visionOS 1.0,watchOS 8.0,tvOS 15.0,iOS 15.0, *) {
+            if #available(tvOS 15.0,watchOS 8.0,visionOS 1.0,iOS 15.0, *) {
             let autocapitalization = autocapitalization as? SwiftUI.TextInputAutocapitalization
             
             __content
                 .textInputAutocapitalization(autocapitalization)
+            
+                
+            } else { __content }
+        #endif
+        }
+    }
+}
+@_documentation(visibility: public)
+@ParseableExpression
+struct _textInputCompletionModifier<R: RootRegistry>: ViewModifier {
+    static var name: String { "textInputCompletion" }
+
+    enum Value {
+        case _never
+        #if os(macOS)
+        indirect case _0(completion: Any)
+        #endif
+    }
+
+    let value: Value
+
+    @ObservedElement private var element
+    @LiveContext<R> private var context
+    
+
+
+
+
+    #if os(macOS)
+    @available(macOS 15.0, *)
+    init(_ completion: AttributeReference<Swift.String>) {
+        self.value = ._0(completion: completion)
+        
+    }
+    #endif
+
+    func body(content __content: Content) -> some View {
+        switch value {
+        case ._never:
+            fatalError("unreachable")
+        #if os(macOS)
+        case let ._0(completion):
+            if #available(macOS 15.0, *) {
+            let completion = completion as! AttributeReference<Swift.String>
+            
+            __content
+                .textInputCompletion(completion.resolve(on: element, in: context))
+            
+                
+            } else { __content }
+        #endif
+        }
+    }
+}
+@_documentation(visibility: public)
+@ParseableExpression
+struct _textInputSuggestionsModifier<R: RootRegistry>: ViewModifier {
+    static var name: String { "textInputSuggestions" }
+
+    enum Value {
+        case _never
+        #if os(macOS)
+        indirect case _0(suggestions: Any)
+        #endif
+    }
+
+    let value: Value
+
+    @ObservedElement private var element
+    @LiveContext<R> private var context
+    
+
+
+
+
+    #if os(macOS)
+    @available(macOS 15.0, *)
+    init(_ suggestions: ViewReference=ViewReference(value: [])) {
+        self.value = ._0(suggestions: suggestions)
+        
+    }
+    #endif
+
+    func body(content __content: Content) -> some View {
+        switch value {
+        case ._never:
+            fatalError("unreachable")
+        #if os(macOS)
+        case let ._0(suggestions):
+            if #available(macOS 15.0, *) {
+            let suggestions = suggestions as! ViewReference
+            
+            __content
+                .textInputSuggestions({ suggestions.resolve(on: element, in: context) })
             
                 
             } else { __content }
@@ -11704,7 +13395,7 @@ struct _textSelectionModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(visionOS 1.0,iOS 15.0,macOS 12.0, *)
+    @available(visionOS 1.0,macOS 12.0,iOS 15.0, *)
     init(_ selectability: AnyTextSelectability) {
         self.value = ._0(selectability: selectability)
         
@@ -11717,11 +13408,58 @@ struct _textSelectionModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(selectability):
-            if #available(visionOS 1.0,iOS 15.0,macOS 12.0, *) {
+            if #available(visionOS 1.0,macOS 12.0,iOS 15.0, *) {
             let selectability = selectability as! AnyTextSelectability
             
             __content
                 .textSelection(selectability)
+            
+                
+            } else { __content }
+        #endif
+        }
+    }
+}
+@_documentation(visibility: public)
+@ParseableExpression
+struct _textSelectionAffinityModifier<R: RootRegistry>: ViewModifier {
+    static var name: String { "textSelectionAffinity" }
+
+    enum Value {
+        case _never
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+        indirect case _0(affinity: Any)
+        #endif
+    }
+
+    let value: Value
+
+    
+    
+    
+
+
+
+
+    #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+    @available(watchOS 11.0,macOS 15.0,visionOS 2.0,tvOS 18.0,iOS 18.0, *)
+    init(_ affinity: SwiftUI.TextSelectionAffinity) {
+        self.value = ._0(affinity: affinity)
+        
+    }
+    #endif
+
+    func body(content __content: Content) -> some View {
+        switch value {
+        case ._never:
+            fatalError("unreachable")
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+        case let ._0(affinity):
+            if #available(watchOS 11.0,macOS 15.0,visionOS 2.0,tvOS 18.0,iOS 18.0, *) {
+            let affinity = affinity as! SwiftUI.TextSelectionAffinity
+            
+            __content
+                .textSelectionAffinity(affinity)
             
                 
             } else { __content }
@@ -11853,17 +13591,14 @@ struct _toolbarModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        
-        indirect case _0(visibility: AttributeReference<SwiftUI.Visibility>,bars: SwiftUI.ToolbarPlacement)
-        
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-        indirect case _1(defaultItemKind: Any?)
+        indirect case _0(defaultItemKind: Any?)
         #endif
         
-        indirect case _3(content: ToolbarContentReference=ToolbarContentReference(value: []))
+        indirect case _2(content: ToolbarContentReference=ToolbarContentReference(value: []))
         
         
-        indirect case _4(id: AttributeReference<Swift.String>,content: CustomizableToolbarContentReference=CustomizableToolbarContentReference(value: []))
+        indirect case _3(id: AttributeReference<Swift.String>,content: CustomizableToolbarContentReference=CustomizableToolbarContentReference(value: []))
         
     }
 
@@ -11880,33 +13615,24 @@ struct _toolbarModifier<R: RootRegistry>: ViewModifier {
 
 
 
-
-
-    
-    
-    init(_ visibility: AttributeReference<SwiftUI.Visibility>,for bars: SwiftUI.ToolbarPlacement) {
-        self.value = ._0(visibility: visibility, bars: bars)
-        
-    }
-    
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(iOS 17.0,watchOS 10.0,visionOS 1.0,macOS 14.0,tvOS 17.0, *)
+    @available(visionOS 1.0,macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0, *)
     init(removing defaultItemKind: SwiftUI.ToolbarDefaultItemKind?) {
-        self.value = ._1(defaultItemKind: defaultItemKind)
+        self.value = ._0(defaultItemKind: defaultItemKind)
         
     }
     #endif
     
     
     init(content: ToolbarContentReference=ToolbarContentReference(value: [])) {
-        self.value = ._3(content: content)
+        self.value = ._2(content: content)
         
     }
     
     
     
     init(id: AttributeReference<Swift.String>,content: CustomizableToolbarContentReference=CustomizableToolbarContentReference(value: [])) {
-        self.value = ._4(id: id, content: content)
+        self.value = ._3(id: id, content: content)
         
     }
     
@@ -11915,20 +13641,9 @@ struct _toolbarModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        
-        case let ._0(visibility, bars):
-            
-            
-            
-            __content
-                .toolbar(visibility.resolve(on: element, in: context), for: bars)
-            
-                
-            
-        
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-        case let ._1(defaultItemKind):
-            if #available(iOS 17.0,watchOS 10.0,visionOS 1.0,macOS 14.0,tvOS 17.0, *) {
+        case let ._0(defaultItemKind):
+            if #available(visionOS 1.0,macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0, *) {
             let defaultItemKind = defaultItemKind as? SwiftUI.ToolbarDefaultItemKind
             
             __content
@@ -11938,7 +13653,7 @@ struct _toolbarModifier<R: RootRegistry>: ViewModifier {
             } else { __content }
         #endif
         
-        case let ._3(content):
+        case let ._2(content):
             
             
             
@@ -11949,7 +13664,7 @@ struct _toolbarModifier<R: RootRegistry>: ViewModifier {
             
         
         
-        case let ._4(id, content):
+        case let ._3(id, content):
             
             
             
@@ -11972,9 +13687,6 @@ struct _toolbarBackgroundModifier<R: RootRegistry>: ViewModifier {
         
         indirect case _0(style: AnyShapeStyle.Resolvable,bars: SwiftUI.ToolbarPlacement)
         
-        
-        indirect case _1(visibility: AttributeReference<SwiftUI.Visibility>,bars: SwiftUI.ToolbarPlacement)
-        
     }
 
     let value: Value
@@ -11986,19 +13698,10 @@ struct _toolbarBackgroundModifier<R: RootRegistry>: ViewModifier {
 
 
 
-
-
     
     
     init(_ style: AnyShapeStyle.Resolvable,for bars: SwiftUI.ToolbarPlacement) {
         self.value = ._0(style: style, bars: bars)
-        
-    }
-    
-    
-    
-    init(_ visibility: AttributeReference<SwiftUI.Visibility>,for bars: SwiftUI.ToolbarPlacement) {
-        self.value = ._1(visibility: visibility, bars: bars)
         
     }
     
@@ -12018,17 +13721,54 @@ struct _toolbarBackgroundModifier<R: RootRegistry>: ViewModifier {
                 
             
         
+        }
+    }
+}
+@_documentation(visibility: public)
+@ParseableExpression
+struct _toolbarBackgroundVisibilityModifier<R: RootRegistry>: ViewModifier {
+    static var name: String { "toolbarBackgroundVisibility" }
+
+    enum Value {
+        case _never
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+        indirect case _0(visibility: Any,bars: Any)
+        #endif
+    }
+
+    let value: Value
+
+    @ObservedElement private var element
+    @LiveContext<R> private var context
+    
+
+
+
+
+    #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+    @available(tvOS 18.0,macOS 15.0,watchOS 11.0,visionOS 2.0,iOS 18.0, *)
+    init(_ visibility: AttributeReference<SwiftUI.Visibility>,for bars: SwiftUI.ToolbarPlacement) {
+        self.value = ._0(visibility: visibility, bars: bars)
         
-        case let ._1(visibility, bars):
-            
-            
+    }
+    #endif
+
+    func body(content __content: Content) -> some View {
+        switch value {
+        case ._never:
+            fatalError("unreachable")
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+        case let ._0(visibility, bars):
+            if #available(tvOS 18.0,macOS 15.0,watchOS 11.0,visionOS 2.0,iOS 18.0, *) {
+            let visibility = visibility as! AttributeReference<SwiftUI.Visibility>
+let bars = bars as! SwiftUI.ToolbarPlacement
             
             __content
-                .toolbarBackground(visibility.resolve(on: element, in: context), for: bars)
+                .toolbarBackgroundVisibility(visibility.resolve(on: element, in: context), for: bars)
             
                 
-            
-        
+            } else { __content }
+        #endif
         }
     }
 }
@@ -12040,7 +13780,7 @@ struct _toolbarColorSchemeModifier<R: RootRegistry>: ViewModifier {
     enum Value {
         case _never
         
-        indirect case _0(colorScheme: AttributeReference<SwiftUI.ColorScheme?>?,bars: SwiftUI.ToolbarPlacement)
+        indirect case _0(colorScheme: AttributeReference<SwiftUICore.ColorScheme?>?,bars: SwiftUI.ToolbarPlacement)
         
     }
 
@@ -12055,7 +13795,7 @@ struct _toolbarColorSchemeModifier<R: RootRegistry>: ViewModifier {
 
     
     
-    init(_ colorScheme: AttributeReference<SwiftUI.ColorScheme?>?,for bars: SwiftUI.ToolbarPlacement) {
+    init(_ colorScheme: AttributeReference<SwiftUICore.ColorScheme?>?,for bars: SwiftUI.ToolbarPlacement) {
         self.value = ._0(colorScheme: colorScheme, bars: bars)
         
     }
@@ -12076,6 +13816,53 @@ struct _toolbarColorSchemeModifier<R: RootRegistry>: ViewModifier {
                 
             
         
+        }
+    }
+}
+@_documentation(visibility: public)
+@ParseableExpression
+struct _toolbarItemHiddenModifier<R: RootRegistry>: ViewModifier {
+    static var name: String { "toolbarItemHidden" }
+
+    enum Value {
+        case _never
+        #if os(macOS)
+        indirect case _0(hidden: Any)
+        #endif
+    }
+
+    let value: Value
+
+    @ObservedElement private var element
+    @LiveContext<R> private var context
+    
+
+
+
+
+    #if os(macOS)
+    @available(macOS 15.0, *)
+    init(_ hidden: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
+        self.value = ._0(hidden: hidden)
+        
+    }
+    #endif
+
+    func body(content __content: Content) -> some View {
+        switch value {
+        case ._never:
+            fatalError("unreachable")
+        #if os(macOS)
+        case let ._0(hidden):
+            if #available(macOS 15.0, *) {
+            let hidden = hidden as! AttributeReference<Swift.Bool>
+            
+            __content
+                .toolbarItemHidden(hidden.resolve(on: element, in: context))
+            
+                
+            } else { __content }
+        #endif
         }
     }
 }
@@ -12148,7 +13935,7 @@ struct _toolbarTitleDisplayModeModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 10.0,macOS 14.0,visionOS 1.0,iOS 17.0,tvOS 17.0, *)
+    @available(macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0,visionOS 1.0, *)
     init(_ mode: SwiftUI.ToolbarTitleDisplayMode) {
         self.value = ._0(mode: mode)
         
@@ -12161,7 +13948,7 @@ struct _toolbarTitleDisplayModeModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(mode):
-            if #available(watchOS 10.0,macOS 14.0,visionOS 1.0,iOS 17.0,tvOS 17.0, *) {
+            if #available(macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0,visionOS 1.0, *) {
             let mode = mode as! SwiftUI.ToolbarTitleDisplayMode
             
             __content
@@ -12217,6 +14004,54 @@ struct _toolbarTitleMenuModifier<R: RootRegistry>: ViewModifier {
                 
             
         
+        }
+    }
+}
+@_documentation(visibility: public)
+@ParseableExpression
+struct _toolbarVisibilityModifier<R: RootRegistry>: ViewModifier {
+    static var name: String { "toolbarVisibility" }
+
+    enum Value {
+        case _never
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+        indirect case _0(visibility: Any,bars: Any)
+        #endif
+    }
+
+    let value: Value
+
+    @ObservedElement private var element
+    @LiveContext<R> private var context
+    
+
+
+
+
+    #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+    @available(tvOS 18.0,macOS 15.0,watchOS 11.0,visionOS 2.0,iOS 18.0, *)
+    init(_ visibility: AttributeReference<SwiftUI.Visibility>,for bars: SwiftUI.ToolbarPlacement) {
+        self.value = ._0(visibility: visibility, bars: bars)
+        
+    }
+    #endif
+
+    func body(content __content: Content) -> some View {
+        switch value {
+        case ._never:
+            fatalError("unreachable")
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+        case let ._0(visibility, bars):
+            if #available(tvOS 18.0,macOS 15.0,watchOS 11.0,visionOS 2.0,iOS 18.0, *) {
+            let visibility = visibility as! AttributeReference<SwiftUI.Visibility>
+let bars = bars as! SwiftUI.ToolbarPlacement
+            
+            __content
+                .toolbarVisibility(visibility.resolve(on: element, in: context), for: bars)
+            
+                
+            } else { __content }
+        #endif
         }
     }
 }
@@ -12416,7 +14251,7 @@ struct _transitionModifier<R: RootRegistry>: ViewModifier {
     enum Value {
         case _never
         
-        indirect case _0(t: SwiftUI.AnyTransition)
+        indirect case _0(t: SwiftUICore.AnyTransition)
         
     }
 
@@ -12431,7 +14266,7 @@ struct _transitionModifier<R: RootRegistry>: ViewModifier {
 
     
     
-    init(_ t: SwiftUI.AnyTransition) {
+    init(_ t: SwiftUICore.AnyTransition) {
         self.value = ._0(t: t)
         
     }
@@ -12463,7 +14298,7 @@ struct _truncationModeModifier<R: RootRegistry>: ViewModifier {
     enum Value {
         case _never
         
-        indirect case _0(mode: SwiftUI.Text.TruncationMode)
+        indirect case _0(mode: SwiftUICore.Text.TruncationMode)
         
     }
 
@@ -12478,7 +14313,7 @@ struct _truncationModeModifier<R: RootRegistry>: ViewModifier {
 
     
     
-    init(_ mode: SwiftUI.Text.TruncationMode) {
+    init(_ mode: SwiftUICore.Text.TruncationMode) {
         self.value = ._0(mode: mode)
         
     }
@@ -12598,6 +14433,335 @@ struct _upperLimbVisibilityModifier<R: RootRegistry>: ViewModifier {
 }
 @_documentation(visibility: public)
 @ParseableExpression
+struct _volumeBaseplateVisibilityModifier<R: RootRegistry>: ViewModifier {
+    static var name: String { "volumeBaseplateVisibility" }
+
+    enum Value {
+        case _never
+        #if os(visionOS)
+        indirect case _0(visibility: Any)
+        #endif
+    }
+
+    let value: Value
+
+    @ObservedElement private var element
+    @LiveContext<R> private var context
+    
+
+
+
+
+    #if os(visionOS)
+    @available(visionOS 2.0, *)
+    init(_ visibility: AttributeReference<SwiftUI.Visibility>) {
+        self.value = ._0(visibility: visibility)
+        
+    }
+    #endif
+
+    func body(content __content: Content) -> some View {
+        switch value {
+        case ._never:
+            fatalError("unreachable")
+        #if os(visionOS)
+        case let ._0(visibility):
+            if #available(visionOS 2.0, *) {
+            let visibility = visibility as! AttributeReference<SwiftUI.Visibility>
+            
+            __content
+                .volumeBaseplateVisibility(visibility.resolve(on: element, in: context))
+            
+                
+            } else { __content }
+        #endif
+        }
+    }
+}
+@_documentation(visibility: public)
+@ParseableExpression
+struct _windowDismissBehaviorModifier<R: RootRegistry>: ViewModifier {
+    static var name: String { "windowDismissBehavior" }
+
+    enum Value {
+        case _never
+        #if os(macOS)
+        indirect case _0(behavior: Any)
+        #endif
+    }
+
+    let value: Value
+
+    
+    
+    
+
+
+
+
+    #if os(macOS)
+    @available(macOS 15.0, *)
+    init(_ behavior: SwiftUI.WindowInteractionBehavior) {
+        self.value = ._0(behavior: behavior)
+        
+    }
+    #endif
+
+    func body(content __content: Content) -> some View {
+        switch value {
+        case ._never:
+            fatalError("unreachable")
+        #if os(macOS)
+        case let ._0(behavior):
+            if #available(macOS 15.0, *) {
+            let behavior = behavior as! SwiftUI.WindowInteractionBehavior
+            
+            __content
+                .windowDismissBehavior(behavior)
+            
+                
+            } else { __content }
+        #endif
+        }
+    }
+}
+@_documentation(visibility: public)
+@ParseableExpression
+struct _windowFullScreenBehaviorModifier<R: RootRegistry>: ViewModifier {
+    static var name: String { "windowFullScreenBehavior" }
+
+    enum Value {
+        case _never
+        #if os(macOS)
+        indirect case _0(behavior: Any)
+        #endif
+    }
+
+    let value: Value
+
+    
+    
+    
+
+
+
+
+    #if os(macOS)
+    @available(macOS 15.0, *)
+    init(_ behavior: SwiftUI.WindowInteractionBehavior) {
+        self.value = ._0(behavior: behavior)
+        
+    }
+    #endif
+
+    func body(content __content: Content) -> some View {
+        switch value {
+        case ._never:
+            fatalError("unreachable")
+        #if os(macOS)
+        case let ._0(behavior):
+            if #available(macOS 15.0, *) {
+            let behavior = behavior as! SwiftUI.WindowInteractionBehavior
+            
+            __content
+                .windowFullScreenBehavior(behavior)
+            
+                
+            } else { __content }
+        #endif
+        }
+    }
+}
+@_documentation(visibility: public)
+@ParseableExpression
+struct _windowMinimizeBehaviorModifier<R: RootRegistry>: ViewModifier {
+    static var name: String { "windowMinimizeBehavior" }
+
+    enum Value {
+        case _never
+        #if os(macOS)
+        indirect case _0(behavior: Any)
+        #endif
+    }
+
+    let value: Value
+
+    
+    
+    
+
+
+
+
+    #if os(macOS)
+    @available(macOS 15.0, *)
+    init(_ behavior: SwiftUI.WindowInteractionBehavior) {
+        self.value = ._0(behavior: behavior)
+        
+    }
+    #endif
+
+    func body(content __content: Content) -> some View {
+        switch value {
+        case ._never:
+            fatalError("unreachable")
+        #if os(macOS)
+        case let ._0(behavior):
+            if #available(macOS 15.0, *) {
+            let behavior = behavior as! SwiftUI.WindowInteractionBehavior
+            
+            __content
+                .windowMinimizeBehavior(behavior)
+            
+                
+            } else { __content }
+        #endif
+        }
+    }
+}
+@_documentation(visibility: public)
+@ParseableExpression
+struct _windowResizeBehaviorModifier<R: RootRegistry>: ViewModifier {
+    static var name: String { "windowResizeBehavior" }
+
+    enum Value {
+        case _never
+        #if os(macOS)
+        indirect case _0(behavior: Any)
+        #endif
+    }
+
+    let value: Value
+
+    
+    
+    
+
+
+
+
+    #if os(macOS)
+    @available(macOS 15.0, *)
+    init(_ behavior: SwiftUI.WindowInteractionBehavior) {
+        self.value = ._0(behavior: behavior)
+        
+    }
+    #endif
+
+    func body(content __content: Content) -> some View {
+        switch value {
+        case ._never:
+            fatalError("unreachable")
+        #if os(macOS)
+        case let ._0(behavior):
+            if #available(macOS 15.0, *) {
+            let behavior = behavior as! SwiftUI.WindowInteractionBehavior
+            
+            __content
+                .windowResizeBehavior(behavior)
+            
+                
+            } else { __content }
+        #endif
+        }
+    }
+}
+@_documentation(visibility: public)
+@ParseableExpression
+struct _windowToolbarFullScreenVisibilityModifier<R: RootRegistry>: ViewModifier {
+    static var name: String { "windowToolbarFullScreenVisibility" }
+
+    enum Value {
+        case _never
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+        indirect case _0(visibility: Any)
+        #endif
+    }
+
+    let value: Value
+
+    
+    
+    
+
+
+
+
+    #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+    @available(visionOS 2.0,macOS 15.0,watchOS 11.0,iOS 18.0,tvOS 18.0, *)
+    init(_ visibility: SwiftUI.WindowToolbarFullScreenVisibility) {
+        self.value = ._0(visibility: visibility)
+        
+    }
+    #endif
+
+    func body(content __content: Content) -> some View {
+        switch value {
+        case ._never:
+            fatalError("unreachable")
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+        case let ._0(visibility):
+            if #available(visionOS 2.0,macOS 15.0,watchOS 11.0,iOS 18.0,tvOS 18.0, *) {
+            let visibility = visibility as! SwiftUI.WindowToolbarFullScreenVisibility
+            
+            __content
+                .windowToolbarFullScreenVisibility(visibility)
+            
+                
+            } else { __content }
+        #endif
+        }
+    }
+}
+@_documentation(visibility: public)
+@ParseableExpression
+struct _writingToolsBehaviorModifier<R: RootRegistry>: ViewModifier {
+    static var name: String { "writingToolsBehavior" }
+
+    enum Value {
+        case _never
+        #if os(iOS) || os(macOS)
+        indirect case _0(behavior: Any)
+        #endif
+    }
+
+    let value: Value
+
+    
+    
+    
+
+
+
+
+    #if os(iOS) || os(macOS)
+    @available(macOS 15.0,iOS 18.0, *)
+    init(_ behavior: SwiftUI.WritingToolsBehavior) {
+        self.value = ._0(behavior: behavior)
+        
+    }
+    #endif
+
+    func body(content __content: Content) -> some View {
+        switch value {
+        case ._never:
+            fatalError("unreachable")
+        #if os(iOS) || os(macOS)
+        case let ._0(behavior):
+            if #available(macOS 15.0,iOS 18.0, *) {
+            let behavior = behavior as! SwiftUI.WritingToolsBehavior
+            
+            __content
+                .writingToolsBehavior(behavior)
+            
+                
+            } else { __content }
+        #endif
+        }
+    }
+}
+@_documentation(visibility: public)
+@ParseableExpression
 struct _zIndexModifier<R: RootRegistry>: ViewModifier {
     static var name: String { "zIndex" }
 
@@ -12655,11 +14819,11 @@ indirect case accessibilityShowsLargeContentViewer(_accessibilityShowsLargeConte
 indirect case alert(_alertModifier<R>)
 indirect case allowsHitTesting(_allowsHitTestingModifier<R>)
 indirect case allowsTightening(_allowsTighteningModifier<R>)
+indirect case allowsWindowActivationEvents(_allowsWindowActivationEventsModifier<R>)
 indirect case animation(_animationModifier<R>)
 indirect case aspectRatio(_aspectRatioModifier<R>)
 indirect case autocorrectionDisabled(_autocorrectionDisabledModifier<R>)
 indirect case background(_backgroundModifier<R>)
-indirect case backgroundStyle(_backgroundStyleModifier<R>)
         
         func body(content: Content) -> some View {
             switch self {
@@ -12681,6 +14845,8 @@ case let .allowsHitTesting(modifier):
     content.modifier(modifier)
 case let .allowsTightening(modifier):
     content.modifier(modifier)
+case let .allowsWindowActivationEvents(modifier):
+    content.modifier(modifier)
 case let .animation(modifier):
     content.modifier(modifier)
 case let .aspectRatio(modifier):
@@ -12689,15 +14855,14 @@ case let .autocorrectionDisabled(modifier):
     content.modifier(modifier)
 case let .background(modifier):
     content.modifier(modifier)
-case let .backgroundStyle(modifier):
-    content.modifier(modifier)
             }
         }
     }
 }
 extension BuiltinRegistry {
     enum _BuiltinModifierChunk1: ViewModifier {
-        indirect case badge(_badgeModifier<R>)
+        indirect case backgroundStyle(_backgroundStyleModifier<R>)
+indirect case badge(_badgeModifier<R>)
 indirect case badgeProminence(_badgeProminenceModifier<R>)
 indirect case blendMode(_blendModeModifier<R>)
 indirect case blur(_blurModifier<R>)
@@ -12710,11 +14875,12 @@ indirect case clipped(_clippedModifier<R>)
 indirect case colorInvert(_colorInvertModifier<R>)
 indirect case colorMultiply(_colorMultiplyModifier<R>)
 indirect case compositingGroup(_compositingGroupModifier<R>)
-indirect case confirmationDialog(_confirmationDialogModifier<R>)
         
         func body(content: Content) -> some View {
             switch self {
-            case let .badge(modifier):
+            case let .backgroundStyle(modifier):
+    content.modifier(modifier)
+case let .badge(modifier):
     content.modifier(modifier)
 case let .badgeProminence(modifier):
     content.modifier(modifier)
@@ -12740,15 +14906,14 @@ case let .colorMultiply(modifier):
     content.modifier(modifier)
 case let .compositingGroup(modifier):
     content.modifier(modifier)
-case let .confirmationDialog(modifier):
-    content.modifier(modifier)
             }
         }
     }
 }
 extension BuiltinRegistry {
     enum _BuiltinModifierChunk2: ViewModifier {
-        indirect case containerRelativeFrame(_containerRelativeFrameModifier<R>)
+        indirect case confirmationDialog(_confirmationDialogModifier<R>)
+indirect case containerRelativeFrame(_containerRelativeFrameModifier<R>)
 indirect case containerShape(_containerShapeModifier<R>)
 indirect case contentMargins(_contentMarginsModifier<R>)
 indirect case contentShape(_contentShapeModifier<R>)
@@ -12759,13 +14924,14 @@ indirect case controlGroupStyle(_controlGroupStyleModifier<R>)
 indirect case controlSize(_controlSizeModifier<R>)
 indirect case coordinateSpace(_coordinateSpaceModifier<R>)
 indirect case datePickerStyle(_datePickerStyleModifier<R>)
+indirect case defaultAdaptableTabBarPlacement(_defaultAdaptableTabBarPlacementModifier<R>)
 indirect case defaultHoverEffect(_defaultHoverEffectModifier<R>)
-indirect case defaultScrollAnchor(_defaultScrollAnchorModifier<R>)
-indirect case defaultWheelPickerItemHeight(_defaultWheelPickerItemHeightModifier<R>)
         
         func body(content: Content) -> some View {
             switch self {
-            case let .containerRelativeFrame(modifier):
+            case let .confirmationDialog(modifier):
+    content.modifier(modifier)
+case let .containerRelativeFrame(modifier):
     content.modifier(modifier)
 case let .containerShape(modifier):
     content.modifier(modifier)
@@ -12787,11 +14953,9 @@ case let .coordinateSpace(modifier):
     content.modifier(modifier)
 case let .datePickerStyle(modifier):
     content.modifier(modifier)
+case let .defaultAdaptableTabBarPlacement(modifier):
+    content.modifier(modifier)
 case let .defaultHoverEffect(modifier):
-    content.modifier(modifier)
-case let .defaultScrollAnchor(modifier):
-    content.modifier(modifier)
-case let .defaultWheelPickerItemHeight(modifier):
     content.modifier(modifier)
             }
         }
@@ -12799,24 +14963,28 @@ case let .defaultWheelPickerItemHeight(modifier):
 }
 extension BuiltinRegistry {
     enum _BuiltinModifierChunk3: ViewModifier {
-        indirect case defersSystemGestures(_defersSystemGesturesModifier<R>)
+        indirect case defaultScrollAnchor(_defaultScrollAnchorModifier<R>)
+indirect case defaultWheelPickerItemHeight(_defaultWheelPickerItemHeightModifier<R>)
+indirect case defersSystemGestures(_defersSystemGesturesModifier<R>)
 indirect case deleteDisabled(_deleteDisabledModifier<R>)
 indirect case dialogSuppressionToggle(_dialogSuppressionToggleModifier<R>)
 indirect case digitalCrownAccessory(_digitalCrownAccessoryModifier<R>)
 indirect case disabled(_disabledModifier<R>)
+indirect case dismissalConfirmationDialog(_dismissalConfirmationDialogModifier<R>)
 indirect case drawingGroup(_drawingGroupModifier<R>)
 indirect case dynamicTypeSize(_dynamicTypeSizeModifier<R>)
 indirect case fileDialogCustomizationID(_fileDialogCustomizationIDModifier<R>)
 indirect case fileDialogImportsUnresolvedAliases(_fileDialogImportsUnresolvedAliasesModifier<R>)
 indirect case findDisabled(_findDisabledModifier<R>)
 indirect case findNavigator(_findNavigatorModifier<R>)
-indirect case fixedSize(_fixedSizeModifier<R>)
-indirect case flipsForRightToLeftLayoutDirection(_flipsForRightToLeftLayoutDirectionModifier<R>)
-indirect case focusEffectDisabled(_focusEffectDisabledModifier<R>)
         
         func body(content: Content) -> some View {
             switch self {
-            case let .defersSystemGestures(modifier):
+            case let .defaultScrollAnchor(modifier):
+    content.modifier(modifier)
+case let .defaultWheelPickerItemHeight(modifier):
+    content.modifier(modifier)
+case let .defersSystemGestures(modifier):
     content.modifier(modifier)
 case let .deleteDisabled(modifier):
     content.modifier(modifier)
@@ -12825,6 +14993,8 @@ case let .dialogSuppressionToggle(modifier):
 case let .digitalCrownAccessory(modifier):
     content.modifier(modifier)
 case let .disabled(modifier):
+    content.modifier(modifier)
+case let .dismissalConfirmationDialog(modifier):
     content.modifier(modifier)
 case let .drawingGroup(modifier):
     content.modifier(modifier)
@@ -12838,19 +15008,16 @@ case let .findDisabled(modifier):
     content.modifier(modifier)
 case let .findNavigator(modifier):
     content.modifier(modifier)
-case let .fixedSize(modifier):
-    content.modifier(modifier)
-case let .flipsForRightToLeftLayoutDirection(modifier):
-    content.modifier(modifier)
-case let .focusEffectDisabled(modifier):
-    content.modifier(modifier)
             }
         }
     }
 }
 extension BuiltinRegistry {
     enum _BuiltinModifierChunk4: ViewModifier {
-        indirect case focusSection(_focusSectionModifier<R>)
+        indirect case fixedSize(_fixedSizeModifier<R>)
+indirect case flipsForRightToLeftLayoutDirection(_flipsForRightToLeftLayoutDirectionModifier<R>)
+indirect case focusEffectDisabled(_focusEffectDisabledModifier<R>)
+indirect case focusSection(_focusSectionModifier<R>)
 indirect case focusable(_focusableModifier<R>)
 indirect case formStyle(_formStyleModifier<R>)
 indirect case frame(_frameModifier<R>)
@@ -12861,13 +15028,16 @@ indirect case gesture(_gestureModifier<R>)
 indirect case glassBackgroundEffect(_glassBackgroundEffectModifier<R>)
 indirect case grayscale(_grayscaleModifier<R>)
 indirect case gridCellAnchor(_gridCellAnchorModifier<R>)
-indirect case gridCellColumns(_gridCellColumnsModifier<R>)
-indirect case gridCellUnsizedAxes(_gridCellUnsizedAxesModifier<R>)
-indirect case gridColumnAlignment(_gridColumnAlignmentModifier<R>)
         
         func body(content: Content) -> some View {
             switch self {
-            case let .focusSection(modifier):
+            case let .fixedSize(modifier):
+    content.modifier(modifier)
+case let .flipsForRightToLeftLayoutDirection(modifier):
+    content.modifier(modifier)
+case let .focusEffectDisabled(modifier):
+    content.modifier(modifier)
+case let .focusSection(modifier):
     content.modifier(modifier)
 case let .focusable(modifier):
     content.modifier(modifier)
@@ -12889,19 +15059,18 @@ case let .grayscale(modifier):
     content.modifier(modifier)
 case let .gridCellAnchor(modifier):
     content.modifier(modifier)
-case let .gridCellColumns(modifier):
-    content.modifier(modifier)
-case let .gridCellUnsizedAxes(modifier):
-    content.modifier(modifier)
-case let .gridColumnAlignment(modifier):
-    content.modifier(modifier)
             }
         }
     }
 }
 extension BuiltinRegistry {
     enum _BuiltinModifierChunk5: ViewModifier {
-        indirect case groupBoxStyle(_groupBoxStyleModifier<R>)
+        indirect case gridCellColumns(_gridCellColumnsModifier<R>)
+indirect case gridCellUnsizedAxes(_gridCellUnsizedAxesModifier<R>)
+indirect case gridColumnAlignment(_gridColumnAlignmentModifier<R>)
+indirect case groupBoxStyle(_groupBoxStyleModifier<R>)
+indirect case handGestureShortcut(_handGestureShortcutModifier<R>)
+indirect case handPointerBehavior(_handPointerBehaviorModifier<R>)
 indirect case headerProminence(_headerProminenceModifier<R>)
 indirect case help(_helpModifier<R>)
 indirect case hidden(_hiddenModifier<R>)
@@ -12909,16 +15078,21 @@ indirect case highPriorityGesture(_highPriorityGestureModifier<R>)
 indirect case horizontalRadioGroupLayout(_horizontalRadioGroupLayoutModifier<R>)
 indirect case hoverEffect(_hoverEffectModifier<R>)
 indirect case hoverEffectDisabled(_hoverEffectDisabledModifier<R>)
-indirect case hueRotation(_hueRotationModifier<R>)
-indirect case ignoresSafeArea(_ignoresSafeAreaModifier<R>)
-indirect case imageScale(_imageScaleModifier<R>)
-indirect case indexViewStyle(_indexViewStyleModifier<R>)
-indirect case inspector(_inspectorModifier<R>)
-indirect case inspectorColumnWidth(_inspectorColumnWidthModifier<R>)
+indirect case hoverEffectGroup(_hoverEffectGroupModifier<R>)
         
         func body(content: Content) -> some View {
             switch self {
-            case let .groupBoxStyle(modifier):
+            case let .gridCellColumns(modifier):
+    content.modifier(modifier)
+case let .gridCellUnsizedAxes(modifier):
+    content.modifier(modifier)
+case let .gridColumnAlignment(modifier):
+    content.modifier(modifier)
+case let .groupBoxStyle(modifier):
+    content.modifier(modifier)
+case let .handGestureShortcut(modifier):
+    content.modifier(modifier)
+case let .handPointerBehavior(modifier):
     content.modifier(modifier)
 case let .headerProminence(modifier):
     content.modifier(modifier)
@@ -12934,17 +15108,7 @@ case let .hoverEffect(modifier):
     content.modifier(modifier)
 case let .hoverEffectDisabled(modifier):
     content.modifier(modifier)
-case let .hueRotation(modifier):
-    content.modifier(modifier)
-case let .ignoresSafeArea(modifier):
-    content.modifier(modifier)
-case let .imageScale(modifier):
-    content.modifier(modifier)
-case let .indexViewStyle(modifier):
-    content.modifier(modifier)
-case let .inspector(modifier):
-    content.modifier(modifier)
-case let .inspectorColumnWidth(modifier):
+case let .hoverEffectGroup(modifier):
     content.modifier(modifier)
             }
         }
@@ -12952,24 +15116,38 @@ case let .inspectorColumnWidth(modifier):
 }
 extension BuiltinRegistry {
     enum _BuiltinModifierChunk6: ViewModifier {
-        indirect case interactionActivityTrackingTag(_interactionActivityTrackingTagModifier<R>)
+        indirect case hueRotation(_hueRotationModifier<R>)
+indirect case ignoresSafeArea(_ignoresSafeAreaModifier<R>)
+indirect case imageScale(_imageScaleModifier<R>)
+indirect case immersiveEnvironmentPicker(_immersiveEnvironmentPickerModifier<R>)
+indirect case indexViewStyle(_indexViewStyleModifier<R>)
+indirect case inspector(_inspectorModifier<R>)
+indirect case inspectorColumnWidth(_inspectorColumnWidthModifier<R>)
+indirect case interactionActivityTrackingTag(_interactionActivityTrackingTagModifier<R>)
 indirect case interactiveDismissDisabled(_interactiveDismissDisabledModifier<R>)
 indirect case invalidatableContent(_invalidatableContentModifier<R>)
 indirect case keyboardShortcut(_keyboardShortcutModifier<R>)
 indirect case keyboardType(_keyboardTypeModifier<R>)
 indirect case labelStyle(_labelStyleModifier<R>)
 indirect case labeledContentStyle(_labeledContentStyleModifier<R>)
-indirect case labelsHidden(_labelsHiddenModifier<R>)
-indirect case layoutPriority(_layoutPriorityModifier<R>)
-indirect case lineLimit(_lineLimitModifier<R>)
-indirect case lineSpacing(_lineSpacingModifier<R>)
-indirect case listItemTint(_listItemTintModifier<R>)
-indirect case listRowBackground(_listRowBackgroundModifier<R>)
-indirect case listRowHoverEffect(_listRowHoverEffectModifier<R>)
         
         func body(content: Content) -> some View {
             switch self {
-            case let .interactionActivityTrackingTag(modifier):
+            case let .hueRotation(modifier):
+    content.modifier(modifier)
+case let .ignoresSafeArea(modifier):
+    content.modifier(modifier)
+case let .imageScale(modifier):
+    content.modifier(modifier)
+case let .immersiveEnvironmentPicker(modifier):
+    content.modifier(modifier)
+case let .indexViewStyle(modifier):
+    content.modifier(modifier)
+case let .inspector(modifier):
+    content.modifier(modifier)
+case let .inspectorColumnWidth(modifier):
+    content.modifier(modifier)
+case let .interactionActivityTrackingTag(modifier):
     content.modifier(modifier)
 case let .interactiveDismissDisabled(modifier):
     content.modifier(modifier)
@@ -12983,7 +15161,32 @@ case let .labelStyle(modifier):
     content.modifier(modifier)
 case let .labeledContentStyle(modifier):
     content.modifier(modifier)
-case let .labelsHidden(modifier):
+            }
+        }
+    }
+}
+extension BuiltinRegistry {
+    enum _BuiltinModifierChunk7: ViewModifier {
+        indirect case labelsHidden(_labelsHiddenModifier<R>)
+indirect case labelsVisibility(_labelsVisibilityModifier<R>)
+indirect case layoutPriority(_layoutPriorityModifier<R>)
+indirect case lineLimit(_lineLimitModifier<R>)
+indirect case lineSpacing(_lineSpacingModifier<R>)
+indirect case listItemTint(_listItemTintModifier<R>)
+indirect case listRowBackground(_listRowBackgroundModifier<R>)
+indirect case listRowHoverEffect(_listRowHoverEffectModifier<R>)
+indirect case listRowHoverEffectDisabled(_listRowHoverEffectDisabledModifier<R>)
+indirect case listRowInsets(_listRowInsetsModifier<R>)
+indirect case listRowSeparator(_listRowSeparatorModifier<R>)
+indirect case listRowSeparatorTint(_listRowSeparatorTintModifier<R>)
+indirect case listRowSpacing(_listRowSpacingModifier<R>)
+indirect case listSectionSeparator(_listSectionSeparatorModifier<R>)
+        
+        func body(content: Content) -> some View {
+            switch self {
+            case let .labelsHidden(modifier):
+    content.modifier(modifier)
+case let .labelsVisibility(modifier):
     content.modifier(modifier)
 case let .layoutPriority(modifier):
     content.modifier(modifier)
@@ -12997,30 +15200,7 @@ case let .listRowBackground(modifier):
     content.modifier(modifier)
 case let .listRowHoverEffect(modifier):
     content.modifier(modifier)
-            }
-        }
-    }
-}
-extension BuiltinRegistry {
-    enum _BuiltinModifierChunk7: ViewModifier {
-        indirect case listRowHoverEffectDisabled(_listRowHoverEffectDisabledModifier<R>)
-indirect case listRowInsets(_listRowInsetsModifier<R>)
-indirect case listRowSeparator(_listRowSeparatorModifier<R>)
-indirect case listRowSeparatorTint(_listRowSeparatorTintModifier<R>)
-indirect case listRowSpacing(_listRowSpacingModifier<R>)
-indirect case listSectionSeparator(_listSectionSeparatorModifier<R>)
-indirect case listSectionSeparatorTint(_listSectionSeparatorTintModifier<R>)
-indirect case listSectionSpacing(_listSectionSpacingModifier<R>)
-indirect case listStyle(_listStyleModifier<R>)
-indirect case luminanceToAlpha(_luminanceToAlphaModifier<R>)
-indirect case menuIndicator(_menuIndicatorModifier<R>)
-indirect case menuOrder(_menuOrderModifier<R>)
-indirect case menuStyle(_menuStyleModifier<R>)
-indirect case minimumScaleFactor(_minimumScaleFactorModifier<R>)
-        
-        func body(content: Content) -> some View {
-            switch self {
-            case let .listRowHoverEffectDisabled(modifier):
+case let .listRowHoverEffectDisabled(modifier):
     content.modifier(modifier)
 case let .listRowInsets(modifier):
     content.modifier(modifier)
@@ -13032,13 +15212,38 @@ case let .listRowSpacing(modifier):
     content.modifier(modifier)
 case let .listSectionSeparator(modifier):
     content.modifier(modifier)
-case let .listSectionSeparatorTint(modifier):
+            }
+        }
+    }
+}
+extension BuiltinRegistry {
+    enum _BuiltinModifierChunk8: ViewModifier {
+        indirect case listSectionSeparatorTint(_listSectionSeparatorTintModifier<R>)
+indirect case listSectionSpacing(_listSectionSpacingModifier<R>)
+indirect case listStyle(_listStyleModifier<R>)
+indirect case luminanceToAlpha(_luminanceToAlphaModifier<R>)
+indirect case materialActiveAppearance(_materialActiveAppearanceModifier<R>)
+indirect case menuIndicator(_menuIndicatorModifier<R>)
+indirect case menuOrder(_menuOrderModifier<R>)
+indirect case menuStyle(_menuStyleModifier<R>)
+indirect case minimumScaleFactor(_minimumScaleFactorModifier<R>)
+indirect case modifierKeyAlternate(_modifierKeyAlternateModifier<R>)
+indirect case moveDisabled(_moveDisabledModifier<R>)
+indirect case multilineTextAlignment(_multilineTextAlignmentModifier<R>)
+indirect case navigationBarBackButtonHidden(_navigationBarBackButtonHiddenModifier<R>)
+indirect case navigationBarTitleDisplayMode(_navigationBarTitleDisplayModeModifier<R>)
+        
+        func body(content: Content) -> some View {
+            switch self {
+            case let .listSectionSeparatorTint(modifier):
     content.modifier(modifier)
 case let .listSectionSpacing(modifier):
     content.modifier(modifier)
 case let .listStyle(modifier):
     content.modifier(modifier)
 case let .luminanceToAlpha(modifier):
+    content.modifier(modifier)
+case let .materialActiveAppearance(modifier):
     content.modifier(modifier)
 case let .menuIndicator(modifier):
     content.modifier(modifier)
@@ -13048,17 +15253,23 @@ case let .menuStyle(modifier):
     content.modifier(modifier)
 case let .minimumScaleFactor(modifier):
     content.modifier(modifier)
+case let .modifierKeyAlternate(modifier):
+    content.modifier(modifier)
+case let .moveDisabled(modifier):
+    content.modifier(modifier)
+case let .multilineTextAlignment(modifier):
+    content.modifier(modifier)
+case let .navigationBarBackButtonHidden(modifier):
+    content.modifier(modifier)
+case let .navigationBarTitleDisplayMode(modifier):
+    content.modifier(modifier)
             }
         }
     }
 }
 extension BuiltinRegistry {
-    enum _BuiltinModifierChunk8: ViewModifier {
-        indirect case moveDisabled(_moveDisabledModifier<R>)
-indirect case multilineTextAlignment(_multilineTextAlignmentModifier<R>)
-indirect case navigationBarBackButtonHidden(_navigationBarBackButtonHiddenModifier<R>)
-indirect case navigationBarTitleDisplayMode(_navigationBarTitleDisplayModeModifier<R>)
-indirect case navigationDestination(_navigationDestinationModifier<R>)
+    enum _BuiltinModifierChunk9: ViewModifier {
+        indirect case navigationDestination(_navigationDestinationModifier<R>)
 indirect case navigationSplitViewColumnWidth(_navigationSplitViewColumnWidthModifier<R>)
 indirect case navigationSplitViewStyle(_navigationSplitViewStyleModifier<R>)
 indirect case navigationSubtitle(_navigationSubtitleModifier<R>)
@@ -13068,18 +15279,14 @@ indirect case onAppear(_onAppearModifier<R>)
 indirect case onDeleteCommand(_onDeleteCommandModifier<R>)
 indirect case onDisappear(_onDisappearModifier<R>)
 indirect case onExitCommand(_onExitCommandModifier<R>)
+indirect case onHover(_onHoverModifier<R>)
+indirect case onImmersionChange(_onImmersionChangeModifier<R>)
+indirect case onLongPressGesture(_onLongPressGestureModifier<R>)
+indirect case onLongTouchGesture(_onLongTouchGestureModifier<R>)
         
         func body(content: Content) -> some View {
             switch self {
-            case let .moveDisabled(modifier):
-    content.modifier(modifier)
-case let .multilineTextAlignment(modifier):
-    content.modifier(modifier)
-case let .navigationBarBackButtonHidden(modifier):
-    content.modifier(modifier)
-case let .navigationBarTitleDisplayMode(modifier):
-    content.modifier(modifier)
-case let .navigationDestination(modifier):
+            case let .navigationDestination(modifier):
     content.modifier(modifier)
 case let .navigationSplitViewColumnWidth(modifier):
     content.modifier(modifier)
@@ -13099,40 +15306,54 @@ case let .onDisappear(modifier):
     content.modifier(modifier)
 case let .onExitCommand(modifier):
     content.modifier(modifier)
-            }
-        }
-    }
-}
-extension BuiltinRegistry {
-    enum _BuiltinModifierChunk9: ViewModifier {
-        indirect case onHover(_onHoverModifier<R>)
-indirect case onLongPressGesture(_onLongPressGestureModifier<R>)
-indirect case onLongTouchGesture(_onLongTouchGestureModifier<R>)
-indirect case onMoveCommand(_onMoveCommandModifier<R>)
-indirect case onPlayPauseCommand(_onPlayPauseCommandModifier<R>)
-indirect case onTapGesture(_onTapGestureModifier<R>)
-indirect case opacity(_opacityModifier<R>)
-indirect case ornament(_ornamentModifier<R>)
-indirect case overlay(_overlayModifier<R>)
-indirect case padding(_paddingModifier<R>)
-indirect case padding3D(_padding3DModifier<R>)
-indirect case persistentSystemOverlays(_persistentSystemOverlaysModifier<R>)
-indirect case pickerStyle(_pickerStyleModifier<R>)
-indirect case popover(_popoverModifier<R>)
-        
-        func body(content: Content) -> some View {
-            switch self {
-            case let .onHover(modifier):
+case let .onHover(modifier):
+    content.modifier(modifier)
+case let .onImmersionChange(modifier):
     content.modifier(modifier)
 case let .onLongPressGesture(modifier):
     content.modifier(modifier)
 case let .onLongTouchGesture(modifier):
     content.modifier(modifier)
+            }
+        }
+    }
+}
+extension BuiltinRegistry {
+    enum _BuiltinModifierChunk10: ViewModifier {
+        indirect case onModifierKeysChanged(_onModifierKeysChangedModifier<R>)
+indirect case onMoveCommand(_onMoveCommandModifier<R>)
+indirect case onPencilDoubleTap(_onPencilDoubleTapModifier<R>)
+indirect case onPencilSqueeze(_onPencilSqueezeModifier<R>)
+indirect case onPlayPauseCommand(_onPlayPauseCommandModifier<R>)
+indirect case onScrollPhaseChange(_onScrollPhaseChangeModifier<R>)
+indirect case onScrollVisibilityChange(_onScrollVisibilityChangeModifier<R>)
+indirect case onTapGesture(_onTapGestureModifier<R>)
+indirect case onVolumeViewpointChange(_onVolumeViewpointChangeModifier<R>)
+indirect case opacity(_opacityModifier<R>)
+indirect case ornament(_ornamentModifier<R>)
+indirect case overlay(_overlayModifier<R>)
+indirect case padding(_paddingModifier<R>)
+indirect case padding3D(_padding3DModifier<R>)
+        
+        func body(content: Content) -> some View {
+            switch self {
+            case let .onModifierKeysChanged(modifier):
+    content.modifier(modifier)
 case let .onMoveCommand(modifier):
+    content.modifier(modifier)
+case let .onPencilDoubleTap(modifier):
+    content.modifier(modifier)
+case let .onPencilSqueeze(modifier):
     content.modifier(modifier)
 case let .onPlayPauseCommand(modifier):
     content.modifier(modifier)
+case let .onScrollPhaseChange(modifier):
+    content.modifier(modifier)
+case let .onScrollVisibilityChange(modifier):
+    content.modifier(modifier)
 case let .onTapGesture(modifier):
+    content.modifier(modifier)
+case let .onVolumeViewpointChange(modifier):
     content.modifier(modifier)
 case let .opacity(modifier):
     content.modifier(modifier)
@@ -13144,19 +15365,18 @@ case let .padding(modifier):
     content.modifier(modifier)
 case let .padding3D(modifier):
     content.modifier(modifier)
-case let .persistentSystemOverlays(modifier):
-    content.modifier(modifier)
-case let .pickerStyle(modifier):
-    content.modifier(modifier)
-case let .popover(modifier):
-    content.modifier(modifier)
             }
         }
     }
 }
 extension BuiltinRegistry {
-    enum _BuiltinModifierChunk10: ViewModifier {
-        indirect case position(_positionModifier<R>)
+    enum _BuiltinModifierChunk11: ViewModifier {
+        indirect case persistentSystemOverlays(_persistentSystemOverlaysModifier<R>)
+indirect case pickerStyle(_pickerStyleModifier<R>)
+indirect case pointerStyle(_pointerStyleModifier<R>)
+indirect case pointerVisibility(_pointerVisibilityModifier<R>)
+indirect case popover(_popoverModifier<R>)
+indirect case position(_positionModifier<R>)
 indirect case preferredColorScheme(_preferredColorSchemeModifier<R>)
 indirect case preferredSurroundingsEffect(_preferredSurroundingsEffectModifier<R>)
 indirect case presentationBackground(_presentationBackgroundModifier<R>)
@@ -13165,15 +15385,20 @@ indirect case presentationCompactAdaptation(_presentationCompactAdaptationModifi
 indirect case presentationContentInteraction(_presentationContentInteractionModifier<R>)
 indirect case presentationCornerRadius(_presentationCornerRadiusModifier<R>)
 indirect case presentationDragIndicator(_presentationDragIndicatorModifier<R>)
-indirect case previewDisplayName(_previewDisplayNameModifier<R>)
-indirect case privacySensitive(_privacySensitiveModifier<R>)
-indirect case progressViewStyle(_progressViewStyleModifier<R>)
-indirect case projectionEffect(_projectionEffectModifier<R>)
-indirect case redacted(_redactedModifier<R>)
         
         func body(content: Content) -> some View {
             switch self {
-            case let .position(modifier):
+            case let .persistentSystemOverlays(modifier):
+    content.modifier(modifier)
+case let .pickerStyle(modifier):
+    content.modifier(modifier)
+case let .pointerStyle(modifier):
+    content.modifier(modifier)
+case let .pointerVisibility(modifier):
+    content.modifier(modifier)
+case let .popover(modifier):
+    content.modifier(modifier)
+case let .position(modifier):
     content.modifier(modifier)
 case let .preferredColorScheme(modifier):
     content.modifier(modifier)
@@ -13191,6 +15416,31 @@ case let .presentationCornerRadius(modifier):
     content.modifier(modifier)
 case let .presentationDragIndicator(modifier):
     content.modifier(modifier)
+            }
+        }
+    }
+}
+extension BuiltinRegistry {
+    enum _BuiltinModifierChunk12: ViewModifier {
+        indirect case presentationSizing(_presentationSizingModifier<R>)
+indirect case previewDisplayName(_previewDisplayNameModifier<R>)
+indirect case privacySensitive(_privacySensitiveModifier<R>)
+indirect case progressViewStyle(_progressViewStyleModifier<R>)
+indirect case projectionEffect(_projectionEffectModifier<R>)
+indirect case redacted(_redactedModifier<R>)
+indirect case refreshable(_refreshableModifier<R>)
+indirect case renameAction(_renameActionModifier<R>)
+indirect case replaceDisabled(_replaceDisabledModifier<R>)
+indirect case rotationEffect(_rotationEffectModifier<R>)
+indirect case safeAreaInset(_safeAreaInsetModifier<R>)
+indirect case safeAreaPadding(_safeAreaPaddingModifier<R>)
+indirect case saturation(_saturationModifier<R>)
+indirect case scaleEffect(_scaleEffectModifier<R>)
+        
+        func body(content: Content) -> some View {
+            switch self {
+            case let .presentationSizing(modifier):
+    content.modifier(modifier)
 case let .previewDisplayName(modifier):
     content.modifier(modifier)
 case let .privacySensitive(modifier):
@@ -13201,30 +15451,7 @@ case let .projectionEffect(modifier):
     content.modifier(modifier)
 case let .redacted(modifier):
     content.modifier(modifier)
-            }
-        }
-    }
-}
-extension BuiltinRegistry {
-    enum _BuiltinModifierChunk11: ViewModifier {
-        indirect case refreshable(_refreshableModifier<R>)
-indirect case renameAction(_renameActionModifier<R>)
-indirect case replaceDisabled(_replaceDisabledModifier<R>)
-indirect case rotationEffect(_rotationEffectModifier<R>)
-indirect case safeAreaInset(_safeAreaInsetModifier<R>)
-indirect case safeAreaPadding(_safeAreaPaddingModifier<R>)
-indirect case saturation(_saturationModifier<R>)
-indirect case scaleEffect(_scaleEffectModifier<R>)
-indirect case scaledToFill(_scaledToFillModifier<R>)
-indirect case scaledToFit(_scaledToFitModifier<R>)
-indirect case scenePadding(_scenePaddingModifier<R>)
-indirect case scrollBounceBehavior(_scrollBounceBehaviorModifier<R>)
-indirect case scrollClipDisabled(_scrollClipDisabledModifier<R>)
-indirect case scrollContentBackground(_scrollContentBackgroundModifier<R>)
-        
-        func body(content: Content) -> some View {
-            switch self {
-            case let .refreshable(modifier):
+case let .refreshable(modifier):
     content.modifier(modifier)
 case let .renameAction(modifier):
     content.modifier(modifier)
@@ -13240,7 +15467,30 @@ case let .saturation(modifier):
     content.modifier(modifier)
 case let .scaleEffect(modifier):
     content.modifier(modifier)
-case let .scaledToFill(modifier):
+            }
+        }
+    }
+}
+extension BuiltinRegistry {
+    enum _BuiltinModifierChunk13: ViewModifier {
+        indirect case scaledToFill(_scaledToFillModifier<R>)
+indirect case scaledToFit(_scaledToFitModifier<R>)
+indirect case scenePadding(_scenePaddingModifier<R>)
+indirect case scrollBounceBehavior(_scrollBounceBehaviorModifier<R>)
+indirect case scrollClipDisabled(_scrollClipDisabledModifier<R>)
+indirect case scrollContentBackground(_scrollContentBackgroundModifier<R>)
+indirect case scrollDisabled(_scrollDisabledModifier<R>)
+indirect case scrollDismissesKeyboard(_scrollDismissesKeyboardModifier<R>)
+indirect case scrollIndicators(_scrollIndicatorsModifier<R>)
+indirect case scrollIndicatorsFlash(_scrollIndicatorsFlashModifier<R>)
+indirect case scrollInputBehavior(_scrollInputBehaviorModifier<R>)
+indirect case scrollPosition(_scrollPositionModifier<R>)
+indirect case scrollTargetBehavior(_scrollTargetBehaviorModifier<R>)
+indirect case scrollTargetLayout(_scrollTargetLayoutModifier<R>)
+        
+        func body(content: Content) -> some View {
+            switch self {
+            case let .scaledToFill(modifier):
     content.modifier(modifier)
 case let .scaledToFit(modifier):
     content.modifier(modifier)
@@ -13252,30 +15502,7 @@ case let .scrollClipDisabled(modifier):
     content.modifier(modifier)
 case let .scrollContentBackground(modifier):
     content.modifier(modifier)
-            }
-        }
-    }
-}
-extension BuiltinRegistry {
-    enum _BuiltinModifierChunk12: ViewModifier {
-        indirect case scrollDisabled(_scrollDisabledModifier<R>)
-indirect case scrollDismissesKeyboard(_scrollDismissesKeyboardModifier<R>)
-indirect case scrollIndicators(_scrollIndicatorsModifier<R>)
-indirect case scrollIndicatorsFlash(_scrollIndicatorsFlashModifier<R>)
-indirect case scrollPosition(_scrollPositionModifier<R>)
-indirect case scrollTargetBehavior(_scrollTargetBehaviorModifier<R>)
-indirect case scrollTargetLayout(_scrollTargetLayoutModifier<R>)
-indirect case searchDictationBehavior(_searchDictationBehaviorModifier<R>)
-indirect case searchPresentationToolbarBehavior(_searchPresentationToolbarBehaviorModifier<R>)
-indirect case searchSuggestions(_searchSuggestionsModifier<R>)
-indirect case searchable(_searchableModifier<R>)
-indirect case selectionDisabled(_selectionDisabledModifier<R>)
-indirect case shadow(_shadowModifier<R>)
-indirect case sheet(_sheetModifier<R>)
-        
-        func body(content: Content) -> some View {
-            switch self {
-            case let .scrollDisabled(modifier):
+case let .scrollDisabled(modifier):
     content.modifier(modifier)
 case let .scrollDismissesKeyboard(modifier):
     content.modifier(modifier)
@@ -13283,13 +15510,38 @@ case let .scrollIndicators(modifier):
     content.modifier(modifier)
 case let .scrollIndicatorsFlash(modifier):
     content.modifier(modifier)
+case let .scrollInputBehavior(modifier):
+    content.modifier(modifier)
 case let .scrollPosition(modifier):
     content.modifier(modifier)
 case let .scrollTargetBehavior(modifier):
     content.modifier(modifier)
 case let .scrollTargetLayout(modifier):
     content.modifier(modifier)
-case let .searchDictationBehavior(modifier):
+            }
+        }
+    }
+}
+extension BuiltinRegistry {
+    enum _BuiltinModifierChunk14: ViewModifier {
+        indirect case searchDictationBehavior(_searchDictationBehaviorModifier<R>)
+indirect case searchPresentationToolbarBehavior(_searchPresentationToolbarBehaviorModifier<R>)
+indirect case searchSuggestions(_searchSuggestionsModifier<R>)
+indirect case searchable(_searchableModifier<R>)
+indirect case sectionActions(_sectionActionsModifier<R>)
+indirect case selectionDisabled(_selectionDisabledModifier<R>)
+indirect case shadow(_shadowModifier<R>)
+indirect case sheet(_sheetModifier<R>)
+indirect case simultaneousGesture(_simultaneousGestureModifier<R>)
+indirect case speechAdjustedPitch(_speechAdjustedPitchModifier<R>)
+indirect case speechAlwaysIncludesPunctuation(_speechAlwaysIncludesPunctuationModifier<R>)
+indirect case speechAnnouncementsQueued(_speechAnnouncementsQueuedModifier<R>)
+indirect case speechSpellsOutCharacters(_speechSpellsOutCharactersModifier<R>)
+indirect case statusBarHidden(_statusBarHiddenModifier<R>)
+        
+        func body(content: Content) -> some View {
+            switch self {
+            case let .searchDictationBehavior(modifier):
     content.modifier(modifier)
 case let .searchPresentationToolbarBehavior(modifier):
     content.modifier(modifier)
@@ -13297,36 +15549,15 @@ case let .searchSuggestions(modifier):
     content.modifier(modifier)
 case let .searchable(modifier):
     content.modifier(modifier)
+case let .sectionActions(modifier):
+    content.modifier(modifier)
 case let .selectionDisabled(modifier):
     content.modifier(modifier)
 case let .shadow(modifier):
     content.modifier(modifier)
 case let .sheet(modifier):
     content.modifier(modifier)
-            }
-        }
-    }
-}
-extension BuiltinRegistry {
-    enum _BuiltinModifierChunk13: ViewModifier {
-        indirect case simultaneousGesture(_simultaneousGestureModifier<R>)
-indirect case speechAdjustedPitch(_speechAdjustedPitchModifier<R>)
-indirect case speechAlwaysIncludesPunctuation(_speechAlwaysIncludesPunctuationModifier<R>)
-indirect case speechAnnouncementsQueued(_speechAnnouncementsQueuedModifier<R>)
-indirect case speechSpellsOutCharacters(_speechSpellsOutCharactersModifier<R>)
-indirect case statusBarHidden(_statusBarHiddenModifier<R>)
-indirect case submitLabel(_submitLabelModifier<R>)
-indirect case submitScope(_submitScopeModifier<R>)
-indirect case swipeActions(_swipeActionsModifier<R>)
-indirect case symbolEffect(_symbolEffectModifier<R>)
-indirect case symbolEffectsRemoved(_symbolEffectsRemovedModifier<R>)
-indirect case symbolRenderingMode(_symbolRenderingModeModifier<R>)
-indirect case symbolVariant(_symbolVariantModifier<R>)
-indirect case tabItem(_tabItemModifier<R>)
-        
-        func body(content: Content) -> some View {
-            switch self {
-            case let .simultaneousGesture(modifier):
+case let .simultaneousGesture(modifier):
     content.modifier(modifier)
 case let .speechAdjustedPitch(modifier):
     content.modifier(modifier)
@@ -13338,9 +15569,34 @@ case let .speechSpellsOutCharacters(modifier):
     content.modifier(modifier)
 case let .statusBarHidden(modifier):
     content.modifier(modifier)
-case let .submitLabel(modifier):
+            }
+        }
+    }
+}
+extension BuiltinRegistry {
+    enum _BuiltinModifierChunk15: ViewModifier {
+        indirect case submitLabel(_submitLabelModifier<R>)
+indirect case submitScope(_submitScopeModifier<R>)
+indirect case supportedVolumeViewpoints(_supportedVolumeViewpointsModifier<R>)
+indirect case swipeActions(_swipeActionsModifier<R>)
+indirect case symbolEffect(_symbolEffectModifier<R>)
+indirect case symbolEffectsRemoved(_symbolEffectsRemovedModifier<R>)
+indirect case symbolRenderingMode(_symbolRenderingModeModifier<R>)
+indirect case symbolVariant(_symbolVariantModifier<R>)
+indirect case tabViewSidebarBottomBar(_tabViewSidebarBottomBarModifier<R>)
+indirect case tabViewSidebarFooter(_tabViewSidebarFooterModifier<R>)
+indirect case tabViewSidebarHeader(_tabViewSidebarHeaderModifier<R>)
+indirect case tabViewStyle(_tabViewStyleModifier<R>)
+indirect case tableStyle(_tableStyleModifier<R>)
+indirect case textCase(_textCaseModifier<R>)
+        
+        func body(content: Content) -> some View {
+            switch self {
+            case let .submitLabel(modifier):
     content.modifier(modifier)
 case let .submitScope(modifier):
+    content.modifier(modifier)
+case let .supportedVolumeViewpoints(modifier):
     content.modifier(modifier)
 case let .swipeActions(modifier):
     content.modifier(modifier)
@@ -13352,38 +15608,42 @@ case let .symbolRenderingMode(modifier):
     content.modifier(modifier)
 case let .symbolVariant(modifier):
     content.modifier(modifier)
-case let .tabItem(modifier):
+case let .tabViewSidebarBottomBar(modifier):
+    content.modifier(modifier)
+case let .tabViewSidebarFooter(modifier):
+    content.modifier(modifier)
+case let .tabViewSidebarHeader(modifier):
+    content.modifier(modifier)
+case let .tabViewStyle(modifier):
+    content.modifier(modifier)
+case let .tableStyle(modifier):
+    content.modifier(modifier)
+case let .textCase(modifier):
     content.modifier(modifier)
             }
         }
     }
 }
 extension BuiltinRegistry {
-    enum _BuiltinModifierChunk14: ViewModifier {
-        indirect case tabViewStyle(_tabViewStyleModifier<R>)
-indirect case tableStyle(_tableStyleModifier<R>)
-indirect case textCase(_textCaseModifier<R>)
-indirect case textContentType(_textContentTypeModifier<R>)
+    enum _BuiltinModifierChunk16: ViewModifier {
+        indirect case textContentType(_textContentTypeModifier<R>)
 indirect case textEditorStyle(_textEditorStyleModifier<R>)
 indirect case textFieldStyle(_textFieldStyleModifier<R>)
 indirect case textInputAutocapitalization(_textInputAutocapitalizationModifier<R>)
+indirect case textInputCompletion(_textInputCompletionModifier<R>)
+indirect case textInputSuggestions(_textInputSuggestionsModifier<R>)
 indirect case textSelection(_textSelectionModifier<R>)
+indirect case textSelectionAffinity(_textSelectionAffinityModifier<R>)
 indirect case tint(_tintModifier<R>)
 indirect case toggleStyle(_toggleStyleModifier<R>)
 indirect case toolbar(_toolbarModifier<R>)
 indirect case toolbarBackground(_toolbarBackgroundModifier<R>)
+indirect case toolbarBackgroundVisibility(_toolbarBackgroundVisibilityModifier<R>)
 indirect case toolbarColorScheme(_toolbarColorSchemeModifier<R>)
-indirect case toolbarRole(_toolbarRoleModifier<R>)
         
         func body(content: Content) -> some View {
             switch self {
-            case let .tabViewStyle(modifier):
-    content.modifier(modifier)
-case let .tableStyle(modifier):
-    content.modifier(modifier)
-case let .textCase(modifier):
-    content.modifier(modifier)
-case let .textContentType(modifier):
+            case let .textContentType(modifier):
     content.modifier(modifier)
 case let .textEditorStyle(modifier):
     content.modifier(modifier)
@@ -13391,7 +15651,13 @@ case let .textFieldStyle(modifier):
     content.modifier(modifier)
 case let .textInputAutocapitalization(modifier):
     content.modifier(modifier)
+case let .textInputCompletion(modifier):
+    content.modifier(modifier)
+case let .textInputSuggestions(modifier):
+    content.modifier(modifier)
 case let .textSelection(modifier):
+    content.modifier(modifier)
+case let .textSelectionAffinity(modifier):
     content.modifier(modifier)
 case let .tint(modifier):
     content.modifier(modifier)
@@ -13401,18 +15667,21 @@ case let .toolbar(modifier):
     content.modifier(modifier)
 case let .toolbarBackground(modifier):
     content.modifier(modifier)
-case let .toolbarColorScheme(modifier):
+case let .toolbarBackgroundVisibility(modifier):
     content.modifier(modifier)
-case let .toolbarRole(modifier):
+case let .toolbarColorScheme(modifier):
     content.modifier(modifier)
             }
         }
     }
 }
 extension BuiltinRegistry {
-    enum _BuiltinModifierChunk15: ViewModifier {
-        indirect case toolbarTitleDisplayMode(_toolbarTitleDisplayModeModifier<R>)
+    enum _BuiltinModifierChunk17: ViewModifier {
+        indirect case toolbarItemHidden(_toolbarItemHiddenModifier<R>)
+indirect case toolbarRole(_toolbarRoleModifier<R>)
+indirect case toolbarTitleDisplayMode(_toolbarTitleDisplayModeModifier<R>)
 indirect case toolbarTitleMenu(_toolbarTitleMenuModifier<R>)
+indirect case toolbarVisibility(_toolbarVisibilityModifier<R>)
 indirect case touchBarCustomizationLabel(_touchBarCustomizationLabelModifier<R>)
 indirect case touchBarItemPrincipal(_touchBarItemPrincipalModifier<R>)
 indirect case transform3DEffect(_transform3DEffectModifier<R>)
@@ -13421,13 +15690,19 @@ indirect case transition(_transitionModifier<R>)
 indirect case truncationMode(_truncationModeModifier<R>)
 indirect case unredacted(_unredactedModifier<R>)
 indirect case upperLimbVisibility(_upperLimbVisibilityModifier<R>)
-indirect case zIndex(_zIndexModifier<R>)
+indirect case volumeBaseplateVisibility(_volumeBaseplateVisibilityModifier<R>)
         
         func body(content: Content) -> some View {
             switch self {
-            case let .toolbarTitleDisplayMode(modifier):
+            case let .toolbarItemHidden(modifier):
+    content.modifier(modifier)
+case let .toolbarRole(modifier):
+    content.modifier(modifier)
+case let .toolbarTitleDisplayMode(modifier):
     content.modifier(modifier)
 case let .toolbarTitleMenu(modifier):
+    content.modifier(modifier)
+case let .toolbarVisibility(modifier):
     content.modifier(modifier)
 case let .touchBarCustomizationLabel(modifier):
     content.modifier(modifier)
@@ -13444,6 +15719,36 @@ case let .truncationMode(modifier):
 case let .unredacted(modifier):
     content.modifier(modifier)
 case let .upperLimbVisibility(modifier):
+    content.modifier(modifier)
+case let .volumeBaseplateVisibility(modifier):
+    content.modifier(modifier)
+            }
+        }
+    }
+}
+extension BuiltinRegistry {
+    enum _BuiltinModifierChunk18: ViewModifier {
+        indirect case windowDismissBehavior(_windowDismissBehaviorModifier<R>)
+indirect case windowFullScreenBehavior(_windowFullScreenBehaviorModifier<R>)
+indirect case windowMinimizeBehavior(_windowMinimizeBehaviorModifier<R>)
+indirect case windowResizeBehavior(_windowResizeBehaviorModifier<R>)
+indirect case windowToolbarFullScreenVisibility(_windowToolbarFullScreenVisibilityModifier<R>)
+indirect case writingToolsBehavior(_writingToolsBehaviorModifier<R>)
+indirect case zIndex(_zIndexModifier<R>)
+        
+        func body(content: Content) -> some View {
+            switch self {
+            case let .windowDismissBehavior(modifier):
+    content.modifier(modifier)
+case let .windowFullScreenBehavior(modifier):
+    content.modifier(modifier)
+case let .windowMinimizeBehavior(modifier):
+    content.modifier(modifier)
+case let .windowResizeBehavior(modifier):
+    content.modifier(modifier)
+case let .windowToolbarFullScreenVisibility(modifier):
+    content.modifier(modifier)
+case let .writingToolsBehavior(modifier):
     content.modifier(modifier)
 case let .zIndex(modifier):
     content.modifier(modifier)
@@ -13469,16 +15774,21 @@ indirect case chunk12(_BuiltinModifierChunk12)
 indirect case chunk13(_BuiltinModifierChunk13)
 indirect case chunk14(_BuiltinModifierChunk14)
 indirect case chunk15(_BuiltinModifierChunk15)
-        indirect case _PerspectiveRotationEffectModifier(LiveViewNative._PerspectiveRotationEffectModifier<R>)
-indirect case _PresentationDetentsModifier(LiveViewNative._PresentationDetentsModifier)
-indirect case _PrefersDefaultFocusModifier(LiveViewNative._PrefersDefaultFocusModifier<R>)
-indirect case _FocusScopeModifier(LiveViewNative._FocusScopeModifier<R>)
-indirect case _OnSubmitModifier(LiveViewNative._OnSubmitModifier)
-indirect case _Rotation3DEffectModifier(LiveViewNative._Rotation3DEffectModifier<R>)
-indirect case _SearchCompletionModifier(LiveViewNative._SearchCompletionModifier<R>)
-indirect case _MaskModifier(LiveViewNative._MaskModifier<R>)
+indirect case chunk16(_BuiltinModifierChunk16)
+indirect case chunk17(_BuiltinModifierChunk17)
+indirect case chunk18(_BuiltinModifierChunk18)
+        indirect case _Rotation3DEffectModifier(LiveViewNative._Rotation3DEffectModifier<R>)
 indirect case _SearchScopesModifier(LiveViewNative._SearchScopesModifier<R>)
+indirect case _MatchedTransitionSourceModifier(LiveViewNative._MatchedTransitionSourceModifier<R>)
+indirect case _PerspectiveRotationEffectModifier(LiveViewNative._PerspectiveRotationEffectModifier<R>)
+indirect case _NavigationTransitionModifier(LiveViewNative._NavigationTransitionModifier<R>)
+indirect case _SearchCompletionModifier(LiveViewNative._SearchCompletionModifier<R>)
+indirect case _PrefersDefaultFocusModifier(LiveViewNative._PrefersDefaultFocusModifier<R>)
+indirect case _MaskModifier(LiveViewNative._MaskModifier<R>)
 indirect case _MatchedGeometryEffectModifier(LiveViewNative._MatchedGeometryEffectModifier<R>)
+indirect case _OnSubmitModifier(LiveViewNative._OnSubmitModifier)
+indirect case _PresentationDetentsModifier(LiveViewNative._PresentationDetentsModifier)
+indirect case _FocusScopeModifier(LiveViewNative._FocusScopeModifier<R>)
         indirect case _customRegistryModifier(R.CustomModifier)
         indirect case _anyTextModifier(_AnyTextModifier<R>)
         indirect case _anyImageModifier(_AnyImageModifier<R>)
@@ -13519,25 +15829,35 @@ case let .chunk14(chunk):
     content.modifier(chunk)
 case let .chunk15(chunk):
     content.modifier(chunk)
-            case let ._PerspectiveRotationEffectModifier(modifier):
-    content.modifier(modifier)
-case let ._PresentationDetentsModifier(modifier):
-    content.modifier(modifier)
-case let ._PrefersDefaultFocusModifier(modifier):
-    content.modifier(modifier)
-case let ._FocusScopeModifier(modifier):
-    content.modifier(modifier)
-case let ._OnSubmitModifier(modifier):
-    content.modifier(modifier)
-case let ._Rotation3DEffectModifier(modifier):
-    content.modifier(modifier)
-case let ._SearchCompletionModifier(modifier):
-    content.modifier(modifier)
-case let ._MaskModifier(modifier):
+case let .chunk16(chunk):
+    content.modifier(chunk)
+case let .chunk17(chunk):
+    content.modifier(chunk)
+case let .chunk18(chunk):
+    content.modifier(chunk)
+            case let ._Rotation3DEffectModifier(modifier):
     content.modifier(modifier)
 case let ._SearchScopesModifier(modifier):
     content.modifier(modifier)
+case let ._MatchedTransitionSourceModifier(modifier):
+    content.modifier(modifier)
+case let ._PerspectiveRotationEffectModifier(modifier):
+    content.modifier(modifier)
+case let ._NavigationTransitionModifier(modifier):
+    content.modifier(modifier)
+case let ._SearchCompletionModifier(modifier):
+    content.modifier(modifier)
+case let ._PrefersDefaultFocusModifier(modifier):
+    content.modifier(modifier)
+case let ._MaskModifier(modifier):
+    content.modifier(modifier)
 case let ._MatchedGeometryEffectModifier(modifier):
+    content.modifier(modifier)
+case let ._OnSubmitModifier(modifier):
+    content.modifier(modifier)
+case let ._PresentationDetentsModifier(modifier):
+    content.modifier(modifier)
+case let ._FocusScopeModifier(modifier):
     content.modifier(modifier)
             case let ._customRegistryModifier(modifier):
                 content.modifier(modifier)
@@ -13573,11 +15893,12 @@ _accessibilityShowsLargeContentViewerModifier<R>.name: _accessibilityShowsLargeC
 _alertModifier<R>.name: _alertModifier<R>.parser(in: context).map({ Output.chunk0(.alert($0)) }).eraseToAnyParser(),
 _allowsHitTestingModifier<R>.name: _allowsHitTestingModifier<R>.parser(in: context).map({ Output.chunk0(.allowsHitTesting($0)) }).eraseToAnyParser(),
 _allowsTighteningModifier<R>.name: _allowsTighteningModifier<R>.parser(in: context).map({ Output.chunk0(.allowsTightening($0)) }).eraseToAnyParser(),
+_allowsWindowActivationEventsModifier<R>.name: _allowsWindowActivationEventsModifier<R>.parser(in: context).map({ Output.chunk0(.allowsWindowActivationEvents($0)) }).eraseToAnyParser(),
 _animationModifier<R>.name: _animationModifier<R>.parser(in: context).map({ Output.chunk0(.animation($0)) }).eraseToAnyParser(),
 _aspectRatioModifier<R>.name: _aspectRatioModifier<R>.parser(in: context).map({ Output.chunk0(.aspectRatio($0)) }).eraseToAnyParser(),
 _autocorrectionDisabledModifier<R>.name: _autocorrectionDisabledModifier<R>.parser(in: context).map({ Output.chunk0(.autocorrectionDisabled($0)) }).eraseToAnyParser(),
 _backgroundModifier<R>.name: _backgroundModifier<R>.parser(in: context).map({ Output.chunk0(.background($0)) }).eraseToAnyParser(),
-_backgroundStyleModifier<R>.name: _backgroundStyleModifier<R>.parser(in: context).map({ Output.chunk0(.backgroundStyle($0)) }).eraseToAnyParser(),
+_backgroundStyleModifier<R>.name: _backgroundStyleModifier<R>.parser(in: context).map({ Output.chunk1(.backgroundStyle($0)) }).eraseToAnyParser(),
 _badgeModifier<R>.name: _badgeModifier<R>.parser(in: context).map({ Output.chunk1(.badge($0)) }).eraseToAnyParser(),
 _badgeProminenceModifier<R>.name: _badgeProminenceModifier<R>.parser(in: context).map({ Output.chunk1(.badgeProminence($0)) }).eraseToAnyParser(),
 _blendModeModifier<R>.name: _blendModeModifier<R>.parser(in: context).map({ Output.chunk1(.blendMode($0)) }).eraseToAnyParser(),
@@ -13591,7 +15912,7 @@ _clippedModifier<R>.name: _clippedModifier<R>.parser(in: context).map({ Output.c
 _colorInvertModifier<R>.name: _colorInvertModifier<R>.parser(in: context).map({ Output.chunk1(.colorInvert($0)) }).eraseToAnyParser(),
 _colorMultiplyModifier<R>.name: _colorMultiplyModifier<R>.parser(in: context).map({ Output.chunk1(.colorMultiply($0)) }).eraseToAnyParser(),
 _compositingGroupModifier<R>.name: _compositingGroupModifier<R>.parser(in: context).map({ Output.chunk1(.compositingGroup($0)) }).eraseToAnyParser(),
-_confirmationDialogModifier<R>.name: _confirmationDialogModifier<R>.parser(in: context).map({ Output.chunk1(.confirmationDialog($0)) }).eraseToAnyParser(),
+_confirmationDialogModifier<R>.name: _confirmationDialogModifier<R>.parser(in: context).map({ Output.chunk2(.confirmationDialog($0)) }).eraseToAnyParser(),
 _containerRelativeFrameModifier<R>.name: _containerRelativeFrameModifier<R>.parser(in: context).map({ Output.chunk2(.containerRelativeFrame($0)) }).eraseToAnyParser(),
 _containerShapeModifier<R>.name: _containerShapeModifier<R>.parser(in: context).map({ Output.chunk2(.containerShape($0)) }).eraseToAnyParser(),
 _contentMarginsModifier<R>.name: _contentMarginsModifier<R>.parser(in: context).map({ Output.chunk2(.contentMargins($0)) }).eraseToAnyParser(),
@@ -13603,23 +15924,25 @@ _controlGroupStyleModifier<R>.name: _controlGroupStyleModifier<R>.parser(in: con
 _controlSizeModifier<R>.name: _controlSizeModifier<R>.parser(in: context).map({ Output.chunk2(.controlSize($0)) }).eraseToAnyParser(),
 _coordinateSpaceModifier<R>.name: _coordinateSpaceModifier<R>.parser(in: context).map({ Output.chunk2(.coordinateSpace($0)) }).eraseToAnyParser(),
 _datePickerStyleModifier<R>.name: _datePickerStyleModifier<R>.parser(in: context).map({ Output.chunk2(.datePickerStyle($0)) }).eraseToAnyParser(),
+_defaultAdaptableTabBarPlacementModifier<R>.name: _defaultAdaptableTabBarPlacementModifier<R>.parser(in: context).map({ Output.chunk2(.defaultAdaptableTabBarPlacement($0)) }).eraseToAnyParser(),
 _defaultHoverEffectModifier<R>.name: _defaultHoverEffectModifier<R>.parser(in: context).map({ Output.chunk2(.defaultHoverEffect($0)) }).eraseToAnyParser(),
-_defaultScrollAnchorModifier<R>.name: _defaultScrollAnchorModifier<R>.parser(in: context).map({ Output.chunk2(.defaultScrollAnchor($0)) }).eraseToAnyParser(),
-_defaultWheelPickerItemHeightModifier<R>.name: _defaultWheelPickerItemHeightModifier<R>.parser(in: context).map({ Output.chunk2(.defaultWheelPickerItemHeight($0)) }).eraseToAnyParser(),
+_defaultScrollAnchorModifier<R>.name: _defaultScrollAnchorModifier<R>.parser(in: context).map({ Output.chunk3(.defaultScrollAnchor($0)) }).eraseToAnyParser(),
+_defaultWheelPickerItemHeightModifier<R>.name: _defaultWheelPickerItemHeightModifier<R>.parser(in: context).map({ Output.chunk3(.defaultWheelPickerItemHeight($0)) }).eraseToAnyParser(),
 _defersSystemGesturesModifier<R>.name: _defersSystemGesturesModifier<R>.parser(in: context).map({ Output.chunk3(.defersSystemGestures($0)) }).eraseToAnyParser(),
 _deleteDisabledModifier<R>.name: _deleteDisabledModifier<R>.parser(in: context).map({ Output.chunk3(.deleteDisabled($0)) }).eraseToAnyParser(),
 _dialogSuppressionToggleModifier<R>.name: _dialogSuppressionToggleModifier<R>.parser(in: context).map({ Output.chunk3(.dialogSuppressionToggle($0)) }).eraseToAnyParser(),
 _digitalCrownAccessoryModifier<R>.name: _digitalCrownAccessoryModifier<R>.parser(in: context).map({ Output.chunk3(.digitalCrownAccessory($0)) }).eraseToAnyParser(),
 _disabledModifier<R>.name: _disabledModifier<R>.parser(in: context).map({ Output.chunk3(.disabled($0)) }).eraseToAnyParser(),
+_dismissalConfirmationDialogModifier<R>.name: _dismissalConfirmationDialogModifier<R>.parser(in: context).map({ Output.chunk3(.dismissalConfirmationDialog($0)) }).eraseToAnyParser(),
 _drawingGroupModifier<R>.name: _drawingGroupModifier<R>.parser(in: context).map({ Output.chunk3(.drawingGroup($0)) }).eraseToAnyParser(),
 _dynamicTypeSizeModifier<R>.name: _dynamicTypeSizeModifier<R>.parser(in: context).map({ Output.chunk3(.dynamicTypeSize($0)) }).eraseToAnyParser(),
 _fileDialogCustomizationIDModifier<R>.name: _fileDialogCustomizationIDModifier<R>.parser(in: context).map({ Output.chunk3(.fileDialogCustomizationID($0)) }).eraseToAnyParser(),
 _fileDialogImportsUnresolvedAliasesModifier<R>.name: _fileDialogImportsUnresolvedAliasesModifier<R>.parser(in: context).map({ Output.chunk3(.fileDialogImportsUnresolvedAliases($0)) }).eraseToAnyParser(),
 _findDisabledModifier<R>.name: _findDisabledModifier<R>.parser(in: context).map({ Output.chunk3(.findDisabled($0)) }).eraseToAnyParser(),
 _findNavigatorModifier<R>.name: _findNavigatorModifier<R>.parser(in: context).map({ Output.chunk3(.findNavigator($0)) }).eraseToAnyParser(),
-_fixedSizeModifier<R>.name: _fixedSizeModifier<R>.parser(in: context).map({ Output.chunk3(.fixedSize($0)) }).eraseToAnyParser(),
-_flipsForRightToLeftLayoutDirectionModifier<R>.name: _flipsForRightToLeftLayoutDirectionModifier<R>.parser(in: context).map({ Output.chunk3(.flipsForRightToLeftLayoutDirection($0)) }).eraseToAnyParser(),
-_focusEffectDisabledModifier<R>.name: _focusEffectDisabledModifier<R>.parser(in: context).map({ Output.chunk3(.focusEffectDisabled($0)) }).eraseToAnyParser(),
+_fixedSizeModifier<R>.name: _fixedSizeModifier<R>.parser(in: context).map({ Output.chunk4(.fixedSize($0)) }).eraseToAnyParser(),
+_flipsForRightToLeftLayoutDirectionModifier<R>.name: _flipsForRightToLeftLayoutDirectionModifier<R>.parser(in: context).map({ Output.chunk4(.flipsForRightToLeftLayoutDirection($0)) }).eraseToAnyParser(),
+_focusEffectDisabledModifier<R>.name: _focusEffectDisabledModifier<R>.parser(in: context).map({ Output.chunk4(.focusEffectDisabled($0)) }).eraseToAnyParser(),
 _focusSectionModifier<R>.name: _focusSectionModifier<R>.parser(in: context).map({ Output.chunk4(.focusSection($0)) }).eraseToAnyParser(),
 _focusableModifier<R>.name: _focusableModifier<R>.parser(in: context).map({ Output.chunk4(.focusable($0)) }).eraseToAnyParser(),
 _formStyleModifier<R>.name: _formStyleModifier<R>.parser(in: context).map({ Output.chunk4(.formStyle($0)) }).eraseToAnyParser(),
@@ -13631,10 +15954,12 @@ _gestureModifier<R>.name: _gestureModifier<R>.parser(in: context).map({ Output.c
 _glassBackgroundEffectModifier<R>.name: _glassBackgroundEffectModifier<R>.parser(in: context).map({ Output.chunk4(.glassBackgroundEffect($0)) }).eraseToAnyParser(),
 _grayscaleModifier<R>.name: _grayscaleModifier<R>.parser(in: context).map({ Output.chunk4(.grayscale($0)) }).eraseToAnyParser(),
 _gridCellAnchorModifier<R>.name: _gridCellAnchorModifier<R>.parser(in: context).map({ Output.chunk4(.gridCellAnchor($0)) }).eraseToAnyParser(),
-_gridCellColumnsModifier<R>.name: _gridCellColumnsModifier<R>.parser(in: context).map({ Output.chunk4(.gridCellColumns($0)) }).eraseToAnyParser(),
-_gridCellUnsizedAxesModifier<R>.name: _gridCellUnsizedAxesModifier<R>.parser(in: context).map({ Output.chunk4(.gridCellUnsizedAxes($0)) }).eraseToAnyParser(),
-_gridColumnAlignmentModifier<R>.name: _gridColumnAlignmentModifier<R>.parser(in: context).map({ Output.chunk4(.gridColumnAlignment($0)) }).eraseToAnyParser(),
+_gridCellColumnsModifier<R>.name: _gridCellColumnsModifier<R>.parser(in: context).map({ Output.chunk5(.gridCellColumns($0)) }).eraseToAnyParser(),
+_gridCellUnsizedAxesModifier<R>.name: _gridCellUnsizedAxesModifier<R>.parser(in: context).map({ Output.chunk5(.gridCellUnsizedAxes($0)) }).eraseToAnyParser(),
+_gridColumnAlignmentModifier<R>.name: _gridColumnAlignmentModifier<R>.parser(in: context).map({ Output.chunk5(.gridColumnAlignment($0)) }).eraseToAnyParser(),
 _groupBoxStyleModifier<R>.name: _groupBoxStyleModifier<R>.parser(in: context).map({ Output.chunk5(.groupBoxStyle($0)) }).eraseToAnyParser(),
+_handGestureShortcutModifier<R>.name: _handGestureShortcutModifier<R>.parser(in: context).map({ Output.chunk5(.handGestureShortcut($0)) }).eraseToAnyParser(),
+_handPointerBehaviorModifier<R>.name: _handPointerBehaviorModifier<R>.parser(in: context).map({ Output.chunk5(.handPointerBehavior($0)) }).eraseToAnyParser(),
 _headerProminenceModifier<R>.name: _headerProminenceModifier<R>.parser(in: context).map({ Output.chunk5(.headerProminence($0)) }).eraseToAnyParser(),
 _helpModifier<R>.name: _helpModifier<R>.parser(in: context).map({ Output.chunk5(.help($0)) }).eraseToAnyParser(),
 _hiddenModifier<R>.name: _hiddenModifier<R>.parser(in: context).map({ Output.chunk5(.hidden($0)) }).eraseToAnyParser(),
@@ -13642,12 +15967,14 @@ _highPriorityGestureModifier<R>.name: _highPriorityGestureModifier<R>.parser(in:
 _horizontalRadioGroupLayoutModifier<R>.name: _horizontalRadioGroupLayoutModifier<R>.parser(in: context).map({ Output.chunk5(.horizontalRadioGroupLayout($0)) }).eraseToAnyParser(),
 _hoverEffectModifier<R>.name: _hoverEffectModifier<R>.parser(in: context).map({ Output.chunk5(.hoverEffect($0)) }).eraseToAnyParser(),
 _hoverEffectDisabledModifier<R>.name: _hoverEffectDisabledModifier<R>.parser(in: context).map({ Output.chunk5(.hoverEffectDisabled($0)) }).eraseToAnyParser(),
-_hueRotationModifier<R>.name: _hueRotationModifier<R>.parser(in: context).map({ Output.chunk5(.hueRotation($0)) }).eraseToAnyParser(),
-_ignoresSafeAreaModifier<R>.name: _ignoresSafeAreaModifier<R>.parser(in: context).map({ Output.chunk5(.ignoresSafeArea($0)) }).eraseToAnyParser(),
-_imageScaleModifier<R>.name: _imageScaleModifier<R>.parser(in: context).map({ Output.chunk5(.imageScale($0)) }).eraseToAnyParser(),
-_indexViewStyleModifier<R>.name: _indexViewStyleModifier<R>.parser(in: context).map({ Output.chunk5(.indexViewStyle($0)) }).eraseToAnyParser(),
-_inspectorModifier<R>.name: _inspectorModifier<R>.parser(in: context).map({ Output.chunk5(.inspector($0)) }).eraseToAnyParser(),
-_inspectorColumnWidthModifier<R>.name: _inspectorColumnWidthModifier<R>.parser(in: context).map({ Output.chunk5(.inspectorColumnWidth($0)) }).eraseToAnyParser(),
+_hoverEffectGroupModifier<R>.name: _hoverEffectGroupModifier<R>.parser(in: context).map({ Output.chunk5(.hoverEffectGroup($0)) }).eraseToAnyParser(),
+_hueRotationModifier<R>.name: _hueRotationModifier<R>.parser(in: context).map({ Output.chunk6(.hueRotation($0)) }).eraseToAnyParser(),
+_ignoresSafeAreaModifier<R>.name: _ignoresSafeAreaModifier<R>.parser(in: context).map({ Output.chunk6(.ignoresSafeArea($0)) }).eraseToAnyParser(),
+_imageScaleModifier<R>.name: _imageScaleModifier<R>.parser(in: context).map({ Output.chunk6(.imageScale($0)) }).eraseToAnyParser(),
+_immersiveEnvironmentPickerModifier<R>.name: _immersiveEnvironmentPickerModifier<R>.parser(in: context).map({ Output.chunk6(.immersiveEnvironmentPicker($0)) }).eraseToAnyParser(),
+_indexViewStyleModifier<R>.name: _indexViewStyleModifier<R>.parser(in: context).map({ Output.chunk6(.indexViewStyle($0)) }).eraseToAnyParser(),
+_inspectorModifier<R>.name: _inspectorModifier<R>.parser(in: context).map({ Output.chunk6(.inspector($0)) }).eraseToAnyParser(),
+_inspectorColumnWidthModifier<R>.name: _inspectorColumnWidthModifier<R>.parser(in: context).map({ Output.chunk6(.inspectorColumnWidth($0)) }).eraseToAnyParser(),
 _interactionActivityTrackingTagModifier<R>.name: _interactionActivityTrackingTagModifier<R>.parser(in: context).map({ Output.chunk6(.interactionActivityTrackingTag($0)) }).eraseToAnyParser(),
 _interactiveDismissDisabledModifier<R>.name: _interactiveDismissDisabledModifier<R>.parser(in: context).map({ Output.chunk6(.interactiveDismissDisabled($0)) }).eraseToAnyParser(),
 _invalidatableContentModifier<R>.name: _invalidatableContentModifier<R>.parser(in: context).map({ Output.chunk6(.invalidatableContent($0)) }).eraseToAnyParser(),
@@ -13655,146 +15982,179 @@ _keyboardShortcutModifier<R>.name: _keyboardShortcutModifier<R>.parser(in: conte
 _keyboardTypeModifier<R>.name: _keyboardTypeModifier<R>.parser(in: context).map({ Output.chunk6(.keyboardType($0)) }).eraseToAnyParser(),
 _labelStyleModifier<R>.name: _labelStyleModifier<R>.parser(in: context).map({ Output.chunk6(.labelStyle($0)) }).eraseToAnyParser(),
 _labeledContentStyleModifier<R>.name: _labeledContentStyleModifier<R>.parser(in: context).map({ Output.chunk6(.labeledContentStyle($0)) }).eraseToAnyParser(),
-_labelsHiddenModifier<R>.name: _labelsHiddenModifier<R>.parser(in: context).map({ Output.chunk6(.labelsHidden($0)) }).eraseToAnyParser(),
-_layoutPriorityModifier<R>.name: _layoutPriorityModifier<R>.parser(in: context).map({ Output.chunk6(.layoutPriority($0)) }).eraseToAnyParser(),
-_lineLimitModifier<R>.name: _lineLimitModifier<R>.parser(in: context).map({ Output.chunk6(.lineLimit($0)) }).eraseToAnyParser(),
-_lineSpacingModifier<R>.name: _lineSpacingModifier<R>.parser(in: context).map({ Output.chunk6(.lineSpacing($0)) }).eraseToAnyParser(),
-_listItemTintModifier<R>.name: _listItemTintModifier<R>.parser(in: context).map({ Output.chunk6(.listItemTint($0)) }).eraseToAnyParser(),
-_listRowBackgroundModifier<R>.name: _listRowBackgroundModifier<R>.parser(in: context).map({ Output.chunk6(.listRowBackground($0)) }).eraseToAnyParser(),
-_listRowHoverEffectModifier<R>.name: _listRowHoverEffectModifier<R>.parser(in: context).map({ Output.chunk6(.listRowHoverEffect($0)) }).eraseToAnyParser(),
+_labelsHiddenModifier<R>.name: _labelsHiddenModifier<R>.parser(in: context).map({ Output.chunk7(.labelsHidden($0)) }).eraseToAnyParser(),
+_labelsVisibilityModifier<R>.name: _labelsVisibilityModifier<R>.parser(in: context).map({ Output.chunk7(.labelsVisibility($0)) }).eraseToAnyParser(),
+_layoutPriorityModifier<R>.name: _layoutPriorityModifier<R>.parser(in: context).map({ Output.chunk7(.layoutPriority($0)) }).eraseToAnyParser(),
+_lineLimitModifier<R>.name: _lineLimitModifier<R>.parser(in: context).map({ Output.chunk7(.lineLimit($0)) }).eraseToAnyParser(),
+_lineSpacingModifier<R>.name: _lineSpacingModifier<R>.parser(in: context).map({ Output.chunk7(.lineSpacing($0)) }).eraseToAnyParser(),
+_listItemTintModifier<R>.name: _listItemTintModifier<R>.parser(in: context).map({ Output.chunk7(.listItemTint($0)) }).eraseToAnyParser(),
+_listRowBackgroundModifier<R>.name: _listRowBackgroundModifier<R>.parser(in: context).map({ Output.chunk7(.listRowBackground($0)) }).eraseToAnyParser(),
+_listRowHoverEffectModifier<R>.name: _listRowHoverEffectModifier<R>.parser(in: context).map({ Output.chunk7(.listRowHoverEffect($0)) }).eraseToAnyParser(),
 _listRowHoverEffectDisabledModifier<R>.name: _listRowHoverEffectDisabledModifier<R>.parser(in: context).map({ Output.chunk7(.listRowHoverEffectDisabled($0)) }).eraseToAnyParser(),
 _listRowInsetsModifier<R>.name: _listRowInsetsModifier<R>.parser(in: context).map({ Output.chunk7(.listRowInsets($0)) }).eraseToAnyParser(),
 _listRowSeparatorModifier<R>.name: _listRowSeparatorModifier<R>.parser(in: context).map({ Output.chunk7(.listRowSeparator($0)) }).eraseToAnyParser(),
 _listRowSeparatorTintModifier<R>.name: _listRowSeparatorTintModifier<R>.parser(in: context).map({ Output.chunk7(.listRowSeparatorTint($0)) }).eraseToAnyParser(),
 _listRowSpacingModifier<R>.name: _listRowSpacingModifier<R>.parser(in: context).map({ Output.chunk7(.listRowSpacing($0)) }).eraseToAnyParser(),
 _listSectionSeparatorModifier<R>.name: _listSectionSeparatorModifier<R>.parser(in: context).map({ Output.chunk7(.listSectionSeparator($0)) }).eraseToAnyParser(),
-_listSectionSeparatorTintModifier<R>.name: _listSectionSeparatorTintModifier<R>.parser(in: context).map({ Output.chunk7(.listSectionSeparatorTint($0)) }).eraseToAnyParser(),
-_listSectionSpacingModifier<R>.name: _listSectionSpacingModifier<R>.parser(in: context).map({ Output.chunk7(.listSectionSpacing($0)) }).eraseToAnyParser(),
-_listStyleModifier<R>.name: _listStyleModifier<R>.parser(in: context).map({ Output.chunk7(.listStyle($0)) }).eraseToAnyParser(),
-_luminanceToAlphaModifier<R>.name: _luminanceToAlphaModifier<R>.parser(in: context).map({ Output.chunk7(.luminanceToAlpha($0)) }).eraseToAnyParser(),
-_menuIndicatorModifier<R>.name: _menuIndicatorModifier<R>.parser(in: context).map({ Output.chunk7(.menuIndicator($0)) }).eraseToAnyParser(),
-_menuOrderModifier<R>.name: _menuOrderModifier<R>.parser(in: context).map({ Output.chunk7(.menuOrder($0)) }).eraseToAnyParser(),
-_menuStyleModifier<R>.name: _menuStyleModifier<R>.parser(in: context).map({ Output.chunk7(.menuStyle($0)) }).eraseToAnyParser(),
-_minimumScaleFactorModifier<R>.name: _minimumScaleFactorModifier<R>.parser(in: context).map({ Output.chunk7(.minimumScaleFactor($0)) }).eraseToAnyParser(),
+_listSectionSeparatorTintModifier<R>.name: _listSectionSeparatorTintModifier<R>.parser(in: context).map({ Output.chunk8(.listSectionSeparatorTint($0)) }).eraseToAnyParser(),
+_listSectionSpacingModifier<R>.name: _listSectionSpacingModifier<R>.parser(in: context).map({ Output.chunk8(.listSectionSpacing($0)) }).eraseToAnyParser(),
+_listStyleModifier<R>.name: _listStyleModifier<R>.parser(in: context).map({ Output.chunk8(.listStyle($0)) }).eraseToAnyParser(),
+_luminanceToAlphaModifier<R>.name: _luminanceToAlphaModifier<R>.parser(in: context).map({ Output.chunk8(.luminanceToAlpha($0)) }).eraseToAnyParser(),
+_materialActiveAppearanceModifier<R>.name: _materialActiveAppearanceModifier<R>.parser(in: context).map({ Output.chunk8(.materialActiveAppearance($0)) }).eraseToAnyParser(),
+_menuIndicatorModifier<R>.name: _menuIndicatorModifier<R>.parser(in: context).map({ Output.chunk8(.menuIndicator($0)) }).eraseToAnyParser(),
+_menuOrderModifier<R>.name: _menuOrderModifier<R>.parser(in: context).map({ Output.chunk8(.menuOrder($0)) }).eraseToAnyParser(),
+_menuStyleModifier<R>.name: _menuStyleModifier<R>.parser(in: context).map({ Output.chunk8(.menuStyle($0)) }).eraseToAnyParser(),
+_minimumScaleFactorModifier<R>.name: _minimumScaleFactorModifier<R>.parser(in: context).map({ Output.chunk8(.minimumScaleFactor($0)) }).eraseToAnyParser(),
+_modifierKeyAlternateModifier<R>.name: _modifierKeyAlternateModifier<R>.parser(in: context).map({ Output.chunk8(.modifierKeyAlternate($0)) }).eraseToAnyParser(),
 _moveDisabledModifier<R>.name: _moveDisabledModifier<R>.parser(in: context).map({ Output.chunk8(.moveDisabled($0)) }).eraseToAnyParser(),
 _multilineTextAlignmentModifier<R>.name: _multilineTextAlignmentModifier<R>.parser(in: context).map({ Output.chunk8(.multilineTextAlignment($0)) }).eraseToAnyParser(),
 _navigationBarBackButtonHiddenModifier<R>.name: _navigationBarBackButtonHiddenModifier<R>.parser(in: context).map({ Output.chunk8(.navigationBarBackButtonHidden($0)) }).eraseToAnyParser(),
 _navigationBarTitleDisplayModeModifier<R>.name: _navigationBarTitleDisplayModeModifier<R>.parser(in: context).map({ Output.chunk8(.navigationBarTitleDisplayMode($0)) }).eraseToAnyParser(),
-_navigationDestinationModifier<R>.name: _navigationDestinationModifier<R>.parser(in: context).map({ Output.chunk8(.navigationDestination($0)) }).eraseToAnyParser(),
-_navigationSplitViewColumnWidthModifier<R>.name: _navigationSplitViewColumnWidthModifier<R>.parser(in: context).map({ Output.chunk8(.navigationSplitViewColumnWidth($0)) }).eraseToAnyParser(),
-_navigationSplitViewStyleModifier<R>.name: _navigationSplitViewStyleModifier<R>.parser(in: context).map({ Output.chunk8(.navigationSplitViewStyle($0)) }).eraseToAnyParser(),
-_navigationSubtitleModifier<R>.name: _navigationSubtitleModifier<R>.parser(in: context).map({ Output.chunk8(.navigationSubtitle($0)) }).eraseToAnyParser(),
-_navigationTitleModifier<R>.name: _navigationTitleModifier<R>.parser(in: context).map({ Output.chunk8(.navigationTitle($0)) }).eraseToAnyParser(),
-_offsetModifier<R>.name: _offsetModifier<R>.parser(in: context).map({ Output.chunk8(.offset($0)) }).eraseToAnyParser(),
-_onAppearModifier<R>.name: _onAppearModifier<R>.parser(in: context).map({ Output.chunk8(.onAppear($0)) }).eraseToAnyParser(),
-_onDeleteCommandModifier<R>.name: _onDeleteCommandModifier<R>.parser(in: context).map({ Output.chunk8(.onDeleteCommand($0)) }).eraseToAnyParser(),
-_onDisappearModifier<R>.name: _onDisappearModifier<R>.parser(in: context).map({ Output.chunk8(.onDisappear($0)) }).eraseToAnyParser(),
-_onExitCommandModifier<R>.name: _onExitCommandModifier<R>.parser(in: context).map({ Output.chunk8(.onExitCommand($0)) }).eraseToAnyParser(),
+_navigationDestinationModifier<R>.name: _navigationDestinationModifier<R>.parser(in: context).map({ Output.chunk9(.navigationDestination($0)) }).eraseToAnyParser(),
+_navigationSplitViewColumnWidthModifier<R>.name: _navigationSplitViewColumnWidthModifier<R>.parser(in: context).map({ Output.chunk9(.navigationSplitViewColumnWidth($0)) }).eraseToAnyParser(),
+_navigationSplitViewStyleModifier<R>.name: _navigationSplitViewStyleModifier<R>.parser(in: context).map({ Output.chunk9(.navigationSplitViewStyle($0)) }).eraseToAnyParser(),
+_navigationSubtitleModifier<R>.name: _navigationSubtitleModifier<R>.parser(in: context).map({ Output.chunk9(.navigationSubtitle($0)) }).eraseToAnyParser(),
+_navigationTitleModifier<R>.name: _navigationTitleModifier<R>.parser(in: context).map({ Output.chunk9(.navigationTitle($0)) }).eraseToAnyParser(),
+_offsetModifier<R>.name: _offsetModifier<R>.parser(in: context).map({ Output.chunk9(.offset($0)) }).eraseToAnyParser(),
+_onAppearModifier<R>.name: _onAppearModifier<R>.parser(in: context).map({ Output.chunk9(.onAppear($0)) }).eraseToAnyParser(),
+_onDeleteCommandModifier<R>.name: _onDeleteCommandModifier<R>.parser(in: context).map({ Output.chunk9(.onDeleteCommand($0)) }).eraseToAnyParser(),
+_onDisappearModifier<R>.name: _onDisappearModifier<R>.parser(in: context).map({ Output.chunk9(.onDisappear($0)) }).eraseToAnyParser(),
+_onExitCommandModifier<R>.name: _onExitCommandModifier<R>.parser(in: context).map({ Output.chunk9(.onExitCommand($0)) }).eraseToAnyParser(),
 _onHoverModifier<R>.name: _onHoverModifier<R>.parser(in: context).map({ Output.chunk9(.onHover($0)) }).eraseToAnyParser(),
+_onImmersionChangeModifier<R>.name: _onImmersionChangeModifier<R>.parser(in: context).map({ Output.chunk9(.onImmersionChange($0)) }).eraseToAnyParser(),
 _onLongPressGestureModifier<R>.name: _onLongPressGestureModifier<R>.parser(in: context).map({ Output.chunk9(.onLongPressGesture($0)) }).eraseToAnyParser(),
 _onLongTouchGestureModifier<R>.name: _onLongTouchGestureModifier<R>.parser(in: context).map({ Output.chunk9(.onLongTouchGesture($0)) }).eraseToAnyParser(),
-_onMoveCommandModifier<R>.name: _onMoveCommandModifier<R>.parser(in: context).map({ Output.chunk9(.onMoveCommand($0)) }).eraseToAnyParser(),
-_onPlayPauseCommandModifier<R>.name: _onPlayPauseCommandModifier<R>.parser(in: context).map({ Output.chunk9(.onPlayPauseCommand($0)) }).eraseToAnyParser(),
-_onTapGestureModifier<R>.name: _onTapGestureModifier<R>.parser(in: context).map({ Output.chunk9(.onTapGesture($0)) }).eraseToAnyParser(),
-_opacityModifier<R>.name: _opacityModifier<R>.parser(in: context).map({ Output.chunk9(.opacity($0)) }).eraseToAnyParser(),
-_ornamentModifier<R>.name: _ornamentModifier<R>.parser(in: context).map({ Output.chunk9(.ornament($0)) }).eraseToAnyParser(),
-_overlayModifier<R>.name: _overlayModifier<R>.parser(in: context).map({ Output.chunk9(.overlay($0)) }).eraseToAnyParser(),
-_paddingModifier<R>.name: _paddingModifier<R>.parser(in: context).map({ Output.chunk9(.padding($0)) }).eraseToAnyParser(),
-_padding3DModifier<R>.name: _padding3DModifier<R>.parser(in: context).map({ Output.chunk9(.padding3D($0)) }).eraseToAnyParser(),
-_persistentSystemOverlaysModifier<R>.name: _persistentSystemOverlaysModifier<R>.parser(in: context).map({ Output.chunk9(.persistentSystemOverlays($0)) }).eraseToAnyParser(),
-_pickerStyleModifier<R>.name: _pickerStyleModifier<R>.parser(in: context).map({ Output.chunk9(.pickerStyle($0)) }).eraseToAnyParser(),
-_popoverModifier<R>.name: _popoverModifier<R>.parser(in: context).map({ Output.chunk9(.popover($0)) }).eraseToAnyParser(),
-_positionModifier<R>.name: _positionModifier<R>.parser(in: context).map({ Output.chunk10(.position($0)) }).eraseToAnyParser(),
-_preferredColorSchemeModifier<R>.name: _preferredColorSchemeModifier<R>.parser(in: context).map({ Output.chunk10(.preferredColorScheme($0)) }).eraseToAnyParser(),
-_preferredSurroundingsEffectModifier<R>.name: _preferredSurroundingsEffectModifier<R>.parser(in: context).map({ Output.chunk10(.preferredSurroundingsEffect($0)) }).eraseToAnyParser(),
-_presentationBackgroundModifier<R>.name: _presentationBackgroundModifier<R>.parser(in: context).map({ Output.chunk10(.presentationBackground($0)) }).eraseToAnyParser(),
-_presentationBackgroundInteractionModifier<R>.name: _presentationBackgroundInteractionModifier<R>.parser(in: context).map({ Output.chunk10(.presentationBackgroundInteraction($0)) }).eraseToAnyParser(),
-_presentationCompactAdaptationModifier<R>.name: _presentationCompactAdaptationModifier<R>.parser(in: context).map({ Output.chunk10(.presentationCompactAdaptation($0)) }).eraseToAnyParser(),
-_presentationContentInteractionModifier<R>.name: _presentationContentInteractionModifier<R>.parser(in: context).map({ Output.chunk10(.presentationContentInteraction($0)) }).eraseToAnyParser(),
-_presentationCornerRadiusModifier<R>.name: _presentationCornerRadiusModifier<R>.parser(in: context).map({ Output.chunk10(.presentationCornerRadius($0)) }).eraseToAnyParser(),
-_presentationDragIndicatorModifier<R>.name: _presentationDragIndicatorModifier<R>.parser(in: context).map({ Output.chunk10(.presentationDragIndicator($0)) }).eraseToAnyParser(),
-_previewDisplayNameModifier<R>.name: _previewDisplayNameModifier<R>.parser(in: context).map({ Output.chunk10(.previewDisplayName($0)) }).eraseToAnyParser(),
-_privacySensitiveModifier<R>.name: _privacySensitiveModifier<R>.parser(in: context).map({ Output.chunk10(.privacySensitive($0)) }).eraseToAnyParser(),
-_progressViewStyleModifier<R>.name: _progressViewStyleModifier<R>.parser(in: context).map({ Output.chunk10(.progressViewStyle($0)) }).eraseToAnyParser(),
-_projectionEffectModifier<R>.name: _projectionEffectModifier<R>.parser(in: context).map({ Output.chunk10(.projectionEffect($0)) }).eraseToAnyParser(),
-_redactedModifier<R>.name: _redactedModifier<R>.parser(in: context).map({ Output.chunk10(.redacted($0)) }).eraseToAnyParser(),
-_refreshableModifier<R>.name: _refreshableModifier<R>.parser(in: context).map({ Output.chunk11(.refreshable($0)) }).eraseToAnyParser(),
-_renameActionModifier<R>.name: _renameActionModifier<R>.parser(in: context).map({ Output.chunk11(.renameAction($0)) }).eraseToAnyParser(),
-_replaceDisabledModifier<R>.name: _replaceDisabledModifier<R>.parser(in: context).map({ Output.chunk11(.replaceDisabled($0)) }).eraseToAnyParser(),
-_rotationEffectModifier<R>.name: _rotationEffectModifier<R>.parser(in: context).map({ Output.chunk11(.rotationEffect($0)) }).eraseToAnyParser(),
-_safeAreaInsetModifier<R>.name: _safeAreaInsetModifier<R>.parser(in: context).map({ Output.chunk11(.safeAreaInset($0)) }).eraseToAnyParser(),
-_safeAreaPaddingModifier<R>.name: _safeAreaPaddingModifier<R>.parser(in: context).map({ Output.chunk11(.safeAreaPadding($0)) }).eraseToAnyParser(),
-_saturationModifier<R>.name: _saturationModifier<R>.parser(in: context).map({ Output.chunk11(.saturation($0)) }).eraseToAnyParser(),
-_scaleEffectModifier<R>.name: _scaleEffectModifier<R>.parser(in: context).map({ Output.chunk11(.scaleEffect($0)) }).eraseToAnyParser(),
-_scaledToFillModifier<R>.name: _scaledToFillModifier<R>.parser(in: context).map({ Output.chunk11(.scaledToFill($0)) }).eraseToAnyParser(),
-_scaledToFitModifier<R>.name: _scaledToFitModifier<R>.parser(in: context).map({ Output.chunk11(.scaledToFit($0)) }).eraseToAnyParser(),
-_scenePaddingModifier<R>.name: _scenePaddingModifier<R>.parser(in: context).map({ Output.chunk11(.scenePadding($0)) }).eraseToAnyParser(),
-_scrollBounceBehaviorModifier<R>.name: _scrollBounceBehaviorModifier<R>.parser(in: context).map({ Output.chunk11(.scrollBounceBehavior($0)) }).eraseToAnyParser(),
-_scrollClipDisabledModifier<R>.name: _scrollClipDisabledModifier<R>.parser(in: context).map({ Output.chunk11(.scrollClipDisabled($0)) }).eraseToAnyParser(),
-_scrollContentBackgroundModifier<R>.name: _scrollContentBackgroundModifier<R>.parser(in: context).map({ Output.chunk11(.scrollContentBackground($0)) }).eraseToAnyParser(),
-_scrollDisabledModifier<R>.name: _scrollDisabledModifier<R>.parser(in: context).map({ Output.chunk12(.scrollDisabled($0)) }).eraseToAnyParser(),
-_scrollDismissesKeyboardModifier<R>.name: _scrollDismissesKeyboardModifier<R>.parser(in: context).map({ Output.chunk12(.scrollDismissesKeyboard($0)) }).eraseToAnyParser(),
-_scrollIndicatorsModifier<R>.name: _scrollIndicatorsModifier<R>.parser(in: context).map({ Output.chunk12(.scrollIndicators($0)) }).eraseToAnyParser(),
-_scrollIndicatorsFlashModifier<R>.name: _scrollIndicatorsFlashModifier<R>.parser(in: context).map({ Output.chunk12(.scrollIndicatorsFlash($0)) }).eraseToAnyParser(),
-_scrollPositionModifier<R>.name: _scrollPositionModifier<R>.parser(in: context).map({ Output.chunk12(.scrollPosition($0)) }).eraseToAnyParser(),
-_scrollTargetBehaviorModifier<R>.name: _scrollTargetBehaviorModifier<R>.parser(in: context).map({ Output.chunk12(.scrollTargetBehavior($0)) }).eraseToAnyParser(),
-_scrollTargetLayoutModifier<R>.name: _scrollTargetLayoutModifier<R>.parser(in: context).map({ Output.chunk12(.scrollTargetLayout($0)) }).eraseToAnyParser(),
-_searchDictationBehaviorModifier<R>.name: _searchDictationBehaviorModifier<R>.parser(in: context).map({ Output.chunk12(.searchDictationBehavior($0)) }).eraseToAnyParser(),
-_searchPresentationToolbarBehaviorModifier<R>.name: _searchPresentationToolbarBehaviorModifier<R>.parser(in: context).map({ Output.chunk12(.searchPresentationToolbarBehavior($0)) }).eraseToAnyParser(),
-_searchSuggestionsModifier<R>.name: _searchSuggestionsModifier<R>.parser(in: context).map({ Output.chunk12(.searchSuggestions($0)) }).eraseToAnyParser(),
-_searchableModifier<R>.name: _searchableModifier<R>.parser(in: context).map({ Output.chunk12(.searchable($0)) }).eraseToAnyParser(),
-_selectionDisabledModifier<R>.name: _selectionDisabledModifier<R>.parser(in: context).map({ Output.chunk12(.selectionDisabled($0)) }).eraseToAnyParser(),
-_shadowModifier<R>.name: _shadowModifier<R>.parser(in: context).map({ Output.chunk12(.shadow($0)) }).eraseToAnyParser(),
-_sheetModifier<R>.name: _sheetModifier<R>.parser(in: context).map({ Output.chunk12(.sheet($0)) }).eraseToAnyParser(),
-_simultaneousGestureModifier<R>.name: _simultaneousGestureModifier<R>.parser(in: context).map({ Output.chunk13(.simultaneousGesture($0)) }).eraseToAnyParser(),
-_speechAdjustedPitchModifier<R>.name: _speechAdjustedPitchModifier<R>.parser(in: context).map({ Output.chunk13(.speechAdjustedPitch($0)) }).eraseToAnyParser(),
-_speechAlwaysIncludesPunctuationModifier<R>.name: _speechAlwaysIncludesPunctuationModifier<R>.parser(in: context).map({ Output.chunk13(.speechAlwaysIncludesPunctuation($0)) }).eraseToAnyParser(),
-_speechAnnouncementsQueuedModifier<R>.name: _speechAnnouncementsQueuedModifier<R>.parser(in: context).map({ Output.chunk13(.speechAnnouncementsQueued($0)) }).eraseToAnyParser(),
-_speechSpellsOutCharactersModifier<R>.name: _speechSpellsOutCharactersModifier<R>.parser(in: context).map({ Output.chunk13(.speechSpellsOutCharacters($0)) }).eraseToAnyParser(),
-_statusBarHiddenModifier<R>.name: _statusBarHiddenModifier<R>.parser(in: context).map({ Output.chunk13(.statusBarHidden($0)) }).eraseToAnyParser(),
-_submitLabelModifier<R>.name: _submitLabelModifier<R>.parser(in: context).map({ Output.chunk13(.submitLabel($0)) }).eraseToAnyParser(),
-_submitScopeModifier<R>.name: _submitScopeModifier<R>.parser(in: context).map({ Output.chunk13(.submitScope($0)) }).eraseToAnyParser(),
-_swipeActionsModifier<R>.name: _swipeActionsModifier<R>.parser(in: context).map({ Output.chunk13(.swipeActions($0)) }).eraseToAnyParser(),
-_symbolEffectModifier<R>.name: _symbolEffectModifier<R>.parser(in: context).map({ Output.chunk13(.symbolEffect($0)) }).eraseToAnyParser(),
-_symbolEffectsRemovedModifier<R>.name: _symbolEffectsRemovedModifier<R>.parser(in: context).map({ Output.chunk13(.symbolEffectsRemoved($0)) }).eraseToAnyParser(),
-_symbolRenderingModeModifier<R>.name: _symbolRenderingModeModifier<R>.parser(in: context).map({ Output.chunk13(.symbolRenderingMode($0)) }).eraseToAnyParser(),
-_symbolVariantModifier<R>.name: _symbolVariantModifier<R>.parser(in: context).map({ Output.chunk13(.symbolVariant($0)) }).eraseToAnyParser(),
-_tabItemModifier<R>.name: _tabItemModifier<R>.parser(in: context).map({ Output.chunk13(.tabItem($0)) }).eraseToAnyParser(),
-_tabViewStyleModifier<R>.name: _tabViewStyleModifier<R>.parser(in: context).map({ Output.chunk14(.tabViewStyle($0)) }).eraseToAnyParser(),
-_tableStyleModifier<R>.name: _tableStyleModifier<R>.parser(in: context).map({ Output.chunk14(.tableStyle($0)) }).eraseToAnyParser(),
-_textCaseModifier<R>.name: _textCaseModifier<R>.parser(in: context).map({ Output.chunk14(.textCase($0)) }).eraseToAnyParser(),
-_textContentTypeModifier<R>.name: _textContentTypeModifier<R>.parser(in: context).map({ Output.chunk14(.textContentType($0)) }).eraseToAnyParser(),
-_textEditorStyleModifier<R>.name: _textEditorStyleModifier<R>.parser(in: context).map({ Output.chunk14(.textEditorStyle($0)) }).eraseToAnyParser(),
-_textFieldStyleModifier<R>.name: _textFieldStyleModifier<R>.parser(in: context).map({ Output.chunk14(.textFieldStyle($0)) }).eraseToAnyParser(),
-_textInputAutocapitalizationModifier<R>.name: _textInputAutocapitalizationModifier<R>.parser(in: context).map({ Output.chunk14(.textInputAutocapitalization($0)) }).eraseToAnyParser(),
-_textSelectionModifier<R>.name: _textSelectionModifier<R>.parser(in: context).map({ Output.chunk14(.textSelection($0)) }).eraseToAnyParser(),
-_tintModifier<R>.name: _tintModifier<R>.parser(in: context).map({ Output.chunk14(.tint($0)) }).eraseToAnyParser(),
-_toggleStyleModifier<R>.name: _toggleStyleModifier<R>.parser(in: context).map({ Output.chunk14(.toggleStyle($0)) }).eraseToAnyParser(),
-_toolbarModifier<R>.name: _toolbarModifier<R>.parser(in: context).map({ Output.chunk14(.toolbar($0)) }).eraseToAnyParser(),
-_toolbarBackgroundModifier<R>.name: _toolbarBackgroundModifier<R>.parser(in: context).map({ Output.chunk14(.toolbarBackground($0)) }).eraseToAnyParser(),
-_toolbarColorSchemeModifier<R>.name: _toolbarColorSchemeModifier<R>.parser(in: context).map({ Output.chunk14(.toolbarColorScheme($0)) }).eraseToAnyParser(),
-_toolbarRoleModifier<R>.name: _toolbarRoleModifier<R>.parser(in: context).map({ Output.chunk14(.toolbarRole($0)) }).eraseToAnyParser(),
-_toolbarTitleDisplayModeModifier<R>.name: _toolbarTitleDisplayModeModifier<R>.parser(in: context).map({ Output.chunk15(.toolbarTitleDisplayMode($0)) }).eraseToAnyParser(),
-_toolbarTitleMenuModifier<R>.name: _toolbarTitleMenuModifier<R>.parser(in: context).map({ Output.chunk15(.toolbarTitleMenu($0)) }).eraseToAnyParser(),
-_touchBarCustomizationLabelModifier<R>.name: _touchBarCustomizationLabelModifier<R>.parser(in: context).map({ Output.chunk15(.touchBarCustomizationLabel($0)) }).eraseToAnyParser(),
-_touchBarItemPrincipalModifier<R>.name: _touchBarItemPrincipalModifier<R>.parser(in: context).map({ Output.chunk15(.touchBarItemPrincipal($0)) }).eraseToAnyParser(),
-_transform3DEffectModifier<R>.name: _transform3DEffectModifier<R>.parser(in: context).map({ Output.chunk15(.transform3DEffect($0)) }).eraseToAnyParser(),
-_transformEffectModifier<R>.name: _transformEffectModifier<R>.parser(in: context).map({ Output.chunk15(.transformEffect($0)) }).eraseToAnyParser(),
-_transitionModifier<R>.name: _transitionModifier<R>.parser(in: context).map({ Output.chunk15(.transition($0)) }).eraseToAnyParser(),
-_truncationModeModifier<R>.name: _truncationModeModifier<R>.parser(in: context).map({ Output.chunk15(.truncationMode($0)) }).eraseToAnyParser(),
-_unredactedModifier<R>.name: _unredactedModifier<R>.parser(in: context).map({ Output.chunk15(.unredacted($0)) }).eraseToAnyParser(),
-_upperLimbVisibilityModifier<R>.name: _upperLimbVisibilityModifier<R>.parser(in: context).map({ Output.chunk15(.upperLimbVisibility($0)) }).eraseToAnyParser(),
-_zIndexModifier<R>.name: _zIndexModifier<R>.parser(in: context).map({ Output.chunk15(.zIndex($0)) }).eraseToAnyParser(),
-                    LiveViewNative._PerspectiveRotationEffectModifier<R>.name: LiveViewNative._PerspectiveRotationEffectModifier<R>.parser(in: context).map(Output._PerspectiveRotationEffectModifier).eraseToAnyParser(),
-LiveViewNative._PresentationDetentsModifier.name: LiveViewNative._PresentationDetentsModifier.parser(in: context).map(Output._PresentationDetentsModifier).eraseToAnyParser(),
-LiveViewNative._PrefersDefaultFocusModifier<R>.name: LiveViewNative._PrefersDefaultFocusModifier<R>.parser(in: context).map(Output._PrefersDefaultFocusModifier).eraseToAnyParser(),
-LiveViewNative._FocusScopeModifier<R>.name: LiveViewNative._FocusScopeModifier<R>.parser(in: context).map(Output._FocusScopeModifier).eraseToAnyParser(),
-LiveViewNative._OnSubmitModifier.name: LiveViewNative._OnSubmitModifier.parser(in: context).map(Output._OnSubmitModifier).eraseToAnyParser(),
-LiveViewNative._Rotation3DEffectModifier<R>.name: LiveViewNative._Rotation3DEffectModifier<R>.parser(in: context).map(Output._Rotation3DEffectModifier).eraseToAnyParser(),
-LiveViewNative._SearchCompletionModifier<R>.name: LiveViewNative._SearchCompletionModifier<R>.parser(in: context).map(Output._SearchCompletionModifier).eraseToAnyParser(),
-LiveViewNative._MaskModifier<R>.name: LiveViewNative._MaskModifier<R>.parser(in: context).map(Output._MaskModifier).eraseToAnyParser(),
+_onModifierKeysChangedModifier<R>.name: _onModifierKeysChangedModifier<R>.parser(in: context).map({ Output.chunk10(.onModifierKeysChanged($0)) }).eraseToAnyParser(),
+_onMoveCommandModifier<R>.name: _onMoveCommandModifier<R>.parser(in: context).map({ Output.chunk10(.onMoveCommand($0)) }).eraseToAnyParser(),
+_onPencilDoubleTapModifier<R>.name: _onPencilDoubleTapModifier<R>.parser(in: context).map({ Output.chunk10(.onPencilDoubleTap($0)) }).eraseToAnyParser(),
+_onPencilSqueezeModifier<R>.name: _onPencilSqueezeModifier<R>.parser(in: context).map({ Output.chunk10(.onPencilSqueeze($0)) }).eraseToAnyParser(),
+_onPlayPauseCommandModifier<R>.name: _onPlayPauseCommandModifier<R>.parser(in: context).map({ Output.chunk10(.onPlayPauseCommand($0)) }).eraseToAnyParser(),
+_onScrollPhaseChangeModifier<R>.name: _onScrollPhaseChangeModifier<R>.parser(in: context).map({ Output.chunk10(.onScrollPhaseChange($0)) }).eraseToAnyParser(),
+_onScrollVisibilityChangeModifier<R>.name: _onScrollVisibilityChangeModifier<R>.parser(in: context).map({ Output.chunk10(.onScrollVisibilityChange($0)) }).eraseToAnyParser(),
+_onTapGestureModifier<R>.name: _onTapGestureModifier<R>.parser(in: context).map({ Output.chunk10(.onTapGesture($0)) }).eraseToAnyParser(),
+_onVolumeViewpointChangeModifier<R>.name: _onVolumeViewpointChangeModifier<R>.parser(in: context).map({ Output.chunk10(.onVolumeViewpointChange($0)) }).eraseToAnyParser(),
+_opacityModifier<R>.name: _opacityModifier<R>.parser(in: context).map({ Output.chunk10(.opacity($0)) }).eraseToAnyParser(),
+_ornamentModifier<R>.name: _ornamentModifier<R>.parser(in: context).map({ Output.chunk10(.ornament($0)) }).eraseToAnyParser(),
+_overlayModifier<R>.name: _overlayModifier<R>.parser(in: context).map({ Output.chunk10(.overlay($0)) }).eraseToAnyParser(),
+_paddingModifier<R>.name: _paddingModifier<R>.parser(in: context).map({ Output.chunk10(.padding($0)) }).eraseToAnyParser(),
+_padding3DModifier<R>.name: _padding3DModifier<R>.parser(in: context).map({ Output.chunk10(.padding3D($0)) }).eraseToAnyParser(),
+_persistentSystemOverlaysModifier<R>.name: _persistentSystemOverlaysModifier<R>.parser(in: context).map({ Output.chunk11(.persistentSystemOverlays($0)) }).eraseToAnyParser(),
+_pickerStyleModifier<R>.name: _pickerStyleModifier<R>.parser(in: context).map({ Output.chunk11(.pickerStyle($0)) }).eraseToAnyParser(),
+_pointerStyleModifier<R>.name: _pointerStyleModifier<R>.parser(in: context).map({ Output.chunk11(.pointerStyle($0)) }).eraseToAnyParser(),
+_pointerVisibilityModifier<R>.name: _pointerVisibilityModifier<R>.parser(in: context).map({ Output.chunk11(.pointerVisibility($0)) }).eraseToAnyParser(),
+_popoverModifier<R>.name: _popoverModifier<R>.parser(in: context).map({ Output.chunk11(.popover($0)) }).eraseToAnyParser(),
+_positionModifier<R>.name: _positionModifier<R>.parser(in: context).map({ Output.chunk11(.position($0)) }).eraseToAnyParser(),
+_preferredColorSchemeModifier<R>.name: _preferredColorSchemeModifier<R>.parser(in: context).map({ Output.chunk11(.preferredColorScheme($0)) }).eraseToAnyParser(),
+_preferredSurroundingsEffectModifier<R>.name: _preferredSurroundingsEffectModifier<R>.parser(in: context).map({ Output.chunk11(.preferredSurroundingsEffect($0)) }).eraseToAnyParser(),
+_presentationBackgroundModifier<R>.name: _presentationBackgroundModifier<R>.parser(in: context).map({ Output.chunk11(.presentationBackground($0)) }).eraseToAnyParser(),
+_presentationBackgroundInteractionModifier<R>.name: _presentationBackgroundInteractionModifier<R>.parser(in: context).map({ Output.chunk11(.presentationBackgroundInteraction($0)) }).eraseToAnyParser(),
+_presentationCompactAdaptationModifier<R>.name: _presentationCompactAdaptationModifier<R>.parser(in: context).map({ Output.chunk11(.presentationCompactAdaptation($0)) }).eraseToAnyParser(),
+_presentationContentInteractionModifier<R>.name: _presentationContentInteractionModifier<R>.parser(in: context).map({ Output.chunk11(.presentationContentInteraction($0)) }).eraseToAnyParser(),
+_presentationCornerRadiusModifier<R>.name: _presentationCornerRadiusModifier<R>.parser(in: context).map({ Output.chunk11(.presentationCornerRadius($0)) }).eraseToAnyParser(),
+_presentationDragIndicatorModifier<R>.name: _presentationDragIndicatorModifier<R>.parser(in: context).map({ Output.chunk11(.presentationDragIndicator($0)) }).eraseToAnyParser(),
+_presentationSizingModifier<R>.name: _presentationSizingModifier<R>.parser(in: context).map({ Output.chunk12(.presentationSizing($0)) }).eraseToAnyParser(),
+_previewDisplayNameModifier<R>.name: _previewDisplayNameModifier<R>.parser(in: context).map({ Output.chunk12(.previewDisplayName($0)) }).eraseToAnyParser(),
+_privacySensitiveModifier<R>.name: _privacySensitiveModifier<R>.parser(in: context).map({ Output.chunk12(.privacySensitive($0)) }).eraseToAnyParser(),
+_progressViewStyleModifier<R>.name: _progressViewStyleModifier<R>.parser(in: context).map({ Output.chunk12(.progressViewStyle($0)) }).eraseToAnyParser(),
+_projectionEffectModifier<R>.name: _projectionEffectModifier<R>.parser(in: context).map({ Output.chunk12(.projectionEffect($0)) }).eraseToAnyParser(),
+_redactedModifier<R>.name: _redactedModifier<R>.parser(in: context).map({ Output.chunk12(.redacted($0)) }).eraseToAnyParser(),
+_refreshableModifier<R>.name: _refreshableModifier<R>.parser(in: context).map({ Output.chunk12(.refreshable($0)) }).eraseToAnyParser(),
+_renameActionModifier<R>.name: _renameActionModifier<R>.parser(in: context).map({ Output.chunk12(.renameAction($0)) }).eraseToAnyParser(),
+_replaceDisabledModifier<R>.name: _replaceDisabledModifier<R>.parser(in: context).map({ Output.chunk12(.replaceDisabled($0)) }).eraseToAnyParser(),
+_rotationEffectModifier<R>.name: _rotationEffectModifier<R>.parser(in: context).map({ Output.chunk12(.rotationEffect($0)) }).eraseToAnyParser(),
+_safeAreaInsetModifier<R>.name: _safeAreaInsetModifier<R>.parser(in: context).map({ Output.chunk12(.safeAreaInset($0)) }).eraseToAnyParser(),
+_safeAreaPaddingModifier<R>.name: _safeAreaPaddingModifier<R>.parser(in: context).map({ Output.chunk12(.safeAreaPadding($0)) }).eraseToAnyParser(),
+_saturationModifier<R>.name: _saturationModifier<R>.parser(in: context).map({ Output.chunk12(.saturation($0)) }).eraseToAnyParser(),
+_scaleEffectModifier<R>.name: _scaleEffectModifier<R>.parser(in: context).map({ Output.chunk12(.scaleEffect($0)) }).eraseToAnyParser(),
+_scaledToFillModifier<R>.name: _scaledToFillModifier<R>.parser(in: context).map({ Output.chunk13(.scaledToFill($0)) }).eraseToAnyParser(),
+_scaledToFitModifier<R>.name: _scaledToFitModifier<R>.parser(in: context).map({ Output.chunk13(.scaledToFit($0)) }).eraseToAnyParser(),
+_scenePaddingModifier<R>.name: _scenePaddingModifier<R>.parser(in: context).map({ Output.chunk13(.scenePadding($0)) }).eraseToAnyParser(),
+_scrollBounceBehaviorModifier<R>.name: _scrollBounceBehaviorModifier<R>.parser(in: context).map({ Output.chunk13(.scrollBounceBehavior($0)) }).eraseToAnyParser(),
+_scrollClipDisabledModifier<R>.name: _scrollClipDisabledModifier<R>.parser(in: context).map({ Output.chunk13(.scrollClipDisabled($0)) }).eraseToAnyParser(),
+_scrollContentBackgroundModifier<R>.name: _scrollContentBackgroundModifier<R>.parser(in: context).map({ Output.chunk13(.scrollContentBackground($0)) }).eraseToAnyParser(),
+_scrollDisabledModifier<R>.name: _scrollDisabledModifier<R>.parser(in: context).map({ Output.chunk13(.scrollDisabled($0)) }).eraseToAnyParser(),
+_scrollDismissesKeyboardModifier<R>.name: _scrollDismissesKeyboardModifier<R>.parser(in: context).map({ Output.chunk13(.scrollDismissesKeyboard($0)) }).eraseToAnyParser(),
+_scrollIndicatorsModifier<R>.name: _scrollIndicatorsModifier<R>.parser(in: context).map({ Output.chunk13(.scrollIndicators($0)) }).eraseToAnyParser(),
+_scrollIndicatorsFlashModifier<R>.name: _scrollIndicatorsFlashModifier<R>.parser(in: context).map({ Output.chunk13(.scrollIndicatorsFlash($0)) }).eraseToAnyParser(),
+_scrollInputBehaviorModifier<R>.name: _scrollInputBehaviorModifier<R>.parser(in: context).map({ Output.chunk13(.scrollInputBehavior($0)) }).eraseToAnyParser(),
+_scrollPositionModifier<R>.name: _scrollPositionModifier<R>.parser(in: context).map({ Output.chunk13(.scrollPosition($0)) }).eraseToAnyParser(),
+_scrollTargetBehaviorModifier<R>.name: _scrollTargetBehaviorModifier<R>.parser(in: context).map({ Output.chunk13(.scrollTargetBehavior($0)) }).eraseToAnyParser(),
+_scrollTargetLayoutModifier<R>.name: _scrollTargetLayoutModifier<R>.parser(in: context).map({ Output.chunk13(.scrollTargetLayout($0)) }).eraseToAnyParser(),
+_searchDictationBehaviorModifier<R>.name: _searchDictationBehaviorModifier<R>.parser(in: context).map({ Output.chunk14(.searchDictationBehavior($0)) }).eraseToAnyParser(),
+_searchPresentationToolbarBehaviorModifier<R>.name: _searchPresentationToolbarBehaviorModifier<R>.parser(in: context).map({ Output.chunk14(.searchPresentationToolbarBehavior($0)) }).eraseToAnyParser(),
+_searchSuggestionsModifier<R>.name: _searchSuggestionsModifier<R>.parser(in: context).map({ Output.chunk14(.searchSuggestions($0)) }).eraseToAnyParser(),
+_searchableModifier<R>.name: _searchableModifier<R>.parser(in: context).map({ Output.chunk14(.searchable($0)) }).eraseToAnyParser(),
+_sectionActionsModifier<R>.name: _sectionActionsModifier<R>.parser(in: context).map({ Output.chunk14(.sectionActions($0)) }).eraseToAnyParser(),
+_selectionDisabledModifier<R>.name: _selectionDisabledModifier<R>.parser(in: context).map({ Output.chunk14(.selectionDisabled($0)) }).eraseToAnyParser(),
+_shadowModifier<R>.name: _shadowModifier<R>.parser(in: context).map({ Output.chunk14(.shadow($0)) }).eraseToAnyParser(),
+_sheetModifier<R>.name: _sheetModifier<R>.parser(in: context).map({ Output.chunk14(.sheet($0)) }).eraseToAnyParser(),
+_simultaneousGestureModifier<R>.name: _simultaneousGestureModifier<R>.parser(in: context).map({ Output.chunk14(.simultaneousGesture($0)) }).eraseToAnyParser(),
+_speechAdjustedPitchModifier<R>.name: _speechAdjustedPitchModifier<R>.parser(in: context).map({ Output.chunk14(.speechAdjustedPitch($0)) }).eraseToAnyParser(),
+_speechAlwaysIncludesPunctuationModifier<R>.name: _speechAlwaysIncludesPunctuationModifier<R>.parser(in: context).map({ Output.chunk14(.speechAlwaysIncludesPunctuation($0)) }).eraseToAnyParser(),
+_speechAnnouncementsQueuedModifier<R>.name: _speechAnnouncementsQueuedModifier<R>.parser(in: context).map({ Output.chunk14(.speechAnnouncementsQueued($0)) }).eraseToAnyParser(),
+_speechSpellsOutCharactersModifier<R>.name: _speechSpellsOutCharactersModifier<R>.parser(in: context).map({ Output.chunk14(.speechSpellsOutCharacters($0)) }).eraseToAnyParser(),
+_statusBarHiddenModifier<R>.name: _statusBarHiddenModifier<R>.parser(in: context).map({ Output.chunk14(.statusBarHidden($0)) }).eraseToAnyParser(),
+_submitLabelModifier<R>.name: _submitLabelModifier<R>.parser(in: context).map({ Output.chunk15(.submitLabel($0)) }).eraseToAnyParser(),
+_submitScopeModifier<R>.name: _submitScopeModifier<R>.parser(in: context).map({ Output.chunk15(.submitScope($0)) }).eraseToAnyParser(),
+_supportedVolumeViewpointsModifier<R>.name: _supportedVolumeViewpointsModifier<R>.parser(in: context).map({ Output.chunk15(.supportedVolumeViewpoints($0)) }).eraseToAnyParser(),
+_swipeActionsModifier<R>.name: _swipeActionsModifier<R>.parser(in: context).map({ Output.chunk15(.swipeActions($0)) }).eraseToAnyParser(),
+_symbolEffectModifier<R>.name: _symbolEffectModifier<R>.parser(in: context).map({ Output.chunk15(.symbolEffect($0)) }).eraseToAnyParser(),
+_symbolEffectsRemovedModifier<R>.name: _symbolEffectsRemovedModifier<R>.parser(in: context).map({ Output.chunk15(.symbolEffectsRemoved($0)) }).eraseToAnyParser(),
+_symbolRenderingModeModifier<R>.name: _symbolRenderingModeModifier<R>.parser(in: context).map({ Output.chunk15(.symbolRenderingMode($0)) }).eraseToAnyParser(),
+_symbolVariantModifier<R>.name: _symbolVariantModifier<R>.parser(in: context).map({ Output.chunk15(.symbolVariant($0)) }).eraseToAnyParser(),
+_tabViewSidebarBottomBarModifier<R>.name: _tabViewSidebarBottomBarModifier<R>.parser(in: context).map({ Output.chunk15(.tabViewSidebarBottomBar($0)) }).eraseToAnyParser(),
+_tabViewSidebarFooterModifier<R>.name: _tabViewSidebarFooterModifier<R>.parser(in: context).map({ Output.chunk15(.tabViewSidebarFooter($0)) }).eraseToAnyParser(),
+_tabViewSidebarHeaderModifier<R>.name: _tabViewSidebarHeaderModifier<R>.parser(in: context).map({ Output.chunk15(.tabViewSidebarHeader($0)) }).eraseToAnyParser(),
+_tabViewStyleModifier<R>.name: _tabViewStyleModifier<R>.parser(in: context).map({ Output.chunk15(.tabViewStyle($0)) }).eraseToAnyParser(),
+_tableStyleModifier<R>.name: _tableStyleModifier<R>.parser(in: context).map({ Output.chunk15(.tableStyle($0)) }).eraseToAnyParser(),
+_textCaseModifier<R>.name: _textCaseModifier<R>.parser(in: context).map({ Output.chunk15(.textCase($0)) }).eraseToAnyParser(),
+_textContentTypeModifier<R>.name: _textContentTypeModifier<R>.parser(in: context).map({ Output.chunk16(.textContentType($0)) }).eraseToAnyParser(),
+_textEditorStyleModifier<R>.name: _textEditorStyleModifier<R>.parser(in: context).map({ Output.chunk16(.textEditorStyle($0)) }).eraseToAnyParser(),
+_textFieldStyleModifier<R>.name: _textFieldStyleModifier<R>.parser(in: context).map({ Output.chunk16(.textFieldStyle($0)) }).eraseToAnyParser(),
+_textInputAutocapitalizationModifier<R>.name: _textInputAutocapitalizationModifier<R>.parser(in: context).map({ Output.chunk16(.textInputAutocapitalization($0)) }).eraseToAnyParser(),
+_textInputCompletionModifier<R>.name: _textInputCompletionModifier<R>.parser(in: context).map({ Output.chunk16(.textInputCompletion($0)) }).eraseToAnyParser(),
+_textInputSuggestionsModifier<R>.name: _textInputSuggestionsModifier<R>.parser(in: context).map({ Output.chunk16(.textInputSuggestions($0)) }).eraseToAnyParser(),
+_textSelectionModifier<R>.name: _textSelectionModifier<R>.parser(in: context).map({ Output.chunk16(.textSelection($0)) }).eraseToAnyParser(),
+_textSelectionAffinityModifier<R>.name: _textSelectionAffinityModifier<R>.parser(in: context).map({ Output.chunk16(.textSelectionAffinity($0)) }).eraseToAnyParser(),
+_tintModifier<R>.name: _tintModifier<R>.parser(in: context).map({ Output.chunk16(.tint($0)) }).eraseToAnyParser(),
+_toggleStyleModifier<R>.name: _toggleStyleModifier<R>.parser(in: context).map({ Output.chunk16(.toggleStyle($0)) }).eraseToAnyParser(),
+_toolbarModifier<R>.name: _toolbarModifier<R>.parser(in: context).map({ Output.chunk16(.toolbar($0)) }).eraseToAnyParser(),
+_toolbarBackgroundModifier<R>.name: _toolbarBackgroundModifier<R>.parser(in: context).map({ Output.chunk16(.toolbarBackground($0)) }).eraseToAnyParser(),
+_toolbarBackgroundVisibilityModifier<R>.name: _toolbarBackgroundVisibilityModifier<R>.parser(in: context).map({ Output.chunk16(.toolbarBackgroundVisibility($0)) }).eraseToAnyParser(),
+_toolbarColorSchemeModifier<R>.name: _toolbarColorSchemeModifier<R>.parser(in: context).map({ Output.chunk16(.toolbarColorScheme($0)) }).eraseToAnyParser(),
+_toolbarItemHiddenModifier<R>.name: _toolbarItemHiddenModifier<R>.parser(in: context).map({ Output.chunk17(.toolbarItemHidden($0)) }).eraseToAnyParser(),
+_toolbarRoleModifier<R>.name: _toolbarRoleModifier<R>.parser(in: context).map({ Output.chunk17(.toolbarRole($0)) }).eraseToAnyParser(),
+_toolbarTitleDisplayModeModifier<R>.name: _toolbarTitleDisplayModeModifier<R>.parser(in: context).map({ Output.chunk17(.toolbarTitleDisplayMode($0)) }).eraseToAnyParser(),
+_toolbarTitleMenuModifier<R>.name: _toolbarTitleMenuModifier<R>.parser(in: context).map({ Output.chunk17(.toolbarTitleMenu($0)) }).eraseToAnyParser(),
+_toolbarVisibilityModifier<R>.name: _toolbarVisibilityModifier<R>.parser(in: context).map({ Output.chunk17(.toolbarVisibility($0)) }).eraseToAnyParser(),
+_touchBarCustomizationLabelModifier<R>.name: _touchBarCustomizationLabelModifier<R>.parser(in: context).map({ Output.chunk17(.touchBarCustomizationLabel($0)) }).eraseToAnyParser(),
+_touchBarItemPrincipalModifier<R>.name: _touchBarItemPrincipalModifier<R>.parser(in: context).map({ Output.chunk17(.touchBarItemPrincipal($0)) }).eraseToAnyParser(),
+_transform3DEffectModifier<R>.name: _transform3DEffectModifier<R>.parser(in: context).map({ Output.chunk17(.transform3DEffect($0)) }).eraseToAnyParser(),
+_transformEffectModifier<R>.name: _transformEffectModifier<R>.parser(in: context).map({ Output.chunk17(.transformEffect($0)) }).eraseToAnyParser(),
+_transitionModifier<R>.name: _transitionModifier<R>.parser(in: context).map({ Output.chunk17(.transition($0)) }).eraseToAnyParser(),
+_truncationModeModifier<R>.name: _truncationModeModifier<R>.parser(in: context).map({ Output.chunk17(.truncationMode($0)) }).eraseToAnyParser(),
+_unredactedModifier<R>.name: _unredactedModifier<R>.parser(in: context).map({ Output.chunk17(.unredacted($0)) }).eraseToAnyParser(),
+_upperLimbVisibilityModifier<R>.name: _upperLimbVisibilityModifier<R>.parser(in: context).map({ Output.chunk17(.upperLimbVisibility($0)) }).eraseToAnyParser(),
+_volumeBaseplateVisibilityModifier<R>.name: _volumeBaseplateVisibilityModifier<R>.parser(in: context).map({ Output.chunk17(.volumeBaseplateVisibility($0)) }).eraseToAnyParser(),
+_windowDismissBehaviorModifier<R>.name: _windowDismissBehaviorModifier<R>.parser(in: context).map({ Output.chunk18(.windowDismissBehavior($0)) }).eraseToAnyParser(),
+_windowFullScreenBehaviorModifier<R>.name: _windowFullScreenBehaviorModifier<R>.parser(in: context).map({ Output.chunk18(.windowFullScreenBehavior($0)) }).eraseToAnyParser(),
+_windowMinimizeBehaviorModifier<R>.name: _windowMinimizeBehaviorModifier<R>.parser(in: context).map({ Output.chunk18(.windowMinimizeBehavior($0)) }).eraseToAnyParser(),
+_windowResizeBehaviorModifier<R>.name: _windowResizeBehaviorModifier<R>.parser(in: context).map({ Output.chunk18(.windowResizeBehavior($0)) }).eraseToAnyParser(),
+_windowToolbarFullScreenVisibilityModifier<R>.name: _windowToolbarFullScreenVisibilityModifier<R>.parser(in: context).map({ Output.chunk18(.windowToolbarFullScreenVisibility($0)) }).eraseToAnyParser(),
+_writingToolsBehaviorModifier<R>.name: _writingToolsBehaviorModifier<R>.parser(in: context).map({ Output.chunk18(.writingToolsBehavior($0)) }).eraseToAnyParser(),
+_zIndexModifier<R>.name: _zIndexModifier<R>.parser(in: context).map({ Output.chunk18(.zIndex($0)) }).eraseToAnyParser(),
+                    LiveViewNative._Rotation3DEffectModifier<R>.name: LiveViewNative._Rotation3DEffectModifier<R>.parser(in: context).map(Output._Rotation3DEffectModifier).eraseToAnyParser(),
 LiveViewNative._SearchScopesModifier<R>.name: LiveViewNative._SearchScopesModifier<R>.parser(in: context).map(Output._SearchScopesModifier).eraseToAnyParser(),
+LiveViewNative._MatchedTransitionSourceModifier<R>.name: LiveViewNative._MatchedTransitionSourceModifier<R>.parser(in: context).map(Output._MatchedTransitionSourceModifier).eraseToAnyParser(),
+LiveViewNative._PerspectiveRotationEffectModifier<R>.name: LiveViewNative._PerspectiveRotationEffectModifier<R>.parser(in: context).map(Output._PerspectiveRotationEffectModifier).eraseToAnyParser(),
+LiveViewNative._NavigationTransitionModifier<R>.name: LiveViewNative._NavigationTransitionModifier<R>.parser(in: context).map(Output._NavigationTransitionModifier).eraseToAnyParser(),
+LiveViewNative._SearchCompletionModifier<R>.name: LiveViewNative._SearchCompletionModifier<R>.parser(in: context).map(Output._SearchCompletionModifier).eraseToAnyParser(),
+LiveViewNative._PrefersDefaultFocusModifier<R>.name: LiveViewNative._PrefersDefaultFocusModifier<R>.parser(in: context).map(Output._PrefersDefaultFocusModifier).eraseToAnyParser(),
+LiveViewNative._MaskModifier<R>.name: LiveViewNative._MaskModifier<R>.parser(in: context).map(Output._MaskModifier).eraseToAnyParser(),
 LiveViewNative._MatchedGeometryEffectModifier<R>.name: LiveViewNative._MatchedGeometryEffectModifier<R>.parser(in: context).map(Output._MatchedGeometryEffectModifier).eraseToAnyParser(),
+LiveViewNative._OnSubmitModifier.name: LiveViewNative._OnSubmitModifier.parser(in: context).map(Output._OnSubmitModifier).eraseToAnyParser(),
+LiveViewNative._PresentationDetentsModifier.name: LiveViewNative._PresentationDetentsModifier.parser(in: context).map(Output._PresentationDetentsModifier).eraseToAnyParser(),
+LiveViewNative._FocusScopeModifier<R>.name: LiveViewNative._FocusScopeModifier<R>.parser(in: context).map(Output._FocusScopeModifier).eraseToAnyParser(),
                 ]
 
                 let deprecations = [
@@ -13828,7 +16188,10 @@ LiveViewNative._MatchedGeometryEffectModifier<R>.name: LiveViewNative._MatchedGe
 "onTapGesture": "use overload that accepts a CoordinateSpaceProtocol instead",
 "overlay": "Use `overlay(alignment:content:)` instead.",
 "searchable": "Use the searchable modifier with the searchSuggestions modifier",
-"statusBar": "renamed to `statusBarHidden(_:)`"
+"statusBar": "renamed to `statusBarHidden(_:)`",
+"tabItem": "Use `Tab(title:image:value:content:)` and related initializers instead",
+"toolbar": "renamed to `toolbarVisibility(_:for:)`",
+"toolbarBackground": "renamed to `toolbarBackgroundVisibility(_:for:)`"
                 ]
                 
                 var copy = input
@@ -13979,6 +16342,48 @@ ConstantAtomLiteral("content").map({ () -> Self in
     }
 }
 
+#if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+/// See [`SwiftUI.AdaptableTabBarPlacement`](https://developer.apple.com/documentation/swiftui/AdaptableTabBarPlacement) for more details.
+///
+/// Possible values:
+/// * `.automatic`
+/// * `.tabBar`
+/// * `.sidebar`
+@_documentation(visibility: public)
+@available(watchOS 11.0,tvOS 18.0,visionOS 2.0,macOS 15.0,iOS 18.0, *)
+extension AdaptableTabBarPlacement: ParseableModifierValue {
+    public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
+        ImplicitStaticMember {
+            OneOf {
+            #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+ConstantAtomLiteral("automatic").map({ () -> Self in
+
+    return Self.automatic
+
+})
+#endif
+#if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+ConstantAtomLiteral("tabBar").map({ () -> Self in
+
+    return Self.tabBar
+
+})
+#endif
+#if os(iOS) || os(visionOS)
+ConstantAtomLiteral("sidebar").map({ () -> Self in
+
+    return Self.sidebar
+
+})
+#endif
+                AtomLiteral().fail(outputType: AdaptableTabBarPlacement.self) {
+                    ModifierParseError(error: .unknownArgument($0), metadata: context.metadata)
+                }
+            }
+        }
+    }
+}
+#endif
 #if os(macOS)
 /// See [`SwiftUI.AlternatingRowBackgroundBehavior`](https://developer.apple.com/documentation/swiftui/AlternatingRowBackgroundBehavior) for more details.
 ///
@@ -14063,7 +16468,7 @@ ConstantAtomLiteral("vertical").map({ () -> Self in
 /// * `.standard`
 /// * `.increased`
 @_documentation(visibility: public)
-@available(macOS 14.0,visionOS 1.0,iOS 17.0, *)
+@available(visionOS 1.0,macOS 14.0,iOS 17.0, *)
 extension BadgeProminence: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -14291,7 +16696,7 @@ ConstantAtomLiteral("plusLighter").map({ () -> Self in
 /// * `.enabled`
 /// * `.disabled`
 @_documentation(visibility: public)
-@available(macOS 14.0,iOS 17.0,visionOS 1.0,tvOS 17.0,watchOS 10.0, *)
+@available(tvOS 17.0,watchOS 10.0,macOS 14.0,iOS 17.0,visionOS 1.0, *)
 extension ButtonRepeatBehavior: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -14407,6 +16812,8 @@ ConstantAtomLiteral("dark").map({ () -> Self in
 /// Possible values:
 /// * `.tabView`
 /// * `.navigation`
+/// * `.navigationSplitView`
+/// * `.window`
 @_documentation(visibility: public)
 @available(watchOS 10.0,tvOS 17.0,visionOS 1.0,macOS 14.0,iOS 17.0, *)
 extension ContainerBackgroundPlacement: ParseableModifierValue {
@@ -14420,11 +16827,25 @@ if #available(watchOS 10.0,tvOS 17.0,macOS 14.0,iOS 17.0, *) {
 } else { fatalError("'tabView' is not available in this OS version") }
 })
 #endif
-#if os(watchOS)
+#if os(iOS) || os(watchOS)
 ConstantAtomLiteral("navigation").map({ () -> Self in
-if #available(watchOS 10.0,tvOS 17.0,macOS 14.0,iOS 17.0, *) {
+if #available(watchOS 10.0,tvOS 17.0,macOS 14.0,iOS 18.0, *) {
     return Self.navigation
 } else { fatalError("'navigation' is not available in this OS version") }
+})
+#endif
+#if os(iOS) || os(watchOS)
+ConstantAtomLiteral("navigationSplitView").map({ () -> Self in
+if #available(watchOS 11.0,tvOS 17.0,macOS 14.0,iOS 18.0, *) {
+    return Self.navigationSplitView
+} else { fatalError("'navigationSplitView' is not available in this OS version") }
+})
+#endif
+#if os(macOS)
+ConstantAtomLiteral("window").map({ () -> Self in
+if #available(watchOS 10.0,tvOS 17.0,macOS 15.0,iOS 17.0, *) {
+    return Self.window
+} else { fatalError("'window' is not available in this OS version") }
 })
 #endif
                 AtomLiteral().fail(outputType: ContainerBackgroundPlacement.self) {
@@ -14443,7 +16864,7 @@ if #available(watchOS 10.0,tvOS 17.0,macOS 14.0,iOS 17.0, *) {
 /// * `.scrollContent`
 /// * `.scrollIndicators`
 @_documentation(visibility: public)
-@available(iOS 17.0,macOS 14.0,tvOS 17.0,visionOS 1.0,watchOS 10.0, *)
+@available(watchOS 10.0,tvOS 17.0,visionOS 1.0,macOS 14.0,iOS 17.0, *)
 extension ContentMarginPlacement: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -14502,35 +16923,35 @@ ConstantAtomLiteral("interaction").map({ () -> Self in
 
 #if os(iOS) || os(macOS) || os(visionOS)
 ConstantAtomLiteral("dragPreview").map({ () -> Self in
-if #available(iOS 15.0,visionOS 1.0,tvOS 15.0,watchOS 8.0,macOS 12.0, *) {
+if #available(tvOS 15.0,watchOS 8.0,macOS 12.0,iOS 15.0,visionOS 1.0, *) {
     return Self.dragPreview
 } else { fatalError("'dragPreview' is not available in this OS version") }
 })
 #endif
 #if os(iOS) || os(tvOS) || os(visionOS)
 ConstantAtomLiteral("contextMenuPreview").map({ () -> Self in
-if #available(iOS 15.0,visionOS 1.0,tvOS 17.0,watchOS 8.0,macOS 12.0, *) {
+if #available(tvOS 17.0,watchOS 8.0,macOS 12.0,iOS 15.0,visionOS 1.0, *) {
     return Self.contextMenuPreview
 } else { fatalError("'contextMenuPreview' is not available in this OS version") }
 })
 #endif
-#if os(iOS) || os(visionOS)
+#if os(iOS) || os(tvOS) || os(visionOS)
 ConstantAtomLiteral("hoverEffect").map({ () -> Self in
-if #available(iOS 15.0,visionOS 1.0,tvOS 15.0,watchOS 8.0,macOS 12.0, *) {
+if #available(tvOS 18.0,watchOS 8.0,macOS 12.0,iOS 15.0,visionOS 1.0, *) {
     return Self.hoverEffect
 } else { fatalError("'hoverEffect' is not available in this OS version") }
 })
 #endif
 #if os(macOS) || os(watchOS)
 ConstantAtomLiteral("focusEffect").map({ () -> Self in
-if #available(iOS 15.0,tvOS 15.0,watchOS 8.0,macOS 12.0, *) {
+if #available(tvOS 15.0,watchOS 8.0,macOS 12.0,iOS 15.0, *) {
     return Self.focusEffect
 } else { fatalError("'focusEffect' is not available in this OS version") }
 })
 #endif
 #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
 ConstantAtomLiteral("accessibility").map({ () -> Self in
-if #available(tvOS 17.0,iOS 17.0,watchOS 10.0,visionOS 1.0,macOS 14.0, *) {
+if #available(visionOS 1.0,iOS 17.0,macOS 14.0,watchOS 10.0,tvOS 17.0, *) {
     return Self.accessibility
 } else { fatalError("'accessibility' is not available in this OS version") }
 })
@@ -14553,7 +16974,7 @@ if #available(tvOS 17.0,iOS 17.0,watchOS 10.0,visionOS 1.0,macOS 14.0, *) {
 /// * `.large`
 /// * `.extraLarge`
 @_documentation(visibility: public)
-@available(watchOS 9.0,iOS 15.0,visionOS 1.0,macOS 10.15, *)
+@available(visionOS 1.0,watchOS 9.0,macOS 10.15,iOS 15.0, *)
 extension ControlSize: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -14581,14 +17002,14 @@ ConstantAtomLiteral("regular").map({ () -> Self in
 #endif
 #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
 ConstantAtomLiteral("large").map({ () -> Self in
-if #available(watchOS 9.0,iOS 15.0,visionOS 1.0,macOS 11.0, *) {
+if #available(visionOS 1.0,watchOS 9.0,macOS 11.0,iOS 15.0, *) {
     return Self.large
 } else { fatalError("'large' is not available in this OS version") }
 })
 #endif
 #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
 ConstantAtomLiteral("extraLarge").map({ () -> Self in
-if #available(watchOS 10.0,iOS 17.0,visionOS 1.0,macOS 14.0, *) {
+if #available(visionOS 1.0,watchOS 10.0,macOS 14.0,iOS 17.0, *) {
     return Self.extraLarge
 } else { fatalError("'extraLarge' is not available in this OS version") }
 })
@@ -14643,7 +17064,7 @@ ConstantAtomLiteral("userInitiated").map({ () -> Self in
 /// * `.critical`
 /// * `.standard`
 @_documentation(visibility: public)
-@available(tvOS 17.0,iOS 17.0,watchOS 10.0,visionOS 1.0,macOS 13.0, *)
+@available(tvOS 17.0,watchOS 10.0,macOS 13.0,iOS 17.0,visionOS 1.0, *)
 extension DialogSeverity: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -14664,7 +17085,7 @@ ConstantAtomLiteral("critical").map({ () -> Self in
 #endif
 #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
 ConstantAtomLiteral("standard").map({ () -> Self in
-if #available(tvOS 17.0,iOS 17.0,watchOS 10.0,visionOS 1.0,macOS 14.0, *) {
+if #available(tvOS 17.0,watchOS 10.0,macOS 14.0,iOS 17.0,visionOS 1.0, *) {
     return Self.standard
 } else { fatalError("'standard' is not available in this OS version") }
 })
@@ -14835,7 +17256,7 @@ ConstantAtomLiteral("all").map({ () -> Self in
 /// * `.includeHiddenFiles`
 /// * `.displayFileExtensions`
 @_documentation(visibility: public)
-@available(iOS 17.0,visionOS 1.0,macOS 14.0, *)
+@available(iOS 17.0,macOS 14.0,visionOS 1.0, *)
 extension FileDialogBrowserOptions: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -14877,7 +17298,7 @@ ConstantAtomLiteral("displayFileExtensions").map({ () -> Self in
 /// * `.edit`
 /// * `.automatic`
 @_documentation(visibility: public)
-@available(macOS 14.0,iOS 17.0,visionOS 1.0,tvOS 17.0,watchOS 10.0, *)
+@available(watchOS 10.0,tvOS 17.0,visionOS 1.0,macOS 14.0,iOS 17.0, *)
 extension FocusInteractions: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -15003,22 +17424,36 @@ ConstantAtomLiteral("never").map({ () -> Self in
     }
 }
 #endif
-
+#if os(iOS) || os(macOS) || os(visionOS)
 /// See [`SwiftUI.HorizontalAlignment`](https://developer.apple.com/documentation/swiftui/HorizontalAlignment) for more details.
 ///
 /// Possible values:
+/// * `.listRowSeparatorLeading`
+/// * `.listRowSeparatorTrailing`
 /// * `.leading`
 /// * `.center`
 /// * `.trailing`
-/// * `.listRowSeparatorLeading`
-/// * `.listRowSeparatorTrailing`
 @_documentation(visibility: public)
-
+@available(visionOS 1.0,macOS 13.0,iOS 16.0, *)
 extension HorizontalAlignment: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
-            
+            #if os(iOS) || os(macOS) || os(visionOS)
+ConstantAtomLiteral("listRowSeparatorLeading").map({ () -> Self in
+
+    return Self.listRowSeparatorLeading
+
+})
+#endif
+#if os(iOS) || os(macOS) || os(visionOS)
+ConstantAtomLiteral("listRowSeparatorTrailing").map({ () -> Self in
+
+    return Self.listRowSeparatorTrailing
+
+})
+#endif
+
 ConstantAtomLiteral("leading").map({ () -> Self in
 
     return Self.leading
@@ -15039,20 +17474,6 @@ ConstantAtomLiteral("trailing").map({ () -> Self in
 
 })
 
-#if os(iOS) || os(macOS) || os(visionOS)
-ConstantAtomLiteral("listRowSeparatorLeading").map({ () -> Self in
-if #available(iOS 16.0,visionOS 1.0,macOS 13.0, *) {
-    return Self.listRowSeparatorLeading
-} else { fatalError("'listRowSeparatorLeading' is not available in this OS version") }
-})
-#endif
-#if os(iOS) || os(macOS) || os(visionOS)
-ConstantAtomLiteral("listRowSeparatorTrailing").map({ () -> Self in
-if #available(iOS 16.0,visionOS 1.0,macOS 13.0, *) {
-    return Self.listRowSeparatorTrailing
-} else { fatalError("'listRowSeparatorTrailing' is not available in this OS version") }
-})
-#endif
                 AtomLiteral().fail(outputType: HorizontalAlignment.self) {
                     ModifierParseError(error: .unknownArgument($0), metadata: context.metadata)
                 }
@@ -15060,7 +17481,7 @@ if #available(iOS 16.0,visionOS 1.0,macOS 13.0, *) {
         }
     }
 }
-
+#endif
 
 /// See [`SwiftUI.HorizontalEdge`](https://developer.apple.com/documentation/swiftui/HorizontalEdge) for more details.
 ///
@@ -15103,7 +17524,7 @@ ConstantAtomLiteral("trailing").map({ () -> Self in
 /// * `.highlight`
 /// * `.lift`
 @_documentation(visibility: public)
-@available(iOS 13.4,visionOS 1.0,tvOS 16.0, *)
+@available(visionOS 1.0,tvOS 16.0,iOS 13.4, *)
 extension HoverEffect: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -15117,7 +17538,7 @@ ConstantAtomLiteral("automatic").map({ () -> Self in
 #endif
 #if os(iOS) || os(tvOS) || os(visionOS)
 ConstantAtomLiteral("highlight").map({ () -> Self in
-if #available(iOS 13.4,visionOS 1.0,tvOS 17.0, *) {
+if #available(visionOS 1.0,tvOS 17.0,iOS 13.4, *) {
     return Self.highlight
 } else { fatalError("'highlight' is not available in this OS version") }
 })
@@ -15235,7 +17656,7 @@ ConstantAtomLiteral("automatic").map({ () -> Self in
 
 #if os(iOS) || os(visionOS)
 ConstantAtomLiteral("priority").map({ () -> Self in
-if #available(watchOS 9.0,visionOS 1.0,iOS 16.0,macOS 13.0,tvOS 16.0, *) {
+if #available(tvOS 16.0,watchOS 9.0,macOS 13.0,iOS 16.0,visionOS 1.0, *) {
     return Self.priority
 } else { fatalError("'priority' is not available in this OS version") }
 })
@@ -15265,7 +17686,7 @@ ConstantAtomLiteral("fixed").map({ () -> Self in
 /// * `.sheet`
 /// * `.fullScreenCover`
 @_documentation(visibility: public)
-@available(iOS 16.4,watchOS 9.4,visionOS 1.0,tvOS 16.4,macOS 13.3, *)
+@available(visionOS 1.0,macOS 13.3,watchOS 9.4,iOS 16.4,tvOS 16.4, *)
 extension PresentationAdaptation: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -15321,7 +17742,7 @@ ConstantAtomLiteral("fullScreenCover").map({ () -> Self in
 /// * `.resizes`
 /// * `.scrolls`
 @_documentation(visibility: public)
-@available(watchOS 9.4,iOS 16.4,tvOS 16.4,visionOS 1.0,macOS 13.3, *)
+@available(macOS 13.3,watchOS 9.4,visionOS 1.0,tvOS 16.4,iOS 16.4, *)
 extension PresentationContentInteraction: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -15418,7 +17839,7 @@ ConstantAtomLiteral("privacy").map({ () -> Self in
 
 #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
 ConstantAtomLiteral("invalidated").map({ () -> Self in
-if #available(iOS 17.0,tvOS 17.0,watchOS 10.0,visionOS 1.0,macOS 14.0, *) {
+if #available(visionOS 1.0,iOS 17.0,macOS 14.0,watchOS 10.0,tvOS 17.0, *) {
     return Self.invalidated
 } else { fatalError("'invalidated' is not available in this OS version") }
 })
@@ -15528,7 +17949,7 @@ ConstantAtomLiteral("minimum").map({ () -> Self in
 
 #if os(watchOS)
 ConstantAtomLiteral("navigationBar").map({ () -> Self in
-if #available(iOS 16.0,macOS 13.0,tvOS 16.0,watchOS 9.0, *) {
+if #available(watchOS 9.0,macOS 13.0,tvOS 16.0,iOS 16.0, *) {
     return Self.navigationBar
 } else { fatalError("'navigationBar' is not available in this OS version") }
 })
@@ -15541,6 +17962,48 @@ if #available(iOS 16.0,macOS 13.0,tvOS 16.0,watchOS 9.0, *) {
     }
 }
 
+#if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+/// See [`SwiftUI.ScrollAnchorRole`](https://developer.apple.com/documentation/swiftui/ScrollAnchorRole) for more details.
+///
+/// Possible values:
+/// * `.initialOffset`
+/// * `.sizeChanges`
+/// * `.alignment`
+@_documentation(visibility: public)
+@available(watchOS 11.0,tvOS 18.0,visionOS 2.0,macOS 15.0,iOS 18.0, *)
+extension ScrollAnchorRole: ParseableModifierValue {
+    public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
+        ImplicitStaticMember {
+            OneOf {
+            #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+ConstantAtomLiteral("initialOffset").map({ () -> Self in
+
+    return Self.initialOffset
+
+})
+#endif
+#if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+ConstantAtomLiteral("sizeChanges").map({ () -> Self in
+
+    return Self.sizeChanges
+
+})
+#endif
+#if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+ConstantAtomLiteral("alignment").map({ () -> Self in
+
+    return Self.alignment
+
+})
+#endif
+                AtomLiteral().fail(outputType: ScrollAnchorRole.self) {
+                    ModifierParseError(error: .unknownArgument($0), metadata: context.metadata)
+                }
+            }
+        }
+    }
+}
+#endif
 #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
 /// See [`SwiftUI.ScrollBounceBehavior`](https://developer.apple.com/documentation/swiftui/ScrollBounceBehavior) for more details.
 ///
@@ -15691,7 +18154,7 @@ ConstantAtomLiteral("never").map({ () -> Self in
 /// * `.onTextEntry`
 /// * `.onSearchPresentation`
 @_documentation(visibility: public)
-@available(iOS 16.4,tvOS 16.4,watchOS 9.4,visionOS 1.0,macOS 13.3, *)
+@available(tvOS 16.4,watchOS 9.4,macOS 13.3,iOS 16.4,visionOS 1.0, *)
 extension SearchScopeActivation: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -15775,7 +18238,7 @@ ConstantAtomLiteral("content").map({ () -> Self in
 /// * `.enabled`
 /// * `.disabled`
 @_documentation(visibility: public)
-@available(watchOS 10.0,visionOS 1.0,iOS 17.0,macOS 14.0,tvOS 17.0, *)
+@available(watchOS 10.0,tvOS 17.0,visionOS 1.0,macOS 14.0,iOS 17.0, *)
 extension SpringLoadingBehavior: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -15934,12 +18397,55 @@ ConstantAtomLiteral("search").map({ () -> Self in
 }
 
 #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+/// See [`SwiftUI.TextSelectionAffinity`](https://developer.apple.com/documentation/swiftui/TextSelectionAffinity) for more details.
+///
+/// Possible values:
+/// * `.automatic`
+/// * `.upstream`
+/// * `.downstream`
+@_documentation(visibility: public)
+@available(visionOS 2.0,macOS 15.0,watchOS 11.0,iOS 18.0,tvOS 18.0, *)
+extension TextSelectionAffinity: ParseableModifierValue {
+    public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
+        ImplicitStaticMember {
+            OneOf {
+            #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+ConstantAtomLiteral("automatic").map({ () -> Self in
+
+    return Self.automatic
+
+})
+#endif
+#if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+ConstantAtomLiteral("upstream").map({ () -> Self in
+
+    return Self.upstream
+
+})
+#endif
+#if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+ConstantAtomLiteral("downstream").map({ () -> Self in
+
+    return Self.downstream
+
+})
+#endif
+                AtomLiteral().fail(outputType: TextSelectionAffinity.self) {
+                    ModifierParseError(error: .unknownArgument($0), metadata: context.metadata)
+                }
+            }
+        }
+    }
+}
+#endif
+#if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
 /// See [`SwiftUI.ToolbarDefaultItemKind`](https://developer.apple.com/documentation/swiftui/ToolbarDefaultItemKind) for more details.
 ///
 /// Possible values:
 /// * `.sidebarToggle`
+/// * `.title`
 @_documentation(visibility: public)
-@available(tvOS 17.0,iOS 17.0,watchOS 10.0,visionOS 1.0,macOS 14.0, *)
+@available(tvOS 17.0,watchOS 10.0,macOS 14.0,iOS 17.0,visionOS 1.0, *)
 extension ToolbarDefaultItemKind: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -15949,6 +18455,13 @@ ConstantAtomLiteral("sidebarToggle").map({ () -> Self in
 
     return Self.sidebarToggle
 
+})
+#endif
+#if os(iOS) || os(macOS) || os(visionOS)
+ConstantAtomLiteral("title").map({ () -> Self in
+if #available(tvOS 17.0,watchOS 10.0,macOS 15.0,iOS 18.0,visionOS 2.0, *) {
+    return Self.title
+} else { fatalError("'title' is not available in this OS version") }
 })
 #endif
                 AtomLiteral().fail(outputType: ToolbarDefaultItemKind.self) {
@@ -15982,21 +18495,21 @@ ConstantAtomLiteral("automatic").map({ () -> Self in
 
 #if os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
 ConstantAtomLiteral("navigationStack").map({ () -> Self in
-if #available(macOS 13.0,iOS 16.0,visionOS 1.0,tvOS 16.0,watchOS 9.0, *) {
+if #available(watchOS 9.0,tvOS 16.0,visionOS 1.0,macOS 13.0,iOS 16.0, *) {
     return Self.navigationStack
 } else { fatalError("'navigationStack' is not available in this OS version") }
 })
 #endif
 #if os(iOS) || os(visionOS)
 ConstantAtomLiteral("browser").map({ () -> Self in
-if #available(macOS 13.0,iOS 16.0,visionOS 1.0,tvOS 16.0,watchOS 9.0, *) {
+if #available(watchOS 9.0,tvOS 16.0,visionOS 1.0,macOS 13.0,iOS 16.0, *) {
     return Self.browser
 } else { fatalError("'browser' is not available in this OS version") }
 })
 #endif
 #if os(iOS) || os(macOS) || os(visionOS)
 ConstantAtomLiteral("editor").map({ () -> Self in
-if #available(macOS 13.0,iOS 16.0,visionOS 1.0,tvOS 16.0,watchOS 9.0, *) {
+if #available(watchOS 9.0,tvOS 16.0,visionOS 1.0,macOS 13.0,iOS 16.0, *) {
     return Self.editor
 } else { fatalError("'editor' is not available in this OS version") }
 })
@@ -16018,7 +18531,7 @@ if #available(macOS 13.0,iOS 16.0,visionOS 1.0,tvOS 16.0,watchOS 9.0, *) {
 /// * `.inlineLarge`
 /// * `.inline`
 @_documentation(visibility: public)
-@available(iOS 17.0,watchOS 10.0,visionOS 1.0,tvOS 17.0,macOS 14.0, *)
+@available(visionOS 1.0,macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0, *)
 extension ToolbarTitleDisplayMode: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {

--- a/Sources/LiveViewNativeMacros/LiveElementMacro.swift
+++ b/Sources/LiveViewNativeMacros/LiveElementMacro.swift
@@ -592,8 +592,6 @@ extension AttributeListSyntax.Element {
       if let availability = ifConfig.availability {
         return .ifConfigDecl(availability)
       }
-    default:
-      break
     }
     return nil
   }

--- a/Sources/LiveViewNativeStylesheetMacros/ParseableExpressionMacro.swift
+++ b/Sources/LiveViewNativeStylesheetMacros/ParseableExpressionMacro.swift
@@ -192,10 +192,10 @@ public enum ParseableExpressionMacro: ExtensionMacro {
             try WhileStmtSyntax("while !input.isEmpty {") {
                 // switch over the argument name to parse the correct type
                 "try Whitespace().parse(&input)"
-                "let name = try Identifier().parse(&input)"
+                "let __name = try Identifier().parse(&input)"
                 #"try ":".utf8.parse(&input)"#
                 "try Whitespace().parse(&input)"
-                SwitchExprSyntax(subject: ExprSyntax("name")) {
+                SwitchExprSyntax(subject: ExprSyntax("__name")) {
                     for argument in labelledArguments {
                         // if parsing fails, add to `failures` and continue.
                         SwitchCaseSyntax("case \(StringLiteralExprSyntax(content: argument.firstName.text)):") {
@@ -216,7 +216,7 @@ public enum ParseableExpressionMacro: ExtensionMacro {
                     SwitchCaseSyntax("default:") {
                         """
                         _ = try _AnyNodeParser.AnyArgument(context: context).parse(&input)
-                        failures.append(.unknownArgument(name))
+                        failures.append(.unknownArgument(__name))
                         """
                     }
                 }

--- a/Sources/ModifierGenerator/FunctionParameterSyntax+isViewBuilder.swift
+++ b/Sources/ModifierGenerator/FunctionParameterSyntax+isViewBuilder.swift
@@ -4,7 +4,7 @@ extension FunctionParameterSyntax {
     var isViewBuilder: Bool {
         attributes.contains(where: {
             guard let attributeType = $0.as(AttributeSyntax.self)?.attributeName.as(MemberTypeSyntax.self),
-                  attributeType.baseType.as(IdentifierTypeSyntax.self)?.name.tokenKind == .identifier("SwiftUI"),
+                  [.identifier("SwiftUI"), .identifier("SwiftUICore")].contains(attributeType.baseType.as(IdentifierTypeSyntax.self)?.name.tokenKind),
                   attributeType.name.tokenKind == .identifier("ViewBuilder")
             else { return false }
             return true
@@ -14,7 +14,7 @@ extension FunctionParameterSyntax {
     var isToolbarContentBuilder: Bool {
         attributes.contains(where: {
             guard let attributeType = $0.as(AttributeSyntax.self)?.attributeName.as(MemberTypeSyntax.self),
-                  attributeType.baseType.as(IdentifierTypeSyntax.self)?.name.tokenKind == .identifier("SwiftUI"),
+                  [.identifier("SwiftUI"), .identifier("SwiftUICore")].contains(attributeType.baseType.as(IdentifierTypeSyntax.self)?.name.tokenKind),
                   attributeType.name.tokenKind == .identifier("ToolbarContentBuilder")
             else { return false }
             return true
@@ -47,5 +47,14 @@ extension FunctionParameterSyntax {
         } else {
             return false
         }
+    }
+    
+    var isCustomHoverEffect: Bool {
+        self.type.as(SomeOrAnyTypeSyntax.self)?.constraint.as(IdentifierTypeSyntax.self)?.name.text == "CustomHoverEffect"
+    }
+    
+    var isScrollPositionBinding: Bool {
+        self.type.as(MemberTypeSyntax.self)?.name.text == "Binding"
+            && self.type.as(MemberTypeSyntax.self)?.genericArgumentClause?.arguments.first?.argument.as(MemberTypeSyntax.self)?.name.text == "ScrollPosition"
     }
 }

--- a/Sources/ModifierGenerator/FunctionParameterSyntax+isViewBuilder.swift
+++ b/Sources/ModifierGenerator/FunctionParameterSyntax+isViewBuilder.swift
@@ -57,4 +57,8 @@ extension FunctionParameterSyntax {
         self.type.as(MemberTypeSyntax.self)?.name.text == "Binding"
             && self.type.as(MemberTypeSyntax.self)?.genericArgumentClause?.arguments.first?.argument.as(MemberTypeSyntax.self)?.name.text == "ScrollPosition"
     }
+    
+    var isUIGestureRecognizerRepresentable: Bool {
+        self.type.as(SomeOrAnyTypeSyntax.self)?.constraint.as(IdentifierTypeSyntax.self)?.name.text == "UIGestureRecognizerRepresentable"
+    }
 }

--- a/Sources/ModifierGenerator/ModifierGenerator.swift
+++ b/Sources/ModifierGenerator/ModifierGenerator.swift
@@ -86,6 +86,11 @@ struct ModifierGenerator: ParsableCommand {
         "TextSelectionAffinity",
         "AdaptableTabBarPlacement",
         "ScrollAnchorRole",
+        "WindowInteractionBehavior",
+        "HorizontalDirection",
+        "VerticalDirection",
+        "FrameResizePosition",
+        "FrameResizeDirection",
     ]
 
     static let denylist: Set<String> = [

--- a/Sources/ModifierGenerator/ModifierGenerator.swift
+++ b/Sources/ModifierGenerator/ModifierGenerator.swift
@@ -27,6 +27,8 @@ struct ModifierGenerator: ParsableCommand {
         "_PresentationDetentsModifier",
         "_FocusScopeModifier<R>",
         "_PrefersDefaultFocusModifier<R>",
+        "_MatchedTransitionSourceModifier<R>",
+        "_NavigationTransitionModifier<R>",
     ]
 
     static let requiredTypes: Set<String> = [
@@ -81,6 +83,9 @@ struct ModifierGenerator: ParsableCommand {
         "RoundedCornerStyle",
         "GlassBackgroundDisplayMode",
         "Edge3D",
+        "TextSelectionAffinity",
+        "AdaptableTabBarPlacement",
+        "ScrollAnchorRole",
     ]
 
     static let denylist: Set<String> = [
@@ -118,6 +123,12 @@ struct ModifierGenerator: ParsableCommand {
         "task",
         
         "fileDialogURLEnabled",
+        
+        "containerValue",
+        
+        "textRenderer",
+        
+        "tabViewCustomization",
 
         // manually implemented due to argument order edge cases
         "searchScopes",
@@ -130,6 +141,8 @@ struct ModifierGenerator: ParsableCommand {
         "presentationDetents",
         "focusScope",
         "prefersDefaultFocus",
+        "navigationTransition",
+        "matchedTransitionSource",
         
         // manually implemented for `Text`
         "font",
@@ -212,6 +225,8 @@ struct ModifierGenerator: ParsableCommand {
         "accessibilityElement",
         "presentedWindowStyle",
         "presentedWindowToolbarStyle",
+        "onScrollTargetVisibilityChange",
+        "matchedTransitionSource",
     ]
 
     static func isValid(_ signature: FunctionDeclSyntax) -> Bool {
@@ -233,6 +248,14 @@ struct ModifierGenerator: ParsableCommand {
 
             // FocusState cannot be used
             if parameter.isFocusState {
+                return false
+            }
+            
+            if parameter.isCustomHoverEffect {
+                return false
+            }
+            
+            if parameter.isScrollPositionBinding {
                 return false
             }
         }

--- a/Sources/ModifierGenerator/ModifierGenerator.swift
+++ b/Sources/ModifierGenerator/ModifierGenerator.swift
@@ -91,6 +91,9 @@ struct ModifierGenerator: ParsableCommand {
         "VerticalDirection",
         "FrameResizePosition",
         "FrameResizeDirection",
+        "WritingToolsBehavior",
+        "ScrollInputBehavior",
+        "WindowToolbarFullScreenVisibility"
     ]
 
     static let denylist: Set<String> = [
@@ -232,6 +235,7 @@ struct ModifierGenerator: ParsableCommand {
         "presentedWindowToolbarStyle",
         "onScrollTargetVisibilityChange",
         "matchedTransitionSource",
+        "scrollInputBehavior",
     ]
 
     static func isValid(_ signature: FunctionDeclSyntax) -> Bool {
@@ -261,6 +265,10 @@ struct ModifierGenerator: ParsableCommand {
             }
             
             if parameter.isScrollPositionBinding {
+                return false
+            }
+            
+            if parameter.isUIGestureRecognizerRepresentable {
                 return false
             }
         }

--- a/Sources/ModifierGenerator/Subcommands/Source.swift
+++ b/Sources/ModifierGenerator/Subcommands/Source.swift
@@ -12,7 +12,7 @@ extension ModifierGenerator {
             help: "The `.swiftinterface` file from `/Applications/Xcode.app/Contents/Developer/Platforms/XROS.platform/Developer/SDKs/XROS.sdk/System/Library/Frameworks/SwiftUI.framework/Modules/SwiftUI.swiftmodule/arm64-apple-xros.swiftinterface`",
             transform: { URL(filePath: $0) }
         )
-        var interface: URL
+        var interface: [URL]
         
         @Option(
             help: "The number of modifiers included in each chunk. Chunks are used to reduce the size of switch statements in SwiftUI. Only applicable when using `--generate-source`"
@@ -20,12 +20,12 @@ extension ModifierGenerator {
         private var chunkSize: Int = 14
 
         func run() throws {
-            let source = try String(contentsOf: interface, encoding: .utf8)
+            let source = try interface.map { try String(contentsOf: $0, encoding: .utf8) }.joined(separator: "\n")
             let sourceFile = Parser.parse(source: source)
             
             FileHandle.standardOutput.write(Data(
                 #"""
-                // File generated with `swift run ModifierGenerator source "/Applications/Xcode.app/Contents/Developer/Platforms/XROS.platform/Developer/SDKs/XROS.sdk/System/Library/Frameworks/SwiftUI.framework/Modules/SwiftUI.swiftmodule/arm64-apple-xros.swiftinterface" > Sources/LiveViewNative/_GeneratedModifiers.swift`
+                // File generated with `swift run ModifierGenerator source "/Applications/Xcode.app/Contents/Developer/Platforms/XROS.platform/Developer/SDKs/XROS.sdk/System/Library/Frameworks/SwiftUI.framework/Modules/SwiftUI.swiftmodule/arm64e-apple-xros.swiftinterface" "/Applications/Xcode.app/Contents/Developer/Platforms/XROS.platform/Developer/SDKs/XROS.sdk/System/Library/Frameworks/SwiftUICore.framework/Modules/SwiftUICore.swiftmodule/arm64e-apple-xros.swiftinterface" > Sources/LiveViewNative/_GeneratedModifiers.swift`
                 
                 import SwiftUI
                 import Symbols

--- a/Sources/ModifierGenerator/VersionTupleSyntax+Comparable.swift
+++ b/Sources/ModifierGenerator/VersionTupleSyntax+Comparable.swift
@@ -1,6 +1,6 @@
 import SwiftSyntax
 
-extension VersionTupleSyntax: Comparable {
+extension VersionTupleSyntax: @retroactive Comparable {
     public static func < (lhs: Self, rhs: Self) -> Bool {
         guard let lhsMajor = Int(lhs.major.text),
               let rhsMajor = Int(rhs.major.text)

--- a/Sources/ModifierGenerator/Visitors/ModifierVisitor.swift
+++ b/Sources/ModifierGenerator/Visitors/ModifierVisitor.swift
@@ -68,9 +68,11 @@ final class ModifierVisitor: SyntaxVisitor {
     }
 
     override func visit(_ node: ExtensionDeclSyntax) -> SyntaxVisitorContinueKind {
-        guard node.extendedType.trimmedDescription == "SwiftUI.View" else { return .skipChildren }
+        guard node.extendedType.trimmedDescription == "SwiftUI.View"
+                || node.extendedType.trimmedDescription == "SwiftUICore.View"
+        else { return .skipChildren }
         guard let extendedType = node.extendedType.as(MemberTypeSyntax.self),
-              extendedType.baseType.as(IdentifierTypeSyntax.self)?.name.tokenKind == .identifier("SwiftUI"),
+              [.identifier("SwiftUI"), .identifier("SwiftUICore")].contains(extendedType.baseType.as(IdentifierTypeSyntax.self)?.name.tokenKind),
               extendedType.name.tokenKind == .identifier("View"),
               node.genericWhereClause == nil
         else { return .skipChildren }
@@ -95,7 +97,7 @@ final class ModifierVisitor: SyntaxVisitor {
             guard let decl = member.decl.as(FunctionDeclSyntax.self),
                   decl.modifiers.contains(where: { $0.name.tokenKind == .keyword(.public) }),
                   let returnType = decl.signature.returnClause?.type.as(SomeOrAnyTypeSyntax.self)?.constraint.as(MemberTypeSyntax.self),
-                  returnType.baseType.as(IdentifierTypeSyntax.self)?.name.tokenKind == .identifier("SwiftUI"),
+                  [.identifier("SwiftUI"), .identifier("SwiftUICore")].contains(returnType.baseType.as(IdentifierTypeSyntax.self)?.name.tokenKind),
                   returnType.name.tokenKind == .identifier("View")
             else { continue }
             let memberAvailabilityAttributes = decl.attributes.compactMap({ $0.as(AttributeSyntax.self)?.arguments?.as(AvailabilityArgumentListSyntax.self) })

--- a/Sources/ModifierGenerator/Visitors/TypeVisitor.swift
+++ b/Sources/ModifierGenerator/Visitors/TypeVisitor.swift
@@ -20,9 +20,8 @@ final class EnumTypeVisitor: SyntaxVisitor {
         guard typeNames.contains(name)
         else { return .skipChildren }
         
-        if !availability.keys.contains(name) {
-            availability[name] = ModifierVisitor.availability(node.attributes, node.attributes)
-        }
+        // the declaration will overwrite any extension availability attributes.
+        availability[name] = ModifierVisitor.availability(node.attributes, node.attributes)
         
         for member in node.memberBlock.members {
             guard let decl = member.decl.as(VariableDeclSyntax.self),
@@ -44,6 +43,7 @@ final class EnumTypeVisitor: SyntaxVisitor {
         guard typeNames.contains(name)
         else { return .skipChildren }
         
+        // only store the availability if the decl didn't set it already.
         if !availability.keys.contains(name) {
             availability[name] = ModifierVisitor.availability(node.attributes, node.attributes)
         }
@@ -66,9 +66,8 @@ final class EnumTypeVisitor: SyntaxVisitor {
         guard typeNames.contains(name)
         else { return .skipChildren }
 
-        if !availability.keys.contains(name) {
-            availability[name] = ModifierVisitor.availability(node.attributes, node.attributes)
-        }
+        // the declaration will overwrite any extension availability attributes.
+        availability[name] = ModifierVisitor.availability(node.attributes, node.attributes)
 
         for member in node.memberBlock.members {
             guard let `case` = member.decl.as(EnumCaseDeclSyntax.self),

--- a/Tests/RenderingTests/PickerTests.swift
+++ b/Tests/RenderingTests/PickerTests.swift
@@ -43,7 +43,7 @@ final class PickerTests: XCTestCase {
     func testPicker() throws {
         try assertMatch(
             #"""
-            <Picker value="paperplane">
+            <Picker selection="paperplane">
                 <Text template="label">Pick an icon</Text>
                 <Group template="content">
                     <Label systemImage="paperplane" tag="paperplane"><Text>paperplane</Text></Label>


### PR DESCRIPTION
This adds support in the `ModifierGenerator` for new modifiers in iOS 18 and aligned releases.

SwiftUI was split into `SwiftUICore` and `SwiftUI` frameworks. The modifier generator now accepts an array of `.swiftinterface` files to support this restructuring.

Here are some highlights:

1. `navigationTransition(_:)`

This modifier can be used to perform a `zoom` transition when navigating, instead of the typical push animation.

https://github.com/liveview-native/liveview-client-swiftui/assets/13581484/b254dd5c-1990-4ecd-9341-f40ab3a0537d

> [!NOTE]
> The animation is not yet correct on backward navigation. This is because the previous page is reloaded when navigating back, causing the source element to be rebuilt with a new identity during the animation.