### PR TITLE
Add new `Tab` elements and `.sidebarAdaptable` TabViewStyle

### DIFF
--- a/Sources/LiveViewNative/Stylesheets/ParseableTypes/Styles/AnyDisclosureGroupStyle+ParseableModifierValue.swift
+++ b/Sources/LiveViewNative/Stylesheets/ParseableTypes/Styles/AnyDisclosureGroupStyle+ParseableModifierValue.swift
@@ -1,0 +1,33 @@
+//
+//  AnyDisclosureGroupStyle+ParseableModifierValue.swift
+//  
+//
+//  Created by Carson Katri on 6/20/24.
+//
+
+import SwiftUI
+import LiveViewNativeStylesheet
+
+/// See [`SwiftUI.DisclosureGroupStyle`](https://developer.apple.com/documentation/swiftui/DisclosureGroupStyle) for more details.
+///
+/// Possible values:
+/// - `.automatic`
+@_documentation(visibility: public)
+enum AnyDisclosureGroupStyle: String, CaseIterable, ParseableModifierValue, DisclosureGroupStyle {
+    typealias _ParserType = ImplicitStaticMember<Self, EnumParser<Self>>
+    
+    case automatic
+    
+    func makeBody(configuration: Configuration) -> some View {
+        let disclosureGroup = SwiftUI.DisclosureGroup.init(isExpanded: configuration.$isExpanded) {
+            configuration.content
+        } label: {
+            configuration.label
+        }
+
+        switch self {
+        case .automatic:
+            disclosureGroup.disclosureGroupStyle(.automatic)
+        }
+    }
+}

--- a/Sources/LiveViewNative/Stylesheets/ParseableTypes/Styles/AnyDisclosureGroupStyle+ParseableModifierValue.swift
+++ b/Sources/LiveViewNative/Stylesheets/ParseableTypes/Styles/AnyDisclosureGroupStyle+ParseableModifierValue.swift
@@ -5,6 +5,7 @@
 //  Created by Carson Katri on 6/20/24.
 //
 
+#if os(iOS) || os(macOS) || os(visionOS)
 import SwiftUI
 import LiveViewNativeStylesheet
 
@@ -31,3 +32,4 @@ enum AnyDisclosureGroupStyle: String, CaseIterable, ParseableModifierValue, Disc
         }
     }
 }
+#endif

--- a/Sources/LiveViewNative/Stylesheets/ParseableTypes/Styles/AnyNavigationViewStyle+ParseableModifierValue.swift
+++ b/Sources/LiveViewNative/Stylesheets/ParseableTypes/Styles/AnyNavigationViewStyle+ParseableModifierValue.swift
@@ -1,0 +1,24 @@
+//
+//  AnyNavigationViewStyle+ParseableModifierValue.swift
+//  
+//
+//  Created by Carson Katri on 6/20/24.
+//
+
+import SwiftUI
+import LiveViewNativeStylesheet
+
+/// See [`SwiftUI.NavigationViewStyle`](https://developer.apple.com/documentation/swiftui/NavigationViewStyle) for more details.
+///
+/// - Note: This type is deprecated and should no longer be used.
+@_documentation(visibility: public)
+enum AnyNavigationViewStyle: String, CaseIterable, ParseableModifierValue, NavigationViewStyle {
+    typealias _ParserType = ImplicitStaticMember<Self, EnumParser<Self>>
+    
+    case __never
+    
+    @ViewBuilder
+    func _body(configuration: _NavigationViewStyleConfiguration) -> some View {
+        fatalError("This type is deprecated and should no longer be used.")
+    }
+}

--- a/Sources/LiveViewNative/Stylesheets/ParseableTypes/Styles/AnyTabViewStyle+ParseableModifierValue.swift
+++ b/Sources/LiveViewNative/Stylesheets/ParseableTypes/Styles/AnyTabViewStyle+ParseableModifierValue.swift
@@ -14,6 +14,7 @@ import LiveViewNativeStylesheet
 /// - `.automatic`
 /// - `.page`
 /// - `.verticalPage`
+/// - `.sidebarAdaptable`
 ///
 /// ### Page Style
 /// Pass an ``SwiftUI/IndexDisplayMode`` to customize this style.
@@ -39,6 +40,9 @@ enum AnyTabViewStyle: ParseableModifierValue {
     #if os(watchOS)
     case verticalPage(transitionStyle: Any?)
     #endif
+    #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS)
+    case sidebarAdaptable
+    #endif
     
     static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -63,6 +67,9 @@ enum AnyTabViewStyle: ParseableModifierValue {
                         return Self.automatic
                     }
                 })
+                #endif
+                #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS)
+                ConstantAtomLiteral("sidebarAdaptable").map({ Self.sidebarAdaptable })
                 #endif
             }
         }
@@ -119,6 +126,14 @@ extension View {
         case let .verticalPage(.some(transitionStyle)):
             if #available(watchOS 10, *) {
                 self.tabViewStyle(.verticalPage(transitionStyle: transitionStyle))
+            } else {
+                self
+            }
+        #endif
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS)
+        case .sidebarAdaptable:
+            if #available(iOS 18.0, macOS 15.0, tvOS 18.0, visionOS 2.0, *) {
+                self.tabViewStyle(.sidebarAdaptable)
             } else {
                 self
             }

--- a/Sources/LiveViewNative/Stylesheets/ParseableTypes/UITextAutocapitalizationType+ParseableModifierValue.swift
+++ b/Sources/LiveViewNative/Stylesheets/ParseableTypes/UITextAutocapitalizationType+ParseableModifierValue.swift
@@ -1,0 +1,20 @@
+//
+//  UITextAutocapitalizationType+ParseableModifierValue.swift
+//  
+//
+//  Created by Carson.Katri on 6/20/24.
+//
+
+import SwiftUI
+import LiveViewNativeStylesheet
+
+extension UITextAutocapitalizationType: ParseableModifierValue {
+    public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
+        ImplicitStaticMember([
+            "none": Self.none,
+            "sentences": Self.sentences,
+            "words": Self.words,
+            "allCharacters": Self.allCharacters,
+        ])
+    }
+}

--- a/Sources/LiveViewNative/Stylesheets/ParseableTypes/UITextAutocapitalizationType+ParseableModifierValue.swift
+++ b/Sources/LiveViewNative/Stylesheets/ParseableTypes/UITextAutocapitalizationType+ParseableModifierValue.swift
@@ -2,9 +2,10 @@
 //  UITextAutocapitalizationType+ParseableModifierValue.swift
 //  
 //
-//  Created by Carson.Katri on 6/20/24.
+//  Created by Carson Katri on 6/20/24.
 //
 
+#if os(iOS) || os(tvOS) || os(visionOS)
 import SwiftUI
 import LiveViewNativeStylesheet
 
@@ -18,3 +19,4 @@ extension UITextAutocapitalizationType: ParseableModifierValue {
         ])
     }
 }
+#endif

--- a/Sources/LiveViewNative/Views/Layout Containers/Presentation Containers/TabView.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Presentation Containers/TabView.swift
@@ -164,9 +164,9 @@ struct Tab<Root: RootRegistry, TabValue: Hashable>: TabContent {
         }
     }
     
-    var title: String? { try? element.attributeValue(for: "title") }
-    var image: String? { try? element.attributeValue(for: "image") }
-    var systemImage: String? { try? element.attributeValue(for: "systemImage") }
+    var title: String? { element.attributeValue(for: "title") }
+    var image: String? { element.attributeValue(for: "image") }
+    var systemImage: String? { element.attributeValue(for: "systemImage") }
     var role: TabRole? { try? element.attributeValue(TabRole.self, for: "role") }
     
     var content: some View {

--- a/Sources/LiveViewNative/Views/Layout Containers/Presentation Containers/TabView.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Presentation Containers/TabView.swift
@@ -6,6 +6,10 @@
 //
 
 import SwiftUI
+import LiveViewNativeCore
+import OSLog
+
+private let logger = Logger(subsystem: "LiveViewNative", category: "TabView")
 
 /// Container that presents content on separate pages.
 ///
@@ -36,10 +40,162 @@ struct TabView<Root: RootRegistry>: View {
     @LiveAttribute(.init(name: "phx-change")) var changeAttribute: String?
     
     var body: some View {
-        SwiftUI.TabView(
-            selection: (selectionAttribute != nil || changeAttribute != nil) ? $selection : nil
-        ) {
-            $liveElement.children()
+        if #available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *),
+           $liveElement.childNodes.contains(where: {
+               guard case let .element(element) = $0.data else { return false }
+               return element.tag == "Tab"
+           })
+        {
+            if selectionAttribute != nil || changeAttribute != nil {
+                SwiftUI.TabView(selection: $selection) {
+                    TabTreeBuilder<Root, String?>().fromNodes($liveElement.childNodes, context: $liveElement.context.storage)
+                }
+            } else {
+                SwiftUI.TabView {
+                    TabTreeBuilder<Root, Never>().fromNodes($liveElement.childNodes, context: $liveElement.context.storage)
+                }
+            }
+        } else {
+            SwiftUI.TabView(
+                selection: (selectionAttribute != nil || changeAttribute != nil) ? $selection : nil
+            ) {
+                $liveElement.children()
+            }
+        }
+    }
+}
+
+/// A builder for `TabContent`.
+@available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
+struct TabTreeBuilder<Root: RootRegistry, TabValue: Hashable> {
+    func fromNodes<Nodes>(_ nodes: Nodes, context: LiveContextStorage<Root>) -> some TabContent<TabValue>
+        where Nodes: RandomAccessCollection, Nodes.Index == Int, Nodes.Element == Node
+    {
+        ForEach(nodes, id: \.id) { node in
+            fromNode(node, context: context)
+        }
+    }
+    
+    @TabContentBuilder<TabValue>
+    fileprivate func fromNode(_ node: Node, context: LiveContextStorage<Root>) -> some TabContent<TabValue> {
+        // ToolbarTreeBuilder.fromNode may not be called with a root or leaf node
+        if case .element(let element) = node.data {
+            Self.lookup(ElementNode(node: node, data: element))
+        }
+    }
+    
+    @TabContentBuilder<TabValue>
+    static func lookup(_ node: ElementNode) -> some TabContent<TabValue> {
+        if node.tag == "Tab" {
+            Tab<Root, TabValue>(element: node)
+        } else if node.tag == "TabSection" {
+            Tab<Root, TabValue>(element: node) // todo
+        }
+    }
+}
+
+@available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
+struct Tab<Root: RootRegistry, TabValue: Hashable>: TabContent {
+    @ObservedElement private var element: ElementNode
+    @LiveContext<Root> private var context
+    
+    init(element: ElementNode) {
+        self._element = .init(element: element)
+    }
+    
+    var body: some TabContent<TabValue> {
+        if TabValue.self == Never.self {
+            noValueTab
+        } else if TabValue.self == String?.self {
+            stringValueTab
+        }
+    }
+    
+    @TabContentBuilder<TabValue>
+    var noValueTab: some TabContent<TabValue> {
+        if let title,
+           let image
+        {
+            SwiftUI.Tab(title, image: image, role: role) {
+                content
+            }
+            .forceCast(as: TabValue.self)
+        } else if let title,
+                  let systemImage
+        {
+            SwiftUI.Tab(title, systemImage: systemImage, role: role) {
+                content
+            }
+            .forceCast(as: TabValue.self)
+        } else {
+            SwiftUI.Tab(role: role) {
+                content
+            } label: {
+                label
+            }
+            .forceCast(as: TabValue.self)
+        }
+    }
+    
+    @TabContentBuilder<TabValue>
+    var stringValueTab: some TabContent<TabValue> {
+        let value = try? element.attributeValue(String.self, for: "value")
+        if let title,
+           let image
+        {
+            SwiftUI.Tab(title, image: image, value: value, role: role) {
+                content
+            }
+            .forceCast(as: TabValue.self)
+        } else if let title,
+                  let systemImage
+        {
+            SwiftUI.Tab(title, systemImage: systemImage, value: value, role: role) {
+                content
+            }
+            .forceCast(as: TabValue.self)
+        } else {
+            SwiftUI.Tab(value: value, role: role) {
+                content
+            } label: {
+                label
+            }
+            .forceCast(as: TabValue.self)
+        }
+    }
+    
+    var title: String? { try? element.attributeValue(for: "title") }
+    var image: String? { try? element.attributeValue(for: "image") }
+    var systemImage: String? { try? element.attributeValue(for: "systemImage") }
+    var role: TabRole? { try? element.attributeValue(TabRole.self, for: "role") }
+    
+    var content: some View {
+        context.buildChildren(of: element, forTemplate: "content", includeDefaultSlot: true)
+    }
+    
+    var label: some View {
+        context.buildChildren(of: element, forTemplate: "label")
+    }
+}
+
+@available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
+extension SwiftUI.Tab {
+    func forceCast<V: Hashable>(as valueType: V.Type = V.self) -> SwiftUI.Tab<V, Content, Label> {
+        self as! SwiftUI.Tab<V, Content, Label>
+    }
+}
+
+@available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
+extension TabRole: AttributeDecodable {
+    public init(from attribute: Attribute?, on element: ElementNode) throws {
+        guard let value = attribute?.value
+        else { throw AttributeDecodingError.missingAttribute(Self.self) }
+        
+        switch value {
+        case "search":
+            self = .search
+        default:
+            throw AttributeDecodingError.badValue(Self.self)
         }
     }
 }

--- a/Sources/LiveViewNative/_GeneratedModifiers.swift
+++ b/Sources/LiveViewNative/_GeneratedModifiers.swift
@@ -125,7 +125,7 @@ struct _accessibilityActionsModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 11.0,visionOS 2.0,iOS 18.0,macOS 15.0,tvOS 18.0, *)
+    @available(tvOS 18.0,macOS 15.0,visionOS 2.0,iOS 18.0,watchOS 11.0, *)
     init(category: SwiftUI.AccessibilityActionCategory,content content: ViewReference=ViewReference(value: [])) {
         self.value = ._0(category: category, content: content)
         
@@ -145,7 +145,7 @@ struct _accessibilityActionsModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(category, content):
-            if #available(watchOS 11.0,visionOS 2.0,iOS 18.0,macOS 15.0,tvOS 18.0, *) {
+            if #available(tvOS 18.0,macOS 15.0,visionOS 2.0,iOS 18.0,watchOS 11.0, *) {
             let category = category as! SwiftUI.AccessibilityActionCategory
 let content = content as! ViewReference
             
@@ -681,7 +681,7 @@ struct _allowsWindowActivationEventsModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(iOS 18.0,macOS 15.0,visionOS 2.0, *)
+    @available(iOS 18.0,visionOS 2.0,macOS 15.0, *)
     init(_ value: AttributeReference<Swift.Bool?>? = .init(storage: .constant(true)) ) {
         self.value = ._0(value: value)
         
@@ -694,7 +694,7 @@ struct _allowsWindowActivationEventsModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(value):
-            if #available(iOS 18.0,macOS 15.0,visionOS 2.0, *) {
+            if #available(iOS 18.0,visionOS 2.0,macOS 15.0, *) {
             let value = value as? AttributeReference<Swift.Bool?>
             
             __content
@@ -868,7 +868,7 @@ struct _autocapitalizationModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(tvOS) || os(visionOS)
-    @available(tvOS 16.0,visionOS 1.0,iOS 16.0, *)
+    @available(iOS 16.0,visionOS 1.0,tvOS 16.0, *)
     init(_ style: UIKit.UITextAutocapitalizationType) {
         self.value = ._0(style: style)
         
@@ -881,7 +881,7 @@ struct _autocapitalizationModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(tvOS) || os(visionOS)
         case let ._0(style):
-            if #available(tvOS 16.0,visionOS 1.0,iOS 16.0, *) {
+            if #available(iOS 16.0,visionOS 1.0,tvOS 16.0, *) {
             let style = style as! UIKit.UITextAutocapitalizationType
             
             __content
@@ -1232,28 +1232,28 @@ struct _badgeModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(visionOS 1.0,macOS 12.0,iOS 15.0, *)
+    @available(iOS 15.0,visionOS 1.0,macOS 12.0, *)
     init(_ count: AttributeReference<Swift.Int>) {
         self.value = ._0(count: count)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(visionOS 1.0,macOS 12.0,iOS 15.0, *)
+    @available(iOS 15.0,visionOS 1.0,macOS 12.0, *)
     init(_ label: TextReference?) {
         self.value = ._1(label: label)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(visionOS 1.0,macOS 12.0,iOS 15.0, *)
+    @available(iOS 15.0,visionOS 1.0,macOS 12.0, *)
     init(_ key: SwiftUICore.LocalizedStringKey?) {
         self.value = ._2(key: key)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(visionOS 1.0,macOS 12.0,iOS 15.0, *)
+    @available(iOS 15.0,visionOS 1.0,macOS 12.0, *)
     init(_ label: AttributeReference<String>) {
         self.value = ._3(label: label)
         
@@ -1266,7 +1266,7 @@ struct _badgeModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(count):
-            if #available(visionOS 1.0,macOS 12.0,iOS 15.0, *) {
+            if #available(iOS 15.0,visionOS 1.0,macOS 12.0, *) {
             let count = count as! AttributeReference<Swift.Int>
             
             __content
@@ -1277,7 +1277,7 @@ struct _badgeModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._1(label):
-            if #available(visionOS 1.0,macOS 12.0,iOS 15.0, *) {
+            if #available(iOS 15.0,visionOS 1.0,macOS 12.0, *) {
             let label = label as? TextReference
             __content._observeTextReference(label, on: element, in: context) { __content in
             __content
@@ -1288,7 +1288,7 @@ struct _badgeModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._2(key):
-            if #available(visionOS 1.0,macOS 12.0,iOS 15.0, *) {
+            if #available(iOS 15.0,visionOS 1.0,macOS 12.0, *) {
             let key = key as? SwiftUICore.LocalizedStringKey
             
             __content
@@ -1299,7 +1299,7 @@ struct _badgeModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._3(label):
-            if #available(visionOS 1.0,macOS 12.0,iOS 15.0, *) {
+            if #available(iOS 15.0,visionOS 1.0,macOS 12.0, *) {
             let label = label as! AttributeReference<String>
             
             __content
@@ -1333,7 +1333,7 @@ struct _badgeProminenceModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(iOS 17.0,macOS 14.0,visionOS 1.0, *)
+    @available(visionOS 1.0,iOS 17.0,macOS 14.0, *)
     init(_ prominence: SwiftUI.BadgeProminence) {
         self.value = ._0(prominence: prominence)
         
@@ -1346,7 +1346,7 @@ struct _badgeProminenceModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(prominence):
-            if #available(iOS 17.0,macOS 14.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,iOS 17.0,macOS 14.0, *) {
             let prominence = prominence as! SwiftUI.BadgeProminence
             
             __content
@@ -2134,14 +2134,14 @@ struct _containerRelativeFrameModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 10.0,visionOS 1.0,iOS 17.0,macOS 14.0,tvOS 17.0, *)
+    @available(iOS 17.0,tvOS 17.0,watchOS 10.0,visionOS 1.0,macOS 14.0, *)
     init(_ axes: SwiftUICore.Axis.Set,alignment: AttributeReference<SwiftUICore.Alignment> = .init(storage: .constant(.center)) ) {
         self.value = ._0(axes: axes, alignment: alignment)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 10.0,visionOS 1.0,iOS 17.0,macOS 14.0,tvOS 17.0, *)
+    @available(iOS 17.0,tvOS 17.0,watchOS 10.0,visionOS 1.0,macOS 14.0, *)
     init(_ axes: SwiftUICore.Axis.Set,count: AttributeReference<Swift.Int>,span: AttributeReference<Swift.Int> = .init(storage: .constant(1)), spacing: AttributeReference<CoreFoundation.CGFloat>,alignment: AttributeReference<SwiftUICore.Alignment> = .init(storage: .constant(.center)) ) {
         self.value = ._1(axes: axes, count: count, span: span, spacing: spacing, alignment: alignment)
         
@@ -2154,7 +2154,7 @@ struct _containerRelativeFrameModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(axes, alignment):
-            if #available(watchOS 10.0,visionOS 1.0,iOS 17.0,macOS 14.0,tvOS 17.0, *) {
+            if #available(iOS 17.0,tvOS 17.0,watchOS 10.0,visionOS 1.0,macOS 14.0, *) {
             let axes = axes as! SwiftUICore.Axis.Set
 let alignment = alignment as! AttributeReference<SwiftUICore.Alignment>
             
@@ -2166,7 +2166,7 @@ let alignment = alignment as! AttributeReference<SwiftUICore.Alignment>
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(axes, count, span, spacing, alignment):
-            if #available(watchOS 10.0,visionOS 1.0,iOS 17.0,macOS 14.0,tvOS 17.0, *) {
+            if #available(iOS 17.0,tvOS 17.0,watchOS 10.0,visionOS 1.0,macOS 14.0, *) {
             let axes = axes as! SwiftUICore.Axis.Set
 let count = count as! AttributeReference<Swift.Int>
 let span = span as! AttributeReference<Swift.Int>
@@ -2261,21 +2261,21 @@ struct _contentMarginsModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(tvOS 17.0,iOS 17.0,macOS 14.0,visionOS 1.0,watchOS 10.0, *)
+    @available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0,visionOS 1.0, *)
     init(_ edges: SwiftUICore.Edge.Set = .all, _ insets: SwiftUICore.EdgeInsets,for placement: SwiftUI.ContentMarginPlacement = .automatic ) {
         self.value = ._0(edges: edges, insets: insets, placement: placement)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(tvOS 17.0,iOS 17.0,macOS 14.0,visionOS 1.0,watchOS 10.0, *)
+    @available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0,visionOS 1.0, *)
     init(_ edges: SwiftUICore.Edge.Set = .all, _ length: AttributeReference<CoreFoundation.CGFloat?>?,for placement: SwiftUI.ContentMarginPlacement = .automatic ) {
         self.value = ._1(edges: edges, length: length, placement: placement)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(tvOS 17.0,iOS 17.0,macOS 14.0,visionOS 1.0,watchOS 10.0, *)
+    @available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0,visionOS 1.0, *)
     init(_ length: AttributeReference<CoreFoundation.CGFloat>,for placement: SwiftUI.ContentMarginPlacement = .automatic ) {
         self.value = ._2(length: length, placement: placement)
         
@@ -2288,7 +2288,7 @@ struct _contentMarginsModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(edges, insets, placement):
-            if #available(tvOS 17.0,iOS 17.0,macOS 14.0,visionOS 1.0,watchOS 10.0, *) {
+            if #available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0,visionOS 1.0, *) {
             let edges = edges as! SwiftUICore.Edge.Set 
 let insets = insets as! SwiftUICore.EdgeInsets
 let placement = placement as! SwiftUI.ContentMarginPlacement 
@@ -2301,7 +2301,7 @@ let placement = placement as! SwiftUI.ContentMarginPlacement
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(edges, length, placement):
-            if #available(tvOS 17.0,iOS 17.0,macOS 14.0,visionOS 1.0,watchOS 10.0, *) {
+            if #available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0,visionOS 1.0, *) {
             let edges = edges as! SwiftUICore.Edge.Set 
 let length = length as? AttributeReference<CoreFoundation.CGFloat?>
 let placement = placement as! SwiftUI.ContentMarginPlacement 
@@ -2314,7 +2314,7 @@ let placement = placement as! SwiftUI.ContentMarginPlacement
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._2(length, placement):
-            if #available(tvOS 17.0,iOS 17.0,macOS 14.0,visionOS 1.0,watchOS 10.0, *) {
+            if #available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0,visionOS 1.0, *) {
             let length = length as! AttributeReference<CoreFoundation.CGFloat>
 let placement = placement as! SwiftUI.ContentMarginPlacement 
             
@@ -2478,7 +2478,7 @@ struct _contextMenuModifier<R: RootRegistry>: ViewModifier {
     }
     
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS)
-    @available(visionOS 1.0,tvOS 16.0,macOS 13.0,iOS 16.0, *)
+    @available(iOS 16.0,macOS 13.0,tvOS 16.0,visionOS 1.0, *)
     init(menuItems: ViewReference=ViewReference(value: []),preview: ViewReference=ViewReference(value: [])) {
         self.value = ._1(menuItems: menuItems, preview: preview)
         
@@ -2502,7 +2502,7 @@ struct _contextMenuModifier<R: RootRegistry>: ViewModifier {
         
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS)
         case let ._1(menuItems, preview):
-            if #available(visionOS 1.0,tvOS 16.0,macOS 13.0,iOS 16.0, *) {
+            if #available(iOS 16.0,macOS 13.0,tvOS 16.0,visionOS 1.0, *) {
             let menuItems = menuItems as! ViewReference
 let preview = preview as! ViewReference
             
@@ -2584,7 +2584,7 @@ struct _controlGroupStyleModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS)
-    @available(macOS 12.0,visionOS 1.0,tvOS 17.0,iOS 15.0, *)
+    @available(iOS 15.0,macOS 12.0,tvOS 17.0,visionOS 1.0, *)
     init(_ style: AnyControlGroupStyle) {
         self.value = ._0(style: style)
         
@@ -2597,7 +2597,7 @@ struct _controlGroupStyleModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS)
         case let ._0(style):
-            if #available(macOS 12.0,visionOS 1.0,tvOS 17.0,iOS 15.0, *) {
+            if #available(iOS 15.0,macOS 12.0,tvOS 17.0,visionOS 1.0, *) {
             let style = style as! AnyControlGroupStyle
             
             __content
@@ -2631,7 +2631,7 @@ struct _controlSizeModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 9.0,visionOS 1.0,iOS 15.0,macOS 10.15, *)
+    @available(visionOS 1.0,watchOS 9.0,macOS 10.15,iOS 15.0, *)
     init(_ controlSize: SwiftUICore.ControlSize) {
         self.value = ._0(controlSize: controlSize)
         
@@ -2644,7 +2644,7 @@ struct _controlSizeModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
         case let ._0(controlSize):
-            if #available(watchOS 9.0,visionOS 1.0,iOS 15.0,macOS 10.15, *) {
+            if #available(visionOS 1.0,watchOS 9.0,macOS 10.15,iOS 15.0, *) {
             let controlSize = controlSize as! SwiftUICore.ControlSize
             
             __content
@@ -2690,7 +2690,7 @@ struct _coordinateSpaceModifier<R: RootRegistry>: ViewModifier {
     }
     
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 10.0,tvOS 17.0,visionOS 1.0,iOS 17.0,macOS 14.0, *)
+    @available(iOS 17.0,tvOS 17.0,watchOS 10.0,visionOS 1.0,macOS 14.0, *)
     init(_ name: SwiftUICore.NamedCoordinateSpace) {
         self.value = ._1(name: name)
         
@@ -2714,7 +2714,7 @@ struct _coordinateSpaceModifier<R: RootRegistry>: ViewModifier {
         
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(name):
-            if #available(watchOS 10.0,tvOS 17.0,visionOS 1.0,iOS 17.0,macOS 14.0, *) {
+            if #available(iOS 17.0,tvOS 17.0,watchOS 10.0,visionOS 1.0,macOS 14.0, *) {
             let name = name as! SwiftUICore.NamedCoordinateSpace
             
             __content
@@ -2795,7 +2795,7 @@ struct _datePickerStyleModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,iOS 13.0,macOS 10.15,watchOS 10.0, *)
+    @available(visionOS 1.0,watchOS 10.0,iOS 13.0,macOS 10.15, *)
     init(_ style: AnyDatePickerStyle) {
         self.value = ._0(style: style)
         
@@ -2808,7 +2808,7 @@ struct _datePickerStyleModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
         case let ._0(style):
-            if #available(visionOS 1.0,iOS 13.0,macOS 10.15,watchOS 10.0, *) {
+            if #available(visionOS 1.0,watchOS 10.0,iOS 13.0,macOS 10.15, *) {
             let style = style as! AnyDatePickerStyle
             
             __content
@@ -2941,14 +2941,14 @@ struct _defaultScrollAnchorModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 10.0,tvOS 17.0,visionOS 1.0,iOS 17.0,macOS 14.0, *)
+    @available(tvOS 17.0,watchOS 10.0,iOS 17.0,visionOS 1.0,macOS 14.0, *)
     init(_ anchor: AttributeReference<SwiftUICore.UnitPoint?>?) {
         self.value = ._0(anchor: anchor)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 11.0,tvOS 18.0,visionOS 2.0,iOS 18.0,macOS 15.0, *)
+    @available(tvOS 18.0,watchOS 11.0,iOS 18.0,visionOS 2.0,macOS 15.0, *)
     init(_ anchor: AttributeReference<SwiftUICore.UnitPoint?>?,for role: SwiftUI.ScrollAnchorRole) {
         self.value = ._1(anchor: anchor, role: role)
         
@@ -2961,7 +2961,7 @@ struct _defaultScrollAnchorModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(anchor):
-            if #available(watchOS 10.0,tvOS 17.0,visionOS 1.0,iOS 17.0,macOS 14.0, *) {
+            if #available(tvOS 17.0,watchOS 10.0,iOS 17.0,visionOS 1.0,macOS 14.0, *) {
             let anchor = anchor as? AttributeReference<SwiftUICore.UnitPoint?>
             
             __content
@@ -2972,7 +2972,7 @@ struct _defaultScrollAnchorModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(anchor, role):
-            if #available(watchOS 11.0,tvOS 18.0,visionOS 2.0,iOS 18.0,macOS 15.0, *) {
+            if #available(tvOS 18.0,watchOS 11.0,iOS 18.0,visionOS 2.0,macOS 15.0, *) {
             let anchor = anchor as? AttributeReference<SwiftUICore.UnitPoint?>
 let role = role as! SwiftUI.ScrollAnchorRole
             
@@ -3163,28 +3163,28 @@ struct _dialogSuppressionToggleModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(tvOS 17.0,watchOS 10.0,iOS 17.0,visionOS 1.0,macOS 14.0, *)
+    @available(iOS 17.0,macOS 14.0,tvOS 17.0,watchOS 10.0,visionOS 1.0, *)
     init(_ titleKey: SwiftUICore.LocalizedStringKey,isSuppressed: ChangeTracked<Swift.Bool>) {
         self.value = ._0(titleKey: titleKey)
         self.__0_isSuppressed = isSuppressed
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(tvOS 17.0,watchOS 10.0,iOS 17.0,visionOS 1.0,macOS 14.0, *)
+    @available(iOS 17.0,macOS 14.0,tvOS 17.0,watchOS 10.0,visionOS 1.0, *)
     init(_ title: AttributeReference<String>,isSuppressed: ChangeTracked<Swift.Bool>) {
         self.value = ._1(title: title)
         self.__1_isSuppressed = isSuppressed
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(tvOS 17.0,watchOS 10.0,iOS 17.0,visionOS 1.0,macOS 14.0, *)
+    @available(iOS 17.0,macOS 14.0,tvOS 17.0,watchOS 10.0,visionOS 1.0, *)
     init(_ label: TextReference,isSuppressed: ChangeTracked<Swift.Bool>) {
         self.value = ._2(label: label)
         self.__2_isSuppressed = isSuppressed
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 10.0,visionOS 1.0,iOS 17.0,macOS 14.0,tvOS 17.0, *)
+    @available(iOS 17.0,macOS 14.0,tvOS 17.0,watchOS 10.0,visionOS 1.0, *)
     init(isSuppressed: ChangeTracked<Swift.Bool>) {
         self.value = ._3
         self.__3_isSuppressed = isSuppressed
@@ -3197,7 +3197,7 @@ struct _dialogSuppressionToggleModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(titleKey):
-            if #available(tvOS 17.0,watchOS 10.0,iOS 17.0,visionOS 1.0,macOS 14.0, *) {
+            if #available(iOS 17.0,macOS 14.0,tvOS 17.0,watchOS 10.0,visionOS 1.0, *) {
             let titleKey = titleKey as! SwiftUICore.LocalizedStringKey
             
             __content
@@ -3208,7 +3208,7 @@ struct _dialogSuppressionToggleModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(title):
-            if #available(tvOS 17.0,watchOS 10.0,iOS 17.0,visionOS 1.0,macOS 14.0, *) {
+            if #available(iOS 17.0,macOS 14.0,tvOS 17.0,watchOS 10.0,visionOS 1.0, *) {
             let title = title as! AttributeReference<String>
             
             __content
@@ -3219,7 +3219,7 @@ struct _dialogSuppressionToggleModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._2(label):
-            if #available(tvOS 17.0,watchOS 10.0,iOS 17.0,visionOS 1.0,macOS 14.0, *) {
+            if #available(iOS 17.0,macOS 14.0,tvOS 17.0,watchOS 10.0,visionOS 1.0, *) {
             let label = label as! TextReference
             __content._observeTextReference(label, on: element, in: context) { __content in
             __content
@@ -3230,7 +3230,7 @@ struct _dialogSuppressionToggleModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case ._3:
-            if #available(watchOS 10.0,visionOS 1.0,iOS 17.0,macOS 14.0,tvOS 17.0, *) {
+            if #available(iOS 17.0,macOS 14.0,tvOS 17.0,watchOS 10.0,visionOS 1.0, *) {
             
             
             __content
@@ -3428,7 +3428,7 @@ struct _disclosureGroupStyleModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(visionOS 1.0,iOS 16.0,macOS 13.0, *)
+    @available(iOS 16.0,macOS 13.0,visionOS 1.0, *)
     init(_ style: AnyDisclosureGroupStyle) {
         self.value = ._0(style: style)
         
@@ -3441,7 +3441,7 @@ struct _disclosureGroupStyleModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(style):
-            if #available(visionOS 1.0,iOS 16.0,macOS 13.0, *) {
+            if #available(iOS 16.0,macOS 13.0,visionOS 1.0, *) {
             let style = style as! AnyDisclosureGroupStyle
             
             __content
@@ -3816,7 +3816,7 @@ struct _fileDialogCustomizationIDModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 14.0,visionOS 1.0,iOS 17.0, *)
+    @available(iOS 17.0,visionOS 1.0,macOS 14.0, *)
     init(_ id: AttributeReference<Swift.String>) {
         self.value = ._0(id: id)
         
@@ -3829,7 +3829,7 @@ struct _fileDialogCustomizationIDModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(id):
-            if #available(macOS 14.0,visionOS 1.0,iOS 17.0, *) {
+            if #available(iOS 17.0,visionOS 1.0,macOS 14.0, *) {
             let id = id as! AttributeReference<Swift.String>
             
             __content
@@ -3863,7 +3863,7 @@ struct _fileDialogImportsUnresolvedAliasesModifier<R: RootRegistry>: ViewModifie
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 14.0,visionOS 1.0,iOS 17.0, *)
+    @available(iOS 17.0,visionOS 1.0,macOS 14.0, *)
     init(_ imports: AttributeReference<Swift.Bool>) {
         self.value = ._0(imports: imports)
         
@@ -3876,7 +3876,7 @@ struct _fileDialogImportsUnresolvedAliasesModifier<R: RootRegistry>: ViewModifie
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(imports):
-            if #available(macOS 14.0,visionOS 1.0,iOS 17.0, *) {
+            if #available(iOS 17.0,visionOS 1.0,macOS 14.0, *) {
             let imports = imports as! AttributeReference<Swift.Bool>
             
             __content
@@ -4121,7 +4121,7 @@ struct _focusEffectDisabledModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0,visionOS 1.0, *)
+    @available(iOS 17.0,macOS 14.0,watchOS 10.0,tvOS 17.0,visionOS 1.0, *)
     init(_ disabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(disabled: disabled)
         
@@ -4134,7 +4134,7 @@ struct _focusEffectDisabledModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(disabled):
-            if #available(macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0,visionOS 1.0, *) {
+            if #available(iOS 17.0,macOS 14.0,watchOS 10.0,tvOS 17.0,visionOS 1.0, *) {
             let disabled = disabled as! AttributeReference<Swift.Bool>
             
             __content
@@ -4168,7 +4168,7 @@ struct _focusSectionModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(macOS) || os(tvOS)
-    @available(tvOS 15.0,macOS 13.0, *)
+    @available(macOS 13.0,tvOS 15.0, *)
     init() {
         self.value = ._0
         
@@ -4181,7 +4181,7 @@ struct _focusSectionModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(macOS) || os(tvOS)
         case ._0:
-            if #available(tvOS 15.0,macOS 13.0, *) {
+            if #available(macOS 13.0,tvOS 15.0, *) {
             
             
             __content
@@ -4225,21 +4225,21 @@ struct _focusableModifier<R: RootRegistry>: ViewModifier {
 @Event private var _2_onFocusChange__1: Event.EventHandler
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 12.0,watchOS 8.0,iOS 17.0,tvOS 15.0,visionOS 1.0, *)
+    @available(iOS 17.0,macOS 12.0,tvOS 15.0,watchOS 8.0,visionOS 1.0, *)
     init(_ isFocusable: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(isFocusable: isFocusable)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0,visionOS 1.0, *)
+    @available(iOS 17.0,macOS 14.0,tvOS 17.0,watchOS 10.0,visionOS 1.0, *)
     init(_ isFocusable: AttributeReference<Swift.Bool> = .init(storage: .constant(true)), interactions: SwiftUI.FocusInteractions) {
         self.value = ._1(isFocusable: isFocusable, interactions: interactions)
         
     }
     #endif
     #if os(macOS) || os(tvOS) || os(watchOS)
-    @available(macOS 13.0,tvOS 16.0,watchOS 9.0, *)
+    @available(tvOS 16.0,macOS 13.0,watchOS 9.0, *)
     init(_ isFocusable: AttributeReference<Swift.Bool> = .init(storage: .constant(true)), onFocusChange onFocusChange__1: Event ) {
         self.value = ._2(isFocusable: isFocusable)
         self.__2_onFocusChange__1 = onFocusChange__1
@@ -4252,7 +4252,7 @@ struct _focusableModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(isFocusable):
-            if #available(macOS 12.0,watchOS 8.0,iOS 17.0,tvOS 15.0,visionOS 1.0, *) {
+            if #available(iOS 17.0,macOS 12.0,tvOS 15.0,watchOS 8.0,visionOS 1.0, *) {
             let isFocusable = isFocusable as! AttributeReference<Swift.Bool>
             
             __content
@@ -4263,7 +4263,7 @@ struct _focusableModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(isFocusable, interactions):
-            if #available(macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0,visionOS 1.0, *) {
+            if #available(iOS 17.0,macOS 14.0,tvOS 17.0,watchOS 10.0,visionOS 1.0, *) {
             let isFocusable = isFocusable as! AttributeReference<Swift.Bool>
 let interactions = interactions as! SwiftUI.FocusInteractions
             
@@ -4275,7 +4275,7 @@ let interactions = interactions as! SwiftUI.FocusInteractions
         #endif
         #if os(macOS) || os(tvOS) || os(watchOS)
         case let ._2(isFocusable):
-            if #available(macOS 13.0,tvOS 16.0,watchOS 9.0, *) {
+            if #available(tvOS 16.0,macOS 13.0,watchOS 9.0, *) {
             let isFocusable = isFocusable as! AttributeReference<Swift.Bool>
             
             __content
@@ -4546,7 +4546,7 @@ struct _fullScreenCoverModifier<R: RootRegistry>: ViewModifier {
 @Event private var _0_onDismiss__0: Event.EventHandler
 
     #if os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,iOS 14.0,watchOS 7.0,tvOS 14.0, *)
+    @available(iOS 14.0,visionOS 1.0,watchOS 7.0,tvOS 14.0, *)
     init(isPresented: ChangeTracked<Swift.Bool>,onDismiss onDismiss__0: Event=Event(), content: ViewReference=ViewReference(value: [])) {
         self.value = ._0(content: content)
         self.__0_isPresented = isPresented
@@ -4560,7 +4560,7 @@ self.__0_onDismiss__0 = onDismiss__0
             fatalError("unreachable")
         #if os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(content):
-            if #available(visionOS 1.0,iOS 14.0,watchOS 7.0,tvOS 14.0, *) {
+            if #available(iOS 14.0,visionOS 1.0,watchOS 7.0,tvOS 14.0, *) {
             let content = content as! ViewReference
             
             __content
@@ -4594,7 +4594,7 @@ struct _gaugeStyleModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
-    @available(macOS 13.0,watchOS 7.0,visionOS 1.0,iOS 16.0, *)
+    @available(iOS 16.0,macOS 13.0,watchOS 7.0,visionOS 1.0, *)
     init(_ style: AnyGaugeStyle) {
         self.value = ._0(style: style)
         
@@ -4607,7 +4607,7 @@ struct _gaugeStyleModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
         case let ._0(style):
-            if #available(macOS 13.0,watchOS 7.0,visionOS 1.0,iOS 16.0, *) {
+            if #available(iOS 16.0,macOS 13.0,watchOS 7.0,visionOS 1.0, *) {
             let style = style as! AnyGaugeStyle
             
             __content
@@ -4641,7 +4641,7 @@ struct _geometryGroupModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 10.0,tvOS 17.0,visionOS 1.0,iOS 17.0,macOS 14.0, *)
+    @available(tvOS 17.0,watchOS 10.0,visionOS 1.0,macOS 14.0,iOS 17.0, *)
     init() {
         self.value = ._0
         
@@ -4654,7 +4654,7 @@ struct _geometryGroupModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case ._0:
-            if #available(watchOS 10.0,tvOS 17.0,visionOS 1.0,iOS 17.0,macOS 14.0, *) {
+            if #available(tvOS 17.0,watchOS 10.0,visionOS 1.0,macOS 14.0,iOS 17.0, *) {
             
             
             __content
@@ -4712,7 +4712,7 @@ struct _gestureModifier<R: RootRegistry>: ViewModifier {
     }
     
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 11.0,visionOS 2.0,iOS 18.0,macOS 15.0,tvOS 18.0, *)
+    @available(iOS 18.0,macOS 15.0,tvOS 18.0,watchOS 11.0,visionOS 2.0, *)
     init(_ gesture: _AnyGesture,name: AttributeReference<Swift.String>,isEnabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._2(gesture: gesture, name: name, isEnabled: isEnabled)
         
@@ -4747,7 +4747,7 @@ struct _gestureModifier<R: RootRegistry>: ViewModifier {
         
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._2(gesture, name, isEnabled):
-            if #available(watchOS 11.0,visionOS 2.0,iOS 18.0,macOS 15.0,tvOS 18.0, *) {
+            if #available(iOS 18.0,macOS 15.0,tvOS 18.0,watchOS 11.0,visionOS 2.0, *) {
             let gesture = gesture as! _AnyGesture
 let name = name as! AttributeReference<Swift.String>
 let isEnabled = isEnabled as! AttributeReference<Swift.Bool>
@@ -5089,7 +5089,7 @@ struct _groupBoxStyleModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(visionOS 1.0,macOS 11.0,iOS 14.0, *)
+    @available(iOS 14.0,visionOS 1.0,macOS 11.0, *)
     init(_ style: AnyGroupBoxStyle) {
         self.value = ._0(style: style)
         
@@ -5102,7 +5102,7 @@ struct _groupBoxStyleModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(style):
-            if #available(visionOS 1.0,macOS 11.0,iOS 14.0, *) {
+            if #available(iOS 14.0,visionOS 1.0,macOS 11.0, *) {
             let style = style as! AnyGroupBoxStyle
             
             __content
@@ -5136,7 +5136,7 @@ struct _handGestureShortcutModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-    @available(watchOS 11.0,iOS 18.0,macOS 15.0,tvOS 18.0, *)
+    @available(tvOS 18.0,macOS 15.0,iOS 18.0,watchOS 11.0, *)
     init(_ shortcut: SwiftUI.HandGestureShortcut,isEnabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(shortcut: shortcut, isEnabled: isEnabled)
         
@@ -5149,7 +5149,7 @@ struct _handGestureShortcutModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
         case let ._0(shortcut, isEnabled):
-            if #available(watchOS 11.0,iOS 18.0,macOS 15.0,tvOS 18.0, *) {
+            if #available(tvOS 18.0,macOS 15.0,iOS 18.0,watchOS 11.0, *) {
             let shortcut = shortcut as! SwiftUI.HandGestureShortcut
 let isEnabled = isEnabled as! AttributeReference<Swift.Bool>
             
@@ -5442,7 +5442,7 @@ struct _highPriorityGestureModifier<R: RootRegistry>: ViewModifier {
     }
     
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 11.0,visionOS 2.0,iOS 18.0,macOS 15.0,tvOS 18.0, *)
+    @available(iOS 18.0,macOS 15.0,tvOS 18.0,watchOS 11.0,visionOS 2.0, *)
     init(_ gesture: _AnyGesture,name: AttributeReference<Swift.String>,isEnabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._2(gesture: gesture, name: name, isEnabled: isEnabled)
         
@@ -5477,7 +5477,7 @@ struct _highPriorityGestureModifier<R: RootRegistry>: ViewModifier {
         
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._2(gesture, name, isEnabled):
-            if #available(watchOS 11.0,visionOS 2.0,iOS 18.0,macOS 15.0,tvOS 18.0, *) {
+            if #available(iOS 18.0,macOS 15.0,tvOS 18.0,watchOS 11.0,visionOS 2.0, *) {
             let gesture = gesture as! _AnyGesture
 let name = name as! AttributeReference<Swift.String>
 let isEnabled = isEnabled as! AttributeReference<Swift.Bool>
@@ -5961,7 +5961,7 @@ struct _indexViewStyleModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(tvOS 14.0,iOS 14.0,visionOS 1.0,watchOS 8.0, *)
+    @available(iOS 14.0,watchOS 8.0,tvOS 14.0,visionOS 1.0, *)
     init(_ style: AnyIndexViewStyle) {
         self.value = ._0(style: style)
         
@@ -5974,7 +5974,7 @@ struct _indexViewStyleModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(style):
-            if #available(tvOS 14.0,iOS 14.0,visionOS 1.0,watchOS 8.0, *) {
+            if #available(iOS 14.0,watchOS 8.0,tvOS 14.0,visionOS 1.0, *) {
             let style = style as! AnyIndexViewStyle
             
             __content
@@ -6221,7 +6221,7 @@ struct _invalidatableContentModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 10.0,macOS 14.0,iOS 17.0,tvOS 17.0,visionOS 1.0, *)
+    @available(watchOS 10.0,macOS 14.0,tvOS 17.0,iOS 17.0,visionOS 1.0, *)
     init(_ invalidatable: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(invalidatable: invalidatable)
         
@@ -6234,7 +6234,7 @@ struct _invalidatableContentModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(invalidatable):
-            if #available(watchOS 10.0,macOS 14.0,iOS 17.0,tvOS 17.0,visionOS 1.0, *) {
+            if #available(watchOS 10.0,macOS 14.0,tvOS 17.0,iOS 17.0,visionOS 1.0, *) {
             let invalidatable = invalidatable as! AttributeReference<Swift.Bool>
             
             __content
@@ -6283,28 +6283,28 @@ struct _keyboardShortcutModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(visionOS 1.0,macOS 11.0,iOS 14.0, *)
+    @available(iOS 14.0,visionOS 1.0,macOS 11.0, *)
     init(_ key: SwiftUI.KeyEquivalent,modifiers: SwiftUICore.EventModifiers = .command ) {
         self.value = ._0(key: key, modifiers: modifiers)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(visionOS 1.0,macOS 11.0,iOS 14.0, *)
+    @available(iOS 14.0,visionOS 1.0,macOS 11.0, *)
     init(_ shortcut: SwiftUI.KeyboardShortcut) {
         self.value = ._1(shortcut: shortcut)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(visionOS 1.0,macOS 12.3,iOS 15.4, *)
+    @available(iOS 15.4,visionOS 1.0,macOS 12.3, *)
     init(_ shortcut: SwiftUI.KeyboardShortcut?) {
         self.value = ._2(shortcut: shortcut)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(visionOS 1.0,macOS 12.0,iOS 15.0, *)
+    @available(iOS 15.0,visionOS 1.0,macOS 12.0, *)
     init(_ key: SwiftUI.KeyEquivalent,modifiers: SwiftUICore.EventModifiers = .command, localization: SwiftUI.KeyboardShortcut.Localization) {
         self.value = ._3(key: key, modifiers: modifiers, localization: localization)
         
@@ -6317,7 +6317,7 @@ struct _keyboardShortcutModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(key, modifiers):
-            if #available(visionOS 1.0,macOS 11.0,iOS 14.0, *) {
+            if #available(iOS 14.0,visionOS 1.0,macOS 11.0, *) {
             let key = key as! SwiftUI.KeyEquivalent
 let modifiers = modifiers as! SwiftUICore.EventModifiers 
             
@@ -6329,7 +6329,7 @@ let modifiers = modifiers as! SwiftUICore.EventModifiers
         #endif
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._1(shortcut):
-            if #available(visionOS 1.0,macOS 11.0,iOS 14.0, *) {
+            if #available(iOS 14.0,visionOS 1.0,macOS 11.0, *) {
             let shortcut = shortcut as! SwiftUI.KeyboardShortcut
             
             __content
@@ -6340,7 +6340,7 @@ let modifiers = modifiers as! SwiftUICore.EventModifiers
         #endif
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._2(shortcut):
-            if #available(visionOS 1.0,macOS 12.3,iOS 15.4, *) {
+            if #available(iOS 15.4,visionOS 1.0,macOS 12.3, *) {
             let shortcut = shortcut as? SwiftUI.KeyboardShortcut
             
             __content
@@ -6351,7 +6351,7 @@ let modifiers = modifiers as! SwiftUICore.EventModifiers
         #endif
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._3(key, modifiers, localization):
-            if #available(visionOS 1.0,macOS 12.0,iOS 15.0, *) {
+            if #available(iOS 15.0,visionOS 1.0,macOS 12.0, *) {
             let key = key as! SwiftUI.KeyEquivalent
 let modifiers = modifiers as! SwiftUICore.EventModifiers 
 let localization = localization as! SwiftUI.KeyboardShortcut.Localization
@@ -6387,7 +6387,7 @@ struct _keyboardTypeModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(tvOS) || os(visionOS)
-    @available(tvOS 13.0,visionOS 1.0,iOS 13.0, *)
+    @available(iOS 13.0,tvOS 13.0,visionOS 1.0, *)
     init(_ type: UIKit.UIKeyboardType) {
         self.value = ._0(type: type)
         
@@ -6400,7 +6400,7 @@ struct _keyboardTypeModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(tvOS) || os(visionOS)
         case let ._0(type):
-            if #available(tvOS 13.0,visionOS 1.0,iOS 13.0, *) {
+            if #available(iOS 13.0,tvOS 13.0,visionOS 1.0, *) {
             let type = type as! UIKit.UIKeyboardType
             
             __content
@@ -6575,7 +6575,7 @@ struct _labelsVisibilityModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 15.0,watchOS 11.0,iOS 18.0,tvOS 18.0,visionOS 2.0, *)
+    @available(tvOS 18.0,watchOS 11.0,visionOS 2.0,macOS 15.0,iOS 18.0, *)
     init(_ visibility: AttributeReference<SwiftUI.Visibility>) {
         self.value = ._0(visibility: visibility)
         
@@ -6588,7 +6588,7 @@ struct _labelsVisibilityModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(visibility):
-            if #available(macOS 15.0,watchOS 11.0,iOS 18.0,tvOS 18.0,visionOS 2.0, *) {
+            if #available(tvOS 18.0,watchOS 11.0,visionOS 2.0,macOS 15.0,iOS 18.0, *) {
             let visibility = visibility as! AttributeReference<SwiftUI.Visibility>
             
             __content
@@ -7256,7 +7256,7 @@ struct _listRowSpacingModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(visionOS)
-    @available(visionOS 1.0,iOS 15.0, *)
+    @available(iOS 15.0,visionOS 1.0, *)
     init(_ spacing: AttributeReference<CoreFoundation.CGFloat?>?) {
         self.value = ._0(spacing: spacing)
         
@@ -7269,7 +7269,7 @@ struct _listRowSpacingModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(visionOS)
         case let ._0(spacing):
-            if #available(visionOS 1.0,iOS 15.0, *) {
+            if #available(iOS 15.0,visionOS 1.0, *) {
             let spacing = spacing as? AttributeReference<CoreFoundation.CGFloat?>
             
             __content
@@ -7303,7 +7303,7 @@ struct _listSectionSeparatorModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(visionOS 1.0,macOS 13.0,iOS 15.0, *)
+    @available(iOS 15.0,visionOS 1.0,macOS 13.0, *)
     init(_ visibility: AttributeReference<SwiftUI.Visibility>,edges: SwiftUICore.VerticalEdge.Set = .all ) {
         self.value = ._0(visibility: visibility, edges: edges)
         
@@ -7316,7 +7316,7 @@ struct _listSectionSeparatorModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(visibility, edges):
-            if #available(visionOS 1.0,macOS 13.0,iOS 15.0, *) {
+            if #available(iOS 15.0,visionOS 1.0,macOS 13.0, *) {
             let visibility = visibility as! AttributeReference<SwiftUI.Visibility>
 let edges = edges as! SwiftUICore.VerticalEdge.Set 
             
@@ -7351,7 +7351,7 @@ struct _listSectionSeparatorTintModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 13.0,visionOS 1.0,iOS 15.0, *)
+    @available(iOS 15.0,visionOS 1.0,macOS 13.0, *)
     init(_ color: Color.Resolvable?,edges: SwiftUICore.VerticalEdge.Set = .all ) {
         self.value = ._0(color: color, edges: edges)
         
@@ -7364,7 +7364,7 @@ struct _listSectionSeparatorTintModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(color, edges):
-            if #available(macOS 13.0,visionOS 1.0,iOS 15.0, *) {
+            if #available(iOS 15.0,visionOS 1.0,macOS 13.0, *) {
             let color = color as? Color.Resolvable
 let edges = edges as! SwiftUICore.VerticalEdge.Set 
             
@@ -7404,14 +7404,14 @@ struct _listSectionSpacingModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 10.0,visionOS 1.0,iOS 17.0, *)
+    @available(iOS 17.0,watchOS 10.0,visionOS 1.0, *)
     init(_ spacing: SwiftUI.ListSectionSpacing) {
         self.value = ._0(spacing: spacing)
         
     }
     #endif
     #if os(iOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 10.0,visionOS 1.0,iOS 17.0, *)
+    @available(iOS 17.0,watchOS 10.0,visionOS 1.0, *)
     init(_ spacing: AttributeReference<CoreFoundation.CGFloat>) {
         self.value = ._1(spacing: spacing)
         
@@ -7424,7 +7424,7 @@ struct _listSectionSpacingModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(visionOS) || os(watchOS)
         case let ._0(spacing):
-            if #available(watchOS 10.0,visionOS 1.0,iOS 17.0, *) {
+            if #available(iOS 17.0,watchOS 10.0,visionOS 1.0, *) {
             let spacing = spacing as! SwiftUI.ListSectionSpacing
             
             __content
@@ -7435,7 +7435,7 @@ struct _listSectionSpacingModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(visionOS) || os(watchOS)
         case let ._1(spacing):
-            if #available(watchOS 10.0,visionOS 1.0,iOS 17.0, *) {
+            if #available(iOS 17.0,watchOS 10.0,visionOS 1.0, *) {
             let spacing = spacing as! AttributeReference<CoreFoundation.CGFloat>
             
             __content
@@ -7563,7 +7563,7 @@ struct _materialActiveAppearanceModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 11.0,tvOS 18.0,visionOS 2.0,iOS 18.0,macOS 15.0, *)
+    @available(tvOS 18.0,watchOS 11.0,visionOS 2.0,macOS 15.0,iOS 18.0, *)
     init(_ appearance: SwiftUICore.MaterialActiveAppearance) {
         self.value = ._0(appearance: appearance)
         
@@ -7576,58 +7576,11 @@ struct _materialActiveAppearanceModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(appearance):
-            if #available(watchOS 11.0,tvOS 18.0,visionOS 2.0,iOS 18.0,macOS 15.0, *) {
+            if #available(tvOS 18.0,watchOS 11.0,visionOS 2.0,macOS 15.0,iOS 18.0, *) {
             let appearance = appearance as! SwiftUICore.MaterialActiveAppearance
             
             __content
                 .materialActiveAppearance(appearance)
-            
-                
-            } else { __content }
-        #endif
-        }
-    }
-}
-@_documentation(visibility: public)
-@ParseableExpression
-struct _menuButtonStyleModifier<R: RootRegistry>: ViewModifier {
-    static var name: String { "menuButtonStyle" }
-
-    enum Value {
-        case _never
-        #if os(macOS)
-        indirect case _0(style: Any)
-        #endif
-    }
-
-    let value: Value
-
-    
-    
-    
-
-
-
-
-    #if os(macOS)
-    @available(macOS 13.0, *)
-    init(_ style: AnyMenuButtonStyle) {
-        self.value = ._0(style: style)
-        
-    }
-    #endif
-
-    func body(content __content: Content) -> some View {
-        switch value {
-        case ._never:
-            fatalError("unreachable")
-        #if os(macOS)
-        case let ._0(style):
-            if #available(macOS 13.0, *) {
-            let style = style as! AnyMenuButtonStyle
-            
-            __content
-                .menuButtonStyle(style)
             
                 
             } else { __content }
@@ -7657,7 +7610,7 @@ struct _menuIndicatorModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS)
-    @available(macOS 12.0,visionOS 1.0,tvOS 17.0,iOS 15.0, *)
+    @available(iOS 15.0,macOS 12.0,tvOS 17.0,visionOS 1.0, *)
     init(_ visibility: AttributeReference<SwiftUI.Visibility>) {
         self.value = ._0(visibility: visibility)
         
@@ -7670,7 +7623,7 @@ struct _menuIndicatorModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS)
         case let ._0(visibility):
-            if #available(macOS 12.0,visionOS 1.0,tvOS 17.0,iOS 15.0, *) {
+            if #available(iOS 15.0,macOS 12.0,tvOS 17.0,visionOS 1.0, *) {
             let visibility = visibility as! AttributeReference<SwiftUI.Visibility>
             
             __content
@@ -7751,7 +7704,7 @@ struct _menuStyleModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS)
-    @available(tvOS 17.0,visionOS 1.0,iOS 14.0,macOS 11.0, *)
+    @available(tvOS 17.0,visionOS 1.0,macOS 11.0,iOS 14.0, *)
     init(_ style: AnyMenuStyle) {
         self.value = ._0(style: style)
         
@@ -7764,7 +7717,7 @@ struct _menuStyleModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS)
         case let ._0(style):
-            if #available(tvOS 17.0,visionOS 1.0,iOS 14.0,macOS 11.0, *) {
+            if #available(tvOS 17.0,visionOS 1.0,macOS 11.0,iOS 14.0, *) {
             let style = style as! AnyMenuStyle
             
             __content
@@ -8034,7 +7987,7 @@ struct _navigationBarHiddenModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 6.0,visionOS 1.0,iOS 13.0,macOS 13.0,tvOS 13.0, *)
+    @available(iOS 13.0,macOS 13.0,tvOS 13.0,watchOS 6.0,visionOS 1.0, *)
     init(_ hidden: AttributeReference<Swift.Bool>) {
         self.value = ._0(hidden: hidden)
         
@@ -8047,7 +8000,7 @@ struct _navigationBarHiddenModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(hidden):
-            if #available(watchOS 6.0,visionOS 1.0,iOS 13.0,macOS 13.0,tvOS 13.0, *) {
+            if #available(iOS 13.0,macOS 13.0,tvOS 13.0,watchOS 6.0,visionOS 1.0, *) {
             let hidden = hidden as! AttributeReference<Swift.Bool>
             
             __content
@@ -8091,21 +8044,21 @@ struct _navigationBarItemsModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(tvOS) || os(visionOS)
-    @available(tvOS 16.0,visionOS 1.0,iOS 16.0, *)
+    @available(iOS 16.0,visionOS 1.0,tvOS 16.0, *)
     init(leading: InlineViewReference,trailing: InlineViewReference) {
         self.value = ._0(leading: leading, trailing: trailing)
         
     }
     #endif
     #if os(iOS) || os(tvOS) || os(visionOS)
-    @available(iOS 16.0,tvOS 16.0,visionOS 1.0, *)
+    @available(iOS 16.0,visionOS 1.0,tvOS 16.0, *)
     init(leading: InlineViewReference) {
         self.value = ._1(leading: leading)
         
     }
     #endif
     #if os(iOS) || os(tvOS) || os(visionOS)
-    @available(visionOS 1.0,iOS 16.0,tvOS 16.0, *)
+    @available(iOS 16.0,visionOS 1.0,tvOS 16.0, *)
     init(trailing: InlineViewReference) {
         self.value = ._2(trailing: trailing)
         
@@ -8118,7 +8071,7 @@ struct _navigationBarItemsModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(tvOS) || os(visionOS)
         case let ._0(leading, trailing):
-            if #available(tvOS 16.0,visionOS 1.0,iOS 16.0, *) {
+            if #available(iOS 16.0,visionOS 1.0,tvOS 16.0, *) {
             let leading = leading as! InlineViewReference
 let trailing = trailing as! InlineViewReference
             
@@ -8130,7 +8083,7 @@ let trailing = trailing as! InlineViewReference
         #endif
         #if os(iOS) || os(tvOS) || os(visionOS)
         case let ._1(leading):
-            if #available(iOS 16.0,tvOS 16.0,visionOS 1.0, *) {
+            if #available(iOS 16.0,visionOS 1.0,tvOS 16.0, *) {
             let leading = leading as! InlineViewReference
             
             __content
@@ -8141,7 +8094,7 @@ let trailing = trailing as! InlineViewReference
         #endif
         #if os(iOS) || os(tvOS) || os(visionOS)
         case let ._2(trailing):
-            if #available(visionOS 1.0,iOS 16.0,tvOS 16.0, *) {
+            if #available(iOS 16.0,visionOS 1.0,tvOS 16.0, *) {
             let trailing = trailing as! InlineViewReference
             
             __content
@@ -8200,42 +8153,42 @@ struct _navigationBarTitleModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 6.0,visionOS 1.0,iOS 13.0,macOS 13.0,tvOS 13.0, *)
+    @available(iOS 13.0,macOS 13.0,tvOS 13.0,watchOS 6.0,visionOS 1.0, *)
     init(_ title: TextReference) {
         self.value = ._0(title: title)
         
     }
     #endif
     #if os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 6.0,visionOS 1.0,iOS 13.0,macOS 13.0,tvOS 13.0, *)
+    @available(iOS 13.0,macOS 13.0,tvOS 13.0,watchOS 6.0,visionOS 1.0, *)
     init(_ titleKey: SwiftUICore.LocalizedStringKey) {
         self.value = ._1(titleKey: titleKey)
         
     }
     #endif
     #if os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 6.0,visionOS 1.0,iOS 13.0,macOS 13.0,tvOS 13.0, *)
+    @available(iOS 13.0,macOS 13.0,tvOS 13.0,watchOS 6.0,visionOS 1.0, *)
     init(_ title: AttributeReference<String>) {
         self.value = ._2(title: title)
         
     }
     #endif
     #if os(iOS) || os(visionOS)
-    @available(watchOS 6.0,visionOS 1.0,iOS 13.0,macOS 13.0,tvOS 13.0, *)
+    @available(iOS 13.0,macOS 13.0,tvOS 13.0,watchOS 6.0,visionOS 1.0, *)
     init(_ title: TextReference,displayMode: SwiftUI.NavigationBarItem.TitleDisplayMode) {
         self.value = ._3(title: title, displayMode: displayMode)
         
     }
     #endif
     #if os(iOS) || os(visionOS)
-    @available(watchOS 6.0,visionOS 1.0,iOS 13.0,macOS 13.0,tvOS 13.0, *)
+    @available(iOS 13.0,macOS 13.0,tvOS 13.0,watchOS 6.0,visionOS 1.0, *)
     init(_ titleKey: SwiftUICore.LocalizedStringKey,displayMode: SwiftUI.NavigationBarItem.TitleDisplayMode) {
         self.value = ._4(titleKey: titleKey, displayMode: displayMode)
         
     }
     #endif
     #if os(iOS) || os(visionOS)
-    @available(watchOS 6.0,visionOS 1.0,iOS 13.0,macOS 13.0,tvOS 13.0, *)
+    @available(iOS 13.0,macOS 13.0,tvOS 13.0,watchOS 6.0,visionOS 1.0, *)
     init(_ title: AttributeReference<String>,displayMode: SwiftUI.NavigationBarItem.TitleDisplayMode) {
         self.value = ._5(title: title, displayMode: displayMode)
         
@@ -8248,7 +8201,7 @@ struct _navigationBarTitleModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(title):
-            if #available(watchOS 6.0,visionOS 1.0,iOS 13.0,macOS 13.0,tvOS 13.0, *) {
+            if #available(iOS 13.0,macOS 13.0,tvOS 13.0,watchOS 6.0,visionOS 1.0, *) {
             let title = title as! TextReference
             __content._observeTextReference(title, on: element, in: context) { __content in
             __content
@@ -8259,7 +8212,7 @@ struct _navigationBarTitleModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(titleKey):
-            if #available(watchOS 6.0,visionOS 1.0,iOS 13.0,macOS 13.0,tvOS 13.0, *) {
+            if #available(iOS 13.0,macOS 13.0,tvOS 13.0,watchOS 6.0,visionOS 1.0, *) {
             let titleKey = titleKey as! SwiftUICore.LocalizedStringKey
             
             __content
@@ -8270,7 +8223,7 @@ struct _navigationBarTitleModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._2(title):
-            if #available(watchOS 6.0,visionOS 1.0,iOS 13.0,macOS 13.0,tvOS 13.0, *) {
+            if #available(iOS 13.0,macOS 13.0,tvOS 13.0,watchOS 6.0,visionOS 1.0, *) {
             let title = title as! AttributeReference<String>
             
             __content
@@ -8281,7 +8234,7 @@ struct _navigationBarTitleModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(visionOS)
         case let ._3(title, displayMode):
-            if #available(watchOS 6.0,visionOS 1.0,iOS 13.0,macOS 13.0,tvOS 13.0, *) {
+            if #available(iOS 13.0,macOS 13.0,tvOS 13.0,watchOS 6.0,visionOS 1.0, *) {
             let title = title as! TextReference
 let displayMode = displayMode as! SwiftUI.NavigationBarItem.TitleDisplayMode
             __content._observeTextReference(title, on: element, in: context) { __content in
@@ -8293,7 +8246,7 @@ let displayMode = displayMode as! SwiftUI.NavigationBarItem.TitleDisplayMode
         #endif
         #if os(iOS) || os(visionOS)
         case let ._4(titleKey, displayMode):
-            if #available(watchOS 6.0,visionOS 1.0,iOS 13.0,macOS 13.0,tvOS 13.0, *) {
+            if #available(iOS 13.0,macOS 13.0,tvOS 13.0,watchOS 6.0,visionOS 1.0, *) {
             let titleKey = titleKey as! SwiftUICore.LocalizedStringKey
 let displayMode = displayMode as! SwiftUI.NavigationBarItem.TitleDisplayMode
             
@@ -8305,7 +8258,7 @@ let displayMode = displayMode as! SwiftUI.NavigationBarItem.TitleDisplayMode
         #endif
         #if os(iOS) || os(visionOS)
         case let ._5(title, displayMode):
-            if #available(watchOS 6.0,visionOS 1.0,iOS 13.0,macOS 13.0,tvOS 13.0, *) {
+            if #available(iOS 13.0,macOS 13.0,tvOS 13.0,watchOS 6.0,visionOS 1.0, *) {
             let title = title as! AttributeReference<String>
 let displayMode = displayMode as! SwiftUI.NavigationBarItem.TitleDisplayMode
             
@@ -8685,7 +8638,7 @@ struct _navigationTitleModifier<R: RootRegistry>: ViewModifier {
     }
     
     #if os(watchOS)
-    @available(tvOS 14.0,iOS 14.0,macOS 11.0,watchOS 7.0, *)
+    @available(tvOS 14.0,watchOS 7.0,macOS 11.0,iOS 14.0, *)
     init(_ title: ViewReference=ViewReference(value: [])) {
         self.value = ._3(title: title)
         
@@ -8738,7 +8691,7 @@ struct _navigationTitleModifier<R: RootRegistry>: ViewModifier {
         
         #if os(watchOS)
         case let ._3(title):
-            if #available(tvOS 14.0,iOS 14.0,macOS 11.0,watchOS 7.0, *) {
+            if #available(tvOS 14.0,watchOS 7.0,macOS 11.0,iOS 14.0, *) {
             let title = title as! ViewReference
             
             __content
@@ -8970,7 +8923,7 @@ struct _onDeleteCommandModifier<R: RootRegistry>: ViewModifier {
 @Event private var _0_action__0: Event.EventHandler
 
     #if os(macOS)
-    @available(tvOS 13.0,macOS 10.15, *)
+    @available(macOS 10.15,tvOS 13.0, *)
     init(perform action__0: Event=Event()) {
         self.value = ._0
         self.__0_action__0 = action__0
@@ -8983,7 +8936,7 @@ struct _onDeleteCommandModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(macOS)
         case ._0:
-            if #available(tvOS 13.0,macOS 10.15, *) {
+            if #available(macOS 10.15,tvOS 13.0, *) {
             
             
             __content
@@ -9064,7 +9017,7 @@ struct _onExitCommandModifier<R: RootRegistry>: ViewModifier {
 @Event private var _0_action__0: Event.EventHandler
 
     #if os(macOS) || os(tvOS)
-    @available(tvOS 13.0,macOS 10.15, *)
+    @available(macOS 10.15,tvOS 13.0, *)
     init(perform action__0: Event=Event()) {
         self.value = ._0
         self.__0_action__0 = action__0
@@ -9077,7 +9030,7 @@ struct _onExitCommandModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(macOS) || os(tvOS)
         case ._0:
-            if #available(tvOS 13.0,macOS 10.15, *) {
+            if #available(macOS 10.15,tvOS 13.0, *) {
             
             
             __content
@@ -9111,7 +9064,7 @@ struct _onHoverModifier<R: RootRegistry>: ViewModifier {
 @Event private var _0_action__1: Event.EventHandler
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 10.15,iOS 13.4,visionOS 1.0, *)
+    @available(iOS 13.4,visionOS 1.0,macOS 10.15, *)
     init(perform action__1: Event) {
         self.value = ._0
         self.__0_action__1 = action__1
@@ -9124,7 +9077,7 @@ struct _onHoverModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case ._0:
-            if #available(macOS 10.15,iOS 13.4,visionOS 1.0, *) {
+            if #available(iOS 13.4,visionOS 1.0,macOS 10.15, *) {
             
             
             __content
@@ -9224,7 +9177,7 @@ struct _onLongPressGestureModifier<R: RootRegistry>: ViewModifier {
 @Event private var _3_action__0: Event.EventHandler
 
     #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
-    @available(macOS 10.15,iOS 13.0,watchOS 6.0,visionOS 1.0,tvOS 14.0, *)
+    @available(tvOS 14.0,iOS 13.0,macOS 10.15,visionOS 1.0,watchOS 6.0, *)
     init(minimumDuration: AttributeReference<Swift.Double> = .init(storage: .constant(0.5)), maximumDistance: AttributeReference<CoreFoundation.CGFloat> = .init(storage: .constant(10)), perform action__0: Event,onPressingChanged onPressingChanged__1: Event=Event() ) {
         self.value = ._0(minimumDuration: minimumDuration, maximumDistance: maximumDistance)
         self.__0_action__0 = action__0
@@ -9232,7 +9185,7 @@ self.__0_onPressingChanged__1 = onPressingChanged__1
     }
     #endif
     #if os(tvOS)
-    @available(macOS 10.15,iOS 13.0,watchOS 6.0,tvOS 14.0, *)
+    @available(tvOS 14.0,iOS 13.0,macOS 10.15,watchOS 6.0, *)
     init(minimumDuration: AttributeReference<Swift.Double> = .init(storage: .constant(0.5)), perform action__0: Event,onPressingChanged onPressingChanged__1: Event=Event() ) {
         self.value = ._1(minimumDuration: minimumDuration)
         self.__1_action__0 = action__0
@@ -9240,7 +9193,7 @@ self.__1_onPressingChanged__1 = onPressingChanged__1
     }
     #endif
     #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
-    @available(macOS 10.15,iOS 13.0,watchOS 6.0,visionOS 1.0,tvOS 14.0, *)
+    @available(tvOS 14.0,iOS 13.0,macOS 10.15,visionOS 1.0,watchOS 6.0, *)
     init(minimumDuration: AttributeReference<Swift.Double> = .init(storage: .constant(0.5)), maximumDistance: AttributeReference<CoreFoundation.CGFloat> = .init(storage: .constant(10)), pressing pressing__1: Event=Event(), perform action__0: Event) {
         self.value = ._2(minimumDuration: minimumDuration, maximumDistance: maximumDistance)
         self.__2_pressing__1 = pressing__1
@@ -9248,7 +9201,7 @@ self.__2_action__0 = action__0
     }
     #endif
     #if os(tvOS)
-    @available(macOS 10.15,iOS 13.0,watchOS 6.0,tvOS 14.0, *)
+    @available(tvOS 14.0,iOS 13.0,macOS 10.15,watchOS 6.0, *)
     init(minimumDuration: AttributeReference<Swift.Double> = .init(storage: .constant(0.5)), pressing pressing__1: Event=Event(), perform action__0: Event) {
         self.value = ._3(minimumDuration: minimumDuration)
         self.__3_pressing__1 = pressing__1
@@ -9262,7 +9215,7 @@ self.__3_action__0 = action__0
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
         case let ._0(minimumDuration, maximumDistance):
-            if #available(macOS 10.15,iOS 13.0,watchOS 6.0,visionOS 1.0,tvOS 14.0, *) {
+            if #available(tvOS 14.0,iOS 13.0,macOS 10.15,visionOS 1.0,watchOS 6.0, *) {
             let minimumDuration = minimumDuration as! AttributeReference<Swift.Double>
 let maximumDistance = maximumDistance as! AttributeReference<CoreFoundation.CGFloat>
             
@@ -9274,7 +9227,7 @@ let maximumDistance = maximumDistance as! AttributeReference<CoreFoundation.CGFl
         #endif
         #if os(tvOS)
         case let ._1(minimumDuration):
-            if #available(macOS 10.15,iOS 13.0,watchOS 6.0,tvOS 14.0, *) {
+            if #available(tvOS 14.0,iOS 13.0,macOS 10.15,watchOS 6.0, *) {
             let minimumDuration = minimumDuration as! AttributeReference<Swift.Double>
             
             __content
@@ -9285,7 +9238,7 @@ let maximumDistance = maximumDistance as! AttributeReference<CoreFoundation.CGFl
         #endif
         #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
         case let ._2(minimumDuration, maximumDistance):
-            if #available(macOS 10.15,iOS 13.0,watchOS 6.0,visionOS 1.0,tvOS 14.0, *) {
+            if #available(tvOS 14.0,iOS 13.0,macOS 10.15,visionOS 1.0,watchOS 6.0, *) {
             let minimumDuration = minimumDuration as! AttributeReference<Swift.Double>
 let maximumDistance = maximumDistance as! AttributeReference<CoreFoundation.CGFloat>
             
@@ -9297,7 +9250,7 @@ let maximumDistance = maximumDistance as! AttributeReference<CoreFoundation.CGFl
         #endif
         #if os(tvOS)
         case let ._3(minimumDuration):
-            if #available(macOS 10.15,iOS 13.0,watchOS 6.0,tvOS 14.0, *) {
+            if #available(tvOS 14.0,iOS 13.0,macOS 10.15,watchOS 6.0, *) {
             let minimumDuration = minimumDuration as! AttributeReference<Swift.Double>
             
             __content
@@ -9380,7 +9333,7 @@ struct _onModifierKeysChangedModifier<R: RootRegistry>: ViewModifier {
 @Event private var _0_action__2: Event.EventHandler
 
     #if os(macOS) || os(visionOS)
-    @available(macOS 15.0,visionOS 1.0, *)
+    @available(visionOS 1.0,macOS 15.0, *)
     init(mask: SwiftUICore.EventModifiers = .all, initial: AttributeReference<Swift.Bool> = .init(storage: .constant(true)), action action__2: Event) {
         self.value = ._0(mask: mask, initial: initial)
         self.__0_action__2 = action__2
@@ -9393,7 +9346,7 @@ struct _onModifierKeysChangedModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(macOS) || os(visionOS)
         case let ._0(mask, initial):
-            if #available(macOS 15.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,macOS 15.0, *) {
             let mask = mask as! SwiftUICore.EventModifiers 
 let initial = initial as! AttributeReference<Swift.Bool>
             
@@ -9428,7 +9381,7 @@ struct _onMoveCommandModifier<R: RootRegistry>: ViewModifier {
 @Event private var _0_action__1: Event.EventHandler
 
     #if os(macOS) || os(tvOS)
-    @available(tvOS 13.0,macOS 10.15, *)
+    @available(macOS 10.15,tvOS 13.0, *)
     init(perform action__1: Event=Event()) {
         self.value = ._0
         self.__0_action__1 = action__1
@@ -9441,7 +9394,7 @@ struct _onMoveCommandModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(macOS) || os(tvOS)
         case ._0:
-            if #available(tvOS 13.0,macOS 10.15, *) {
+            if #available(macOS 10.15,tvOS 13.0, *) {
             
             
             __content
@@ -9569,7 +9522,7 @@ struct _onPlayPauseCommandModifier<R: RootRegistry>: ViewModifier {
 @Event private var _0_action__0: Event.EventHandler
 
     #if os(tvOS)
-    @available(tvOS 13.0,macOS 10.15, *)
+    @available(macOS 10.15,tvOS 13.0, *)
     init(perform action__0: Event=Event()) {
         self.value = ._0
         self.__0_action__0 = action__0
@@ -9582,7 +9535,7 @@ struct _onPlayPauseCommandModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(tvOS)
         case ._0:
-            if #available(tvOS 13.0,macOS 10.15, *) {
+            if #available(macOS 10.15,tvOS 13.0, *) {
             
             
             __content
@@ -9616,7 +9569,7 @@ struct _onScrollPhaseChangeModifier<R: RootRegistry>: ViewModifier {
 @Event private var _0_action__2: Event.EventHandler
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 11.0,tvOS 18.0,visionOS 2.0,iOS 18.0,macOS 15.0, *)
+    @available(tvOS 18.0,visionOS 2.0,watchOS 11.0,macOS 15.0,iOS 18.0, *)
     init(_ action__2: Event) {
         self.value = ._0
         self.__0_action__2 = action__2
@@ -9629,7 +9582,7 @@ struct _onScrollPhaseChangeModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case ._0:
-            if #available(watchOS 11.0,tvOS 18.0,visionOS 2.0,iOS 18.0,macOS 15.0, *) {
+            if #available(tvOS 18.0,visionOS 2.0,watchOS 11.0,macOS 15.0,iOS 18.0, *) {
             
             
             __content
@@ -9663,7 +9616,7 @@ struct _onScrollVisibilityChangeModifier<R: RootRegistry>: ViewModifier {
 @Event private var _0_action__1: Event.EventHandler
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(tvOS 18.0,iOS 18.0,macOS 15.0,visionOS 2.0,watchOS 11.0, *)
+    @available(tvOS 18.0,watchOS 11.0,iOS 18.0,visionOS 2.0,macOS 15.0, *)
     init(threshold: AttributeReference<Swift.Double> = .init(storage: .constant(0.5)), action action__1: Event) {
         self.value = ._0(threshold: threshold)
         self.__0_action__1 = action__1
@@ -9676,7 +9629,7 @@ struct _onScrollVisibilityChangeModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(threshold):
-            if #available(tvOS 18.0,iOS 18.0,macOS 15.0,visionOS 2.0,watchOS 11.0, *) {
+            if #available(tvOS 18.0,watchOS 11.0,iOS 18.0,visionOS 2.0,macOS 15.0, *) {
             let threshold = threshold as! AttributeReference<Swift.Double>
             
             __content
@@ -9715,7 +9668,7 @@ struct _onTapGestureModifier<R: RootRegistry>: ViewModifier {
 @Event private var _1_action__0: Event.EventHandler
 
     #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,iOS 17.0,macOS 14.0,watchOS 10.0, *)
+    @available(iOS 17.0,visionOS 1.0,watchOS 10.0,macOS 14.0, *)
     init(count: AttributeReference<Swift.Int> = .init(storage: .constant(1)), coordinateSpace: AnyCoordinateSpaceProtocol = .local, perform action__1: Event) {
         self.value = ._0(count: count, coordinateSpace: coordinateSpace)
         self.__0_action__1 = action__1
@@ -9735,7 +9688,7 @@ struct _onTapGestureModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
         case let ._0(count, coordinateSpace):
-            if #available(visionOS 1.0,iOS 17.0,macOS 14.0,watchOS 10.0, *) {
+            if #available(iOS 17.0,visionOS 1.0,watchOS 10.0,macOS 14.0, *) {
             let count = count as! AttributeReference<Swift.Int>
 let coordinateSpace = coordinateSpace as! AnyCoordinateSpaceProtocol 
             
@@ -10422,14 +10375,14 @@ struct _popoverModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(visionOS 1.0,iOS 13.0,macOS 10.15, *)
+    @available(macOS 10.15,visionOS 1.0,iOS 13.0, *)
     init(isPresented: ChangeTracked<Swift.Bool>,attachmentAnchor: SwiftUI.PopoverAttachmentAnchor = .rect(.bounds), arrowEdge: SwiftUICore.Edge = .top, content: ViewReference=ViewReference(value: [])) {
         self.value = ._0(attachmentAnchor: attachmentAnchor, arrowEdge: arrowEdge, content: content)
         self.__0_isPresented = isPresented
     }
     #endif
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(visionOS 2.0,iOS 18.0,macOS 15.0, *)
+    @available(macOS 15.0,visionOS 2.0,iOS 18.0, *)
     init(isPresented: ChangeTracked<Swift.Bool>,attachmentAnchor: SwiftUI.PopoverAttachmentAnchor = .rect(.bounds), content: ViewReference=ViewReference(value: [])) {
         self.value = ._1(attachmentAnchor: attachmentAnchor, content: content)
         self.__1_isPresented = isPresented
@@ -10442,7 +10395,7 @@ struct _popoverModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(attachmentAnchor, arrowEdge, content):
-            if #available(visionOS 1.0,iOS 13.0,macOS 10.15, *) {
+            if #available(macOS 10.15,visionOS 1.0,iOS 13.0, *) {
             let attachmentAnchor = attachmentAnchor as! SwiftUI.PopoverAttachmentAnchor 
 let arrowEdge = arrowEdge as! SwiftUICore.Edge 
 let content = content as! ViewReference
@@ -10455,7 +10408,7 @@ let content = content as! ViewReference
         #endif
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._1(attachmentAnchor, content):
-            if #available(visionOS 2.0,iOS 18.0,macOS 15.0, *) {
+            if #available(macOS 15.0,visionOS 2.0,iOS 18.0, *) {
             let attachmentAnchor = attachmentAnchor as! SwiftUI.PopoverAttachmentAnchor 
 let content = content as! ViewReference
             
@@ -10659,14 +10612,14 @@ struct _presentationBackgroundModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 9.4,visionOS 1.0,iOS 16.4,macOS 13.3,tvOS 16.4, *)
+    @available(tvOS 16.4,iOS 16.4,visionOS 1.0,macOS 13.3,watchOS 9.4, *)
     init(_ style: AnyShapeStyle.Resolvable) {
         self.value = ._0(style: style)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 9.4,visionOS 1.0,iOS 16.4,macOS 13.3,tvOS 16.4, *)
+    @available(tvOS 16.4,iOS 16.4,visionOS 1.0,macOS 13.3,watchOS 9.4, *)
     init(alignment: AttributeReference<SwiftUICore.Alignment> = .init(storage: .constant(.center)), content: ViewReference=ViewReference(value: [])) {
         self.value = ._1(alignment: alignment, content: content)
         
@@ -10679,7 +10632,7 @@ struct _presentationBackgroundModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(style):
-            if #available(watchOS 9.4,visionOS 1.0,iOS 16.4,macOS 13.3,tvOS 16.4, *) {
+            if #available(tvOS 16.4,iOS 16.4,visionOS 1.0,macOS 13.3,watchOS 9.4, *) {
             let style = style as! AnyShapeStyle.Resolvable
             
             __content
@@ -10690,7 +10643,7 @@ struct _presentationBackgroundModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(alignment, content):
-            if #available(watchOS 9.4,visionOS 1.0,iOS 16.4,macOS 13.3,tvOS 16.4, *) {
+            if #available(tvOS 16.4,iOS 16.4,visionOS 1.0,macOS 13.3,watchOS 9.4, *) {
             let alignment = alignment as! AttributeReference<SwiftUICore.Alignment>
 let content = content as! ViewReference
             
@@ -10725,7 +10678,7 @@ struct _presentationBackgroundInteractionModifier<R: RootRegistry>: ViewModifier
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 13.3,watchOS 9.4,visionOS 1.0,tvOS 16.4,iOS 16.4, *)
+    @available(iOS 16.4,macOS 13.3,tvOS 16.4,watchOS 9.4,visionOS 1.0, *)
     init(_ interaction: SwiftUI.PresentationBackgroundInteraction) {
         self.value = ._0(interaction: interaction)
         
@@ -10738,7 +10691,7 @@ struct _presentationBackgroundInteractionModifier<R: RootRegistry>: ViewModifier
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(interaction):
-            if #available(macOS 13.3,watchOS 9.4,visionOS 1.0,tvOS 16.4,iOS 16.4, *) {
+            if #available(iOS 16.4,macOS 13.3,tvOS 16.4,watchOS 9.4,visionOS 1.0, *) {
             let interaction = interaction as! SwiftUI.PresentationBackgroundInteraction
             
             __content
@@ -10777,14 +10730,14 @@ struct _presentationCompactAdaptationModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 13.3,watchOS 9.4,visionOS 1.0,tvOS 16.4,iOS 16.4, *)
+    @available(iOS 16.4,macOS 13.3,tvOS 16.4,watchOS 9.4,visionOS 1.0, *)
     init(_ adaptation: SwiftUI.PresentationAdaptation) {
         self.value = ._0(adaptation: adaptation)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 13.3,watchOS 9.4,visionOS 1.0,tvOS 16.4,iOS 16.4, *)
+    @available(iOS 16.4,macOS 13.3,tvOS 16.4,watchOS 9.4,visionOS 1.0, *)
     init(horizontal horizontalAdaptation: SwiftUI.PresentationAdaptation,vertical verticalAdaptation: SwiftUI.PresentationAdaptation) {
         self.value = ._1(horizontalAdaptation: horizontalAdaptation, verticalAdaptation: verticalAdaptation)
         
@@ -10797,7 +10750,7 @@ struct _presentationCompactAdaptationModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(adaptation):
-            if #available(macOS 13.3,watchOS 9.4,visionOS 1.0,tvOS 16.4,iOS 16.4, *) {
+            if #available(iOS 16.4,macOS 13.3,tvOS 16.4,watchOS 9.4,visionOS 1.0, *) {
             let adaptation = adaptation as! SwiftUI.PresentationAdaptation
             
             __content
@@ -10808,7 +10761,7 @@ struct _presentationCompactAdaptationModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(horizontalAdaptation, verticalAdaptation):
-            if #available(macOS 13.3,watchOS 9.4,visionOS 1.0,tvOS 16.4,iOS 16.4, *) {
+            if #available(iOS 16.4,macOS 13.3,tvOS 16.4,watchOS 9.4,visionOS 1.0, *) {
             let horizontalAdaptation = horizontalAdaptation as! SwiftUI.PresentationAdaptation
 let verticalAdaptation = verticalAdaptation as! SwiftUI.PresentationAdaptation
             
@@ -10843,7 +10796,7 @@ struct _presentationContentInteractionModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 13.3,watchOS 9.4,visionOS 1.0,tvOS 16.4,iOS 16.4, *)
+    @available(iOS 16.4,macOS 13.3,tvOS 16.4,watchOS 9.4,visionOS 1.0, *)
     init(_ behavior: SwiftUI.PresentationContentInteraction) {
         self.value = ._0(behavior: behavior)
         
@@ -10856,7 +10809,7 @@ struct _presentationContentInteractionModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(behavior):
-            if #available(macOS 13.3,watchOS 9.4,visionOS 1.0,tvOS 16.4,iOS 16.4, *) {
+            if #available(iOS 16.4,macOS 13.3,tvOS 16.4,watchOS 9.4,visionOS 1.0, *) {
             let behavior = behavior as! SwiftUI.PresentationContentInteraction
             
             __content
@@ -10890,7 +10843,7 @@ struct _presentationCornerRadiusModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 13.3,watchOS 9.4,visionOS 1.0,tvOS 16.4,iOS 16.4, *)
+    @available(iOS 16.4,macOS 13.3,tvOS 16.4,watchOS 9.4,visionOS 1.0, *)
     init(_ cornerRadius: AttributeReference<CoreFoundation.CGFloat?>?) {
         self.value = ._0(cornerRadius: cornerRadius)
         
@@ -10903,7 +10856,7 @@ struct _presentationCornerRadiusModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(cornerRadius):
-            if #available(macOS 13.3,watchOS 9.4,visionOS 1.0,tvOS 16.4,iOS 16.4, *) {
+            if #available(iOS 16.4,macOS 13.3,tvOS 16.4,watchOS 9.4,visionOS 1.0, *) {
             let cornerRadius = cornerRadius as? AttributeReference<CoreFoundation.CGFloat?>
             
             __content
@@ -10984,7 +10937,7 @@ struct _presentationSizingModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(iOS 18.0,visionOS 2.0,tvOS 18.0,watchOS 11.0,macOS 15.0, *)
+    @available(tvOS 18.0,visionOS 2.0,watchOS 11.0,macOS 15.0,iOS 18.0, *)
     init(_ sizing: AnyPresentationSizing) {
         self.value = ._0(sizing: sizing)
         
@@ -10997,7 +10950,7 @@ struct _presentationSizingModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(sizing):
-            if #available(iOS 18.0,visionOS 2.0,tvOS 18.0,watchOS 11.0,macOS 15.0, *) {
+            if #available(tvOS 18.0,visionOS 2.0,watchOS 11.0,macOS 15.0,iOS 18.0, *) {
             let sizing = sizing as! AnyPresentationSizing
             
             __content
@@ -11534,21 +11487,21 @@ struct _safeAreaPaddingModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,macOS 14.0,tvOS 17.0,iOS 17.0,watchOS 10.0, *)
+    @available(iOS 17.0,macOS 14.0,tvOS 17.0,watchOS 10.0,visionOS 1.0, *)
     init(_ insets: SwiftUICore.EdgeInsets) {
         self.value = ._0(insets: insets)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,macOS 14.0,tvOS 17.0,iOS 17.0,watchOS 10.0, *)
+    @available(iOS 17.0,macOS 14.0,tvOS 17.0,watchOS 10.0,visionOS 1.0, *)
     init(_ edges: SwiftUICore.Edge.Set = .all, _ length: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)) ) {
         self.value = ._1(edges: edges, length: length)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,macOS 14.0,tvOS 17.0,iOS 17.0,watchOS 10.0, *)
+    @available(iOS 17.0,macOS 14.0,tvOS 17.0,watchOS 10.0,visionOS 1.0, *)
     init(_ length: AttributeReference<CoreFoundation.CGFloat>) {
         self.value = ._2(length: length)
         
@@ -11561,7 +11514,7 @@ struct _safeAreaPaddingModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(insets):
-            if #available(visionOS 1.0,macOS 14.0,tvOS 17.0,iOS 17.0,watchOS 10.0, *) {
+            if #available(iOS 17.0,macOS 14.0,tvOS 17.0,watchOS 10.0,visionOS 1.0, *) {
             let insets = insets as! SwiftUICore.EdgeInsets
             
             __content
@@ -11572,7 +11525,7 @@ struct _safeAreaPaddingModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(edges, length):
-            if #available(visionOS 1.0,macOS 14.0,tvOS 17.0,iOS 17.0,watchOS 10.0, *) {
+            if #available(iOS 17.0,macOS 14.0,tvOS 17.0,watchOS 10.0,visionOS 1.0, *) {
             let edges = edges as! SwiftUICore.Edge.Set 
 let length = length as? AttributeReference<CoreFoundation.CGFloat?>
             
@@ -11584,7 +11537,7 @@ let length = length as? AttributeReference<CoreFoundation.CGFloat?>
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._2(length):
-            if #available(visionOS 1.0,macOS 14.0,tvOS 17.0,iOS 17.0,watchOS 10.0, *) {
+            if #available(iOS 17.0,macOS 14.0,tvOS 17.0,watchOS 10.0,visionOS 1.0, *) {
             let length = length as! AttributeReference<CoreFoundation.CGFloat>
             
             __content
@@ -11996,7 +11949,7 @@ struct _scrollBounceBehaviorModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 9.4,tvOS 16.4,visionOS 1.0,iOS 16.4,macOS 13.3, *)
+    @available(tvOS 16.4,watchOS 9.4,iOS 16.4,visionOS 1.0,macOS 13.3, *)
     init(_ behavior: SwiftUI.ScrollBounceBehavior,axes: SwiftUICore.Axis.Set = [.vertical] ) {
         self.value = ._0(behavior: behavior, axes: axes)
         
@@ -12009,7 +11962,7 @@ struct _scrollBounceBehaviorModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(behavior, axes):
-            if #available(watchOS 9.4,tvOS 16.4,visionOS 1.0,iOS 16.4,macOS 13.3, *) {
+            if #available(tvOS 16.4,watchOS 9.4,iOS 16.4,visionOS 1.0,macOS 13.3, *) {
             let behavior = behavior as! SwiftUI.ScrollBounceBehavior
 let axes = axes as! SwiftUICore.Axis.Set 
             
@@ -12044,7 +11997,7 @@ struct _scrollClipDisabledModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 10.0,tvOS 17.0,visionOS 1.0,iOS 17.0,macOS 14.0, *)
+    @available(tvOS 17.0,watchOS 10.0,iOS 17.0,visionOS 1.0,macOS 14.0, *)
     init(_ disabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(disabled: disabled)
         
@@ -12057,7 +12010,7 @@ struct _scrollClipDisabledModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(disabled):
-            if #available(watchOS 10.0,tvOS 17.0,visionOS 1.0,iOS 17.0,macOS 14.0, *) {
+            if #available(tvOS 17.0,watchOS 10.0,iOS 17.0,visionOS 1.0,macOS 14.0, *) {
             let disabled = disabled as! AttributeReference<Swift.Bool>
             
             __content
@@ -12091,7 +12044,7 @@ struct _scrollContentBackgroundModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
-    @available(iOS 16.0,watchOS 9.0,visionOS 1.0,macOS 13.0, *)
+    @available(visionOS 1.0,watchOS 9.0,macOS 13.0,iOS 16.0, *)
     init(_ visibility: AttributeReference<SwiftUI.Visibility>) {
         self.value = ._0(visibility: visibility)
         
@@ -12104,7 +12057,7 @@ struct _scrollContentBackgroundModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
         case let ._0(visibility):
-            if #available(iOS 16.0,watchOS 9.0,visionOS 1.0,macOS 13.0, *) {
+            if #available(visionOS 1.0,watchOS 9.0,macOS 13.0,iOS 16.0, *) {
             let visibility = visibility as! AttributeReference<SwiftUI.Visibility>
             
             __content
@@ -12185,7 +12138,7 @@ struct _scrollDismissesKeyboardModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-    @available(watchOS 9.0,tvOS 16.0,iOS 16.0,macOS 13.0, *)
+    @available(tvOS 16.0,watchOS 9.0,iOS 16.0,macOS 13.0, *)
     init(_ mode: SwiftUI.ScrollDismissesKeyboardMode) {
         self.value = ._0(mode: mode)
         
@@ -12198,7 +12151,7 @@ struct _scrollDismissesKeyboardModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
         case let ._0(mode):
-            if #available(watchOS 9.0,tvOS 16.0,iOS 16.0,macOS 13.0, *) {
+            if #available(tvOS 16.0,watchOS 9.0,iOS 16.0,macOS 13.0, *) {
             let mode = mode as! SwiftUI.ScrollDismissesKeyboardMode
             
             __content
@@ -12284,14 +12237,14 @@ struct _scrollIndicatorsFlashModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 10.0,tvOS 17.0,visionOS 1.0,iOS 17.0,macOS 14.0, *)
+    @available(tvOS 17.0,watchOS 10.0,iOS 17.0,visionOS 1.0,macOS 14.0, *)
     init(trigger value: AttributeReference<String>) {
         self.value = ._0(value: value)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 10.0,tvOS 17.0,visionOS 1.0,iOS 17.0,macOS 14.0, *)
+    @available(tvOS 17.0,watchOS 10.0,iOS 17.0,visionOS 1.0,macOS 14.0, *)
     init(onAppear: AttributeReference<Swift.Bool>) {
         self.value = ._1(onAppear: onAppear)
         
@@ -12304,7 +12257,7 @@ struct _scrollIndicatorsFlashModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(value):
-            if #available(watchOS 10.0,tvOS 17.0,visionOS 1.0,iOS 17.0,macOS 14.0, *) {
+            if #available(tvOS 17.0,watchOS 10.0,iOS 17.0,visionOS 1.0,macOS 14.0, *) {
             let value = value as! AttributeReference<String>
             
             __content
@@ -12315,7 +12268,7 @@ struct _scrollIndicatorsFlashModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(onAppear):
-            if #available(watchOS 10.0,tvOS 17.0,visionOS 1.0,iOS 17.0,macOS 14.0, *) {
+            if #available(tvOS 17.0,watchOS 10.0,iOS 17.0,visionOS 1.0,macOS 14.0, *) {
             let onAppear = onAppear as! AttributeReference<Swift.Bool>
             
             __content
@@ -12349,7 +12302,7 @@ struct _scrollPositionModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0,visionOS 1.0, *)
+    @available(iOS 17.0,macOS 14.0,tvOS 17.0,watchOS 10.0,visionOS 1.0, *)
     init(id: ChangeTracked<String?>,anchor: AttributeReference<SwiftUICore.UnitPoint?>? = .init(storage: .constant(nil)) ) {
         self.value = ._0(anchor: anchor)
         self.__0_id = id
@@ -12362,7 +12315,7 @@ struct _scrollPositionModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(anchor):
-            if #available(macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0,visionOS 1.0, *) {
+            if #available(iOS 17.0,macOS 14.0,tvOS 17.0,watchOS 10.0,visionOS 1.0, *) {
             let anchor = anchor as? AttributeReference<SwiftUICore.UnitPoint?>
             
             __content
@@ -12396,7 +12349,7 @@ struct _scrollTargetBehaviorModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 10.0,visionOS 1.0,iOS 17.0,macOS 14.0,tvOS 17.0, *)
+    @available(iOS 17.0,tvOS 17.0,watchOS 10.0,visionOS 1.0,macOS 14.0, *)
     init(_ behavior: AnyScrollTargetBehavior) {
         self.value = ._0(behavior: behavior)
         
@@ -12409,7 +12362,7 @@ struct _scrollTargetBehaviorModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(behavior):
-            if #available(watchOS 10.0,visionOS 1.0,iOS 17.0,macOS 14.0,tvOS 17.0, *) {
+            if #available(iOS 17.0,tvOS 17.0,watchOS 10.0,visionOS 1.0,macOS 14.0, *) {
             let behavior = behavior as! AnyScrollTargetBehavior
             
             __content
@@ -12443,7 +12396,7 @@ struct _scrollTargetLayoutModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 10.0,visionOS 1.0,iOS 17.0,macOS 14.0,tvOS 17.0, *)
+    @available(iOS 17.0,tvOS 17.0,watchOS 10.0,visionOS 1.0,macOS 14.0, *)
     init(isEnabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(isEnabled: isEnabled)
         
@@ -12456,7 +12409,7 @@ struct _scrollTargetLayoutModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(isEnabled):
-            if #available(watchOS 10.0,visionOS 1.0,iOS 17.0,macOS 14.0,tvOS 17.0, *) {
+            if #available(iOS 17.0,tvOS 17.0,watchOS 10.0,visionOS 1.0,macOS 14.0, *) {
             let isEnabled = isEnabled as! AttributeReference<Swift.Bool>
             
             __content
@@ -12490,7 +12443,7 @@ struct _searchDictationBehaviorModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(visionOS)
-    @available(visionOS 1.0,iOS 17.0, *)
+    @available(iOS 17.0,visionOS 1.0, *)
     init(_ dictationBehavior: SwiftUI.TextInputDictationBehavior) {
         self.value = ._0(dictationBehavior: dictationBehavior)
         
@@ -12503,7 +12456,7 @@ struct _searchDictationBehaviorModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(visionOS)
         case let ._0(dictationBehavior):
-            if #available(visionOS 1.0,iOS 17.0, *) {
+            if #available(iOS 17.0,visionOS 1.0, *) {
             let dictationBehavior = dictationBehavior as! SwiftUI.TextInputDictationBehavior
             
             __content
@@ -12537,7 +12490,7 @@ struct _searchPresentationToolbarBehaviorModifier<R: RootRegistry>: ViewModifier
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 14.1,watchOS 10.1,visionOS 1.0,tvOS 17.1,iOS 17.1, *)
+    @available(tvOS 17.1,watchOS 10.1,visionOS 1.0,macOS 14.1,iOS 17.1, *)
     init(_ behavior: SwiftUI.SearchPresentationToolbarBehavior) {
         self.value = ._0(behavior: behavior)
         
@@ -12550,7 +12503,7 @@ struct _searchPresentationToolbarBehaviorModifier<R: RootRegistry>: ViewModifier
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(behavior):
-            if #available(macOS 14.1,watchOS 10.1,visionOS 1.0,tvOS 17.1,iOS 17.1, *) {
+            if #available(tvOS 17.1,watchOS 10.1,visionOS 1.0,macOS 14.1,iOS 17.1, *) {
             let behavior = behavior as! SwiftUI.SearchPresentationToolbarBehavior
             
             __content
@@ -12894,7 +12847,7 @@ struct _sectionActionsModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(visionOS 2.0,macOS 15.0,iOS 18.0, *)
+    @available(iOS 18.0,visionOS 2.0,macOS 15.0, *)
     init(content: ViewReference=ViewReference(value: [])) {
         self.value = ._0(content: content)
         
@@ -12907,7 +12860,7 @@ struct _sectionActionsModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(content):
-            if #available(visionOS 2.0,macOS 15.0,iOS 18.0, *) {
+            if #available(iOS 18.0,visionOS 2.0,macOS 15.0, *) {
             let content = content as! ViewReference
             
             __content
@@ -12941,7 +12894,7 @@ struct _selectionDisabledModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 10.0,tvOS 17.0,visionOS 1.0,iOS 17.0,macOS 14.0, *)
+    @available(iOS 17.0,tvOS 17.0,watchOS 10.0,visionOS 1.0,macOS 14.0, *)
     init(_ isDisabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(isDisabled: isDisabled)
         
@@ -12954,7 +12907,7 @@ struct _selectionDisabledModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(isDisabled):
-            if #available(watchOS 10.0,tvOS 17.0,visionOS 1.0,iOS 17.0,macOS 14.0, *) {
+            if #available(iOS 17.0,tvOS 17.0,watchOS 10.0,visionOS 1.0,macOS 14.0, *) {
             let isDisabled = isDisabled as! AttributeReference<Swift.Bool>
             
             __content
@@ -13107,7 +13060,7 @@ struct _simultaneousGestureModifier<R: RootRegistry>: ViewModifier {
     }
     
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 11.0,visionOS 2.0,iOS 18.0,macOS 15.0,tvOS 18.0, *)
+    @available(iOS 18.0,macOS 15.0,tvOS 18.0,watchOS 11.0,visionOS 2.0, *)
     init(_ gesture: _AnyGesture,name: AttributeReference<Swift.String>,isEnabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._2(gesture: gesture, name: name, isEnabled: isEnabled)
         
@@ -13142,7 +13095,7 @@ struct _simultaneousGestureModifier<R: RootRegistry>: ViewModifier {
         
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._2(gesture, name, isEnabled):
-            if #available(watchOS 11.0,visionOS 2.0,iOS 18.0,macOS 15.0,tvOS 18.0, *) {
+            if #available(iOS 18.0,macOS 15.0,tvOS 18.0,watchOS 11.0,visionOS 2.0, *) {
             let gesture = gesture as! _AnyGesture
 let name = name as! AttributeReference<Swift.String>
 let isEnabled = isEnabled as! AttributeReference<Swift.Bool>
@@ -13366,7 +13319,7 @@ struct _statusBarModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(visionOS)
-    @available(visionOS 1.0,iOS 16.0, *)
+    @available(iOS 16.0,visionOS 1.0, *)
     init(hidden: AttributeReference<Swift.Bool>) {
         self.value = ._0(hidden: hidden)
         
@@ -13379,7 +13332,7 @@ struct _statusBarModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(visionOS)
         case let ._0(hidden):
-            if #available(visionOS 1.0,iOS 16.0, *) {
+            if #available(iOS 16.0,visionOS 1.0, *) {
             let hidden = hidden as! AttributeReference<Swift.Bool>
             
             __content
@@ -13413,7 +13366,7 @@ struct _statusBarHiddenModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(visionOS)
-    @available(visionOS 1.0,iOS 13.0, *)
+    @available(iOS 13.0,visionOS 1.0, *)
     init(_ hidden: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(hidden: hidden)
         
@@ -13426,7 +13379,7 @@ struct _statusBarHiddenModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(visionOS)
         case let ._0(hidden):
-            if #available(visionOS 1.0,iOS 13.0, *) {
+            if #available(iOS 13.0,visionOS 1.0, *) {
             let hidden = hidden as! AttributeReference<Swift.Bool>
             
             __content
@@ -13655,14 +13608,14 @@ struct _symbolEffectModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(tvOS 17.0,iOS 17.0,macOS 14.0,visionOS 1.0,watchOS 10.0, *)
+    @available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0,visionOS 1.0, *)
     init(_ effect: AnyIndefiniteSymbolEffect,options: Symbols.SymbolEffectOptions = .default, isActive: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(effect: effect, options: options, isActive: isActive)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(tvOS 17.0,iOS 17.0,macOS 14.0,visionOS 1.0,watchOS 10.0, *)
+    @available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0,visionOS 1.0, *)
     init(_ effect: AnyDiscreteSymbolEffect,options: Symbols.SymbolEffectOptions = .default, value: AttributeReference<String>) {
         self.value = ._1(effect: effect, options: options, value: value)
         
@@ -13675,7 +13628,7 @@ struct _symbolEffectModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(effect, options, isActive):
-            if #available(tvOS 17.0,iOS 17.0,macOS 14.0,visionOS 1.0,watchOS 10.0, *) {
+            if #available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0,visionOS 1.0, *) {
             let effect = effect as! AnyIndefiniteSymbolEffect
 let options = options as! Symbols.SymbolEffectOptions 
 let isActive = isActive as! AttributeReference<Swift.Bool>
@@ -13688,7 +13641,7 @@ let isActive = isActive as! AttributeReference<Swift.Bool>
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(effect, options, value):
-            if #available(tvOS 17.0,iOS 17.0,macOS 14.0,visionOS 1.0,watchOS 10.0, *) {
+            if #available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0,visionOS 1.0, *) {
             let effect = effect as! AnyDiscreteSymbolEffect
 let options = options as! Symbols.SymbolEffectOptions 
 let value = value as! AttributeReference<String>
@@ -13724,7 +13677,7 @@ struct _symbolEffectsRemovedModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 10.0,tvOS 17.0,visionOS 1.0,iOS 17.0,macOS 14.0, *)
+    @available(iOS 17.0,tvOS 17.0,watchOS 10.0,visionOS 1.0,macOS 14.0, *)
     init(_ isEnabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(isEnabled: isEnabled)
         
@@ -13737,7 +13690,7 @@ struct _symbolEffectsRemovedModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(isEnabled):
-            if #available(watchOS 10.0,tvOS 17.0,visionOS 1.0,iOS 17.0,macOS 14.0, *) {
+            if #available(iOS 17.0,tvOS 17.0,watchOS 10.0,visionOS 1.0,macOS 14.0, *) {
             let isEnabled = isEnabled as! AttributeReference<Swift.Bool>
             
             __content
@@ -13912,7 +13865,7 @@ struct _tabViewSidebarBottomBarModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(visionOS 2.0,iOS 18.0,macOS 15.0, *)
+    @available(iOS 18.0,macOS 15.0,visionOS 2.0, *)
     init(content: ViewReference=ViewReference(value: [])) {
         self.value = ._0(content: content)
         
@@ -13925,7 +13878,7 @@ struct _tabViewSidebarBottomBarModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(content):
-            if #available(visionOS 2.0,iOS 18.0,macOS 15.0, *) {
+            if #available(iOS 18.0,macOS 15.0,visionOS 2.0, *) {
             let content = content as! ViewReference
             
             __content
@@ -13959,7 +13912,7 @@ struct _tabViewSidebarFooterModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(visionOS 2.0,iOS 18.0,macOS 15.0, *)
+    @available(iOS 18.0,macOS 15.0,visionOS 2.0, *)
     init(content: ViewReference=ViewReference(value: [])) {
         self.value = ._0(content: content)
         
@@ -13972,7 +13925,7 @@ struct _tabViewSidebarFooterModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(content):
-            if #available(visionOS 2.0,iOS 18.0,macOS 15.0, *) {
+            if #available(iOS 18.0,macOS 15.0,visionOS 2.0, *) {
             let content = content as! ViewReference
             
             __content
@@ -14006,7 +13959,7 @@ struct _tabViewSidebarHeaderModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(visionOS 2.0,iOS 18.0,macOS 15.0, *)
+    @available(iOS 18.0,macOS 15.0,visionOS 2.0, *)
     init(content: ViewReference=ViewReference(value: [])) {
         self.value = ._0(content: content)
         
@@ -14019,7 +13972,7 @@ struct _tabViewSidebarHeaderModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(content):
-            if #available(visionOS 2.0,iOS 18.0,macOS 15.0, *) {
+            if #available(iOS 18.0,macOS 15.0,visionOS 2.0, *) {
             let content = content as! ViewReference
             
             __content
@@ -14100,7 +14053,7 @@ struct _tableStyleModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(visionOS 1.0,macOS 12.0,iOS 16.0, *)
+    @available(iOS 16.0,visionOS 1.0,macOS 12.0, *)
     init(_ style: AnyTableStyle) {
         self.value = ._0(style: style)
         
@@ -14113,7 +14066,7 @@ struct _tableStyleModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(style):
-            if #available(visionOS 1.0,macOS 12.0,iOS 16.0, *) {
+            if #available(iOS 16.0,visionOS 1.0,macOS 12.0, *) {
             let style = style as! AnyTableStyle
             
             __content
@@ -14194,7 +14147,7 @@ struct _textContentTypeModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(tvOS) || os(visionOS)
-    @available(tvOS 13.0,visionOS 1.0,iOS 13.0, *)
+    @available(iOS 13.0,tvOS 13.0,visionOS 1.0, *)
     init(_ textContentType: UIKit.UITextContentType?) {
         self.value = ._0(textContentType: textContentType)
         
@@ -14207,7 +14160,7 @@ struct _textContentTypeModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(tvOS) || os(visionOS)
         case let ._0(textContentType):
-            if #available(tvOS 13.0,visionOS 1.0,iOS 13.0, *) {
+            if #available(iOS 13.0,tvOS 13.0,visionOS 1.0, *) {
             let textContentType = textContentType as? UIKit.UITextContentType
             
             __content
@@ -14241,7 +14194,7 @@ struct _textEditorStyleModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(visionOS 1.0,iOS 17.0,macOS 14.0, *)
+    @available(iOS 17.0,macOS 14.0,visionOS 1.0, *)
     init(_ style: AnyTextEditorStyle) {
         self.value = ._0(style: style)
         
@@ -14254,7 +14207,7 @@ struct _textEditorStyleModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(style):
-            if #available(visionOS 1.0,iOS 17.0,macOS 14.0, *) {
+            if #available(iOS 17.0,macOS 14.0,visionOS 1.0, *) {
             let style = style as! AnyTextEditorStyle
             
             __content
@@ -14335,7 +14288,7 @@ struct _textInputAutocapitalizationModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(tvOS 15.0,iOS 15.0,visionOS 1.0,watchOS 8.0, *)
+    @available(iOS 15.0,watchOS 8.0,tvOS 15.0,visionOS 1.0, *)
     init(_ autocapitalization: SwiftUI.TextInputAutocapitalization?) {
         self.value = ._0(autocapitalization: autocapitalization)
         
@@ -14348,7 +14301,7 @@ struct _textInputAutocapitalizationModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(autocapitalization):
-            if #available(tvOS 15.0,iOS 15.0,visionOS 1.0,watchOS 8.0, *) {
+            if #available(iOS 15.0,watchOS 8.0,tvOS 15.0,visionOS 1.0, *) {
             let autocapitalization = autocapitalization as? SwiftUI.TextInputAutocapitalization
             
             __content
@@ -14476,7 +14429,7 @@ struct _textSelectionModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(iOS 15.0,macOS 12.0,visionOS 1.0, *)
+    @available(macOS 12.0,visionOS 1.0,iOS 15.0, *)
     init(_ selectability: AnyTextSelectability) {
         self.value = ._0(selectability: selectability)
         
@@ -14489,7 +14442,7 @@ struct _textSelectionModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(selectability):
-            if #available(iOS 15.0,macOS 12.0,visionOS 1.0, *) {
+            if #available(macOS 12.0,visionOS 1.0,iOS 15.0, *) {
             let selectability = selectability as! AnyTextSelectability
             
             __content
@@ -14523,7 +14476,7 @@ struct _textSelectionAffinityModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 15.0,watchOS 11.0,visionOS 2.0,tvOS 18.0,iOS 18.0, *)
+    @available(tvOS 18.0,watchOS 11.0,visionOS 2.0,macOS 15.0,iOS 18.0, *)
     init(_ affinity: SwiftUI.TextSelectionAffinity) {
         self.value = ._0(affinity: affinity)
         
@@ -14536,7 +14489,7 @@ struct _textSelectionAffinityModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(affinity):
-            if #available(macOS 15.0,watchOS 11.0,visionOS 2.0,tvOS 18.0,iOS 18.0, *) {
+            if #available(tvOS 18.0,watchOS 11.0,visionOS 2.0,macOS 15.0,iOS 18.0, *) {
             let affinity = affinity as! SwiftUI.TextSelectionAffinity
             
             __content
@@ -14709,7 +14662,7 @@ struct _toolbarModifier<R: RootRegistry>: ViewModifier {
     }
     
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 14.0,iOS 17.0,watchOS 10.0,visionOS 1.0,tvOS 17.0, *)
+    @available(watchOS 10.0,iOS 17.0,macOS 14.0,visionOS 1.0,tvOS 17.0, *)
     init(removing defaultItemKind: SwiftUI.ToolbarDefaultItemKind?) {
         self.value = ._1(defaultItemKind: defaultItemKind)
         
@@ -14747,7 +14700,7 @@ struct _toolbarModifier<R: RootRegistry>: ViewModifier {
         
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(defaultItemKind):
-            if #available(macOS 14.0,iOS 17.0,watchOS 10.0,visionOS 1.0,tvOS 17.0, *) {
+            if #available(watchOS 10.0,iOS 17.0,macOS 14.0,visionOS 1.0,tvOS 17.0, *) {
             let defaultItemKind = defaultItemKind as? SwiftUI.ToolbarDefaultItemKind
             
             __content
@@ -14873,7 +14826,7 @@ struct _toolbarBackgroundVisibilityModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 11.0,visionOS 2.0,iOS 18.0,macOS 15.0,tvOS 18.0, *)
+    @available(iOS 18.0,macOS 15.0,tvOS 18.0,watchOS 11.0,visionOS 2.0, *)
     init(_ visibility: AttributeReference<SwiftUI.Visibility>,for bars: SwiftUI.ToolbarPlacement) {
         self.value = ._0(visibility: visibility, bars: bars)
         
@@ -14886,7 +14839,7 @@ struct _toolbarBackgroundVisibilityModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(visibility, bars):
-            if #available(watchOS 11.0,visionOS 2.0,iOS 18.0,macOS 15.0,tvOS 18.0, *) {
+            if #available(iOS 18.0,macOS 15.0,tvOS 18.0,watchOS 11.0,visionOS 2.0, *) {
             let visibility = visibility as! AttributeReference<SwiftUI.Visibility>
 let bars = bars as! SwiftUI.ToolbarPlacement
             
@@ -15062,7 +15015,7 @@ struct _toolbarTitleDisplayModeModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 14.0,watchOS 10.0,visionOS 1.0,tvOS 17.0,iOS 17.0, *)
+    @available(iOS 17.0,macOS 14.0,tvOS 17.0,watchOS 10.0,visionOS 1.0, *)
     init(_ mode: SwiftUI.ToolbarTitleDisplayMode) {
         self.value = ._0(mode: mode)
         
@@ -15075,7 +15028,7 @@ struct _toolbarTitleDisplayModeModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(mode):
-            if #available(macOS 14.0,watchOS 10.0,visionOS 1.0,tvOS 17.0,iOS 17.0, *) {
+            if #available(iOS 17.0,macOS 14.0,tvOS 17.0,watchOS 10.0,visionOS 1.0, *) {
             let mode = mode as! SwiftUI.ToolbarTitleDisplayMode
             
             __content
@@ -15156,7 +15109,7 @@ struct _toolbarVisibilityModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(iOS 18.0,watchOS 11.0,tvOS 18.0,visionOS 2.0,macOS 15.0, *)
+    @available(iOS 18.0,macOS 15.0,tvOS 18.0,watchOS 11.0,visionOS 2.0, *)
     init(_ visibility: AttributeReference<SwiftUI.Visibility>,for bars: SwiftUI.ToolbarPlacement) {
         self.value = ._0(visibility: visibility, bars: bars)
         
@@ -15169,7 +15122,7 @@ struct _toolbarVisibilityModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(visibility, bars):
-            if #available(iOS 18.0,watchOS 11.0,tvOS 18.0,visionOS 2.0,macOS 15.0, *) {
+            if #available(iOS 18.0,macOS 15.0,tvOS 18.0,watchOS 11.0,visionOS 2.0, *) {
             let visibility = visibility as! AttributeReference<SwiftUI.Visibility>
 let bars = bars as! SwiftUI.ToolbarPlacement
             
@@ -15815,7 +15768,7 @@ struct _windowToolbarFullScreenVisibilityModifier<R: RootRegistry>: ViewModifier
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 11.0,macOS 15.0,visionOS 2.0,iOS 18.0,tvOS 18.0, *)
+    @available(iOS 18.0,macOS 15.0,tvOS 18.0,watchOS 11.0,visionOS 2.0, *)
     init(_ visibility: SwiftUI.WindowToolbarFullScreenVisibility) {
         self.value = ._0(visibility: visibility)
         
@@ -15828,7 +15781,7 @@ struct _windowToolbarFullScreenVisibilityModifier<R: RootRegistry>: ViewModifier
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(visibility):
-            if #available(watchOS 11.0,macOS 15.0,visionOS 2.0,iOS 18.0,tvOS 18.0, *) {
+            if #available(iOS 18.0,macOS 15.0,tvOS 18.0,watchOS 11.0,visionOS 2.0, *) {
             let visibility = visibility as! SwiftUI.WindowToolbarFullScreenVisibility
             
             __content
@@ -15862,7 +15815,7 @@ struct _writingToolsBehaviorModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS)
-    @available(iOS 18.0,macOS 15.0, *)
+    @available(macOS 15.0,iOS 18.0, *)
     init(_ behavior: SwiftUI.WritingToolsBehavior) {
         self.value = ._0(behavior: behavior)
         
@@ -15875,7 +15828,7 @@ struct _writingToolsBehaviorModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS)
         case let ._0(behavior):
-            if #available(iOS 18.0,macOS 15.0, *) {
+            if #available(macOS 15.0,iOS 18.0, *) {
             let behavior = behavior as! SwiftUI.WritingToolsBehavior
             
             __content
@@ -16396,8 +16349,7 @@ case let .materialActiveAppearance(modifier):
 }
 extension BuiltinRegistry {
     enum _BuiltinModifierChunk9: ViewModifier {
-        indirect case menuButtonStyle(_menuButtonStyleModifier<R>)
-indirect case menuIndicator(_menuIndicatorModifier<R>)
+        indirect case menuIndicator(_menuIndicatorModifier<R>)
 indirect case menuOrder(_menuOrderModifier<R>)
 indirect case menuStyle(_menuStyleModifier<R>)
 indirect case minimumScaleFactor(_minimumScaleFactorModifier<R>)
@@ -16410,12 +16362,11 @@ indirect case navigationBarItems(_navigationBarItemsModifier<R>)
 indirect case navigationBarTitle(_navigationBarTitleModifier<R>)
 indirect case navigationBarTitleDisplayMode(_navigationBarTitleDisplayModeModifier<R>)
 indirect case navigationDestination(_navigationDestinationModifier<R>)
+indirect case navigationSplitViewColumnWidth(_navigationSplitViewColumnWidthModifier<R>)
         
         func body(content: Content) -> some View {
             switch self {
-            case let .menuButtonStyle(modifier):
-    content.modifier(modifier)
-case let .menuIndicator(modifier):
+            case let .menuIndicator(modifier):
     content.modifier(modifier)
 case let .menuOrder(modifier):
     content.modifier(modifier)
@@ -16441,14 +16392,15 @@ case let .navigationBarTitleDisplayMode(modifier):
     content.modifier(modifier)
 case let .navigationDestination(modifier):
     content.modifier(modifier)
+case let .navigationSplitViewColumnWidth(modifier):
+    content.modifier(modifier)
             }
         }
     }
 }
 extension BuiltinRegistry {
     enum _BuiltinModifierChunk10: ViewModifier {
-        indirect case navigationSplitViewColumnWidth(_navigationSplitViewColumnWidthModifier<R>)
-indirect case navigationSplitViewStyle(_navigationSplitViewStyleModifier<R>)
+        indirect case navigationSplitViewStyle(_navigationSplitViewStyleModifier<R>)
 indirect case navigationSubtitle(_navigationSubtitleModifier<R>)
 indirect case navigationTitle(_navigationTitleModifier<R>)
 indirect case navigationViewStyle(_navigationViewStyleModifier<R>)
@@ -16461,12 +16413,11 @@ indirect case onHover(_onHoverModifier<R>)
 indirect case onImmersionChange(_onImmersionChangeModifier<R>)
 indirect case onLongPressGesture(_onLongPressGestureModifier<R>)
 indirect case onLongTouchGesture(_onLongTouchGestureModifier<R>)
+indirect case onModifierKeysChanged(_onModifierKeysChangedModifier<R>)
         
         func body(content: Content) -> some View {
             switch self {
-            case let .navigationSplitViewColumnWidth(modifier):
-    content.modifier(modifier)
-case let .navigationSplitViewStyle(modifier):
+            case let .navigationSplitViewStyle(modifier):
     content.modifier(modifier)
 case let .navigationSubtitle(modifier):
     content.modifier(modifier)
@@ -16492,14 +16443,15 @@ case let .onLongPressGesture(modifier):
     content.modifier(modifier)
 case let .onLongTouchGesture(modifier):
     content.modifier(modifier)
+case let .onModifierKeysChanged(modifier):
+    content.modifier(modifier)
             }
         }
     }
 }
 extension BuiltinRegistry {
     enum _BuiltinModifierChunk11: ViewModifier {
-        indirect case onModifierKeysChanged(_onModifierKeysChangedModifier<R>)
-indirect case onMoveCommand(_onMoveCommandModifier<R>)
+        indirect case onMoveCommand(_onMoveCommandModifier<R>)
 indirect case onPencilDoubleTap(_onPencilDoubleTapModifier<R>)
 indirect case onPencilSqueeze(_onPencilSqueezeModifier<R>)
 indirect case onPlayPauseCommand(_onPlayPauseCommandModifier<R>)
@@ -16512,12 +16464,11 @@ indirect case ornament(_ornamentModifier<R>)
 indirect case overlay(_overlayModifier<R>)
 indirect case padding(_paddingModifier<R>)
 indirect case padding3D(_padding3DModifier<R>)
+indirect case persistentSystemOverlays(_persistentSystemOverlaysModifier<R>)
         
         func body(content: Content) -> some View {
             switch self {
-            case let .onModifierKeysChanged(modifier):
-    content.modifier(modifier)
-case let .onMoveCommand(modifier):
+            case let .onMoveCommand(modifier):
     content.modifier(modifier)
 case let .onPencilDoubleTap(modifier):
     content.modifier(modifier)
@@ -16543,14 +16494,15 @@ case let .padding(modifier):
     content.modifier(modifier)
 case let .padding3D(modifier):
     content.modifier(modifier)
+case let .persistentSystemOverlays(modifier):
+    content.modifier(modifier)
             }
         }
     }
 }
 extension BuiltinRegistry {
     enum _BuiltinModifierChunk12: ViewModifier {
-        indirect case persistentSystemOverlays(_persistentSystemOverlaysModifier<R>)
-indirect case pickerStyle(_pickerStyleModifier<R>)
+        indirect case pickerStyle(_pickerStyleModifier<R>)
 indirect case pointerStyle(_pointerStyleModifier<R>)
 indirect case pointerVisibility(_pointerVisibilityModifier<R>)
 indirect case popover(_popoverModifier<R>)
@@ -16563,12 +16515,11 @@ indirect case presentationCompactAdaptation(_presentationCompactAdaptationModifi
 indirect case presentationContentInteraction(_presentationContentInteractionModifier<R>)
 indirect case presentationCornerRadius(_presentationCornerRadiusModifier<R>)
 indirect case presentationDragIndicator(_presentationDragIndicatorModifier<R>)
+indirect case presentationSizing(_presentationSizingModifier<R>)
         
         func body(content: Content) -> some View {
             switch self {
-            case let .persistentSystemOverlays(modifier):
-    content.modifier(modifier)
-case let .pickerStyle(modifier):
+            case let .pickerStyle(modifier):
     content.modifier(modifier)
 case let .pointerStyle(modifier):
     content.modifier(modifier)
@@ -16594,14 +16545,15 @@ case let .presentationCornerRadius(modifier):
     content.modifier(modifier)
 case let .presentationDragIndicator(modifier):
     content.modifier(modifier)
+case let .presentationSizing(modifier):
+    content.modifier(modifier)
             }
         }
     }
 }
 extension BuiltinRegistry {
     enum _BuiltinModifierChunk13: ViewModifier {
-        indirect case presentationSizing(_presentationSizingModifier<R>)
-indirect case previewDisplayName(_previewDisplayNameModifier<R>)
+        indirect case previewDisplayName(_previewDisplayNameModifier<R>)
 indirect case privacySensitive(_privacySensitiveModifier<R>)
 indirect case progressViewStyle(_progressViewStyleModifier<R>)
 indirect case projectionEffect(_projectionEffectModifier<R>)
@@ -16614,12 +16566,11 @@ indirect case safeAreaInset(_safeAreaInsetModifier<R>)
 indirect case safeAreaPadding(_safeAreaPaddingModifier<R>)
 indirect case saturation(_saturationModifier<R>)
 indirect case scaleEffect(_scaleEffectModifier<R>)
+indirect case scaledToFill(_scaledToFillModifier<R>)
         
         func body(content: Content) -> some View {
             switch self {
-            case let .presentationSizing(modifier):
-    content.modifier(modifier)
-case let .previewDisplayName(modifier):
+            case let .previewDisplayName(modifier):
     content.modifier(modifier)
 case let .privacySensitive(modifier):
     content.modifier(modifier)
@@ -16645,14 +16596,15 @@ case let .saturation(modifier):
     content.modifier(modifier)
 case let .scaleEffect(modifier):
     content.modifier(modifier)
+case let .scaledToFill(modifier):
+    content.modifier(modifier)
             }
         }
     }
 }
 extension BuiltinRegistry {
     enum _BuiltinModifierChunk14: ViewModifier {
-        indirect case scaledToFill(_scaledToFillModifier<R>)
-indirect case scaledToFit(_scaledToFitModifier<R>)
+        indirect case scaledToFit(_scaledToFitModifier<R>)
 indirect case scenePadding(_scenePaddingModifier<R>)
 indirect case scrollBounceBehavior(_scrollBounceBehaviorModifier<R>)
 indirect case scrollClipDisabled(_scrollClipDisabledModifier<R>)
@@ -16665,12 +16617,11 @@ indirect case scrollPosition(_scrollPositionModifier<R>)
 indirect case scrollTargetBehavior(_scrollTargetBehaviorModifier<R>)
 indirect case scrollTargetLayout(_scrollTargetLayoutModifier<R>)
 indirect case searchDictationBehavior(_searchDictationBehaviorModifier<R>)
+indirect case searchPresentationToolbarBehavior(_searchPresentationToolbarBehaviorModifier<R>)
         
         func body(content: Content) -> some View {
             switch self {
-            case let .scaledToFill(modifier):
-    content.modifier(modifier)
-case let .scaledToFit(modifier):
+            case let .scaledToFit(modifier):
     content.modifier(modifier)
 case let .scenePadding(modifier):
     content.modifier(modifier)
@@ -16696,14 +16647,15 @@ case let .scrollTargetLayout(modifier):
     content.modifier(modifier)
 case let .searchDictationBehavior(modifier):
     content.modifier(modifier)
+case let .searchPresentationToolbarBehavior(modifier):
+    content.modifier(modifier)
             }
         }
     }
 }
 extension BuiltinRegistry {
     enum _BuiltinModifierChunk15: ViewModifier {
-        indirect case searchPresentationToolbarBehavior(_searchPresentationToolbarBehaviorModifier<R>)
-indirect case searchSuggestions(_searchSuggestionsModifier<R>)
+        indirect case searchSuggestions(_searchSuggestionsModifier<R>)
 indirect case searchable(_searchableModifier<R>)
 indirect case sectionActions(_sectionActionsModifier<R>)
 indirect case selectionDisabled(_selectionDisabledModifier<R>)
@@ -16716,12 +16668,11 @@ indirect case speechAnnouncementsQueued(_speechAnnouncementsQueuedModifier<R>)
 indirect case speechSpellsOutCharacters(_speechSpellsOutCharactersModifier<R>)
 indirect case statusBar(_statusBarModifier<R>)
 indirect case statusBarHidden(_statusBarHiddenModifier<R>)
+indirect case submitLabel(_submitLabelModifier<R>)
         
         func body(content: Content) -> some View {
             switch self {
-            case let .searchPresentationToolbarBehavior(modifier):
-    content.modifier(modifier)
-case let .searchSuggestions(modifier):
+            case let .searchSuggestions(modifier):
     content.modifier(modifier)
 case let .searchable(modifier):
     content.modifier(modifier)
@@ -16747,14 +16698,15 @@ case let .statusBar(modifier):
     content.modifier(modifier)
 case let .statusBarHidden(modifier):
     content.modifier(modifier)
+case let .submitLabel(modifier):
+    content.modifier(modifier)
             }
         }
     }
 }
 extension BuiltinRegistry {
     enum _BuiltinModifierChunk16: ViewModifier {
-        indirect case submitLabel(_submitLabelModifier<R>)
-indirect case submitScope(_submitScopeModifier<R>)
+        indirect case submitScope(_submitScopeModifier<R>)
 indirect case supportedVolumeViewpoints(_supportedVolumeViewpointsModifier<R>)
 indirect case swipeActions(_swipeActionsModifier<R>)
 indirect case symbolEffect(_symbolEffectModifier<R>)
@@ -16767,12 +16719,11 @@ indirect case tabViewSidebarFooter(_tabViewSidebarFooterModifier<R>)
 indirect case tabViewSidebarHeader(_tabViewSidebarHeaderModifier<R>)
 indirect case tabViewStyle(_tabViewStyleModifier<R>)
 indirect case tableStyle(_tableStyleModifier<R>)
+indirect case textCase(_textCaseModifier<R>)
         
         func body(content: Content) -> some View {
             switch self {
-            case let .submitLabel(modifier):
-    content.modifier(modifier)
-case let .submitScope(modifier):
+            case let .submitScope(modifier):
     content.modifier(modifier)
 case let .supportedVolumeViewpoints(modifier):
     content.modifier(modifier)
@@ -16798,14 +16749,15 @@ case let .tabViewStyle(modifier):
     content.modifier(modifier)
 case let .tableStyle(modifier):
     content.modifier(modifier)
+case let .textCase(modifier):
+    content.modifier(modifier)
             }
         }
     }
 }
 extension BuiltinRegistry {
     enum _BuiltinModifierChunk17: ViewModifier {
-        indirect case textCase(_textCaseModifier<R>)
-indirect case textContentType(_textContentTypeModifier<R>)
+        indirect case textContentType(_textContentTypeModifier<R>)
 indirect case textEditorStyle(_textEditorStyleModifier<R>)
 indirect case textFieldStyle(_textFieldStyleModifier<R>)
 indirect case textInputAutocapitalization(_textInputAutocapitalizationModifier<R>)
@@ -16818,12 +16770,11 @@ indirect case toggleStyle(_toggleStyleModifier<R>)
 indirect case toolbar(_toolbarModifier<R>)
 indirect case toolbarBackground(_toolbarBackgroundModifier<R>)
 indirect case toolbarBackgroundVisibility(_toolbarBackgroundVisibilityModifier<R>)
+indirect case toolbarColorScheme(_toolbarColorSchemeModifier<R>)
         
         func body(content: Content) -> some View {
             switch self {
-            case let .textCase(modifier):
-    content.modifier(modifier)
-case let .textContentType(modifier):
+            case let .textContentType(modifier):
     content.modifier(modifier)
 case let .textEditorStyle(modifier):
     content.modifier(modifier)
@@ -16849,14 +16800,15 @@ case let .toolbarBackground(modifier):
     content.modifier(modifier)
 case let .toolbarBackgroundVisibility(modifier):
     content.modifier(modifier)
+case let .toolbarColorScheme(modifier):
+    content.modifier(modifier)
             }
         }
     }
 }
 extension BuiltinRegistry {
     enum _BuiltinModifierChunk18: ViewModifier {
-        indirect case toolbarColorScheme(_toolbarColorSchemeModifier<R>)
-indirect case toolbarItemHidden(_toolbarItemHiddenModifier<R>)
+        indirect case toolbarItemHidden(_toolbarItemHiddenModifier<R>)
 indirect case toolbarRole(_toolbarRoleModifier<R>)
 indirect case toolbarTitleDisplayMode(_toolbarTitleDisplayModeModifier<R>)
 indirect case toolbarTitleMenu(_toolbarTitleMenuModifier<R>)
@@ -16869,12 +16821,11 @@ indirect case transition(_transitionModifier<R>)
 indirect case truncationMode(_truncationModeModifier<R>)
 indirect case unredacted(_unredactedModifier<R>)
 indirect case upperLimbVisibility(_upperLimbVisibilityModifier<R>)
+indirect case volumeBaseplateVisibility(_volumeBaseplateVisibilityModifier<R>)
         
         func body(content: Content) -> some View {
             switch self {
-            case let .toolbarColorScheme(modifier):
-    content.modifier(modifier)
-case let .toolbarItemHidden(modifier):
+            case let .toolbarItemHidden(modifier):
     content.modifier(modifier)
 case let .toolbarRole(modifier):
     content.modifier(modifier)
@@ -16900,14 +16851,15 @@ case let .unredacted(modifier):
     content.modifier(modifier)
 case let .upperLimbVisibility(modifier):
     content.modifier(modifier)
+case let .volumeBaseplateVisibility(modifier):
+    content.modifier(modifier)
             }
         }
     }
 }
 extension BuiltinRegistry {
     enum _BuiltinModifierChunk19: ViewModifier {
-        indirect case volumeBaseplateVisibility(_volumeBaseplateVisibilityModifier<R>)
-indirect case windowDismissBehavior(_windowDismissBehaviorModifier<R>)
+        indirect case windowDismissBehavior(_windowDismissBehaviorModifier<R>)
 indirect case windowFullScreenBehavior(_windowFullScreenBehaviorModifier<R>)
 indirect case windowMinimizeBehavior(_windowMinimizeBehaviorModifier<R>)
 indirect case windowResizeBehavior(_windowResizeBehaviorModifier<R>)
@@ -16917,9 +16869,7 @@ indirect case zIndex(_zIndexModifier<R>)
         
         func body(content: Content) -> some View {
             switch self {
-            case let .volumeBaseplateVisibility(modifier):
-    content.modifier(modifier)
-case let .windowDismissBehavior(modifier):
+            case let .windowDismissBehavior(modifier):
     content.modifier(modifier)
 case let .windowFullScreenBehavior(modifier):
     content.modifier(modifier)
@@ -16960,16 +16910,16 @@ indirect case chunk17(_BuiltinModifierChunk17)
 indirect case chunk18(_BuiltinModifierChunk18)
 indirect case chunk19(_BuiltinModifierChunk19)
         indirect case _OnSubmitModifier(LiveViewNative._OnSubmitModifier)
-indirect case _NavigationTransitionModifier(LiveViewNative._NavigationTransitionModifier<R>)
-indirect case _MatchedTransitionSourceModifier(LiveViewNative._MatchedTransitionSourceModifier<R>)
-indirect case _FocusScopeModifier(LiveViewNative._FocusScopeModifier<R>)
+indirect case _PerspectiveRotationEffectModifier(LiveViewNative._PerspectiveRotationEffectModifier<R>)
+indirect case _MaskModifier(LiveViewNative._MaskModifier<R>)
 indirect case _SearchScopesModifier(LiveViewNative._SearchScopesModifier<R>)
+indirect case _NavigationTransitionModifier(LiveViewNative._NavigationTransitionModifier<R>)
+indirect case _MatchedGeometryEffectModifier(LiveViewNative._MatchedGeometryEffectModifier<R>)
 indirect case _PresentationDetentsModifier(LiveViewNative._PresentationDetentsModifier)
 indirect case _Rotation3DEffectModifier(LiveViewNative._Rotation3DEffectModifier<R>)
-indirect case _MaskModifier(LiveViewNative._MaskModifier<R>)
-indirect case _PerspectiveRotationEffectModifier(LiveViewNative._PerspectiveRotationEffectModifier<R>)
-indirect case _MatchedGeometryEffectModifier(LiveViewNative._MatchedGeometryEffectModifier<R>)
+indirect case _FocusScopeModifier(LiveViewNative._FocusScopeModifier<R>)
 indirect case _PrefersDefaultFocusModifier(LiveViewNative._PrefersDefaultFocusModifier<R>)
+indirect case _MatchedTransitionSourceModifier(LiveViewNative._MatchedTransitionSourceModifier<R>)
 indirect case _SearchCompletionModifier(LiveViewNative._SearchCompletionModifier<R>)
         indirect case _customRegistryModifier(R.CustomModifier)
         indirect case _anyTextModifier(_AnyTextModifier<R>)
@@ -17021,25 +16971,25 @@ case let .chunk19(chunk):
     content.modifier(chunk)
             case let ._OnSubmitModifier(modifier):
     content.modifier(modifier)
-case let ._NavigationTransitionModifier(modifier):
+case let ._PerspectiveRotationEffectModifier(modifier):
     content.modifier(modifier)
-case let ._MatchedTransitionSourceModifier(modifier):
-    content.modifier(modifier)
-case let ._FocusScopeModifier(modifier):
+case let ._MaskModifier(modifier):
     content.modifier(modifier)
 case let ._SearchScopesModifier(modifier):
+    content.modifier(modifier)
+case let ._NavigationTransitionModifier(modifier):
+    content.modifier(modifier)
+case let ._MatchedGeometryEffectModifier(modifier):
     content.modifier(modifier)
 case let ._PresentationDetentsModifier(modifier):
     content.modifier(modifier)
 case let ._Rotation3DEffectModifier(modifier):
     content.modifier(modifier)
-case let ._MaskModifier(modifier):
-    content.modifier(modifier)
-case let ._PerspectiveRotationEffectModifier(modifier):
-    content.modifier(modifier)
-case let ._MatchedGeometryEffectModifier(modifier):
+case let ._FocusScopeModifier(modifier):
     content.modifier(modifier)
 case let ._PrefersDefaultFocusModifier(modifier):
+    content.modifier(modifier)
+case let ._MatchedTransitionSourceModifier(modifier):
     content.modifier(modifier)
 case let ._SearchCompletionModifier(modifier):
     content.modifier(modifier)
@@ -17194,7 +17144,6 @@ _listSectionSpacingModifier<R>.name: _listSectionSpacingModifier<R>.parser(in: c
 _listStyleModifier<R>.name: _listStyleModifier<R>.parser(in: context).map({ Output.chunk8(.listStyle($0)) }).eraseToAnyParser(),
 _luminanceToAlphaModifier<R>.name: _luminanceToAlphaModifier<R>.parser(in: context).map({ Output.chunk8(.luminanceToAlpha($0)) }).eraseToAnyParser(),
 _materialActiveAppearanceModifier<R>.name: _materialActiveAppearanceModifier<R>.parser(in: context).map({ Output.chunk8(.materialActiveAppearance($0)) }).eraseToAnyParser(),
-_menuButtonStyleModifier<R>.name: _menuButtonStyleModifier<R>.parser(in: context).map({ Output.chunk9(.menuButtonStyle($0)) }).eraseToAnyParser(),
 _menuIndicatorModifier<R>.name: _menuIndicatorModifier<R>.parser(in: context).map({ Output.chunk9(.menuIndicator($0)) }).eraseToAnyParser(),
 _menuOrderModifier<R>.name: _menuOrderModifier<R>.parser(in: context).map({ Output.chunk9(.menuOrder($0)) }).eraseToAnyParser(),
 _menuStyleModifier<R>.name: _menuStyleModifier<R>.parser(in: context).map({ Output.chunk9(.menuStyle($0)) }).eraseToAnyParser(),
@@ -17208,7 +17157,7 @@ _navigationBarItemsModifier<R>.name: _navigationBarItemsModifier<R>.parser(in: c
 _navigationBarTitleModifier<R>.name: _navigationBarTitleModifier<R>.parser(in: context).map({ Output.chunk9(.navigationBarTitle($0)) }).eraseToAnyParser(),
 _navigationBarTitleDisplayModeModifier<R>.name: _navigationBarTitleDisplayModeModifier<R>.parser(in: context).map({ Output.chunk9(.navigationBarTitleDisplayMode($0)) }).eraseToAnyParser(),
 _navigationDestinationModifier<R>.name: _navigationDestinationModifier<R>.parser(in: context).map({ Output.chunk9(.navigationDestination($0)) }).eraseToAnyParser(),
-_navigationSplitViewColumnWidthModifier<R>.name: _navigationSplitViewColumnWidthModifier<R>.parser(in: context).map({ Output.chunk10(.navigationSplitViewColumnWidth($0)) }).eraseToAnyParser(),
+_navigationSplitViewColumnWidthModifier<R>.name: _navigationSplitViewColumnWidthModifier<R>.parser(in: context).map({ Output.chunk9(.navigationSplitViewColumnWidth($0)) }).eraseToAnyParser(),
 _navigationSplitViewStyleModifier<R>.name: _navigationSplitViewStyleModifier<R>.parser(in: context).map({ Output.chunk10(.navigationSplitViewStyle($0)) }).eraseToAnyParser(),
 _navigationSubtitleModifier<R>.name: _navigationSubtitleModifier<R>.parser(in: context).map({ Output.chunk10(.navigationSubtitle($0)) }).eraseToAnyParser(),
 _navigationTitleModifier<R>.name: _navigationTitleModifier<R>.parser(in: context).map({ Output.chunk10(.navigationTitle($0)) }).eraseToAnyParser(),
@@ -17222,7 +17171,7 @@ _onHoverModifier<R>.name: _onHoverModifier<R>.parser(in: context).map({ Output.c
 _onImmersionChangeModifier<R>.name: _onImmersionChangeModifier<R>.parser(in: context).map({ Output.chunk10(.onImmersionChange($0)) }).eraseToAnyParser(),
 _onLongPressGestureModifier<R>.name: _onLongPressGestureModifier<R>.parser(in: context).map({ Output.chunk10(.onLongPressGesture($0)) }).eraseToAnyParser(),
 _onLongTouchGestureModifier<R>.name: _onLongTouchGestureModifier<R>.parser(in: context).map({ Output.chunk10(.onLongTouchGesture($0)) }).eraseToAnyParser(),
-_onModifierKeysChangedModifier<R>.name: _onModifierKeysChangedModifier<R>.parser(in: context).map({ Output.chunk11(.onModifierKeysChanged($0)) }).eraseToAnyParser(),
+_onModifierKeysChangedModifier<R>.name: _onModifierKeysChangedModifier<R>.parser(in: context).map({ Output.chunk10(.onModifierKeysChanged($0)) }).eraseToAnyParser(),
 _onMoveCommandModifier<R>.name: _onMoveCommandModifier<R>.parser(in: context).map({ Output.chunk11(.onMoveCommand($0)) }).eraseToAnyParser(),
 _onPencilDoubleTapModifier<R>.name: _onPencilDoubleTapModifier<R>.parser(in: context).map({ Output.chunk11(.onPencilDoubleTap($0)) }).eraseToAnyParser(),
 _onPencilSqueezeModifier<R>.name: _onPencilSqueezeModifier<R>.parser(in: context).map({ Output.chunk11(.onPencilSqueeze($0)) }).eraseToAnyParser(),
@@ -17236,7 +17185,7 @@ _ornamentModifier<R>.name: _ornamentModifier<R>.parser(in: context).map({ Output
 _overlayModifier<R>.name: _overlayModifier<R>.parser(in: context).map({ Output.chunk11(.overlay($0)) }).eraseToAnyParser(),
 _paddingModifier<R>.name: _paddingModifier<R>.parser(in: context).map({ Output.chunk11(.padding($0)) }).eraseToAnyParser(),
 _padding3DModifier<R>.name: _padding3DModifier<R>.parser(in: context).map({ Output.chunk11(.padding3D($0)) }).eraseToAnyParser(),
-_persistentSystemOverlaysModifier<R>.name: _persistentSystemOverlaysModifier<R>.parser(in: context).map({ Output.chunk12(.persistentSystemOverlays($0)) }).eraseToAnyParser(),
+_persistentSystemOverlaysModifier<R>.name: _persistentSystemOverlaysModifier<R>.parser(in: context).map({ Output.chunk11(.persistentSystemOverlays($0)) }).eraseToAnyParser(),
 _pickerStyleModifier<R>.name: _pickerStyleModifier<R>.parser(in: context).map({ Output.chunk12(.pickerStyle($0)) }).eraseToAnyParser(),
 _pointerStyleModifier<R>.name: _pointerStyleModifier<R>.parser(in: context).map({ Output.chunk12(.pointerStyle($0)) }).eraseToAnyParser(),
 _pointerVisibilityModifier<R>.name: _pointerVisibilityModifier<R>.parser(in: context).map({ Output.chunk12(.pointerVisibility($0)) }).eraseToAnyParser(),
@@ -17250,7 +17199,7 @@ _presentationCompactAdaptationModifier<R>.name: _presentationCompactAdaptationMo
 _presentationContentInteractionModifier<R>.name: _presentationContentInteractionModifier<R>.parser(in: context).map({ Output.chunk12(.presentationContentInteraction($0)) }).eraseToAnyParser(),
 _presentationCornerRadiusModifier<R>.name: _presentationCornerRadiusModifier<R>.parser(in: context).map({ Output.chunk12(.presentationCornerRadius($0)) }).eraseToAnyParser(),
 _presentationDragIndicatorModifier<R>.name: _presentationDragIndicatorModifier<R>.parser(in: context).map({ Output.chunk12(.presentationDragIndicator($0)) }).eraseToAnyParser(),
-_presentationSizingModifier<R>.name: _presentationSizingModifier<R>.parser(in: context).map({ Output.chunk13(.presentationSizing($0)) }).eraseToAnyParser(),
+_presentationSizingModifier<R>.name: _presentationSizingModifier<R>.parser(in: context).map({ Output.chunk12(.presentationSizing($0)) }).eraseToAnyParser(),
 _previewDisplayNameModifier<R>.name: _previewDisplayNameModifier<R>.parser(in: context).map({ Output.chunk13(.previewDisplayName($0)) }).eraseToAnyParser(),
 _privacySensitiveModifier<R>.name: _privacySensitiveModifier<R>.parser(in: context).map({ Output.chunk13(.privacySensitive($0)) }).eraseToAnyParser(),
 _progressViewStyleModifier<R>.name: _progressViewStyleModifier<R>.parser(in: context).map({ Output.chunk13(.progressViewStyle($0)) }).eraseToAnyParser(),
@@ -17264,7 +17213,7 @@ _safeAreaInsetModifier<R>.name: _safeAreaInsetModifier<R>.parser(in: context).ma
 _safeAreaPaddingModifier<R>.name: _safeAreaPaddingModifier<R>.parser(in: context).map({ Output.chunk13(.safeAreaPadding($0)) }).eraseToAnyParser(),
 _saturationModifier<R>.name: _saturationModifier<R>.parser(in: context).map({ Output.chunk13(.saturation($0)) }).eraseToAnyParser(),
 _scaleEffectModifier<R>.name: _scaleEffectModifier<R>.parser(in: context).map({ Output.chunk13(.scaleEffect($0)) }).eraseToAnyParser(),
-_scaledToFillModifier<R>.name: _scaledToFillModifier<R>.parser(in: context).map({ Output.chunk14(.scaledToFill($0)) }).eraseToAnyParser(),
+_scaledToFillModifier<R>.name: _scaledToFillModifier<R>.parser(in: context).map({ Output.chunk13(.scaledToFill($0)) }).eraseToAnyParser(),
 _scaledToFitModifier<R>.name: _scaledToFitModifier<R>.parser(in: context).map({ Output.chunk14(.scaledToFit($0)) }).eraseToAnyParser(),
 _scenePaddingModifier<R>.name: _scenePaddingModifier<R>.parser(in: context).map({ Output.chunk14(.scenePadding($0)) }).eraseToAnyParser(),
 _scrollBounceBehaviorModifier<R>.name: _scrollBounceBehaviorModifier<R>.parser(in: context).map({ Output.chunk14(.scrollBounceBehavior($0)) }).eraseToAnyParser(),
@@ -17278,7 +17227,7 @@ _scrollPositionModifier<R>.name: _scrollPositionModifier<R>.parser(in: context).
 _scrollTargetBehaviorModifier<R>.name: _scrollTargetBehaviorModifier<R>.parser(in: context).map({ Output.chunk14(.scrollTargetBehavior($0)) }).eraseToAnyParser(),
 _scrollTargetLayoutModifier<R>.name: _scrollTargetLayoutModifier<R>.parser(in: context).map({ Output.chunk14(.scrollTargetLayout($0)) }).eraseToAnyParser(),
 _searchDictationBehaviorModifier<R>.name: _searchDictationBehaviorModifier<R>.parser(in: context).map({ Output.chunk14(.searchDictationBehavior($0)) }).eraseToAnyParser(),
-_searchPresentationToolbarBehaviorModifier<R>.name: _searchPresentationToolbarBehaviorModifier<R>.parser(in: context).map({ Output.chunk15(.searchPresentationToolbarBehavior($0)) }).eraseToAnyParser(),
+_searchPresentationToolbarBehaviorModifier<R>.name: _searchPresentationToolbarBehaviorModifier<R>.parser(in: context).map({ Output.chunk14(.searchPresentationToolbarBehavior($0)) }).eraseToAnyParser(),
 _searchSuggestionsModifier<R>.name: _searchSuggestionsModifier<R>.parser(in: context).map({ Output.chunk15(.searchSuggestions($0)) }).eraseToAnyParser(),
 _searchableModifier<R>.name: _searchableModifier<R>.parser(in: context).map({ Output.chunk15(.searchable($0)) }).eraseToAnyParser(),
 _sectionActionsModifier<R>.name: _sectionActionsModifier<R>.parser(in: context).map({ Output.chunk15(.sectionActions($0)) }).eraseToAnyParser(),
@@ -17292,7 +17241,7 @@ _speechAnnouncementsQueuedModifier<R>.name: _speechAnnouncementsQueuedModifier<R
 _speechSpellsOutCharactersModifier<R>.name: _speechSpellsOutCharactersModifier<R>.parser(in: context).map({ Output.chunk15(.speechSpellsOutCharacters($0)) }).eraseToAnyParser(),
 _statusBarModifier<R>.name: _statusBarModifier<R>.parser(in: context).map({ Output.chunk15(.statusBar($0)) }).eraseToAnyParser(),
 _statusBarHiddenModifier<R>.name: _statusBarHiddenModifier<R>.parser(in: context).map({ Output.chunk15(.statusBarHidden($0)) }).eraseToAnyParser(),
-_submitLabelModifier<R>.name: _submitLabelModifier<R>.parser(in: context).map({ Output.chunk16(.submitLabel($0)) }).eraseToAnyParser(),
+_submitLabelModifier<R>.name: _submitLabelModifier<R>.parser(in: context).map({ Output.chunk15(.submitLabel($0)) }).eraseToAnyParser(),
 _submitScopeModifier<R>.name: _submitScopeModifier<R>.parser(in: context).map({ Output.chunk16(.submitScope($0)) }).eraseToAnyParser(),
 _supportedVolumeViewpointsModifier<R>.name: _supportedVolumeViewpointsModifier<R>.parser(in: context).map({ Output.chunk16(.supportedVolumeViewpoints($0)) }).eraseToAnyParser(),
 _swipeActionsModifier<R>.name: _swipeActionsModifier<R>.parser(in: context).map({ Output.chunk16(.swipeActions($0)) }).eraseToAnyParser(),
@@ -17306,7 +17255,7 @@ _tabViewSidebarFooterModifier<R>.name: _tabViewSidebarFooterModifier<R>.parser(i
 _tabViewSidebarHeaderModifier<R>.name: _tabViewSidebarHeaderModifier<R>.parser(in: context).map({ Output.chunk16(.tabViewSidebarHeader($0)) }).eraseToAnyParser(),
 _tabViewStyleModifier<R>.name: _tabViewStyleModifier<R>.parser(in: context).map({ Output.chunk16(.tabViewStyle($0)) }).eraseToAnyParser(),
 _tableStyleModifier<R>.name: _tableStyleModifier<R>.parser(in: context).map({ Output.chunk16(.tableStyle($0)) }).eraseToAnyParser(),
-_textCaseModifier<R>.name: _textCaseModifier<R>.parser(in: context).map({ Output.chunk17(.textCase($0)) }).eraseToAnyParser(),
+_textCaseModifier<R>.name: _textCaseModifier<R>.parser(in: context).map({ Output.chunk16(.textCase($0)) }).eraseToAnyParser(),
 _textContentTypeModifier<R>.name: _textContentTypeModifier<R>.parser(in: context).map({ Output.chunk17(.textContentType($0)) }).eraseToAnyParser(),
 _textEditorStyleModifier<R>.name: _textEditorStyleModifier<R>.parser(in: context).map({ Output.chunk17(.textEditorStyle($0)) }).eraseToAnyParser(),
 _textFieldStyleModifier<R>.name: _textFieldStyleModifier<R>.parser(in: context).map({ Output.chunk17(.textFieldStyle($0)) }).eraseToAnyParser(),
@@ -17320,7 +17269,7 @@ _toggleStyleModifier<R>.name: _toggleStyleModifier<R>.parser(in: context).map({ 
 _toolbarModifier<R>.name: _toolbarModifier<R>.parser(in: context).map({ Output.chunk17(.toolbar($0)) }).eraseToAnyParser(),
 _toolbarBackgroundModifier<R>.name: _toolbarBackgroundModifier<R>.parser(in: context).map({ Output.chunk17(.toolbarBackground($0)) }).eraseToAnyParser(),
 _toolbarBackgroundVisibilityModifier<R>.name: _toolbarBackgroundVisibilityModifier<R>.parser(in: context).map({ Output.chunk17(.toolbarBackgroundVisibility($0)) }).eraseToAnyParser(),
-_toolbarColorSchemeModifier<R>.name: _toolbarColorSchemeModifier<R>.parser(in: context).map({ Output.chunk18(.toolbarColorScheme($0)) }).eraseToAnyParser(),
+_toolbarColorSchemeModifier<R>.name: _toolbarColorSchemeModifier<R>.parser(in: context).map({ Output.chunk17(.toolbarColorScheme($0)) }).eraseToAnyParser(),
 _toolbarItemHiddenModifier<R>.name: _toolbarItemHiddenModifier<R>.parser(in: context).map({ Output.chunk18(.toolbarItemHidden($0)) }).eraseToAnyParser(),
 _toolbarRoleModifier<R>.name: _toolbarRoleModifier<R>.parser(in: context).map({ Output.chunk18(.toolbarRole($0)) }).eraseToAnyParser(),
 _toolbarTitleDisplayModeModifier<R>.name: _toolbarTitleDisplayModeModifier<R>.parser(in: context).map({ Output.chunk18(.toolbarTitleDisplayMode($0)) }).eraseToAnyParser(),
@@ -17334,7 +17283,7 @@ _transitionModifier<R>.name: _transitionModifier<R>.parser(in: context).map({ Ou
 _truncationModeModifier<R>.name: _truncationModeModifier<R>.parser(in: context).map({ Output.chunk18(.truncationMode($0)) }).eraseToAnyParser(),
 _unredactedModifier<R>.name: _unredactedModifier<R>.parser(in: context).map({ Output.chunk18(.unredacted($0)) }).eraseToAnyParser(),
 _upperLimbVisibilityModifier<R>.name: _upperLimbVisibilityModifier<R>.parser(in: context).map({ Output.chunk18(.upperLimbVisibility($0)) }).eraseToAnyParser(),
-_volumeBaseplateVisibilityModifier<R>.name: _volumeBaseplateVisibilityModifier<R>.parser(in: context).map({ Output.chunk19(.volumeBaseplateVisibility($0)) }).eraseToAnyParser(),
+_volumeBaseplateVisibilityModifier<R>.name: _volumeBaseplateVisibilityModifier<R>.parser(in: context).map({ Output.chunk18(.volumeBaseplateVisibility($0)) }).eraseToAnyParser(),
 _windowDismissBehaviorModifier<R>.name: _windowDismissBehaviorModifier<R>.parser(in: context).map({ Output.chunk19(.windowDismissBehavior($0)) }).eraseToAnyParser(),
 _windowFullScreenBehaviorModifier<R>.name: _windowFullScreenBehaviorModifier<R>.parser(in: context).map({ Output.chunk19(.windowFullScreenBehavior($0)) }).eraseToAnyParser(),
 _windowMinimizeBehaviorModifier<R>.name: _windowMinimizeBehaviorModifier<R>.parser(in: context).map({ Output.chunk19(.windowMinimizeBehavior($0)) }).eraseToAnyParser(),
@@ -17343,16 +17292,16 @@ _windowToolbarFullScreenVisibilityModifier<R>.name: _windowToolbarFullScreenVisi
 _writingToolsBehaviorModifier<R>.name: _writingToolsBehaviorModifier<R>.parser(in: context).map({ Output.chunk19(.writingToolsBehavior($0)) }).eraseToAnyParser(),
 _zIndexModifier<R>.name: _zIndexModifier<R>.parser(in: context).map({ Output.chunk19(.zIndex($0)) }).eraseToAnyParser(),
                     LiveViewNative._OnSubmitModifier.name: LiveViewNative._OnSubmitModifier.parser(in: context).map(Output._OnSubmitModifier).eraseToAnyParser(),
-LiveViewNative._NavigationTransitionModifier<R>.name: LiveViewNative._NavigationTransitionModifier<R>.parser(in: context).map(Output._NavigationTransitionModifier).eraseToAnyParser(),
-LiveViewNative._MatchedTransitionSourceModifier<R>.name: LiveViewNative._MatchedTransitionSourceModifier<R>.parser(in: context).map(Output._MatchedTransitionSourceModifier).eraseToAnyParser(),
-LiveViewNative._FocusScopeModifier<R>.name: LiveViewNative._FocusScopeModifier<R>.parser(in: context).map(Output._FocusScopeModifier).eraseToAnyParser(),
+LiveViewNative._PerspectiveRotationEffectModifier<R>.name: LiveViewNative._PerspectiveRotationEffectModifier<R>.parser(in: context).map(Output._PerspectiveRotationEffectModifier).eraseToAnyParser(),
+LiveViewNative._MaskModifier<R>.name: LiveViewNative._MaskModifier<R>.parser(in: context).map(Output._MaskModifier).eraseToAnyParser(),
 LiveViewNative._SearchScopesModifier<R>.name: LiveViewNative._SearchScopesModifier<R>.parser(in: context).map(Output._SearchScopesModifier).eraseToAnyParser(),
+LiveViewNative._NavigationTransitionModifier<R>.name: LiveViewNative._NavigationTransitionModifier<R>.parser(in: context).map(Output._NavigationTransitionModifier).eraseToAnyParser(),
+LiveViewNative._MatchedGeometryEffectModifier<R>.name: LiveViewNative._MatchedGeometryEffectModifier<R>.parser(in: context).map(Output._MatchedGeometryEffectModifier).eraseToAnyParser(),
 LiveViewNative._PresentationDetentsModifier.name: LiveViewNative._PresentationDetentsModifier.parser(in: context).map(Output._PresentationDetentsModifier).eraseToAnyParser(),
 LiveViewNative._Rotation3DEffectModifier<R>.name: LiveViewNative._Rotation3DEffectModifier<R>.parser(in: context).map(Output._Rotation3DEffectModifier).eraseToAnyParser(),
-LiveViewNative._MaskModifier<R>.name: LiveViewNative._MaskModifier<R>.parser(in: context).map(Output._MaskModifier).eraseToAnyParser(),
-LiveViewNative._PerspectiveRotationEffectModifier<R>.name: LiveViewNative._PerspectiveRotationEffectModifier<R>.parser(in: context).map(Output._PerspectiveRotationEffectModifier).eraseToAnyParser(),
-LiveViewNative._MatchedGeometryEffectModifier<R>.name: LiveViewNative._MatchedGeometryEffectModifier<R>.parser(in: context).map(Output._MatchedGeometryEffectModifier).eraseToAnyParser(),
+LiveViewNative._FocusScopeModifier<R>.name: LiveViewNative._FocusScopeModifier<R>.parser(in: context).map(Output._FocusScopeModifier).eraseToAnyParser(),
 LiveViewNative._PrefersDefaultFocusModifier<R>.name: LiveViewNative._PrefersDefaultFocusModifier<R>.parser(in: context).map(Output._PrefersDefaultFocusModifier).eraseToAnyParser(),
+LiveViewNative._MatchedTransitionSourceModifier<R>.name: LiveViewNative._MatchedTransitionSourceModifier<R>.parser(in: context).map(Output._MatchedTransitionSourceModifier).eraseToAnyParser(),
 LiveViewNative._SearchCompletionModifier<R>.name: LiveViewNative._SearchCompletionModifier<R>.parser(in: context).map(Output._SearchCompletionModifier).eraseToAnyParser(),
                 ]
 
@@ -17549,7 +17498,7 @@ ConstantAtomLiteral("content").map({ () -> Self in
 /// * `.tabBar`
 /// * `.sidebar`
 @_documentation(visibility: public)
-@available(iOS 18.0,visionOS 2.0,watchOS 11.0,macOS 15.0,tvOS 18.0, *)
+@available(watchOS 11.0,iOS 18.0,macOS 15.0,visionOS 2.0,tvOS 18.0, *)
 extension AdaptableTabBarPlacement: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -17667,7 +17616,7 @@ ConstantAtomLiteral("vertical").map({ () -> Self in
 /// * `.standard`
 /// * `.increased`
 @_documentation(visibility: public)
-@available(visionOS 1.0,macOS 14.0,iOS 17.0, *)
+@available(iOS 17.0,macOS 14.0,visionOS 1.0, *)
 extension BadgeProminence: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -17895,7 +17844,7 @@ ConstantAtomLiteral("plusLighter").map({ () -> Self in
 /// * `.enabled`
 /// * `.disabled`
 @_documentation(visibility: public)
-@available(iOS 17.0,visionOS 1.0,watchOS 10.0,macOS 14.0,tvOS 17.0, *)
+@available(watchOS 10.0,iOS 17.0,macOS 14.0,visionOS 1.0,tvOS 17.0, *)
 extension ButtonRepeatBehavior: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -18014,7 +17963,7 @@ ConstantAtomLiteral("dark").map({ () -> Self in
 /// * `.navigationSplitView`
 /// * `.window`
 @_documentation(visibility: public)
-@available(visionOS 1.0,tvOS 17.0,iOS 17.0,watchOS 10.0,macOS 14.0, *)
+@available(tvOS 17.0,iOS 17.0,watchOS 10.0,visionOS 1.0,macOS 14.0, *)
 extension ContainerBackgroundPlacement: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -18063,7 +18012,7 @@ if #available(tvOS 17.0,iOS 17.0,watchOS 10.0,macOS 15.0, *) {
 /// * `.scrollContent`
 /// * `.scrollIndicators`
 @_documentation(visibility: public)
-@available(visionOS 1.0,tvOS 17.0,iOS 17.0,watchOS 10.0,macOS 14.0, *)
+@available(tvOS 17.0,iOS 17.0,watchOS 10.0,visionOS 1.0,macOS 14.0, *)
 extension ContentMarginPlacement: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -18122,35 +18071,35 @@ ConstantAtomLiteral("interaction").map({ () -> Self in
 
 #if os(iOS) || os(macOS) || os(visionOS)
 ConstantAtomLiteral("dragPreview").map({ () -> Self in
-if #available(visionOS 1.0,tvOS 15.0,iOS 15.0,macOS 12.0,watchOS 8.0, *) {
+if #available(macOS 12.0,visionOS 1.0,watchOS 8.0,tvOS 15.0,iOS 15.0, *) {
     return Self.dragPreview
 } else { fatalError("'dragPreview' is not available in this OS version") }
 })
 #endif
 #if os(iOS) || os(tvOS) || os(visionOS)
 ConstantAtomLiteral("contextMenuPreview").map({ () -> Self in
-if #available(visionOS 1.0,tvOS 17.0,iOS 15.0,macOS 12.0,watchOS 8.0, *) {
+if #available(macOS 12.0,visionOS 1.0,watchOS 8.0,tvOS 17.0,iOS 15.0, *) {
     return Self.contextMenuPreview
 } else { fatalError("'contextMenuPreview' is not available in this OS version") }
 })
 #endif
 #if os(iOS) || os(tvOS) || os(visionOS)
 ConstantAtomLiteral("hoverEffect").map({ () -> Self in
-if #available(visionOS 1.0,tvOS 18.0,iOS 15.0,macOS 12.0,watchOS 8.0, *) {
+if #available(macOS 12.0,visionOS 1.0,watchOS 8.0,tvOS 18.0,iOS 15.0, *) {
     return Self.hoverEffect
 } else { fatalError("'hoverEffect' is not available in this OS version") }
 })
 #endif
 #if os(macOS) || os(watchOS)
 ConstantAtomLiteral("focusEffect").map({ () -> Self in
-if #available(tvOS 15.0,iOS 15.0,macOS 12.0,watchOS 8.0, *) {
+if #available(macOS 12.0,watchOS 8.0,tvOS 15.0,iOS 15.0, *) {
     return Self.focusEffect
 } else { fatalError("'focusEffect' is not available in this OS version") }
 })
 #endif
 #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
 ConstantAtomLiteral("accessibility").map({ () -> Self in
-if #available(tvOS 17.0,visionOS 1.0,macOS 14.0,iOS 17.0,watchOS 10.0, *) {
+if #available(watchOS 10.0,iOS 17.0,tvOS 17.0,macOS 14.0,visionOS 1.0, *) {
     return Self.accessibility
 } else { fatalError("'accessibility' is not available in this OS version") }
 })
@@ -18173,7 +18122,7 @@ if #available(tvOS 17.0,visionOS 1.0,macOS 14.0,iOS 17.0,watchOS 10.0, *) {
 /// * `.large`
 /// * `.extraLarge`
 @_documentation(visibility: public)
-@available(visionOS 1.0,macOS 10.15,watchOS 9.0,iOS 15.0, *)
+@available(watchOS 9.0,iOS 15.0,macOS 10.15,visionOS 1.0, *)
 extension ControlSize: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -18201,14 +18150,14 @@ ConstantAtomLiteral("regular").map({ () -> Self in
 #endif
 #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
 ConstantAtomLiteral("large").map({ () -> Self in
-if #available(visionOS 1.0,macOS 11.0,watchOS 9.0,iOS 15.0, *) {
+if #available(watchOS 9.0,iOS 15.0,macOS 11.0,visionOS 1.0, *) {
     return Self.large
 } else { fatalError("'large' is not available in this OS version") }
 })
 #endif
 #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
 ConstantAtomLiteral("extraLarge").map({ () -> Self in
-if #available(visionOS 1.0,macOS 14.0,watchOS 10.0,iOS 17.0, *) {
+if #available(watchOS 10.0,iOS 17.0,macOS 14.0,visionOS 1.0, *) {
     return Self.extraLarge
 } else { fatalError("'extraLarge' is not available in this OS version") }
 })
@@ -18263,7 +18212,7 @@ ConstantAtomLiteral("userInitiated").map({ () -> Self in
 /// * `.critical`
 /// * `.standard`
 @_documentation(visibility: public)
-@available(visionOS 1.0,tvOS 17.0,iOS 17.0,watchOS 10.0,macOS 13.0, *)
+@available(tvOS 17.0,iOS 17.0,watchOS 10.0,visionOS 1.0,macOS 13.0, *)
 extension DialogSeverity: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -18284,7 +18233,7 @@ ConstantAtomLiteral("critical").map({ () -> Self in
 #endif
 #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
 ConstantAtomLiteral("standard").map({ () -> Self in
-if #available(visionOS 1.0,tvOS 17.0,iOS 17.0,watchOS 10.0,macOS 14.0, *) {
+if #available(tvOS 17.0,iOS 17.0,watchOS 10.0,visionOS 1.0,macOS 14.0, *) {
     return Self.standard
 } else { fatalError("'standard' is not available in this OS version") }
 })
@@ -18455,7 +18404,7 @@ ConstantAtomLiteral("all").map({ () -> Self in
 /// * `.includeHiddenFiles`
 /// * `.displayFileExtensions`
 @_documentation(visibility: public)
-@available(visionOS 1.0,macOS 14.0,iOS 17.0, *)
+@available(iOS 17.0,macOS 14.0,visionOS 1.0, *)
 extension FileDialogBrowserOptions: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -18497,7 +18446,7 @@ ConstantAtomLiteral("displayFileExtensions").map({ () -> Self in
 /// * `.edit`
 /// * `.automatic`
 @_documentation(visibility: public)
-@available(iOS 17.0,visionOS 1.0,watchOS 10.0,macOS 14.0,tvOS 17.0, *)
+@available(watchOS 10.0,iOS 17.0,macOS 14.0,visionOS 1.0,tvOS 17.0, *)
 extension FocusInteractions: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -18756,14 +18705,14 @@ extension HorizontalAlignment: ParseableModifierValue {
             OneOf {
             #if os(iOS) || os(macOS) || os(visionOS)
 ConstantAtomLiteral("listRowSeparatorLeading").map({ () -> Self in
-if #available(visionOS 1.0,macOS 13.0,iOS 16.0, *) {
+if #available(iOS 16.0,macOS 13.0,visionOS 1.0, *) {
     return Self.listRowSeparatorLeading
 } else { fatalError("'listRowSeparatorLeading' is not available in this OS version") }
 })
 #endif
 #if os(iOS) || os(macOS) || os(visionOS)
 ConstantAtomLiteral("listRowSeparatorTrailing").map({ () -> Self in
-if #available(visionOS 1.0,macOS 13.0,iOS 16.0, *) {
+if #available(iOS 16.0,macOS 13.0,visionOS 1.0, *) {
     return Self.listRowSeparatorTrailing
 } else { fatalError("'listRowSeparatorTrailing' is not available in this OS version") }
 })
@@ -18804,7 +18753,7 @@ ConstantAtomLiteral("trailing").map({ () -> Self in
 /// * `.leading`
 /// * `.trailing`
 @_documentation(visibility: public)
-@available(visionOS 2.0,tvOS 18.0,iOS 18.0,macOS 15.0,watchOS 11.0, *)
+@available(macOS 15.0,visionOS 2.0,watchOS 11.0,tvOS 18.0,iOS 18.0, *)
 extension HorizontalDirection: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -18873,7 +18822,7 @@ ConstantAtomLiteral("trailing").map({ () -> Self in
 /// * `.highlight`
 /// * `.lift`
 @_documentation(visibility: public)
-@available(tvOS 16.0,visionOS 1.0,iOS 13.4, *)
+@available(iOS 13.4,tvOS 16.0,visionOS 1.0, *)
 extension HoverEffect: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -18887,7 +18836,7 @@ ConstantAtomLiteral("automatic").map({ () -> Self in
 #endif
 #if os(iOS) || os(tvOS) || os(visionOS)
 ConstantAtomLiteral("highlight").map({ () -> Self in
-if #available(tvOS 17.0,visionOS 1.0,iOS 13.4, *) {
+if #available(iOS 13.4,tvOS 17.0,visionOS 1.0, *) {
     return Self.highlight
 } else { fatalError("'highlight' is not available in this OS version") }
 })
@@ -18914,7 +18863,7 @@ ConstantAtomLiteral("lift").map({ () -> Self in
 /// * `.defaultAction`
 /// * `.cancelAction`
 @_documentation(visibility: public)
-@available(visionOS 1.0,macOS 11.0,iOS 14.0, *)
+@available(iOS 14.0,macOS 11.0,visionOS 1.0, *)
 extension KeyboardShortcut: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -19005,7 +18954,7 @@ ConstantAtomLiteral("automatic").map({ () -> Self in
 
 #if os(iOS) || os(visionOS)
 ConstantAtomLiteral("priority").map({ () -> Self in
-if #available(watchOS 9.0,iOS 16.0,macOS 13.0,tvOS 16.0,visionOS 1.0, *) {
+if #available(tvOS 16.0,iOS 16.0,watchOS 9.0,visionOS 1.0,macOS 13.0, *) {
     return Self.priority
 } else { fatalError("'priority' is not available in this OS version") }
 })
@@ -19035,7 +18984,7 @@ ConstantAtomLiteral("fixed").map({ () -> Self in
 /// * `.sheet`
 /// * `.fullScreenCover`
 @_documentation(visibility: public)
-@available(visionOS 1.0,tvOS 16.4,iOS 16.4,watchOS 9.4,macOS 13.3, *)
+@available(tvOS 16.4,iOS 16.4,watchOS 9.4,visionOS 1.0,macOS 13.3, *)
 extension PresentationAdaptation: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -19091,7 +19040,7 @@ ConstantAtomLiteral("fullScreenCover").map({ () -> Self in
 /// * `.resizes`
 /// * `.scrolls`
 @_documentation(visibility: public)
-@available(iOS 16.4,visionOS 1.0,watchOS 9.4,macOS 13.3,tvOS 16.4, *)
+@available(watchOS 9.4,iOS 16.4,macOS 13.3,visionOS 1.0,tvOS 16.4, *)
 extension PresentationContentInteraction: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -19188,7 +19137,7 @@ ConstantAtomLiteral("privacy").map({ () -> Self in
 
 #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
 ConstantAtomLiteral("invalidated").map({ () -> Self in
-if #available(tvOS 17.0,visionOS 1.0,macOS 14.0,iOS 17.0,watchOS 10.0, *) {
+if #available(watchOS 10.0,iOS 17.0,tvOS 17.0,macOS 14.0,visionOS 1.0, *) {
     return Self.invalidated
 } else { fatalError("'invalidated' is not available in this OS version") }
 })
@@ -19298,7 +19247,7 @@ ConstantAtomLiteral("minimum").map({ () -> Self in
 
 #if os(watchOS)
 ConstantAtomLiteral("navigationBar").map({ () -> Self in
-if #available(watchOS 9.0,macOS 13.0,iOS 16.0,tvOS 16.0, *) {
+if #available(macOS 13.0,watchOS 9.0,iOS 16.0,tvOS 16.0, *) {
     return Self.navigationBar
 } else { fatalError("'navigationBar' is not available in this OS version") }
 })
@@ -19319,7 +19268,7 @@ if #available(watchOS 9.0,macOS 13.0,iOS 16.0,tvOS 16.0, *) {
 /// * `.sizeChanges`
 /// * `.alignment`
 @_documentation(visibility: public)
-@available(visionOS 2.0,tvOS 18.0,iOS 18.0,watchOS 11.0,macOS 15.0, *)
+@available(tvOS 18.0,iOS 18.0,watchOS 11.0,visionOS 2.0,macOS 15.0, *)
 extension ScrollAnchorRole: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -19361,7 +19310,7 @@ ConstantAtomLiteral("alignment").map({ () -> Self in
 /// * `.always`
 /// * `.basedOnSize`
 @_documentation(visibility: public)
-@available(visionOS 1.0,tvOS 16.4,iOS 16.4,watchOS 9.4,macOS 13.3, *)
+@available(tvOS 16.4,iOS 16.4,watchOS 9.4,visionOS 1.0,macOS 13.3, *)
 extension ScrollBounceBehavior: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -19503,7 +19452,7 @@ ConstantAtomLiteral("never").map({ () -> Self in
 /// * `.enabled`
 /// * `.disabled`
 @_documentation(visibility: public)
-@available(visionOS 2.0,tvOS 18.0,iOS 18.0,watchOS 11.0,macOS 15.0, *)
+@available(tvOS 18.0,iOS 18.0,watchOS 11.0,visionOS 2.0,macOS 15.0, *)
 extension ScrollInputBehavior: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -19545,7 +19494,7 @@ ConstantAtomLiteral("disabled").map({ () -> Self in
 /// * `.onTextEntry`
 /// * `.onSearchPresentation`
 @_documentation(visibility: public)
-@available(watchOS 9.4,iOS 16.4,macOS 13.3,tvOS 16.4,visionOS 1.0, *)
+@available(tvOS 16.4,iOS 16.4,watchOS 9.4,visionOS 1.0,macOS 13.3, *)
 extension SearchScopeActivation: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -19629,7 +19578,7 @@ ConstantAtomLiteral("content").map({ () -> Self in
 /// * `.enabled`
 /// * `.disabled`
 @_documentation(visibility: public)
-@available(iOS 17.0,visionOS 1.0,watchOS 10.0,macOS 14.0,tvOS 17.0, *)
+@available(visionOS 1.0,macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0, *)
 extension SpringLoadingBehavior: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -19795,7 +19744,7 @@ ConstantAtomLiteral("search").map({ () -> Self in
 /// * `.upstream`
 /// * `.downstream`
 @_documentation(visibility: public)
-@available(visionOS 2.0,tvOS 18.0,iOS 18.0,watchOS 11.0,macOS 15.0, *)
+@available(tvOS 18.0,iOS 18.0,watchOS 11.0,visionOS 2.0,macOS 15.0, *)
 extension TextSelectionAffinity: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -19836,7 +19785,7 @@ ConstantAtomLiteral("downstream").map({ () -> Self in
 /// * `.sidebarToggle`
 /// * `.title`
 @_documentation(visibility: public)
-@available(visionOS 1.0,tvOS 17.0,iOS 17.0,watchOS 10.0,macOS 14.0, *)
+@available(tvOS 17.0,iOS 17.0,watchOS 10.0,visionOS 1.0,macOS 14.0, *)
 extension ToolbarDefaultItemKind: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -19850,7 +19799,7 @@ ConstantAtomLiteral("sidebarToggle").map({ () -> Self in
 #endif
 #if os(iOS) || os(macOS) || os(visionOS)
 ConstantAtomLiteral("title").map({ () -> Self in
-if #available(visionOS 2.0,tvOS 17.0,iOS 18.0,watchOS 10.0,macOS 15.0, *) {
+if #available(tvOS 17.0,iOS 18.0,watchOS 10.0,visionOS 2.0,macOS 15.0, *) {
     return Self.title
 } else { fatalError("'title' is not available in this OS version") }
 })
@@ -19886,21 +19835,21 @@ ConstantAtomLiteral("automatic").map({ () -> Self in
 
 #if os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
 ConstantAtomLiteral("navigationStack").map({ () -> Self in
-if #available(iOS 16.0,visionOS 1.0,watchOS 9.0,macOS 13.0,tvOS 16.0, *) {
+if #available(watchOS 9.0,iOS 16.0,macOS 13.0,visionOS 1.0,tvOS 16.0, *) {
     return Self.navigationStack
 } else { fatalError("'navigationStack' is not available in this OS version") }
 })
 #endif
 #if os(iOS) || os(visionOS)
 ConstantAtomLiteral("browser").map({ () -> Self in
-if #available(iOS 16.0,visionOS 1.0,watchOS 9.0,macOS 13.0,tvOS 16.0, *) {
+if #available(watchOS 9.0,iOS 16.0,macOS 13.0,visionOS 1.0,tvOS 16.0, *) {
     return Self.browser
 } else { fatalError("'browser' is not available in this OS version") }
 })
 #endif
 #if os(iOS) || os(macOS) || os(visionOS)
 ConstantAtomLiteral("editor").map({ () -> Self in
-if #available(iOS 16.0,visionOS 1.0,watchOS 9.0,macOS 13.0,tvOS 16.0, *) {
+if #available(watchOS 9.0,iOS 16.0,macOS 13.0,visionOS 1.0,tvOS 16.0, *) {
     return Self.editor
 } else { fatalError("'editor' is not available in this OS version") }
 })
@@ -19922,7 +19871,7 @@ if #available(iOS 16.0,visionOS 1.0,watchOS 9.0,macOS 13.0,tvOS 16.0, *) {
 /// * `.inlineLarge`
 /// * `.inline`
 @_documentation(visibility: public)
-@available(visionOS 1.0,tvOS 17.0,iOS 17.0,watchOS 10.0,macOS 14.0, *)
+@available(tvOS 17.0,iOS 17.0,watchOS 10.0,visionOS 1.0,macOS 14.0, *)
 extension ToolbarTitleDisplayMode: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -20028,7 +19977,7 @@ ConstantAtomLiteral("lastTextBaseline").map({ () -> Self in
 /// * `.up`
 /// * `.down`
 @_documentation(visibility: public)
-@available(visionOS 2.0,tvOS 18.0,iOS 18.0,macOS 15.0,watchOS 11.0, *)
+@available(macOS 15.0,visionOS 2.0,watchOS 11.0,tvOS 18.0,iOS 18.0, *)
 extension VerticalDirection: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -20181,7 +20130,7 @@ ConstantAtomLiteral("disabled").map({ () -> Self in
 /// * `.visible`
 /// * `.onHover`
 @_documentation(visibility: public)
-@available(visionOS 2.0,tvOS 18.0,iOS 18.0,watchOS 11.0,macOS 15.0, *)
+@available(tvOS 18.0,iOS 18.0,watchOS 11.0,visionOS 2.0,macOS 15.0, *)
 extension WindowToolbarFullScreenVisibility: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -20224,7 +20173,7 @@ ConstantAtomLiteral("onHover").map({ () -> Self in
 /// * `.limited`
 /// * `.disabled`
 @_documentation(visibility: public)
-@available(macOS 15.0,iOS 18.0, *)
+@available(iOS 18.0,macOS 15.0, *)
 extension WritingToolsBehavior: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {

--- a/Sources/LiveViewNative/_GeneratedModifiers.swift
+++ b/Sources/LiveViewNative/_GeneratedModifiers.swift
@@ -6,6 +6,53 @@ import LiveViewNativeStylesheet
 
 @_documentation(visibility: public)
 @ParseableExpression
+struct _accentColorModifier<R: RootRegistry>: ViewModifier {
+    static var name: String { "accentColor" }
+
+    enum Value {
+        case _never
+        
+        indirect case _0(accentColor: Color.Resolvable?)
+        
+    }
+
+    let value: Value
+
+    @ObservedElement private var element
+    @LiveContext<R> private var context
+    
+
+
+
+
+    
+    
+    init(_ accentColor: Color.Resolvable?) {
+        self.value = ._0(accentColor: accentColor)
+        
+    }
+    
+
+    func body(content __content: Content) -> some View {
+        switch value {
+        case ._never:
+            fatalError("unreachable")
+        
+        case let ._0(accentColor):
+            
+            
+            
+            __content
+                .accentColor(accentColor?.resolve(on: element, in: context))
+            
+                
+            
+        
+        }
+    }
+}
+@_documentation(visibility: public)
+@ParseableExpression
 struct _accessibilityActionModifier<R: RootRegistry>: ViewModifier {
     static var name: String { "accessibilityAction" }
 
@@ -78,7 +125,7 @@ struct _accessibilityActionsModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 2.0,macOS 15.0,tvOS 18.0,iOS 18.0,watchOS 11.0, *)
+    @available(watchOS 11.0,visionOS 2.0,iOS 18.0,macOS 15.0,tvOS 18.0, *)
     init(category: SwiftUI.AccessibilityActionCategory,content content: ViewReference=ViewReference(value: [])) {
         self.value = ._0(category: category, content: content)
         
@@ -98,7 +145,7 @@ struct _accessibilityActionsModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(category, content):
-            if #available(visionOS 2.0,macOS 15.0,tvOS 18.0,iOS 18.0,watchOS 11.0, *) {
+            if #available(watchOS 11.0,visionOS 2.0,iOS 18.0,macOS 15.0,tvOS 18.0, *) {
             let category = category as! SwiftUI.AccessibilityActionCategory
 let content = content as! ViewReference
             
@@ -634,7 +681,7 @@ struct _allowsWindowActivationEventsModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(iOS 18.0,visionOS 2.0,macOS 15.0, *)
+    @available(iOS 18.0,macOS 15.0,visionOS 2.0, *)
     init(_ value: AttributeReference<Swift.Bool?>? = .init(storage: .constant(true)) ) {
         self.value = ._0(value: value)
         
@@ -647,7 +694,7 @@ struct _allowsWindowActivationEventsModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(value):
-            if #available(iOS 18.0,visionOS 2.0,macOS 15.0, *) {
+            if #available(iOS 18.0,macOS 15.0,visionOS 2.0, *) {
             let value = value as? AttributeReference<Swift.Bool?>
             
             __content
@@ -669,6 +716,9 @@ struct _animationModifier<R: RootRegistry>: ViewModifier {
         
         indirect case _0(animation: SwiftUICore.Animation?,value: AttributeReference<String>)
         
+        
+        indirect case _1(animation: SwiftUICore.Animation?)
+        
     }
 
     let value: Value
@@ -680,10 +730,19 @@ struct _animationModifier<R: RootRegistry>: ViewModifier {
 
 
 
+
+
     
     
     init(_ animation: SwiftUICore.Animation?,value: AttributeReference<String>) {
         self.value = ._0(animation: animation, value: value)
+        
+    }
+    
+    
+    
+    init(_ animation: SwiftUICore.Animation?) {
+        self.value = ._1(animation: animation)
         
     }
     
@@ -699,6 +758,17 @@ struct _animationModifier<R: RootRegistry>: ViewModifier {
             
             __content
                 .animation(animation, value: value.resolve(on: element, in: context))
+            
+                
+            
+        
+        
+        case let ._1(animation):
+            
+            
+            
+            __content
+                .animation(animation)
             
                 
             
@@ -778,6 +848,53 @@ struct _aspectRatioModifier<R: RootRegistry>: ViewModifier {
 }
 @_documentation(visibility: public)
 @ParseableExpression
+struct _autocapitalizationModifier<R: RootRegistry>: ViewModifier {
+    static var name: String { "autocapitalization" }
+
+    enum Value {
+        case _never
+        #if os(iOS) || os(tvOS) || os(visionOS)
+        indirect case _0(style: Any)
+        #endif
+    }
+
+    let value: Value
+
+    
+    
+    
+
+
+
+
+    #if os(iOS) || os(tvOS) || os(visionOS)
+    @available(tvOS 16.0,visionOS 1.0,iOS 16.0, *)
+    init(_ style: UIKit.UITextAutocapitalizationType) {
+        self.value = ._0(style: style)
+        
+    }
+    #endif
+
+    func body(content __content: Content) -> some View {
+        switch value {
+        case ._never:
+            fatalError("unreachable")
+        #if os(iOS) || os(tvOS) || os(visionOS)
+        case let ._0(style):
+            if #available(tvOS 16.0,visionOS 1.0,iOS 16.0, *) {
+            let style = style as! UIKit.UITextAutocapitalizationType
+            
+            __content
+                .autocapitalization(style)
+            
+                
+            } else { __content }
+        #endif
+        }
+    }
+}
+@_documentation(visibility: public)
+@ParseableExpression
 struct _autocorrectionDisabledModifier<R: RootRegistry>: ViewModifier {
     static var name: String { "autocorrectionDisabled" }
 
@@ -831,25 +948,28 @@ struct _backgroundModifier<R: RootRegistry>: ViewModifier {
     enum Value {
         case _never
         
-        indirect case _0(alignment: AttributeReference<SwiftUICore.Alignment> = .init(storage: .constant(.center)), content: ViewReference=ViewReference(value: []))
+        indirect case _0(background: InlineViewReference,alignment: AttributeReference<SwiftUICore.Alignment> = .init(storage: .constant(.center)) )
         
         
-        indirect case _1(edges: SwiftUICore.Edge.Set = .all )
+        indirect case _1(alignment: AttributeReference<SwiftUICore.Alignment> = .init(storage: .constant(.center)), content: ViewReference=ViewReference(value: []))
         
         
-        indirect case _2(style: AnyShapeStyle.Resolvable,edges: SwiftUICore.Edge.Set = .all )
+        indirect case _2(edges: SwiftUICore.Edge.Set = .all )
         
         
-        indirect case _3(shape: AnyShape,fillStyle: SwiftUICore.FillStyle = FillStyle() )
+        indirect case _3(style: AnyShapeStyle.Resolvable,edges: SwiftUICore.Edge.Set = .all )
         
         
-        indirect case _4(style: AnyShapeStyle.Resolvable,shape: AnyShape,fillStyle: SwiftUICore.FillStyle = FillStyle() )
+        indirect case _4(shape: AnyShape,fillStyle: SwiftUICore.FillStyle = FillStyle() )
         
         
-        indirect case _5(shape: AnyInsettableShape,fillStyle: SwiftUICore.FillStyle = FillStyle() )
+        indirect case _5(style: AnyShapeStyle.Resolvable,shape: AnyShape,fillStyle: SwiftUICore.FillStyle = FillStyle() )
         
         
-        indirect case _6(style: AnyShapeStyle.Resolvable,shape: AnyInsettableShape,fillStyle: SwiftUICore.FillStyle = FillStyle() )
+        indirect case _6(shape: AnyInsettableShape,fillStyle: SwiftUICore.FillStyle = FillStyle() )
+        
+        
+        indirect case _7(style: AnyShapeStyle.Resolvable,shape: AnyInsettableShape,fillStyle: SwiftUICore.FillStyle = FillStyle() )
         
     }
 
@@ -874,52 +994,61 @@ struct _backgroundModifier<R: RootRegistry>: ViewModifier {
 
 
 
+
+
+    
+    
+    init(_ background: InlineViewReference,alignment: AttributeReference<SwiftUICore.Alignment> = .init(storage: .constant(.center)) ) {
+        self.value = ._0(background: background, alignment: alignment)
+        
+    }
+    
     
     
     init(alignment: AttributeReference<SwiftUICore.Alignment> = .init(storage: .constant(.center)), content: ViewReference=ViewReference(value: [])) {
-        self.value = ._0(alignment: alignment, content: content)
+        self.value = ._1(alignment: alignment, content: content)
         
     }
     
     
     
     init(ignoresSafeAreaEdges edges: SwiftUICore.Edge.Set = .all ) {
-        self.value = ._1(edges: edges)
+        self.value = ._2(edges: edges)
         
     }
     
     
     
     init(_ style: AnyShapeStyle.Resolvable,ignoresSafeAreaEdges edges: SwiftUICore.Edge.Set = .all ) {
-        self.value = ._2(style: style, edges: edges)
+        self.value = ._3(style: style, edges: edges)
         
     }
     
     
     
     init(in shape: AnyShape,fillStyle: SwiftUICore.FillStyle = FillStyle() ) {
-        self.value = ._3(shape: shape, fillStyle: fillStyle)
+        self.value = ._4(shape: shape, fillStyle: fillStyle)
         
     }
     
     
     
     init(_ style: AnyShapeStyle.Resolvable,in shape: AnyShape,fillStyle: SwiftUICore.FillStyle = FillStyle() ) {
-        self.value = ._4(style: style, shape: shape, fillStyle: fillStyle)
+        self.value = ._5(style: style, shape: shape, fillStyle: fillStyle)
         
     }
     
     
     
     init(in shape: AnyInsettableShape,fillStyle: SwiftUICore.FillStyle = FillStyle() ) {
-        self.value = ._5(shape: shape, fillStyle: fillStyle)
+        self.value = ._6(shape: shape, fillStyle: fillStyle)
         
     }
     
     
     
     init(_ style: AnyShapeStyle.Resolvable,in shape: AnyInsettableShape,fillStyle: SwiftUICore.FillStyle = FillStyle() ) {
-        self.value = ._6(style: style, shape: shape, fillStyle: fillStyle)
+        self.value = ._7(style: style, shape: shape, fillStyle: fillStyle)
         
     }
     
@@ -929,7 +1058,18 @@ struct _backgroundModifier<R: RootRegistry>: ViewModifier {
         case ._never:
             fatalError("unreachable")
         
-        case let ._0(alignment, content):
+        case let ._0(background, alignment):
+            
+            
+            
+            __content
+                .background(background.resolve(on: element, in: context), alignment: alignment.resolve(on: element, in: context))
+            
+                
+            
+        
+        
+        case let ._1(alignment, content):
             
             
             
@@ -940,7 +1080,7 @@ struct _backgroundModifier<R: RootRegistry>: ViewModifier {
             
         
         
-        case let ._1(edges):
+        case let ._2(edges):
             
             
             
@@ -951,7 +1091,7 @@ struct _backgroundModifier<R: RootRegistry>: ViewModifier {
             
         
         
-        case let ._2(style, edges):
+        case let ._3(style, edges):
             
             
             
@@ -962,7 +1102,7 @@ struct _backgroundModifier<R: RootRegistry>: ViewModifier {
             
         
         
-        case let ._3(shape, fillStyle):
+        case let ._4(shape, fillStyle):
             
             
             
@@ -973,7 +1113,7 @@ struct _backgroundModifier<R: RootRegistry>: ViewModifier {
             
         
         
-        case let ._4(style, shape, fillStyle):
+        case let ._5(style, shape, fillStyle):
             
             
             
@@ -984,7 +1124,7 @@ struct _backgroundModifier<R: RootRegistry>: ViewModifier {
             
         
         
-        case let ._5(shape, fillStyle):
+        case let ._6(shape, fillStyle):
             
             
             
@@ -995,7 +1135,7 @@ struct _backgroundModifier<R: RootRegistry>: ViewModifier {
             
         
         
-        case let ._6(style, shape, fillStyle):
+        case let ._7(style, shape, fillStyle):
             
             
             
@@ -1092,28 +1232,28 @@ struct _badgeModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 12.0,iOS 15.0,visionOS 1.0, *)
+    @available(visionOS 1.0,macOS 12.0,iOS 15.0, *)
     init(_ count: AttributeReference<Swift.Int>) {
         self.value = ._0(count: count)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 12.0,iOS 15.0,visionOS 1.0, *)
+    @available(visionOS 1.0,macOS 12.0,iOS 15.0, *)
     init(_ label: TextReference?) {
         self.value = ._1(label: label)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 12.0,iOS 15.0,visionOS 1.0, *)
+    @available(visionOS 1.0,macOS 12.0,iOS 15.0, *)
     init(_ key: SwiftUICore.LocalizedStringKey?) {
         self.value = ._2(key: key)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 12.0,iOS 15.0,visionOS 1.0, *)
+    @available(visionOS 1.0,macOS 12.0,iOS 15.0, *)
     init(_ label: AttributeReference<String>) {
         self.value = ._3(label: label)
         
@@ -1126,7 +1266,7 @@ struct _badgeModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(count):
-            if #available(macOS 12.0,iOS 15.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,macOS 12.0,iOS 15.0, *) {
             let count = count as! AttributeReference<Swift.Int>
             
             __content
@@ -1137,7 +1277,7 @@ struct _badgeModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._1(label):
-            if #available(macOS 12.0,iOS 15.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,macOS 12.0,iOS 15.0, *) {
             let label = label as? TextReference
             __content._observeTextReference(label, on: element, in: context) { __content in
             __content
@@ -1148,7 +1288,7 @@ struct _badgeModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._2(key):
-            if #available(macOS 12.0,iOS 15.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,macOS 12.0,iOS 15.0, *) {
             let key = key as? SwiftUICore.LocalizedStringKey
             
             __content
@@ -1159,7 +1299,7 @@ struct _badgeModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._3(label):
-            if #available(macOS 12.0,iOS 15.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,macOS 12.0,iOS 15.0, *) {
             let label = label as! AttributeReference<String>
             
             __content
@@ -1193,7 +1333,7 @@ struct _badgeProminenceModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 14.0,iOS 17.0,visionOS 1.0, *)
+    @available(iOS 17.0,macOS 14.0,visionOS 1.0, *)
     init(_ prominence: SwiftUI.BadgeProminence) {
         self.value = ._0(prominence: prominence)
         
@@ -1206,7 +1346,7 @@ struct _badgeProminenceModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(prominence):
-            if #available(macOS 14.0,iOS 17.0,visionOS 1.0, *) {
+            if #available(iOS 17.0,macOS 14.0,visionOS 1.0, *) {
             let prominence = prominence as! SwiftUI.BadgeProminence
             
             __content
@@ -1713,6 +1853,53 @@ struct _colorMultiplyModifier<R: RootRegistry>: ViewModifier {
 }
 @_documentation(visibility: public)
 @ParseableExpression
+struct _colorSchemeModifier<R: RootRegistry>: ViewModifier {
+    static var name: String { "colorScheme" }
+
+    enum Value {
+        case _never
+        
+        indirect case _0(colorScheme: AttributeReference<SwiftUICore.ColorScheme>)
+        
+    }
+
+    let value: Value
+
+    @ObservedElement private var element
+    @LiveContext<R> private var context
+    
+
+
+
+
+    
+    
+    init(_ colorScheme: AttributeReference<SwiftUICore.ColorScheme>) {
+        self.value = ._0(colorScheme: colorScheme)
+        
+    }
+    
+
+    func body(content __content: Content) -> some View {
+        switch value {
+        case ._never:
+            fatalError("unreachable")
+        
+        case let ._0(colorScheme):
+            
+            
+            
+            __content
+                .colorScheme(colorScheme.resolve(on: element, in: context))
+            
+                
+            
+        
+        }
+    }
+}
+@_documentation(visibility: public)
+@ParseableExpression
 struct _compositingGroupModifier<R: RootRegistry>: ViewModifier {
     static var name: String { "compositingGroup" }
 
@@ -1947,14 +2134,14 @@ struct _containerRelativeFrameModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0, *)
+    @available(watchOS 10.0,visionOS 1.0,iOS 17.0,macOS 14.0,tvOS 17.0, *)
     init(_ axes: SwiftUICore.Axis.Set,alignment: AttributeReference<SwiftUICore.Alignment> = .init(storage: .constant(.center)) ) {
         self.value = ._0(axes: axes, alignment: alignment)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0, *)
+    @available(watchOS 10.0,visionOS 1.0,iOS 17.0,macOS 14.0,tvOS 17.0, *)
     init(_ axes: SwiftUICore.Axis.Set,count: AttributeReference<Swift.Int>,span: AttributeReference<Swift.Int> = .init(storage: .constant(1)), spacing: AttributeReference<CoreFoundation.CGFloat>,alignment: AttributeReference<SwiftUICore.Alignment> = .init(storage: .constant(.center)) ) {
         self.value = ._1(axes: axes, count: count, span: span, spacing: spacing, alignment: alignment)
         
@@ -1967,7 +2154,7 @@ struct _containerRelativeFrameModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(axes, alignment):
-            if #available(visionOS 1.0,tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0, *) {
+            if #available(watchOS 10.0,visionOS 1.0,iOS 17.0,macOS 14.0,tvOS 17.0, *) {
             let axes = axes as! SwiftUICore.Axis.Set
 let alignment = alignment as! AttributeReference<SwiftUICore.Alignment>
             
@@ -1979,7 +2166,7 @@ let alignment = alignment as! AttributeReference<SwiftUICore.Alignment>
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(axes, count, span, spacing, alignment):
-            if #available(visionOS 1.0,tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0, *) {
+            if #available(watchOS 10.0,visionOS 1.0,iOS 17.0,macOS 14.0,tvOS 17.0, *) {
             let axes = axes as! SwiftUICore.Axis.Set
 let count = count as! AttributeReference<Swift.Int>
 let span = span as! AttributeReference<Swift.Int>
@@ -2074,21 +2261,21 @@ struct _contentMarginsModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 10.0,visionOS 1.0,iOS 17.0,macOS 14.0,tvOS 17.0, *)
+    @available(tvOS 17.0,iOS 17.0,macOS 14.0,visionOS 1.0,watchOS 10.0, *)
     init(_ edges: SwiftUICore.Edge.Set = .all, _ insets: SwiftUICore.EdgeInsets,for placement: SwiftUI.ContentMarginPlacement = .automatic ) {
         self.value = ._0(edges: edges, insets: insets, placement: placement)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 10.0,visionOS 1.0,iOS 17.0,macOS 14.0,tvOS 17.0, *)
+    @available(tvOS 17.0,iOS 17.0,macOS 14.0,visionOS 1.0,watchOS 10.0, *)
     init(_ edges: SwiftUICore.Edge.Set = .all, _ length: AttributeReference<CoreFoundation.CGFloat?>?,for placement: SwiftUI.ContentMarginPlacement = .automatic ) {
         self.value = ._1(edges: edges, length: length, placement: placement)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 10.0,visionOS 1.0,iOS 17.0,macOS 14.0,tvOS 17.0, *)
+    @available(tvOS 17.0,iOS 17.0,macOS 14.0,visionOS 1.0,watchOS 10.0, *)
     init(_ length: AttributeReference<CoreFoundation.CGFloat>,for placement: SwiftUI.ContentMarginPlacement = .automatic ) {
         self.value = ._2(length: length, placement: placement)
         
@@ -2101,7 +2288,7 @@ struct _contentMarginsModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(edges, insets, placement):
-            if #available(watchOS 10.0,visionOS 1.0,iOS 17.0,macOS 14.0,tvOS 17.0, *) {
+            if #available(tvOS 17.0,iOS 17.0,macOS 14.0,visionOS 1.0,watchOS 10.0, *) {
             let edges = edges as! SwiftUICore.Edge.Set 
 let insets = insets as! SwiftUICore.EdgeInsets
 let placement = placement as! SwiftUI.ContentMarginPlacement 
@@ -2114,7 +2301,7 @@ let placement = placement as! SwiftUI.ContentMarginPlacement
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(edges, length, placement):
-            if #available(watchOS 10.0,visionOS 1.0,iOS 17.0,macOS 14.0,tvOS 17.0, *) {
+            if #available(tvOS 17.0,iOS 17.0,macOS 14.0,visionOS 1.0,watchOS 10.0, *) {
             let edges = edges as! SwiftUICore.Edge.Set 
 let length = length as? AttributeReference<CoreFoundation.CGFloat?>
 let placement = placement as! SwiftUI.ContentMarginPlacement 
@@ -2127,7 +2314,7 @@ let placement = placement as! SwiftUI.ContentMarginPlacement
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._2(length, placement):
-            if #available(watchOS 10.0,visionOS 1.0,iOS 17.0,macOS 14.0,tvOS 17.0, *) {
+            if #available(tvOS 17.0,iOS 17.0,macOS 14.0,visionOS 1.0,watchOS 10.0, *) {
             let length = length as! AttributeReference<CoreFoundation.CGFloat>
 let placement = placement as! SwiftUI.ContentMarginPlacement 
             
@@ -2291,7 +2478,7 @@ struct _contextMenuModifier<R: RootRegistry>: ViewModifier {
     }
     
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS)
-    @available(macOS 13.0,tvOS 16.0,iOS 16.0,visionOS 1.0, *)
+    @available(visionOS 1.0,tvOS 16.0,macOS 13.0,iOS 16.0, *)
     init(menuItems: ViewReference=ViewReference(value: []),preview: ViewReference=ViewReference(value: [])) {
         self.value = ._1(menuItems: menuItems, preview: preview)
         
@@ -2315,7 +2502,7 @@ struct _contextMenuModifier<R: RootRegistry>: ViewModifier {
         
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS)
         case let ._1(menuItems, preview):
-            if #available(macOS 13.0,tvOS 16.0,iOS 16.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,tvOS 16.0,macOS 13.0,iOS 16.0, *) {
             let menuItems = menuItems as! ViewReference
 let preview = preview as! ViewReference
             
@@ -2397,7 +2584,7 @@ struct _controlGroupStyleModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS)
-    @available(macOS 12.0,iOS 15.0,tvOS 17.0,visionOS 1.0, *)
+    @available(macOS 12.0,visionOS 1.0,tvOS 17.0,iOS 15.0, *)
     init(_ style: AnyControlGroupStyle) {
         self.value = ._0(style: style)
         
@@ -2410,7 +2597,7 @@ struct _controlGroupStyleModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS)
         case let ._0(style):
-            if #available(macOS 12.0,iOS 15.0,tvOS 17.0,visionOS 1.0, *) {
+            if #available(macOS 12.0,visionOS 1.0,tvOS 17.0,iOS 15.0, *) {
             let style = style as! AnyControlGroupStyle
             
             __content
@@ -2444,7 +2631,7 @@ struct _controlSizeModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
-    @available(macOS 10.15,iOS 15.0,watchOS 9.0,visionOS 1.0, *)
+    @available(watchOS 9.0,visionOS 1.0,iOS 15.0,macOS 10.15, *)
     init(_ controlSize: SwiftUICore.ControlSize) {
         self.value = ._0(controlSize: controlSize)
         
@@ -2457,7 +2644,7 @@ struct _controlSizeModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
         case let ._0(controlSize):
-            if #available(macOS 10.15,iOS 15.0,watchOS 9.0,visionOS 1.0, *) {
+            if #available(watchOS 9.0,visionOS 1.0,iOS 15.0,macOS 10.15, *) {
             let controlSize = controlSize as! SwiftUICore.ControlSize
             
             __content
@@ -2476,24 +2663,36 @@ struct _coordinateSpaceModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
+        
+        indirect case _0(name: AttributeReference<String>)
+        
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-        indirect case _0(name: Any)
+        indirect case _1(name: Any)
         #endif
     }
 
     let value: Value
 
+    @ObservedElement private var element
+    @LiveContext<R> private var context
+    
+
+
+
+
+
+
     
     
-    
-
-
-
-
-    #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0, *)
-    init(_ name: SwiftUICore.NamedCoordinateSpace) {
+    init(name: AttributeReference<String>) {
         self.value = ._0(name: name)
+        
+    }
+    
+    #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+    @available(watchOS 10.0,tvOS 17.0,visionOS 1.0,iOS 17.0,macOS 14.0, *)
+    init(_ name: SwiftUICore.NamedCoordinateSpace) {
+        self.value = ._1(name: name)
         
     }
     #endif
@@ -2502,9 +2701,20 @@ struct _coordinateSpaceModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+        
         case let ._0(name):
-            if #available(visionOS 1.0,tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0, *) {
+            
+            
+            
+            __content
+                .coordinateSpace(name: name.resolve(on: element, in: context))
+            
+                
+            
+        
+        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+        case let ._1(name):
+            if #available(watchOS 10.0,tvOS 17.0,visionOS 1.0,iOS 17.0,macOS 14.0, *) {
             let name = name as! SwiftUICore.NamedCoordinateSpace
             
             __content
@@ -2513,6 +2723,53 @@ struct _coordinateSpaceModifier<R: RootRegistry>: ViewModifier {
                 
             } else { __content }
         #endif
+        }
+    }
+}
+@_documentation(visibility: public)
+@ParseableExpression
+struct _cornerRadiusModifier<R: RootRegistry>: ViewModifier {
+    static var name: String { "cornerRadius" }
+
+    enum Value {
+        case _never
+        
+        indirect case _0(radius: AttributeReference<CoreFoundation.CGFloat>,antialiased: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) )
+        
+    }
+
+    let value: Value
+
+    @ObservedElement private var element
+    @LiveContext<R> private var context
+    
+
+
+
+
+    
+    
+    init(_ radius: AttributeReference<CoreFoundation.CGFloat>,antialiased: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
+        self.value = ._0(radius: radius, antialiased: antialiased)
+        
+    }
+    
+
+    func body(content __content: Content) -> some View {
+        switch value {
+        case ._never:
+            fatalError("unreachable")
+        
+        case let ._0(radius, antialiased):
+            
+            
+            
+            __content
+                .cornerRadius(radius.resolve(on: element, in: context), antialiased: antialiased.resolve(on: element, in: context))
+            
+                
+            
+        
         }
     }
 }
@@ -2538,7 +2795,7 @@ struct _datePickerStyleModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,macOS 10.15,watchOS 10.0,iOS 13.0, *)
+    @available(visionOS 1.0,iOS 13.0,macOS 10.15,watchOS 10.0, *)
     init(_ style: AnyDatePickerStyle) {
         self.value = ._0(style: style)
         
@@ -2551,7 +2808,7 @@ struct _datePickerStyleModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
         case let ._0(style):
-            if #available(visionOS 1.0,macOS 10.15,watchOS 10.0,iOS 13.0, *) {
+            if #available(visionOS 1.0,iOS 13.0,macOS 10.15,watchOS 10.0, *) {
             let style = style as! AnyDatePickerStyle
             
             __content
@@ -2632,7 +2889,7 @@ struct _defaultHoverEffectModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(tvOS) || os(visionOS)
-    @available(visionOS 1.0,tvOS 17.0,iOS 17.0, *)
+    @available(iOS 17.0,visionOS 1.0,tvOS 17.0, *)
     init(_ effect: SwiftUI.HoverEffect?) {
         self.value = ._0(effect: effect)
         
@@ -2645,7 +2902,7 @@ struct _defaultHoverEffectModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(tvOS) || os(visionOS)
         case let ._0(effect):
-            if #available(visionOS 1.0,tvOS 17.0,iOS 17.0, *) {
+            if #available(iOS 17.0,visionOS 1.0,tvOS 17.0, *) {
             let effect = effect as? SwiftUI.HoverEffect
             
             __content
@@ -2684,14 +2941,14 @@ struct _defaultScrollAnchorModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,macOS 14.0,tvOS 17.0,iOS 17.0,watchOS 10.0, *)
+    @available(watchOS 10.0,tvOS 17.0,visionOS 1.0,iOS 17.0,macOS 14.0, *)
     init(_ anchor: AttributeReference<SwiftUICore.UnitPoint?>?) {
         self.value = ._0(anchor: anchor)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 2.0,macOS 15.0,tvOS 18.0,iOS 18.0,watchOS 11.0, *)
+    @available(watchOS 11.0,tvOS 18.0,visionOS 2.0,iOS 18.0,macOS 15.0, *)
     init(_ anchor: AttributeReference<SwiftUICore.UnitPoint?>?,for role: SwiftUI.ScrollAnchorRole) {
         self.value = ._1(anchor: anchor, role: role)
         
@@ -2704,7 +2961,7 @@ struct _defaultScrollAnchorModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(anchor):
-            if #available(visionOS 1.0,macOS 14.0,tvOS 17.0,iOS 17.0,watchOS 10.0, *) {
+            if #available(watchOS 10.0,tvOS 17.0,visionOS 1.0,iOS 17.0,macOS 14.0, *) {
             let anchor = anchor as? AttributeReference<SwiftUICore.UnitPoint?>
             
             __content
@@ -2715,7 +2972,7 @@ struct _defaultScrollAnchorModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(anchor, role):
-            if #available(visionOS 2.0,macOS 15.0,tvOS 18.0,iOS 18.0,watchOS 11.0, *) {
+            if #available(watchOS 11.0,tvOS 18.0,visionOS 2.0,iOS 18.0,macOS 15.0, *) {
             let anchor = anchor as? AttributeReference<SwiftUICore.UnitPoint?>
 let role = role as! SwiftUI.ScrollAnchorRole
             
@@ -2750,7 +3007,7 @@ struct _defaultWheelPickerItemHeightModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(visionOS) || os(watchOS)
-    @available(watchOS 6.0,visionOS 1.0, *)
+    @available(visionOS 1.0,watchOS 6.0, *)
     init(_ height: AttributeReference<CoreFoundation.CGFloat>) {
         self.value = ._0(height: height)
         
@@ -2763,7 +3020,7 @@ struct _defaultWheelPickerItemHeightModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(visionOS) || os(watchOS)
         case let ._0(height):
-            if #available(watchOS 6.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,watchOS 6.0, *) {
             let height = height as! AttributeReference<CoreFoundation.CGFloat>
             
             __content
@@ -2906,28 +3163,28 @@ struct _dialogSuppressionToggleModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,macOS 14.0,tvOS 17.0,iOS 17.0,watchOS 10.0, *)
+    @available(tvOS 17.0,watchOS 10.0,iOS 17.0,visionOS 1.0,macOS 14.0, *)
     init(_ titleKey: SwiftUICore.LocalizedStringKey,isSuppressed: ChangeTracked<Swift.Bool>) {
         self.value = ._0(titleKey: titleKey)
         self.__0_isSuppressed = isSuppressed
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,macOS 14.0,tvOS 17.0,iOS 17.0,watchOS 10.0, *)
+    @available(tvOS 17.0,watchOS 10.0,iOS 17.0,visionOS 1.0,macOS 14.0, *)
     init(_ title: AttributeReference<String>,isSuppressed: ChangeTracked<Swift.Bool>) {
         self.value = ._1(title: title)
         self.__1_isSuppressed = isSuppressed
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,macOS 14.0,tvOS 17.0,iOS 17.0,watchOS 10.0, *)
+    @available(tvOS 17.0,watchOS 10.0,iOS 17.0,visionOS 1.0,macOS 14.0, *)
     init(_ label: TextReference,isSuppressed: ChangeTracked<Swift.Bool>) {
         self.value = ._2(label: label)
         self.__2_isSuppressed = isSuppressed
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,macOS 14.0,tvOS 17.0,iOS 17.0,watchOS 10.0, *)
+    @available(watchOS 10.0,visionOS 1.0,iOS 17.0,macOS 14.0,tvOS 17.0, *)
     init(isSuppressed: ChangeTracked<Swift.Bool>) {
         self.value = ._3
         self.__3_isSuppressed = isSuppressed
@@ -2940,7 +3197,7 @@ struct _dialogSuppressionToggleModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(titleKey):
-            if #available(visionOS 1.0,macOS 14.0,tvOS 17.0,iOS 17.0,watchOS 10.0, *) {
+            if #available(tvOS 17.0,watchOS 10.0,iOS 17.0,visionOS 1.0,macOS 14.0, *) {
             let titleKey = titleKey as! SwiftUICore.LocalizedStringKey
             
             __content
@@ -2951,7 +3208,7 @@ struct _dialogSuppressionToggleModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(title):
-            if #available(visionOS 1.0,macOS 14.0,tvOS 17.0,iOS 17.0,watchOS 10.0, *) {
+            if #available(tvOS 17.0,watchOS 10.0,iOS 17.0,visionOS 1.0,macOS 14.0, *) {
             let title = title as! AttributeReference<String>
             
             __content
@@ -2962,7 +3219,7 @@ struct _dialogSuppressionToggleModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._2(label):
-            if #available(visionOS 1.0,macOS 14.0,tvOS 17.0,iOS 17.0,watchOS 10.0, *) {
+            if #available(tvOS 17.0,watchOS 10.0,iOS 17.0,visionOS 1.0,macOS 14.0, *) {
             let label = label as! TextReference
             __content._observeTextReference(label, on: element, in: context) { __content in
             __content
@@ -2973,7 +3230,7 @@ struct _dialogSuppressionToggleModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case ._3:
-            if #available(visionOS 1.0,macOS 14.0,tvOS 17.0,iOS 17.0,watchOS 10.0, *) {
+            if #available(watchOS 10.0,visionOS 1.0,iOS 17.0,macOS 14.0,tvOS 17.0, *) {
             
             
             __content
@@ -3057,6 +3314,53 @@ struct _digitalCrownAccessoryModifier<R: RootRegistry>: ViewModifier {
 }
 @_documentation(visibility: public)
 @ParseableExpression
+struct _disableAutocorrectionModifier<R: RootRegistry>: ViewModifier {
+    static var name: String { "disableAutocorrection" }
+
+    enum Value {
+        case _never
+        
+        indirect case _0(disable: AttributeReference<Swift.Bool?>?)
+        
+    }
+
+    let value: Value
+
+    @ObservedElement private var element
+    @LiveContext<R> private var context
+    
+
+
+
+
+    
+    
+    init(_ disable: AttributeReference<Swift.Bool?>?) {
+        self.value = ._0(disable: disable)
+        
+    }
+    
+
+    func body(content __content: Content) -> some View {
+        switch value {
+        case ._never:
+            fatalError("unreachable")
+        
+        case let ._0(disable):
+            
+            
+            
+            __content
+                .disableAutocorrection(disable?.resolve(on: element, in: context))
+            
+                
+            
+        
+        }
+    }
+}
+@_documentation(visibility: public)
+@ParseableExpression
 struct _disabledModifier<R: RootRegistry>: ViewModifier {
     static var name: String { "disabled" }
 
@@ -3099,6 +3403,53 @@ struct _disabledModifier<R: RootRegistry>: ViewModifier {
                 
             
         
+        }
+    }
+}
+@_documentation(visibility: public)
+@ParseableExpression
+struct _disclosureGroupStyleModifier<R: RootRegistry>: ViewModifier {
+    static var name: String { "disclosureGroupStyle" }
+
+    enum Value {
+        case _never
+        #if os(iOS) || os(macOS) || os(visionOS)
+        indirect case _0(style: Any)
+        #endif
+    }
+
+    let value: Value
+
+    
+    
+    
+
+
+
+
+    #if os(iOS) || os(macOS) || os(visionOS)
+    @available(visionOS 1.0,iOS 16.0,macOS 13.0, *)
+    init(_ style: AnyDisclosureGroupStyle) {
+        self.value = ._0(style: style)
+        
+    }
+    #endif
+
+    func body(content __content: Content) -> some View {
+        switch value {
+        case ._never:
+            fatalError("unreachable")
+        #if os(iOS) || os(macOS) || os(visionOS)
+        case let ._0(style):
+            if #available(visionOS 1.0,iOS 16.0,macOS 13.0, *) {
+            let style = style as! AnyDisclosureGroupStyle
+            
+            __content
+                .disclosureGroupStyle(style)
+            
+                
+            } else { __content }
+        #endif
         }
     }
 }
@@ -3398,6 +3749,53 @@ struct _dynamicTypeSizeModifier<R: RootRegistry>: ViewModifier {
 }
 @_documentation(visibility: public)
 @ParseableExpression
+struct _edgesIgnoringSafeAreaModifier<R: RootRegistry>: ViewModifier {
+    static var name: String { "edgesIgnoringSafeArea" }
+
+    enum Value {
+        case _never
+        
+        indirect case _0(edges: SwiftUICore.Edge.Set)
+        
+    }
+
+    let value: Value
+
+    
+    
+    
+
+
+
+
+    
+    
+    init(_ edges: SwiftUICore.Edge.Set) {
+        self.value = ._0(edges: edges)
+        
+    }
+    
+
+    func body(content __content: Content) -> some View {
+        switch value {
+        case ._never:
+            fatalError("unreachable")
+        
+        case let ._0(edges):
+            
+            
+            
+            __content
+                .edgesIgnoringSafeArea(edges)
+            
+                
+            
+        
+        }
+    }
+}
+@_documentation(visibility: public)
+@ParseableExpression
 struct _fileDialogCustomizationIDModifier<R: RootRegistry>: ViewModifier {
     static var name: String { "fileDialogCustomizationID" }
 
@@ -3418,7 +3816,7 @@ struct _fileDialogCustomizationIDModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 14.0,iOS 17.0,visionOS 1.0, *)
+    @available(macOS 14.0,visionOS 1.0,iOS 17.0, *)
     init(_ id: AttributeReference<Swift.String>) {
         self.value = ._0(id: id)
         
@@ -3431,7 +3829,7 @@ struct _fileDialogCustomizationIDModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(id):
-            if #available(macOS 14.0,iOS 17.0,visionOS 1.0, *) {
+            if #available(macOS 14.0,visionOS 1.0,iOS 17.0, *) {
             let id = id as! AttributeReference<Swift.String>
             
             __content
@@ -3723,7 +4121,7 @@ struct _focusEffectDisabledModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0,visionOS 1.0, *)
+    @available(macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0,visionOS 1.0, *)
     init(_ disabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(disabled: disabled)
         
@@ -3736,7 +4134,7 @@ struct _focusEffectDisabledModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(disabled):
-            if #available(macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0,visionOS 1.0, *) {
+            if #available(macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0,visionOS 1.0, *) {
             let disabled = disabled as! AttributeReference<Swift.Bool>
             
             __content
@@ -3770,7 +4168,7 @@ struct _focusSectionModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(macOS) || os(tvOS)
-    @available(macOS 13.0,tvOS 15.0, *)
+    @available(tvOS 15.0,macOS 13.0, *)
     init() {
         self.value = ._0
         
@@ -3783,7 +4181,7 @@ struct _focusSectionModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(macOS) || os(tvOS)
         case ._0:
-            if #available(macOS 13.0,tvOS 15.0, *) {
+            if #available(tvOS 15.0,macOS 13.0, *) {
             
             
             __content
@@ -3808,6 +4206,9 @@ struct _focusableModifier<R: RootRegistry>: ViewModifier {
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         indirect case _1(isFocusable: Any, interactions: Any)
         #endif
+        #if os(macOS) || os(tvOS) || os(watchOS)
+        indirect case _2(isFocusable: Any)
+        #endif
     }
 
     let value: Value
@@ -3821,18 +4222,27 @@ struct _focusableModifier<R: RootRegistry>: ViewModifier {
 
 
 
+@Event private var _2_onFocusChange__1: Event.EventHandler
+
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 12.0,iOS 17.0,tvOS 15.0,watchOS 8.0,visionOS 1.0, *)
+    @available(macOS 12.0,watchOS 8.0,iOS 17.0,tvOS 15.0,visionOS 1.0, *)
     init(_ isFocusable: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(isFocusable: isFocusable)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0,visionOS 1.0, *)
+    @available(macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0,visionOS 1.0, *)
     init(_ isFocusable: AttributeReference<Swift.Bool> = .init(storage: .constant(true)), interactions: SwiftUI.FocusInteractions) {
         self.value = ._1(isFocusable: isFocusable, interactions: interactions)
         
+    }
+    #endif
+    #if os(macOS) || os(tvOS) || os(watchOS)
+    @available(macOS 13.0,tvOS 16.0,watchOS 9.0, *)
+    init(_ isFocusable: AttributeReference<Swift.Bool> = .init(storage: .constant(true)), onFocusChange onFocusChange__1: Event ) {
+        self.value = ._2(isFocusable: isFocusable)
+        self.__2_onFocusChange__1 = onFocusChange__1
     }
     #endif
 
@@ -3842,7 +4252,7 @@ struct _focusableModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(isFocusable):
-            if #available(macOS 12.0,iOS 17.0,tvOS 15.0,watchOS 8.0,visionOS 1.0, *) {
+            if #available(macOS 12.0,watchOS 8.0,iOS 17.0,tvOS 15.0,visionOS 1.0, *) {
             let isFocusable = isFocusable as! AttributeReference<Swift.Bool>
             
             __content
@@ -3853,7 +4263,7 @@ struct _focusableModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(isFocusable, interactions):
-            if #available(macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0,visionOS 1.0, *) {
+            if #available(macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0,visionOS 1.0, *) {
             let isFocusable = isFocusable as! AttributeReference<Swift.Bool>
 let interactions = interactions as! SwiftUI.FocusInteractions
             
@@ -3863,6 +4273,64 @@ let interactions = interactions as! SwiftUI.FocusInteractions
                 
             } else { __content }
         #endif
+        #if os(macOS) || os(tvOS) || os(watchOS)
+        case let ._2(isFocusable):
+            if #available(macOS 13.0,tvOS 16.0,watchOS 9.0, *) {
+            let isFocusable = isFocusable as! AttributeReference<Swift.Bool>
+            
+            __content
+                .focusable(isFocusable.resolve(on: element, in: context), onFocusChange: { __2_onFocusChange__1.wrappedValue(value: $0) })
+            
+                
+            } else { __content }
+        #endif
+        }
+    }
+}
+@_documentation(visibility: public)
+@ParseableExpression
+struct _foregroundColorModifier<R: RootRegistry>: ViewModifier {
+    static var name: String { "foregroundColor" }
+
+    enum Value {
+        case _never
+        
+        indirect case _0(color: Color.Resolvable?)
+        
+    }
+
+    let value: Value
+
+    @ObservedElement private var element
+    @LiveContext<R> private var context
+    
+
+
+
+
+    
+    
+    init(_ color: Color.Resolvable?) {
+        self.value = ._0(color: color)
+        
+    }
+    
+
+    func body(content __content: Content) -> some View {
+        switch value {
+        case ._never:
+            fatalError("unreachable")
+        
+        case let ._0(color):
+            
+            
+            
+            __content
+                .foregroundColor(color?.resolve(on: element, in: context))
+            
+                
+            
+        
         }
     }
 }
@@ -4078,7 +4546,7 @@ struct _fullScreenCoverModifier<R: RootRegistry>: ViewModifier {
 @Event private var _0_onDismiss__0: Event.EventHandler
 
     #if os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,watchOS 7.0,tvOS 14.0,iOS 14.0, *)
+    @available(visionOS 1.0,iOS 14.0,watchOS 7.0,tvOS 14.0, *)
     init(isPresented: ChangeTracked<Swift.Bool>,onDismiss onDismiss__0: Event=Event(), content: ViewReference=ViewReference(value: [])) {
         self.value = ._0(content: content)
         self.__0_isPresented = isPresented
@@ -4092,7 +4560,7 @@ self.__0_onDismiss__0 = onDismiss__0
             fatalError("unreachable")
         #if os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(content):
-            if #available(visionOS 1.0,watchOS 7.0,tvOS 14.0,iOS 14.0, *) {
+            if #available(visionOS 1.0,iOS 14.0,watchOS 7.0,tvOS 14.0, *) {
             let content = content as! ViewReference
             
             __content
@@ -4126,7 +4594,7 @@ struct _gaugeStyleModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,macOS 13.0,watchOS 7.0,iOS 16.0, *)
+    @available(macOS 13.0,watchOS 7.0,visionOS 1.0,iOS 16.0, *)
     init(_ style: AnyGaugeStyle) {
         self.value = ._0(style: style)
         
@@ -4139,7 +4607,7 @@ struct _gaugeStyleModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
         case let ._0(style):
-            if #available(visionOS 1.0,macOS 13.0,watchOS 7.0,iOS 16.0, *) {
+            if #available(macOS 13.0,watchOS 7.0,visionOS 1.0,iOS 16.0, *) {
             let style = style as! AnyGaugeStyle
             
             __content
@@ -4173,7 +4641,7 @@ struct _geometryGroupModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0,visionOS 1.0, *)
+    @available(watchOS 10.0,tvOS 17.0,visionOS 1.0,iOS 17.0,macOS 14.0, *)
     init() {
         self.value = ._0
         
@@ -4186,7 +4654,7 @@ struct _geometryGroupModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case ._0:
-            if #available(macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0,visionOS 1.0, *) {
+            if #available(watchOS 10.0,tvOS 17.0,visionOS 1.0,iOS 17.0,macOS 14.0, *) {
             
             
             __content
@@ -4244,7 +4712,7 @@ struct _gestureModifier<R: RootRegistry>: ViewModifier {
     }
     
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 11.0,iOS 18.0,visionOS 2.0,tvOS 18.0,macOS 15.0, *)
+    @available(watchOS 11.0,visionOS 2.0,iOS 18.0,macOS 15.0,tvOS 18.0, *)
     init(_ gesture: _AnyGesture,name: AttributeReference<Swift.String>,isEnabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._2(gesture: gesture, name: name, isEnabled: isEnabled)
         
@@ -4279,7 +4747,7 @@ struct _gestureModifier<R: RootRegistry>: ViewModifier {
         
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._2(gesture, name, isEnabled):
-            if #available(watchOS 11.0,iOS 18.0,visionOS 2.0,tvOS 18.0,macOS 15.0, *) {
+            if #available(watchOS 11.0,visionOS 2.0,iOS 18.0,macOS 15.0,tvOS 18.0, *) {
             let gesture = gesture as! _AnyGesture
 let name = name as! AttributeReference<Swift.String>
 let isEnabled = isEnabled as! AttributeReference<Swift.Bool>
@@ -4621,7 +5089,7 @@ struct _groupBoxStyleModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 11.0,visionOS 1.0,iOS 14.0, *)
+    @available(visionOS 1.0,macOS 11.0,iOS 14.0, *)
     init(_ style: AnyGroupBoxStyle) {
         self.value = ._0(style: style)
         
@@ -4634,7 +5102,7 @@ struct _groupBoxStyleModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(style):
-            if #available(macOS 11.0,visionOS 1.0,iOS 14.0, *) {
+            if #available(visionOS 1.0,macOS 11.0,iOS 14.0, *) {
             let style = style as! AnyGroupBoxStyle
             
             __content
@@ -4668,7 +5136,7 @@ struct _handGestureShortcutModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-    @available(macOS 15.0,tvOS 18.0,iOS 18.0,watchOS 11.0, *)
+    @available(watchOS 11.0,iOS 18.0,macOS 15.0,tvOS 18.0, *)
     init(_ shortcut: SwiftUI.HandGestureShortcut,isEnabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(shortcut: shortcut, isEnabled: isEnabled)
         
@@ -4681,7 +5149,7 @@ struct _handGestureShortcutModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
         case let ._0(shortcut, isEnabled):
-            if #available(macOS 15.0,tvOS 18.0,iOS 18.0,watchOS 11.0, *) {
+            if #available(watchOS 11.0,iOS 18.0,macOS 15.0,tvOS 18.0, *) {
             let shortcut = shortcut as! SwiftUI.HandGestureShortcut
 let isEnabled = isEnabled as! AttributeReference<Swift.Bool>
             
@@ -4974,7 +5442,7 @@ struct _highPriorityGestureModifier<R: RootRegistry>: ViewModifier {
     }
     
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 11.0,iOS 18.0,visionOS 2.0,tvOS 18.0,macOS 15.0, *)
+    @available(watchOS 11.0,visionOS 2.0,iOS 18.0,macOS 15.0,tvOS 18.0, *)
     init(_ gesture: _AnyGesture,name: AttributeReference<Swift.String>,isEnabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._2(gesture: gesture, name: name, isEnabled: isEnabled)
         
@@ -5009,7 +5477,7 @@ struct _highPriorityGestureModifier<R: RootRegistry>: ViewModifier {
         
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._2(gesture, name, isEnabled):
-            if #available(watchOS 11.0,iOS 18.0,visionOS 2.0,tvOS 18.0,macOS 15.0, *) {
+            if #available(watchOS 11.0,visionOS 2.0,iOS 18.0,macOS 15.0,tvOS 18.0, *) {
             let gesture = gesture as! _AnyGesture
 let name = name as! AttributeReference<Swift.String>
 let isEnabled = isEnabled as! AttributeReference<Swift.Bool>
@@ -5097,14 +5565,14 @@ struct _hoverEffectModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(tvOS) || os(visionOS)
-    @available(visionOS 1.0,tvOS 16.0,iOS 13.4, *)
+    @available(iOS 13.4,visionOS 1.0,tvOS 16.0, *)
     init(_ effect: SwiftUI.HoverEffect = .automatic ) {
         self.value = ._0(effect: effect)
         
     }
     #endif
     #if os(iOS) || os(tvOS) || os(visionOS)
-    @available(visionOS 1.0,tvOS 17.0,iOS 17.0, *)
+    @available(iOS 17.0,visionOS 1.0,tvOS 17.0, *)
     init(_ effect: SwiftUI.HoverEffect = .automatic, isEnabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._1(effect: effect, isEnabled: isEnabled)
         
@@ -5117,7 +5585,7 @@ struct _hoverEffectModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(tvOS) || os(visionOS)
         case let ._0(effect):
-            if #available(visionOS 1.0,tvOS 16.0,iOS 13.4, *) {
+            if #available(iOS 13.4,visionOS 1.0,tvOS 16.0, *) {
             let effect = effect as! SwiftUI.HoverEffect 
             
             __content
@@ -5128,7 +5596,7 @@ struct _hoverEffectModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(tvOS) || os(visionOS)
         case let ._1(effect, isEnabled):
-            if #available(visionOS 1.0,tvOS 17.0,iOS 17.0, *) {
+            if #available(iOS 17.0,visionOS 1.0,tvOS 17.0, *) {
             let effect = effect as! SwiftUI.HoverEffect 
 let isEnabled = isEnabled as! AttributeReference<Swift.Bool>
             
@@ -5163,7 +5631,7 @@ struct _hoverEffectDisabledModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(tvOS) || os(visionOS)
-    @available(visionOS 1.0,tvOS 17.0,iOS 17.0, *)
+    @available(iOS 17.0,visionOS 1.0,tvOS 17.0, *)
     init(_ disabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(disabled: disabled)
         
@@ -5176,7 +5644,7 @@ struct _hoverEffectDisabledModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(tvOS) || os(visionOS)
         case let ._0(disabled):
-            if #available(visionOS 1.0,tvOS 17.0,iOS 17.0, *) {
+            if #available(iOS 17.0,visionOS 1.0,tvOS 17.0, *) {
             let disabled = disabled as! AttributeReference<Swift.Bool>
             
             __content
@@ -5493,7 +5961,7 @@ struct _indexViewStyleModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,watchOS 8.0,tvOS 14.0,iOS 14.0, *)
+    @available(tvOS 14.0,iOS 14.0,visionOS 1.0,watchOS 8.0, *)
     init(_ style: AnyIndexViewStyle) {
         self.value = ._0(style: style)
         
@@ -5506,7 +5974,7 @@ struct _indexViewStyleModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(style):
-            if #available(visionOS 1.0,watchOS 8.0,tvOS 14.0,iOS 14.0, *) {
+            if #available(tvOS 14.0,iOS 14.0,visionOS 1.0,watchOS 8.0, *) {
             let style = style as! AnyIndexViewStyle
             
             __content
@@ -5540,7 +6008,7 @@ struct _inspectorModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS)
-    @available(macOS 14.0,iOS 17.0, *)
+    @available(iOS 17.0,macOS 14.0, *)
     init(isPresented: ChangeTracked<Swift.Bool>,content: ViewReference=ViewReference(value: [])) {
         self.value = ._0(content: content)
         self.__0_isPresented = isPresented
@@ -5553,7 +6021,7 @@ struct _inspectorModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS)
         case let ._0(content):
-            if #available(macOS 14.0,iOS 17.0, *) {
+            if #available(iOS 17.0,macOS 14.0, *) {
             let content = content as! ViewReference
             
             __content
@@ -5592,14 +6060,14 @@ struct _inspectorColumnWidthModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS)
-    @available(macOS 14.0,iOS 17.0, *)
+    @available(iOS 17.0,macOS 14.0, *)
     init(min: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), ideal: AttributeReference<CoreFoundation.CGFloat>,max: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)) ) {
         self.value = ._0(min: min, ideal: ideal, max: max)
         
     }
     #endif
     #if os(iOS) || os(macOS)
-    @available(macOS 14.0,iOS 17.0, *)
+    @available(iOS 17.0,macOS 14.0, *)
     init(_ width: AttributeReference<CoreFoundation.CGFloat>) {
         self.value = ._1(width: width)
         
@@ -5612,7 +6080,7 @@ struct _inspectorColumnWidthModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS)
         case let ._0(min, ideal, max):
-            if #available(macOS 14.0,iOS 17.0, *) {
+            if #available(iOS 17.0,macOS 14.0, *) {
             let min = min as? AttributeReference<CoreFoundation.CGFloat?>
 let ideal = ideal as! AttributeReference<CoreFoundation.CGFloat>
 let max = max as? AttributeReference<CoreFoundation.CGFloat?>
@@ -5625,7 +6093,7 @@ let max = max as? AttributeReference<CoreFoundation.CGFloat?>
         #endif
         #if os(iOS) || os(macOS)
         case let ._1(width):
-            if #available(macOS 14.0,iOS 17.0, *) {
+            if #available(iOS 17.0,macOS 14.0, *) {
             let width = width as! AttributeReference<CoreFoundation.CGFloat>
             
             __content
@@ -5753,7 +6221,7 @@ struct _invalidatableContentModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 14.0,iOS 17.0,watchOS 10.0,visionOS 1.0,tvOS 17.0, *)
+    @available(watchOS 10.0,macOS 14.0,iOS 17.0,tvOS 17.0,visionOS 1.0, *)
     init(_ invalidatable: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(invalidatable: invalidatable)
         
@@ -5766,7 +6234,7 @@ struct _invalidatableContentModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(invalidatable):
-            if #available(macOS 14.0,iOS 17.0,watchOS 10.0,visionOS 1.0,tvOS 17.0, *) {
+            if #available(watchOS 10.0,macOS 14.0,iOS 17.0,tvOS 17.0,visionOS 1.0, *) {
             let invalidatable = invalidatable as! AttributeReference<Swift.Bool>
             
             __content
@@ -5815,28 +6283,28 @@ struct _keyboardShortcutModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 11.0,iOS 14.0,visionOS 1.0, *)
+    @available(visionOS 1.0,macOS 11.0,iOS 14.0, *)
     init(_ key: SwiftUI.KeyEquivalent,modifiers: SwiftUICore.EventModifiers = .command ) {
         self.value = ._0(key: key, modifiers: modifiers)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 11.0,iOS 14.0,visionOS 1.0, *)
+    @available(visionOS 1.0,macOS 11.0,iOS 14.0, *)
     init(_ shortcut: SwiftUI.KeyboardShortcut) {
         self.value = ._1(shortcut: shortcut)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 12.3,iOS 15.4,visionOS 1.0, *)
+    @available(visionOS 1.0,macOS 12.3,iOS 15.4, *)
     init(_ shortcut: SwiftUI.KeyboardShortcut?) {
         self.value = ._2(shortcut: shortcut)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 12.0,iOS 15.0,visionOS 1.0, *)
+    @available(visionOS 1.0,macOS 12.0,iOS 15.0, *)
     init(_ key: SwiftUI.KeyEquivalent,modifiers: SwiftUICore.EventModifiers = .command, localization: SwiftUI.KeyboardShortcut.Localization) {
         self.value = ._3(key: key, modifiers: modifiers, localization: localization)
         
@@ -5849,7 +6317,7 @@ struct _keyboardShortcutModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(key, modifiers):
-            if #available(macOS 11.0,iOS 14.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,macOS 11.0,iOS 14.0, *) {
             let key = key as! SwiftUI.KeyEquivalent
 let modifiers = modifiers as! SwiftUICore.EventModifiers 
             
@@ -5861,7 +6329,7 @@ let modifiers = modifiers as! SwiftUICore.EventModifiers
         #endif
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._1(shortcut):
-            if #available(macOS 11.0,iOS 14.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,macOS 11.0,iOS 14.0, *) {
             let shortcut = shortcut as! SwiftUI.KeyboardShortcut
             
             __content
@@ -5872,7 +6340,7 @@ let modifiers = modifiers as! SwiftUICore.EventModifiers
         #endif
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._2(shortcut):
-            if #available(macOS 12.3,iOS 15.4,visionOS 1.0, *) {
+            if #available(visionOS 1.0,macOS 12.3,iOS 15.4, *) {
             let shortcut = shortcut as? SwiftUI.KeyboardShortcut
             
             __content
@@ -5883,7 +6351,7 @@ let modifiers = modifiers as! SwiftUICore.EventModifiers
         #endif
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._3(key, modifiers, localization):
-            if #available(macOS 12.0,iOS 15.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,macOS 12.0,iOS 15.0, *) {
             let key = key as! SwiftUI.KeyEquivalent
 let modifiers = modifiers as! SwiftUICore.EventModifiers 
 let localization = localization as! SwiftUI.KeyboardShortcut.Localization
@@ -5919,7 +6387,7 @@ struct _keyboardTypeModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(tvOS) || os(visionOS)
-    @available(tvOS 13.0,iOS 13.0,visionOS 1.0, *)
+    @available(tvOS 13.0,visionOS 1.0,iOS 13.0, *)
     init(_ type: UIKit.UIKeyboardType) {
         self.value = ._0(type: type)
         
@@ -5932,7 +6400,7 @@ struct _keyboardTypeModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(tvOS) || os(visionOS)
         case let ._0(type):
-            if #available(tvOS 13.0,iOS 13.0,visionOS 1.0, *) {
+            if #available(tvOS 13.0,visionOS 1.0,iOS 13.0, *) {
             let type = type as! UIKit.UIKeyboardType
             
             __content
@@ -6107,7 +6575,7 @@ struct _labelsVisibilityModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 15.0,iOS 18.0,tvOS 18.0,watchOS 11.0,visionOS 2.0, *)
+    @available(macOS 15.0,watchOS 11.0,iOS 18.0,tvOS 18.0,visionOS 2.0, *)
     init(_ visibility: AttributeReference<SwiftUI.Visibility>) {
         self.value = ._0(visibility: visibility)
         
@@ -6120,7 +6588,7 @@ struct _labelsVisibilityModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(visibility):
-            if #available(macOS 15.0,iOS 18.0,tvOS 18.0,watchOS 11.0,visionOS 2.0, *) {
+            if #available(macOS 15.0,watchOS 11.0,iOS 18.0,tvOS 18.0,visionOS 2.0, *) {
             let visibility = visibility as! AttributeReference<SwiftUI.Visibility>
             
             __content
@@ -6625,6 +7093,53 @@ struct _listRowInsetsModifier<R: RootRegistry>: ViewModifier {
 }
 @_documentation(visibility: public)
 @ParseableExpression
+struct _listRowPlatterColorModifier<R: RootRegistry>: ViewModifier {
+    static var name: String { "listRowPlatterColor" }
+
+    enum Value {
+        case _never
+        #if os(watchOS)
+        indirect case _0(color: Any?)
+        #endif
+    }
+
+    let value: Value
+
+    @ObservedElement private var element
+    @LiveContext<R> private var context
+    
+
+
+
+
+    #if os(watchOS)
+    @available(watchOS 6.0, *)
+    init(_ color: Color.Resolvable?) {
+        self.value = ._0(color: color)
+        
+    }
+    #endif
+
+    func body(content __content: Content) -> some View {
+        switch value {
+        case ._never:
+            fatalError("unreachable")
+        #if os(watchOS)
+        case let ._0(color):
+            if #available(watchOS 6.0, *) {
+            let color = color as? Color.Resolvable
+            
+            __content
+                .listRowPlatterColor(color?.resolve(on: element, in: context))
+            
+                
+            } else { __content }
+        #endif
+        }
+    }
+}
+@_documentation(visibility: public)
+@ParseableExpression
 struct _listRowSeparatorModifier<R: RootRegistry>: ViewModifier {
     static var name: String { "listRowSeparator" }
 
@@ -6645,7 +7160,7 @@ struct _listRowSeparatorModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 13.0,iOS 15.0,visionOS 1.0, *)
+    @available(iOS 15.0,visionOS 1.0,macOS 13.0, *)
     init(_ visibility: AttributeReference<SwiftUI.Visibility>,edges: SwiftUICore.VerticalEdge.Set = .all ) {
         self.value = ._0(visibility: visibility, edges: edges)
         
@@ -6658,7 +7173,7 @@ struct _listRowSeparatorModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(visibility, edges):
-            if #available(macOS 13.0,iOS 15.0,visionOS 1.0, *) {
+            if #available(iOS 15.0,visionOS 1.0,macOS 13.0, *) {
             let visibility = visibility as! AttributeReference<SwiftUI.Visibility>
 let edges = edges as! SwiftUICore.VerticalEdge.Set 
             
@@ -6693,7 +7208,7 @@ struct _listRowSeparatorTintModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 13.0,iOS 15.0,visionOS 1.0, *)
+    @available(iOS 15.0,visionOS 1.0,macOS 13.0, *)
     init(_ color: Color.Resolvable?,edges: SwiftUICore.VerticalEdge.Set = .all ) {
         self.value = ._0(color: color, edges: edges)
         
@@ -6706,7 +7221,7 @@ struct _listRowSeparatorTintModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(color, edges):
-            if #available(macOS 13.0,iOS 15.0,visionOS 1.0, *) {
+            if #available(iOS 15.0,visionOS 1.0,macOS 13.0, *) {
             let color = color as? Color.Resolvable
 let edges = edges as! SwiftUICore.VerticalEdge.Set 
             
@@ -6788,7 +7303,7 @@ struct _listSectionSeparatorModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 13.0,iOS 15.0,visionOS 1.0, *)
+    @available(visionOS 1.0,macOS 13.0,iOS 15.0, *)
     init(_ visibility: AttributeReference<SwiftUI.Visibility>,edges: SwiftUICore.VerticalEdge.Set = .all ) {
         self.value = ._0(visibility: visibility, edges: edges)
         
@@ -6801,7 +7316,7 @@ struct _listSectionSeparatorModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(visibility, edges):
-            if #available(macOS 13.0,iOS 15.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,macOS 13.0,iOS 15.0, *) {
             let visibility = visibility as! AttributeReference<SwiftUI.Visibility>
 let edges = edges as! SwiftUICore.VerticalEdge.Set 
             
@@ -6836,7 +7351,7 @@ struct _listSectionSeparatorTintModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 13.0,iOS 15.0,visionOS 1.0, *)
+    @available(macOS 13.0,visionOS 1.0,iOS 15.0, *)
     init(_ color: Color.Resolvable?,edges: SwiftUICore.VerticalEdge.Set = .all ) {
         self.value = ._0(color: color, edges: edges)
         
@@ -6849,7 +7364,7 @@ struct _listSectionSeparatorTintModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(color, edges):
-            if #available(macOS 13.0,iOS 15.0,visionOS 1.0, *) {
+            if #available(macOS 13.0,visionOS 1.0,iOS 15.0, *) {
             let color = color as? Color.Resolvable
 let edges = edges as! SwiftUICore.VerticalEdge.Set 
             
@@ -7048,7 +7563,7 @@ struct _materialActiveAppearanceModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 15.0,iOS 18.0,tvOS 18.0,watchOS 11.0,visionOS 2.0, *)
+    @available(watchOS 11.0,tvOS 18.0,visionOS 2.0,iOS 18.0,macOS 15.0, *)
     init(_ appearance: SwiftUICore.MaterialActiveAppearance) {
         self.value = ._0(appearance: appearance)
         
@@ -7061,11 +7576,58 @@ struct _materialActiveAppearanceModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(appearance):
-            if #available(macOS 15.0,iOS 18.0,tvOS 18.0,watchOS 11.0,visionOS 2.0, *) {
+            if #available(watchOS 11.0,tvOS 18.0,visionOS 2.0,iOS 18.0,macOS 15.0, *) {
             let appearance = appearance as! SwiftUICore.MaterialActiveAppearance
             
             __content
                 .materialActiveAppearance(appearance)
+            
+                
+            } else { __content }
+        #endif
+        }
+    }
+}
+@_documentation(visibility: public)
+@ParseableExpression
+struct _menuButtonStyleModifier<R: RootRegistry>: ViewModifier {
+    static var name: String { "menuButtonStyle" }
+
+    enum Value {
+        case _never
+        #if os(macOS)
+        indirect case _0(style: Any)
+        #endif
+    }
+
+    let value: Value
+
+    
+    
+    
+
+
+
+
+    #if os(macOS)
+    @available(macOS 13.0, *)
+    init(_ style: AnyMenuButtonStyle) {
+        self.value = ._0(style: style)
+        
+    }
+    #endif
+
+    func body(content __content: Content) -> some View {
+        switch value {
+        case ._never:
+            fatalError("unreachable")
+        #if os(macOS)
+        case let ._0(style):
+            if #available(macOS 13.0, *) {
+            let style = style as! AnyMenuButtonStyle
+            
+            __content
+                .menuButtonStyle(style)
             
                 
             } else { __content }
@@ -7095,7 +7657,7 @@ struct _menuIndicatorModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS)
-    @available(macOS 12.0,iOS 15.0,tvOS 17.0,visionOS 1.0, *)
+    @available(macOS 12.0,visionOS 1.0,tvOS 17.0,iOS 15.0, *)
     init(_ visibility: AttributeReference<SwiftUI.Visibility>) {
         self.value = ._0(visibility: visibility)
         
@@ -7108,7 +7670,7 @@ struct _menuIndicatorModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS)
         case let ._0(visibility):
-            if #available(macOS 12.0,iOS 15.0,tvOS 17.0,visionOS 1.0, *) {
+            if #available(macOS 12.0,visionOS 1.0,tvOS 17.0,iOS 15.0, *) {
             let visibility = visibility as! AttributeReference<SwiftUI.Visibility>
             
             __content
@@ -7189,7 +7751,7 @@ struct _menuStyleModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS)
-    @available(macOS 11.0,iOS 14.0,visionOS 1.0,tvOS 17.0, *)
+    @available(tvOS 17.0,visionOS 1.0,iOS 14.0,macOS 11.0, *)
     init(_ style: AnyMenuStyle) {
         self.value = ._0(style: style)
         
@@ -7202,7 +7764,7 @@ struct _menuStyleModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS)
         case let ._0(style):
-            if #available(macOS 11.0,iOS 14.0,visionOS 1.0,tvOS 17.0, *) {
+            if #available(tvOS 17.0,visionOS 1.0,iOS 14.0,macOS 11.0, *) {
             let style = style as! AnyMenuStyle
             
             __content
@@ -7283,7 +7845,7 @@ struct _modifierKeyAlternateModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(macOS) || os(visionOS)
-    @available(macOS 15.0,visionOS 1.0, *)
+    @available(visionOS 1.0,macOS 15.0, *)
     init(_ modifiers: SwiftUICore.EventModifiers,_ alternate: ViewReference=ViewReference(value: [])) {
         self.value = ._0(modifiers: modifiers, alternate: alternate)
         
@@ -7296,7 +7858,7 @@ struct _modifierKeyAlternateModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(macOS) || os(visionOS)
         case let ._0(modifiers, alternate):
-            if #available(macOS 15.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,macOS 15.0, *) {
             let modifiers = modifiers as! SwiftUICore.EventModifiers
 let alternate = alternate as! ViewReference
             
@@ -7447,6 +8009,312 @@ struct _navigationBarBackButtonHiddenModifier<R: RootRegistry>: ViewModifier {
                 
             
         
+        }
+    }
+}
+@_documentation(visibility: public)
+@ParseableExpression
+struct _navigationBarHiddenModifier<R: RootRegistry>: ViewModifier {
+    static var name: String { "navigationBarHidden" }
+
+    enum Value {
+        case _never
+        #if os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
+        indirect case _0(hidden: Any)
+        #endif
+    }
+
+    let value: Value
+
+    @ObservedElement private var element
+    @LiveContext<R> private var context
+    
+
+
+
+
+    #if os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
+    @available(watchOS 6.0,visionOS 1.0,iOS 13.0,macOS 13.0,tvOS 13.0, *)
+    init(_ hidden: AttributeReference<Swift.Bool>) {
+        self.value = ._0(hidden: hidden)
+        
+    }
+    #endif
+
+    func body(content __content: Content) -> some View {
+        switch value {
+        case ._never:
+            fatalError("unreachable")
+        #if os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
+        case let ._0(hidden):
+            if #available(watchOS 6.0,visionOS 1.0,iOS 13.0,macOS 13.0,tvOS 13.0, *) {
+            let hidden = hidden as! AttributeReference<Swift.Bool>
+            
+            __content
+                .navigationBarHidden(hidden.resolve(on: element, in: context))
+            
+                
+            } else { __content }
+        #endif
+        }
+    }
+}
+@_documentation(visibility: public)
+@ParseableExpression
+struct _navigationBarItemsModifier<R: RootRegistry>: ViewModifier {
+    static var name: String { "navigationBarItems" }
+
+    enum Value {
+        case _never
+        #if os(iOS) || os(tvOS) || os(visionOS)
+        indirect case _0(leading: Any,trailing: Any)
+        #endif
+        #if os(iOS) || os(tvOS) || os(visionOS)
+        indirect case _1(leading: Any)
+        #endif
+        #if os(iOS) || os(tvOS) || os(visionOS)
+        indirect case _2(trailing: Any)
+        #endif
+    }
+
+    let value: Value
+
+    @ObservedElement private var element
+    @LiveContext<R> private var context
+    
+
+
+
+
+
+
+
+
+    #if os(iOS) || os(tvOS) || os(visionOS)
+    @available(tvOS 16.0,visionOS 1.0,iOS 16.0, *)
+    init(leading: InlineViewReference,trailing: InlineViewReference) {
+        self.value = ._0(leading: leading, trailing: trailing)
+        
+    }
+    #endif
+    #if os(iOS) || os(tvOS) || os(visionOS)
+    @available(iOS 16.0,tvOS 16.0,visionOS 1.0, *)
+    init(leading: InlineViewReference) {
+        self.value = ._1(leading: leading)
+        
+    }
+    #endif
+    #if os(iOS) || os(tvOS) || os(visionOS)
+    @available(visionOS 1.0,iOS 16.0,tvOS 16.0, *)
+    init(trailing: InlineViewReference) {
+        self.value = ._2(trailing: trailing)
+        
+    }
+    #endif
+
+    func body(content __content: Content) -> some View {
+        switch value {
+        case ._never:
+            fatalError("unreachable")
+        #if os(iOS) || os(tvOS) || os(visionOS)
+        case let ._0(leading, trailing):
+            if #available(tvOS 16.0,visionOS 1.0,iOS 16.0, *) {
+            let leading = leading as! InlineViewReference
+let trailing = trailing as! InlineViewReference
+            
+            __content
+                .navigationBarItems(leading: leading.resolve(on: element, in: context), trailing: trailing.resolve(on: element, in: context))
+            
+                
+            } else { __content }
+        #endif
+        #if os(iOS) || os(tvOS) || os(visionOS)
+        case let ._1(leading):
+            if #available(iOS 16.0,tvOS 16.0,visionOS 1.0, *) {
+            let leading = leading as! InlineViewReference
+            
+            __content
+                .navigationBarItems(leading: leading.resolve(on: element, in: context))
+            
+                
+            } else { __content }
+        #endif
+        #if os(iOS) || os(tvOS) || os(visionOS)
+        case let ._2(trailing):
+            if #available(visionOS 1.0,iOS 16.0,tvOS 16.0, *) {
+            let trailing = trailing as! InlineViewReference
+            
+            __content
+                .navigationBarItems(trailing: trailing.resolve(on: element, in: context))
+            
+                
+            } else { __content }
+        #endif
+        }
+    }
+}
+@_documentation(visibility: public)
+@ParseableExpression
+struct _navigationBarTitleModifier<R: RootRegistry>: ViewModifier {
+    static var name: String { "navigationBarTitle" }
+
+    enum Value {
+        case _never
+        #if os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
+        indirect case _0(title: Any)
+        #endif
+        #if os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
+        indirect case _1(titleKey: Any)
+        #endif
+        #if os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
+        indirect case _2(title: Any)
+        #endif
+        #if os(iOS) || os(visionOS)
+        indirect case _3(title: Any,displayMode: Any)
+        #endif
+        #if os(iOS) || os(visionOS)
+        indirect case _4(titleKey: Any,displayMode: Any)
+        #endif
+        #if os(iOS) || os(visionOS)
+        indirect case _5(title: Any,displayMode: Any)
+        #endif
+    }
+
+    let value: Value
+
+    @ObservedElement private var element
+    @LiveContext<R> private var context
+    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+    #if os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
+    @available(watchOS 6.0,visionOS 1.0,iOS 13.0,macOS 13.0,tvOS 13.0, *)
+    init(_ title: TextReference) {
+        self.value = ._0(title: title)
+        
+    }
+    #endif
+    #if os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
+    @available(watchOS 6.0,visionOS 1.0,iOS 13.0,macOS 13.0,tvOS 13.0, *)
+    init(_ titleKey: SwiftUICore.LocalizedStringKey) {
+        self.value = ._1(titleKey: titleKey)
+        
+    }
+    #endif
+    #if os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
+    @available(watchOS 6.0,visionOS 1.0,iOS 13.0,macOS 13.0,tvOS 13.0, *)
+    init(_ title: AttributeReference<String>) {
+        self.value = ._2(title: title)
+        
+    }
+    #endif
+    #if os(iOS) || os(visionOS)
+    @available(watchOS 6.0,visionOS 1.0,iOS 13.0,macOS 13.0,tvOS 13.0, *)
+    init(_ title: TextReference,displayMode: SwiftUI.NavigationBarItem.TitleDisplayMode) {
+        self.value = ._3(title: title, displayMode: displayMode)
+        
+    }
+    #endif
+    #if os(iOS) || os(visionOS)
+    @available(watchOS 6.0,visionOS 1.0,iOS 13.0,macOS 13.0,tvOS 13.0, *)
+    init(_ titleKey: SwiftUICore.LocalizedStringKey,displayMode: SwiftUI.NavigationBarItem.TitleDisplayMode) {
+        self.value = ._4(titleKey: titleKey, displayMode: displayMode)
+        
+    }
+    #endif
+    #if os(iOS) || os(visionOS)
+    @available(watchOS 6.0,visionOS 1.0,iOS 13.0,macOS 13.0,tvOS 13.0, *)
+    init(_ title: AttributeReference<String>,displayMode: SwiftUI.NavigationBarItem.TitleDisplayMode) {
+        self.value = ._5(title: title, displayMode: displayMode)
+        
+    }
+    #endif
+
+    func body(content __content: Content) -> some View {
+        switch value {
+        case ._never:
+            fatalError("unreachable")
+        #if os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
+        case let ._0(title):
+            if #available(watchOS 6.0,visionOS 1.0,iOS 13.0,macOS 13.0,tvOS 13.0, *) {
+            let title = title as! TextReference
+            __content._observeTextReference(title, on: element, in: context) { __content in
+            __content
+                .navigationBarTitle(title.resolve(on: element, in: context))
+            }
+                
+            } else { __content }
+        #endif
+        #if os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
+        case let ._1(titleKey):
+            if #available(watchOS 6.0,visionOS 1.0,iOS 13.0,macOS 13.0,tvOS 13.0, *) {
+            let titleKey = titleKey as! SwiftUICore.LocalizedStringKey
+            
+            __content
+                .navigationBarTitle(titleKey)
+            
+                
+            } else { __content }
+        #endif
+        #if os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
+        case let ._2(title):
+            if #available(watchOS 6.0,visionOS 1.0,iOS 13.0,macOS 13.0,tvOS 13.0, *) {
+            let title = title as! AttributeReference<String>
+            
+            __content
+                .navigationBarTitle(title.resolve(on: element, in: context))
+            
+                
+            } else { __content }
+        #endif
+        #if os(iOS) || os(visionOS)
+        case let ._3(title, displayMode):
+            if #available(watchOS 6.0,visionOS 1.0,iOS 13.0,macOS 13.0,tvOS 13.0, *) {
+            let title = title as! TextReference
+let displayMode = displayMode as! SwiftUI.NavigationBarItem.TitleDisplayMode
+            __content._observeTextReference(title, on: element, in: context) { __content in
+            __content
+                .navigationBarTitle(title.resolve(on: element, in: context), displayMode: displayMode)
+            }
+                
+            } else { __content }
+        #endif
+        #if os(iOS) || os(visionOS)
+        case let ._4(titleKey, displayMode):
+            if #available(watchOS 6.0,visionOS 1.0,iOS 13.0,macOS 13.0,tvOS 13.0, *) {
+            let titleKey = titleKey as! SwiftUICore.LocalizedStringKey
+let displayMode = displayMode as! SwiftUI.NavigationBarItem.TitleDisplayMode
+            
+            __content
+                .navigationBarTitle(titleKey, displayMode: displayMode)
+            
+                
+            } else { __content }
+        #endif
+        #if os(iOS) || os(visionOS)
+        case let ._5(title, displayMode):
+            if #available(watchOS 6.0,visionOS 1.0,iOS 13.0,macOS 13.0,tvOS 13.0, *) {
+            let title = title as! AttributeReference<String>
+let displayMode = displayMode as! SwiftUI.NavigationBarItem.TitleDisplayMode
+            
+            __content
+                .navigationBarTitle(title.resolve(on: element, in: context), displayMode: displayMode)
+            
+                
+            } else { __content }
+        #endif
         }
     }
 }
@@ -7817,7 +8685,7 @@ struct _navigationTitleModifier<R: RootRegistry>: ViewModifier {
     }
     
     #if os(watchOS)
-    @available(macOS 11.0,tvOS 14.0,iOS 14.0,watchOS 7.0, *)
+    @available(tvOS 14.0,iOS 14.0,macOS 11.0,watchOS 7.0, *)
     init(_ title: ViewReference=ViewReference(value: [])) {
         self.value = ._3(title: title)
         
@@ -7870,7 +8738,7 @@ struct _navigationTitleModifier<R: RootRegistry>: ViewModifier {
         
         #if os(watchOS)
         case let ._3(title):
-            if #available(macOS 11.0,tvOS 14.0,iOS 14.0,watchOS 7.0, *) {
+            if #available(tvOS 14.0,iOS 14.0,macOS 11.0,watchOS 7.0, *) {
             let title = title as! ViewReference
             
             __content
@@ -7886,6 +8754,53 @@ struct _navigationTitleModifier<R: RootRegistry>: ViewModifier {
             
             __content
                 .navigationTitle(__4_title.projectedValue)
+            
+                
+            
+        
+        }
+    }
+}
+@_documentation(visibility: public)
+@ParseableExpression
+struct _navigationViewStyleModifier<R: RootRegistry>: ViewModifier {
+    static var name: String { "navigationViewStyle" }
+
+    enum Value {
+        case _never
+        
+        indirect case _0(style: AnyNavigationViewStyle)
+        
+    }
+
+    let value: Value
+
+    
+    
+    
+
+
+
+
+    
+    
+    init(_ style: AnyNavigationViewStyle) {
+        self.value = ._0(style: style)
+        
+    }
+    
+
+    func body(content __content: Content) -> some View {
+        switch value {
+        case ._never:
+            fatalError("unreachable")
+        
+        case let ._0(style):
+            
+            
+            
+            __content
+                .navigationViewStyle(style)
             
                 
             
@@ -8055,7 +8970,7 @@ struct _onDeleteCommandModifier<R: RootRegistry>: ViewModifier {
 @Event private var _0_action__0: Event.EventHandler
 
     #if os(macOS)
-    @available(macOS 10.15,tvOS 13.0, *)
+    @available(tvOS 13.0,macOS 10.15, *)
     init(perform action__0: Event=Event()) {
         self.value = ._0
         self.__0_action__0 = action__0
@@ -8068,7 +8983,7 @@ struct _onDeleteCommandModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(macOS)
         case ._0:
-            if #available(macOS 10.15,tvOS 13.0, *) {
+            if #available(tvOS 13.0,macOS 10.15, *) {
             
             
             __content
@@ -8149,7 +9064,7 @@ struct _onExitCommandModifier<R: RootRegistry>: ViewModifier {
 @Event private var _0_action__0: Event.EventHandler
 
     #if os(macOS) || os(tvOS)
-    @available(macOS 10.15,tvOS 13.0, *)
+    @available(tvOS 13.0,macOS 10.15, *)
     init(perform action__0: Event=Event()) {
         self.value = ._0
         self.__0_action__0 = action__0
@@ -8162,7 +9077,7 @@ struct _onExitCommandModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(macOS) || os(tvOS)
         case ._0:
-            if #available(macOS 10.15,tvOS 13.0, *) {
+            if #available(tvOS 13.0,macOS 10.15, *) {
             
             
             __content
@@ -8281,6 +9196,12 @@ struct _onLongPressGestureModifier<R: RootRegistry>: ViewModifier {
         #if os(tvOS)
         indirect case _1(minimumDuration: Any)
         #endif
+        #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
+        indirect case _2(minimumDuration: Any, maximumDistance: Any)
+        #endif
+        #if os(tvOS)
+        indirect case _3(minimumDuration: Any)
+        #endif
     }
 
     let value: Value
@@ -8296,8 +9217,14 @@ struct _onLongPressGestureModifier<R: RootRegistry>: ViewModifier {
 @Event private var _1_action__0: Event.EventHandler
 @Event private var _1_onPressingChanged__1: Event.EventHandler
 
+@Event private var _2_pressing__1: Event.EventHandler
+@Event private var _2_action__0: Event.EventHandler
+
+@Event private var _3_pressing__1: Event.EventHandler
+@Event private var _3_action__0: Event.EventHandler
+
     #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 6.0,iOS 13.0,visionOS 1.0,tvOS 14.0,macOS 10.15, *)
+    @available(macOS 10.15,iOS 13.0,watchOS 6.0,visionOS 1.0,tvOS 14.0, *)
     init(minimumDuration: AttributeReference<Swift.Double> = .init(storage: .constant(0.5)), maximumDistance: AttributeReference<CoreFoundation.CGFloat> = .init(storage: .constant(10)), perform action__0: Event,onPressingChanged onPressingChanged__1: Event=Event() ) {
         self.value = ._0(minimumDuration: minimumDuration, maximumDistance: maximumDistance)
         self.__0_action__0 = action__0
@@ -8305,11 +9232,27 @@ self.__0_onPressingChanged__1 = onPressingChanged__1
     }
     #endif
     #if os(tvOS)
-    @available(watchOS 6.0,iOS 13.0,tvOS 14.0,macOS 10.15, *)
+    @available(macOS 10.15,iOS 13.0,watchOS 6.0,tvOS 14.0, *)
     init(minimumDuration: AttributeReference<Swift.Double> = .init(storage: .constant(0.5)), perform action__0: Event,onPressingChanged onPressingChanged__1: Event=Event() ) {
         self.value = ._1(minimumDuration: minimumDuration)
         self.__1_action__0 = action__0
 self.__1_onPressingChanged__1 = onPressingChanged__1
+    }
+    #endif
+    #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
+    @available(macOS 10.15,iOS 13.0,watchOS 6.0,visionOS 1.0,tvOS 14.0, *)
+    init(minimumDuration: AttributeReference<Swift.Double> = .init(storage: .constant(0.5)), maximumDistance: AttributeReference<CoreFoundation.CGFloat> = .init(storage: .constant(10)), pressing pressing__1: Event=Event(), perform action__0: Event) {
+        self.value = ._2(minimumDuration: minimumDuration, maximumDistance: maximumDistance)
+        self.__2_pressing__1 = pressing__1
+self.__2_action__0 = action__0
+    }
+    #endif
+    #if os(tvOS)
+    @available(macOS 10.15,iOS 13.0,watchOS 6.0,tvOS 14.0, *)
+    init(minimumDuration: AttributeReference<Swift.Double> = .init(storage: .constant(0.5)), pressing pressing__1: Event=Event(), perform action__0: Event) {
+        self.value = ._3(minimumDuration: minimumDuration)
+        self.__3_pressing__1 = pressing__1
+self.__3_action__0 = action__0
     }
     #endif
 
@@ -8319,7 +9262,7 @@ self.__1_onPressingChanged__1 = onPressingChanged__1
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
         case let ._0(minimumDuration, maximumDistance):
-            if #available(watchOS 6.0,iOS 13.0,visionOS 1.0,tvOS 14.0,macOS 10.15, *) {
+            if #available(macOS 10.15,iOS 13.0,watchOS 6.0,visionOS 1.0,tvOS 14.0, *) {
             let minimumDuration = minimumDuration as! AttributeReference<Swift.Double>
 let maximumDistance = maximumDistance as! AttributeReference<CoreFoundation.CGFloat>
             
@@ -8331,11 +9274,34 @@ let maximumDistance = maximumDistance as! AttributeReference<CoreFoundation.CGFl
         #endif
         #if os(tvOS)
         case let ._1(minimumDuration):
-            if #available(watchOS 6.0,iOS 13.0,tvOS 14.0,macOS 10.15, *) {
+            if #available(macOS 10.15,iOS 13.0,watchOS 6.0,tvOS 14.0, *) {
             let minimumDuration = minimumDuration as! AttributeReference<Swift.Double>
             
             __content
                 .onLongPressGesture(minimumDuration: minimumDuration.resolve(on: element, in: context), perform: { __1_action__0.wrappedValue() }, onPressingChanged: { __1_onPressingChanged__1.wrappedValue(value: $0) })
+            
+                
+            } else { __content }
+        #endif
+        #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
+        case let ._2(minimumDuration, maximumDistance):
+            if #available(macOS 10.15,iOS 13.0,watchOS 6.0,visionOS 1.0,tvOS 14.0, *) {
+            let minimumDuration = minimumDuration as! AttributeReference<Swift.Double>
+let maximumDistance = maximumDistance as! AttributeReference<CoreFoundation.CGFloat>
+            
+            __content
+                .onLongPressGesture(minimumDuration: minimumDuration.resolve(on: element, in: context), maximumDistance: maximumDistance.resolve(on: element, in: context), pressing: { __2_pressing__1.wrappedValue(value: $0) }, perform: { __2_action__0.wrappedValue() })
+            
+                
+            } else { __content }
+        #endif
+        #if os(tvOS)
+        case let ._3(minimumDuration):
+            if #available(macOS 10.15,iOS 13.0,watchOS 6.0,tvOS 14.0, *) {
+            let minimumDuration = minimumDuration as! AttributeReference<Swift.Double>
+            
+            __content
+                .onLongPressGesture(minimumDuration: minimumDuration.resolve(on: element, in: context), pressing: { __3_pressing__1.wrappedValue(value: $0) }, perform: { __3_action__0.wrappedValue() })
             
                 
             } else { __content }
@@ -8462,7 +9428,7 @@ struct _onMoveCommandModifier<R: RootRegistry>: ViewModifier {
 @Event private var _0_action__1: Event.EventHandler
 
     #if os(macOS) || os(tvOS)
-    @available(macOS 10.15,tvOS 13.0, *)
+    @available(tvOS 13.0,macOS 10.15, *)
     init(perform action__1: Event=Event()) {
         self.value = ._0
         self.__0_action__1 = action__1
@@ -8475,7 +9441,7 @@ struct _onMoveCommandModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(macOS) || os(tvOS)
         case ._0:
-            if #available(macOS 10.15,tvOS 13.0, *) {
+            if #available(tvOS 13.0,macOS 10.15, *) {
             
             
             __content
@@ -8509,7 +9475,7 @@ struct _onPencilDoubleTapModifier<R: RootRegistry>: ViewModifier {
 @Event private var _0_action__1: Event.EventHandler
 
     #if os(iOS) || os(macOS)
-    @available(macOS 14.5,iOS 17.5, *)
+    @available(iOS 17.5,macOS 14.5, *)
     init(perform action__1: Event) {
         self.value = ._0
         self.__0_action__1 = action__1
@@ -8522,7 +9488,7 @@ struct _onPencilDoubleTapModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS)
         case ._0:
-            if #available(macOS 14.5,iOS 17.5, *) {
+            if #available(iOS 17.5,macOS 14.5, *) {
             
             
             __content
@@ -8556,7 +9522,7 @@ struct _onPencilSqueezeModifier<R: RootRegistry>: ViewModifier {
 @Event private var _0_action__1: Event.EventHandler
 
     #if os(iOS) || os(macOS)
-    @available(macOS 14.5,iOS 17.5, *)
+    @available(iOS 17.5,macOS 14.5, *)
     init(perform action__1: Event) {
         self.value = ._0
         self.__0_action__1 = action__1
@@ -8569,7 +9535,7 @@ struct _onPencilSqueezeModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS)
         case ._0:
-            if #available(macOS 14.5,iOS 17.5, *) {
+            if #available(iOS 17.5,macOS 14.5, *) {
             
             
             __content
@@ -8603,7 +9569,7 @@ struct _onPlayPauseCommandModifier<R: RootRegistry>: ViewModifier {
 @Event private var _0_action__0: Event.EventHandler
 
     #if os(tvOS)
-    @available(macOS 10.15,tvOS 13.0, *)
+    @available(tvOS 13.0,macOS 10.15, *)
     init(perform action__0: Event=Event()) {
         self.value = ._0
         self.__0_action__0 = action__0
@@ -8616,7 +9582,7 @@ struct _onPlayPauseCommandModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(tvOS)
         case ._0:
-            if #available(macOS 10.15,tvOS 13.0, *) {
+            if #available(tvOS 13.0,macOS 10.15, *) {
             
             
             __content
@@ -8650,7 +9616,7 @@ struct _onScrollPhaseChangeModifier<R: RootRegistry>: ViewModifier {
 @Event private var _0_action__2: Event.EventHandler
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 15.0,watchOS 11.0,tvOS 18.0,iOS 18.0,visionOS 2.0, *)
+    @available(watchOS 11.0,tvOS 18.0,visionOS 2.0,iOS 18.0,macOS 15.0, *)
     init(_ action__2: Event) {
         self.value = ._0
         self.__0_action__2 = action__2
@@ -8663,7 +9629,7 @@ struct _onScrollPhaseChangeModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case ._0:
-            if #available(macOS 15.0,watchOS 11.0,tvOS 18.0,iOS 18.0,visionOS 2.0, *) {
+            if #available(watchOS 11.0,tvOS 18.0,visionOS 2.0,iOS 18.0,macOS 15.0, *) {
             
             
             __content
@@ -8697,7 +9663,7 @@ struct _onScrollVisibilityChangeModifier<R: RootRegistry>: ViewModifier {
 @Event private var _0_action__1: Event.EventHandler
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 2.0,macOS 15.0,tvOS 18.0,iOS 18.0,watchOS 11.0, *)
+    @available(tvOS 18.0,iOS 18.0,macOS 15.0,visionOS 2.0,watchOS 11.0, *)
     init(threshold: AttributeReference<Swift.Double> = .init(storage: .constant(0.5)), action action__1: Event) {
         self.value = ._0(threshold: threshold)
         self.__0_action__1 = action__1
@@ -8710,7 +9676,7 @@ struct _onScrollVisibilityChangeModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(threshold):
-            if #available(visionOS 2.0,macOS 15.0,tvOS 18.0,iOS 18.0,watchOS 11.0, *) {
+            if #available(tvOS 18.0,iOS 18.0,macOS 15.0,visionOS 2.0,watchOS 11.0, *) {
             let threshold = threshold as! AttributeReference<Swift.Double>
             
             __content
@@ -8749,7 +9715,7 @@ struct _onTapGestureModifier<R: RootRegistry>: ViewModifier {
 @Event private var _1_action__0: Event.EventHandler
 
     #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
-    @available(macOS 14.0,iOS 17.0,watchOS 10.0,visionOS 1.0, *)
+    @available(visionOS 1.0,iOS 17.0,macOS 14.0,watchOS 10.0, *)
     init(count: AttributeReference<Swift.Int> = .init(storage: .constant(1)), coordinateSpace: AnyCoordinateSpaceProtocol = .local, perform action__1: Event) {
         self.value = ._0(count: count, coordinateSpace: coordinateSpace)
         self.__0_action__1 = action__1
@@ -8769,7 +9735,7 @@ struct _onTapGestureModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
         case let ._0(count, coordinateSpace):
-            if #available(macOS 14.0,iOS 17.0,watchOS 10.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,iOS 17.0,macOS 14.0,watchOS 10.0, *) {
             let count = count as! AttributeReference<Swift.Int>
 let coordinateSpace = coordinateSpace as! AnyCoordinateSpaceProtocol 
             
@@ -8946,13 +9912,16 @@ struct _overlayModifier<R: RootRegistry>: ViewModifier {
     enum Value {
         case _never
         
-        indirect case _0(alignment: AttributeReference<SwiftUICore.Alignment> = .init(storage: .constant(.center)), content: ViewReference=ViewReference(value: []))
+        indirect case _0(overlay: InlineViewReference,alignment: AttributeReference<SwiftUICore.Alignment> = .init(storage: .constant(.center)) )
         
         
-        indirect case _1(style: AnyShapeStyle.Resolvable,edges: SwiftUICore.Edge.Set = .all )
+        indirect case _1(alignment: AttributeReference<SwiftUICore.Alignment> = .init(storage: .constant(.center)), content: ViewReference=ViewReference(value: []))
         
         
-        indirect case _2(style: AnyShapeStyle.Resolvable,shape: AnyShape,fillStyle: SwiftUICore.FillStyle = FillStyle() )
+        indirect case _2(style: AnyShapeStyle.Resolvable,edges: SwiftUICore.Edge.Set = .all )
+        
+        
+        indirect case _3(style: AnyShapeStyle.Resolvable,shape: AnyShape,fillStyle: SwiftUICore.FillStyle = FillStyle() )
         
     }
 
@@ -8969,24 +9938,33 @@ struct _overlayModifier<R: RootRegistry>: ViewModifier {
 
 
 
+
+
+    
+    
+    init(_ overlay: InlineViewReference,alignment: AttributeReference<SwiftUICore.Alignment> = .init(storage: .constant(.center)) ) {
+        self.value = ._0(overlay: overlay, alignment: alignment)
+        
+    }
+    
     
     
     init(alignment: AttributeReference<SwiftUICore.Alignment> = .init(storage: .constant(.center)), content: ViewReference=ViewReference(value: [])) {
-        self.value = ._0(alignment: alignment, content: content)
+        self.value = ._1(alignment: alignment, content: content)
         
     }
     
     
     
     init(_ style: AnyShapeStyle.Resolvable,ignoresSafeAreaEdges edges: SwiftUICore.Edge.Set = .all ) {
-        self.value = ._1(style: style, edges: edges)
+        self.value = ._2(style: style, edges: edges)
         
     }
     
     
     
     init(_ style: AnyShapeStyle.Resolvable,in shape: AnyShape,fillStyle: SwiftUICore.FillStyle = FillStyle() ) {
-        self.value = ._2(style: style, shape: shape, fillStyle: fillStyle)
+        self.value = ._3(style: style, shape: shape, fillStyle: fillStyle)
         
     }
     
@@ -8996,7 +9974,18 @@ struct _overlayModifier<R: RootRegistry>: ViewModifier {
         case ._never:
             fatalError("unreachable")
         
-        case let ._0(alignment, content):
+        case let ._0(overlay, alignment):
+            
+            
+            
+            __content
+                .overlay(overlay.resolve(on: element, in: context), alignment: alignment.resolve(on: element, in: context))
+            
+                
+            
+        
+        
+        case let ._1(alignment, content):
             
             
             
@@ -9007,7 +9996,7 @@ struct _overlayModifier<R: RootRegistry>: ViewModifier {
             
         
         
-        case let ._1(style, edges):
+        case let ._2(style, edges):
             
             
             
@@ -9018,7 +10007,7 @@ struct _overlayModifier<R: RootRegistry>: ViewModifier {
             
         
         
-        case let ._2(style, shape, fillStyle):
+        case let ._3(style, shape, fillStyle):
             
             
             
@@ -9334,7 +10323,7 @@ struct _pointerStyleModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(macOS) || os(visionOS)
-    @available(macOS 15.0,visionOS 2.0, *)
+    @available(visionOS 2.0,macOS 15.0, *)
     init(_ style: SwiftUI.PointerStyle?) {
         self.value = ._0(style: style)
         
@@ -9347,7 +10336,7 @@ struct _pointerStyleModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(macOS) || os(visionOS)
         case let ._0(style):
-            if #available(macOS 15.0,visionOS 2.0, *) {
+            if #available(visionOS 2.0,macOS 15.0, *) {
             let style = style as? SwiftUI.PointerStyle
             
             __content
@@ -9433,14 +10422,14 @@ struct _popoverModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 10.15,visionOS 1.0,iOS 13.0, *)
+    @available(visionOS 1.0,iOS 13.0,macOS 10.15, *)
     init(isPresented: ChangeTracked<Swift.Bool>,attachmentAnchor: SwiftUI.PopoverAttachmentAnchor = .rect(.bounds), arrowEdge: SwiftUICore.Edge = .top, content: ViewReference=ViewReference(value: [])) {
         self.value = ._0(attachmentAnchor: attachmentAnchor, arrowEdge: arrowEdge, content: content)
         self.__0_isPresented = isPresented
     }
     #endif
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 15.0,visionOS 2.0,iOS 18.0, *)
+    @available(visionOS 2.0,iOS 18.0,macOS 15.0, *)
     init(isPresented: ChangeTracked<Swift.Bool>,attachmentAnchor: SwiftUI.PopoverAttachmentAnchor = .rect(.bounds), content: ViewReference=ViewReference(value: [])) {
         self.value = ._1(attachmentAnchor: attachmentAnchor, content: content)
         self.__1_isPresented = isPresented
@@ -9453,7 +10442,7 @@ struct _popoverModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(attachmentAnchor, arrowEdge, content):
-            if #available(macOS 10.15,visionOS 1.0,iOS 13.0, *) {
+            if #available(visionOS 1.0,iOS 13.0,macOS 10.15, *) {
             let attachmentAnchor = attachmentAnchor as! SwiftUI.PopoverAttachmentAnchor 
 let arrowEdge = arrowEdge as! SwiftUICore.Edge 
 let content = content as! ViewReference
@@ -9466,7 +10455,7 @@ let content = content as! ViewReference
         #endif
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._1(attachmentAnchor, content):
-            if #available(macOS 15.0,visionOS 2.0,iOS 18.0, *) {
+            if #available(visionOS 2.0,iOS 18.0,macOS 15.0, *) {
             let attachmentAnchor = attachmentAnchor as! SwiftUI.PopoverAttachmentAnchor 
 let content = content as! ViewReference
             
@@ -9670,14 +10659,14 @@ struct _presentationBackgroundModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 13.3,iOS 16.4,tvOS 16.4,watchOS 9.4,visionOS 1.0, *)
+    @available(watchOS 9.4,visionOS 1.0,iOS 16.4,macOS 13.3,tvOS 16.4, *)
     init(_ style: AnyShapeStyle.Resolvable) {
         self.value = ._0(style: style)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 13.3,iOS 16.4,tvOS 16.4,watchOS 9.4,visionOS 1.0, *)
+    @available(watchOS 9.4,visionOS 1.0,iOS 16.4,macOS 13.3,tvOS 16.4, *)
     init(alignment: AttributeReference<SwiftUICore.Alignment> = .init(storage: .constant(.center)), content: ViewReference=ViewReference(value: [])) {
         self.value = ._1(alignment: alignment, content: content)
         
@@ -9690,7 +10679,7 @@ struct _presentationBackgroundModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(style):
-            if #available(macOS 13.3,iOS 16.4,tvOS 16.4,watchOS 9.4,visionOS 1.0, *) {
+            if #available(watchOS 9.4,visionOS 1.0,iOS 16.4,macOS 13.3,tvOS 16.4, *) {
             let style = style as! AnyShapeStyle.Resolvable
             
             __content
@@ -9701,7 +10690,7 @@ struct _presentationBackgroundModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(alignment, content):
-            if #available(macOS 13.3,iOS 16.4,tvOS 16.4,watchOS 9.4,visionOS 1.0, *) {
+            if #available(watchOS 9.4,visionOS 1.0,iOS 16.4,macOS 13.3,tvOS 16.4, *) {
             let alignment = alignment as! AttributeReference<SwiftUICore.Alignment>
 let content = content as! ViewReference
             
@@ -9736,7 +10725,7 @@ struct _presentationBackgroundInteractionModifier<R: RootRegistry>: ViewModifier
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,macOS 13.3,tvOS 16.4,iOS 16.4,watchOS 9.4, *)
+    @available(macOS 13.3,watchOS 9.4,visionOS 1.0,tvOS 16.4,iOS 16.4, *)
     init(_ interaction: SwiftUI.PresentationBackgroundInteraction) {
         self.value = ._0(interaction: interaction)
         
@@ -9749,7 +10738,7 @@ struct _presentationBackgroundInteractionModifier<R: RootRegistry>: ViewModifier
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(interaction):
-            if #available(visionOS 1.0,macOS 13.3,tvOS 16.4,iOS 16.4,watchOS 9.4, *) {
+            if #available(macOS 13.3,watchOS 9.4,visionOS 1.0,tvOS 16.4,iOS 16.4, *) {
             let interaction = interaction as! SwiftUI.PresentationBackgroundInteraction
             
             __content
@@ -9788,14 +10777,14 @@ struct _presentationCompactAdaptationModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,macOS 13.3,tvOS 16.4,iOS 16.4,watchOS 9.4, *)
+    @available(macOS 13.3,watchOS 9.4,visionOS 1.0,tvOS 16.4,iOS 16.4, *)
     init(_ adaptation: SwiftUI.PresentationAdaptation) {
         self.value = ._0(adaptation: adaptation)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,macOS 13.3,tvOS 16.4,iOS 16.4,watchOS 9.4, *)
+    @available(macOS 13.3,watchOS 9.4,visionOS 1.0,tvOS 16.4,iOS 16.4, *)
     init(horizontal horizontalAdaptation: SwiftUI.PresentationAdaptation,vertical verticalAdaptation: SwiftUI.PresentationAdaptation) {
         self.value = ._1(horizontalAdaptation: horizontalAdaptation, verticalAdaptation: verticalAdaptation)
         
@@ -9808,7 +10797,7 @@ struct _presentationCompactAdaptationModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(adaptation):
-            if #available(visionOS 1.0,macOS 13.3,tvOS 16.4,iOS 16.4,watchOS 9.4, *) {
+            if #available(macOS 13.3,watchOS 9.4,visionOS 1.0,tvOS 16.4,iOS 16.4, *) {
             let adaptation = adaptation as! SwiftUI.PresentationAdaptation
             
             __content
@@ -9819,7 +10808,7 @@ struct _presentationCompactAdaptationModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(horizontalAdaptation, verticalAdaptation):
-            if #available(visionOS 1.0,macOS 13.3,tvOS 16.4,iOS 16.4,watchOS 9.4, *) {
+            if #available(macOS 13.3,watchOS 9.4,visionOS 1.0,tvOS 16.4,iOS 16.4, *) {
             let horizontalAdaptation = horizontalAdaptation as! SwiftUI.PresentationAdaptation
 let verticalAdaptation = verticalAdaptation as! SwiftUI.PresentationAdaptation
             
@@ -9854,7 +10843,7 @@ struct _presentationContentInteractionModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,macOS 13.3,tvOS 16.4,iOS 16.4,watchOS 9.4, *)
+    @available(macOS 13.3,watchOS 9.4,visionOS 1.0,tvOS 16.4,iOS 16.4, *)
     init(_ behavior: SwiftUI.PresentationContentInteraction) {
         self.value = ._0(behavior: behavior)
         
@@ -9867,7 +10856,7 @@ struct _presentationContentInteractionModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(behavior):
-            if #available(visionOS 1.0,macOS 13.3,tvOS 16.4,iOS 16.4,watchOS 9.4, *) {
+            if #available(macOS 13.3,watchOS 9.4,visionOS 1.0,tvOS 16.4,iOS 16.4, *) {
             let behavior = behavior as! SwiftUI.PresentationContentInteraction
             
             __content
@@ -9901,7 +10890,7 @@ struct _presentationCornerRadiusModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,macOS 13.3,tvOS 16.4,iOS 16.4,watchOS 9.4, *)
+    @available(macOS 13.3,watchOS 9.4,visionOS 1.0,tvOS 16.4,iOS 16.4, *)
     init(_ cornerRadius: AttributeReference<CoreFoundation.CGFloat?>?) {
         self.value = ._0(cornerRadius: cornerRadius)
         
@@ -9914,7 +10903,7 @@ struct _presentationCornerRadiusModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(cornerRadius):
-            if #available(visionOS 1.0,macOS 13.3,tvOS 16.4,iOS 16.4,watchOS 9.4, *) {
+            if #available(macOS 13.3,watchOS 9.4,visionOS 1.0,tvOS 16.4,iOS 16.4, *) {
             let cornerRadius = cornerRadius as? AttributeReference<CoreFoundation.CGFloat?>
             
             __content
@@ -9995,7 +10984,7 @@ struct _presentationSizingModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 15.0,watchOS 11.0,tvOS 18.0,iOS 18.0,visionOS 2.0, *)
+    @available(iOS 18.0,visionOS 2.0,tvOS 18.0,watchOS 11.0,macOS 15.0, *)
     init(_ sizing: AnyPresentationSizing) {
         self.value = ._0(sizing: sizing)
         
@@ -10008,7 +10997,7 @@ struct _presentationSizingModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(sizing):
-            if #available(macOS 15.0,watchOS 11.0,tvOS 18.0,iOS 18.0,visionOS 2.0, *) {
+            if #available(iOS 18.0,visionOS 2.0,tvOS 18.0,watchOS 11.0,macOS 15.0, *) {
             let sizing = sizing as! AnyPresentationSizing
             
             __content
@@ -10545,21 +11534,21 @@ struct _safeAreaPaddingModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 14.0,watchOS 10.0,tvOS 17.0,iOS 17.0,visionOS 1.0, *)
+    @available(visionOS 1.0,macOS 14.0,tvOS 17.0,iOS 17.0,watchOS 10.0, *)
     init(_ insets: SwiftUICore.EdgeInsets) {
         self.value = ._0(insets: insets)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 14.0,watchOS 10.0,tvOS 17.0,iOS 17.0,visionOS 1.0, *)
+    @available(visionOS 1.0,macOS 14.0,tvOS 17.0,iOS 17.0,watchOS 10.0, *)
     init(_ edges: SwiftUICore.Edge.Set = .all, _ length: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)) ) {
         self.value = ._1(edges: edges, length: length)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 14.0,watchOS 10.0,tvOS 17.0,iOS 17.0,visionOS 1.0, *)
+    @available(visionOS 1.0,macOS 14.0,tvOS 17.0,iOS 17.0,watchOS 10.0, *)
     init(_ length: AttributeReference<CoreFoundation.CGFloat>) {
         self.value = ._2(length: length)
         
@@ -10572,7 +11561,7 @@ struct _safeAreaPaddingModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(insets):
-            if #available(macOS 14.0,watchOS 10.0,tvOS 17.0,iOS 17.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,macOS 14.0,tvOS 17.0,iOS 17.0,watchOS 10.0, *) {
             let insets = insets as! SwiftUICore.EdgeInsets
             
             __content
@@ -10583,7 +11572,7 @@ struct _safeAreaPaddingModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(edges, length):
-            if #available(macOS 14.0,watchOS 10.0,tvOS 17.0,iOS 17.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,macOS 14.0,tvOS 17.0,iOS 17.0,watchOS 10.0, *) {
             let edges = edges as! SwiftUICore.Edge.Set 
 let length = length as? AttributeReference<CoreFoundation.CGFloat?>
             
@@ -10595,7 +11584,7 @@ let length = length as? AttributeReference<CoreFoundation.CGFloat?>
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._2(length):
-            if #available(macOS 14.0,watchOS 10.0,tvOS 17.0,iOS 17.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,macOS 14.0,tvOS 17.0,iOS 17.0,watchOS 10.0, *) {
             let length = length as! AttributeReference<CoreFoundation.CGFloat>
             
             __content
@@ -11007,7 +11996,7 @@ struct _scrollBounceBehaviorModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 13.3,watchOS 9.4,tvOS 16.4,iOS 16.4,visionOS 1.0, *)
+    @available(watchOS 9.4,tvOS 16.4,visionOS 1.0,iOS 16.4,macOS 13.3, *)
     init(_ behavior: SwiftUI.ScrollBounceBehavior,axes: SwiftUICore.Axis.Set = [.vertical] ) {
         self.value = ._0(behavior: behavior, axes: axes)
         
@@ -11020,7 +12009,7 @@ struct _scrollBounceBehaviorModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(behavior, axes):
-            if #available(macOS 13.3,watchOS 9.4,tvOS 16.4,iOS 16.4,visionOS 1.0, *) {
+            if #available(watchOS 9.4,tvOS 16.4,visionOS 1.0,iOS 16.4,macOS 13.3, *) {
             let behavior = behavior as! SwiftUI.ScrollBounceBehavior
 let axes = axes as! SwiftUICore.Axis.Set 
             
@@ -11055,7 +12044,7 @@ struct _scrollClipDisabledModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 14.0,watchOS 10.0,tvOS 17.0,iOS 17.0,visionOS 1.0, *)
+    @available(watchOS 10.0,tvOS 17.0,visionOS 1.0,iOS 17.0,macOS 14.0, *)
     init(_ disabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(disabled: disabled)
         
@@ -11068,7 +12057,7 @@ struct _scrollClipDisabledModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(disabled):
-            if #available(macOS 14.0,watchOS 10.0,tvOS 17.0,iOS 17.0,visionOS 1.0, *) {
+            if #available(watchOS 10.0,tvOS 17.0,visionOS 1.0,iOS 17.0,macOS 14.0, *) {
             let disabled = disabled as! AttributeReference<Swift.Bool>
             
             __content
@@ -11102,7 +12091,7 @@ struct _scrollContentBackgroundModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,macOS 13.0,watchOS 9.0,iOS 16.0, *)
+    @available(iOS 16.0,watchOS 9.0,visionOS 1.0,macOS 13.0, *)
     init(_ visibility: AttributeReference<SwiftUI.Visibility>) {
         self.value = ._0(visibility: visibility)
         
@@ -11115,7 +12104,7 @@ struct _scrollContentBackgroundModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
         case let ._0(visibility):
-            if #available(visionOS 1.0,macOS 13.0,watchOS 9.0,iOS 16.0, *) {
+            if #available(iOS 16.0,watchOS 9.0,visionOS 1.0,macOS 13.0, *) {
             let visibility = visibility as! AttributeReference<SwiftUI.Visibility>
             
             __content
@@ -11196,7 +12185,7 @@ struct _scrollDismissesKeyboardModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-    @available(macOS 13.0,watchOS 9.0,tvOS 16.0,iOS 16.0, *)
+    @available(watchOS 9.0,tvOS 16.0,iOS 16.0,macOS 13.0, *)
     init(_ mode: SwiftUI.ScrollDismissesKeyboardMode) {
         self.value = ._0(mode: mode)
         
@@ -11209,7 +12198,7 @@ struct _scrollDismissesKeyboardModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
         case let ._0(mode):
-            if #available(macOS 13.0,watchOS 9.0,tvOS 16.0,iOS 16.0, *) {
+            if #available(watchOS 9.0,tvOS 16.0,iOS 16.0,macOS 13.0, *) {
             let mode = mode as! SwiftUI.ScrollDismissesKeyboardMode
             
             __content
@@ -11295,14 +12284,14 @@ struct _scrollIndicatorsFlashModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,macOS 14.0,tvOS 17.0,iOS 17.0,watchOS 10.0, *)
+    @available(watchOS 10.0,tvOS 17.0,visionOS 1.0,iOS 17.0,macOS 14.0, *)
     init(trigger value: AttributeReference<String>) {
         self.value = ._0(value: value)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,macOS 14.0,tvOS 17.0,iOS 17.0,watchOS 10.0, *)
+    @available(watchOS 10.0,tvOS 17.0,visionOS 1.0,iOS 17.0,macOS 14.0, *)
     init(onAppear: AttributeReference<Swift.Bool>) {
         self.value = ._1(onAppear: onAppear)
         
@@ -11315,7 +12304,7 @@ struct _scrollIndicatorsFlashModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(value):
-            if #available(visionOS 1.0,macOS 14.0,tvOS 17.0,iOS 17.0,watchOS 10.0, *) {
+            if #available(watchOS 10.0,tvOS 17.0,visionOS 1.0,iOS 17.0,macOS 14.0, *) {
             let value = value as! AttributeReference<String>
             
             __content
@@ -11326,7 +12315,7 @@ struct _scrollIndicatorsFlashModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(onAppear):
-            if #available(visionOS 1.0,macOS 14.0,tvOS 17.0,iOS 17.0,watchOS 10.0, *) {
+            if #available(watchOS 10.0,tvOS 17.0,visionOS 1.0,iOS 17.0,macOS 14.0, *) {
             let onAppear = onAppear as! AttributeReference<Swift.Bool>
             
             __content
@@ -11360,7 +12349,7 @@ struct _scrollPositionModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0,visionOS 1.0, *)
+    @available(macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0,visionOS 1.0, *)
     init(id: ChangeTracked<String?>,anchor: AttributeReference<SwiftUICore.UnitPoint?>? = .init(storage: .constant(nil)) ) {
         self.value = ._0(anchor: anchor)
         self.__0_id = id
@@ -11373,7 +12362,7 @@ struct _scrollPositionModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(anchor):
-            if #available(macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0,visionOS 1.0, *) {
+            if #available(macOS 14.0,watchOS 10.0,iOS 17.0,tvOS 17.0,visionOS 1.0, *) {
             let anchor = anchor as? AttributeReference<SwiftUICore.UnitPoint?>
             
             __content
@@ -11407,7 +12396,7 @@ struct _scrollTargetBehaviorModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 14.0,watchOS 10.0,tvOS 17.0,iOS 17.0,visionOS 1.0, *)
+    @available(watchOS 10.0,visionOS 1.0,iOS 17.0,macOS 14.0,tvOS 17.0, *)
     init(_ behavior: AnyScrollTargetBehavior) {
         self.value = ._0(behavior: behavior)
         
@@ -11420,7 +12409,7 @@ struct _scrollTargetBehaviorModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(behavior):
-            if #available(macOS 14.0,watchOS 10.0,tvOS 17.0,iOS 17.0,visionOS 1.0, *) {
+            if #available(watchOS 10.0,visionOS 1.0,iOS 17.0,macOS 14.0,tvOS 17.0, *) {
             let behavior = behavior as! AnyScrollTargetBehavior
             
             __content
@@ -11454,7 +12443,7 @@ struct _scrollTargetLayoutModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 14.0,iOS 17.0,watchOS 10.0,visionOS 1.0,tvOS 17.0, *)
+    @available(watchOS 10.0,visionOS 1.0,iOS 17.0,macOS 14.0,tvOS 17.0, *)
     init(isEnabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(isEnabled: isEnabled)
         
@@ -11467,7 +12456,7 @@ struct _scrollTargetLayoutModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(isEnabled):
-            if #available(macOS 14.0,iOS 17.0,watchOS 10.0,visionOS 1.0,tvOS 17.0, *) {
+            if #available(watchOS 10.0,visionOS 1.0,iOS 17.0,macOS 14.0,tvOS 17.0, *) {
             let isEnabled = isEnabled as! AttributeReference<Swift.Bool>
             
             __content
@@ -11548,7 +12537,7 @@ struct _searchPresentationToolbarBehaviorModifier<R: RootRegistry>: ViewModifier
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,macOS 14.1,tvOS 17.1,iOS 17.1,watchOS 10.1, *)
+    @available(macOS 14.1,watchOS 10.1,visionOS 1.0,tvOS 17.1,iOS 17.1, *)
     init(_ behavior: SwiftUI.SearchPresentationToolbarBehavior) {
         self.value = ._0(behavior: behavior)
         
@@ -11561,7 +12550,7 @@ struct _searchPresentationToolbarBehaviorModifier<R: RootRegistry>: ViewModifier
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(behavior):
-            if #available(visionOS 1.0,macOS 14.1,tvOS 17.1,iOS 17.1,watchOS 10.1, *) {
+            if #available(macOS 14.1,watchOS 10.1,visionOS 1.0,tvOS 17.1,iOS 17.1, *) {
             let behavior = behavior as! SwiftUI.SearchPresentationToolbarBehavior
             
             __content
@@ -11668,6 +12657,15 @@ struct _searchableModifier<R: RootRegistry>: ViewModifier {
         #if os(iOS) || os(macOS) || os(visionOS)
         indirect case _5(placement: Any, prompt: Any)
         #endif
+        
+        indirect case _6(placement: SwiftUI.SearchFieldPlacement = .automatic, prompt: TextReference? = nil, suggestions: ViewReference=ViewReference(value: []))
+        
+        
+        indirect case _7(placement: SwiftUI.SearchFieldPlacement = .automatic, prompt: SwiftUICore.LocalizedStringKey,suggestions: ViewReference=ViewReference(value: []))
+        
+        
+        indirect case _8(placement: SwiftUI.SearchFieldPlacement = .automatic, prompt: AttributeReference<String>,suggestions: ViewReference=ViewReference(value: []))
+        
     }
 
     let value: Value
@@ -11690,6 +12688,12 @@ struct _searchableModifier<R: RootRegistry>: ViewModifier {
 
 @ChangeTracked private var _5_text: Swift.String
 @ChangeTracked private var _5_isPresented: Swift.Bool
+
+@ChangeTracked private var _6_text: Swift.String
+
+@ChangeTracked private var _7_text: Swift.String
+
+@ChangeTracked private var _8_text: Swift.String
 
 
     
@@ -11714,7 +12718,7 @@ struct _searchableModifier<R: RootRegistry>: ViewModifier {
     }
     
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(iOS 17.0,visionOS 1.0,macOS 14.0, *)
+    @available(visionOS 1.0,iOS 17.0,macOS 14.0, *)
     init(text: ChangeTracked<Swift.String>,isPresented: ChangeTracked<Swift.Bool>,placement: SwiftUI.SearchFieldPlacement = .automatic, prompt: TextReference? = nil ) {
         self.value = ._3(placement: placement, prompt: prompt)
         self.__3_text = text
@@ -11722,7 +12726,7 @@ self.__3_isPresented = isPresented
     }
     #endif
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(iOS 17.0,visionOS 1.0,macOS 14.0, *)
+    @available(visionOS 1.0,iOS 17.0,macOS 14.0, *)
     init(text: ChangeTracked<Swift.String>,isPresented: ChangeTracked<Swift.Bool>,placement: SwiftUI.SearchFieldPlacement = .automatic, prompt: SwiftUICore.LocalizedStringKey) {
         self.value = ._4(placement: placement, prompt: prompt)
         self.__4_text = text
@@ -11730,13 +12734,34 @@ self.__4_isPresented = isPresented
     }
     #endif
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(iOS 17.0,visionOS 1.0,macOS 14.0, *)
+    @available(visionOS 1.0,iOS 17.0,macOS 14.0, *)
     init(text: ChangeTracked<Swift.String>,isPresented: ChangeTracked<Swift.Bool>,placement: SwiftUI.SearchFieldPlacement = .automatic, prompt: AttributeReference<String>) {
         self.value = ._5(placement: placement, prompt: prompt)
         self.__5_text = text
 self.__5_isPresented = isPresented
     }
     #endif
+    
+    
+    init(text: ChangeTracked<Swift.String>,placement: SwiftUI.SearchFieldPlacement = .automatic, prompt: TextReference? = nil, suggestions: ViewReference=ViewReference(value: [])) {
+        self.value = ._6(placement: placement, prompt: prompt, suggestions: suggestions)
+        self.__6_text = text
+    }
+    
+    
+    
+    init(text: ChangeTracked<Swift.String>,placement: SwiftUI.SearchFieldPlacement = .automatic, prompt: SwiftUICore.LocalizedStringKey,suggestions: ViewReference=ViewReference(value: [])) {
+        self.value = ._7(placement: placement, prompt: prompt, suggestions: suggestions)
+        self.__7_text = text
+    }
+    
+    
+    
+    init(text: ChangeTracked<Swift.String>,placement: SwiftUI.SearchFieldPlacement = .automatic, prompt: AttributeReference<String>,suggestions: ViewReference=ViewReference(value: [])) {
+        self.value = ._8(placement: placement, prompt: prompt, suggestions: suggestions)
+        self.__8_text = text
+    }
+    
 
     func body(content __content: Content) -> some View {
         switch value {
@@ -11777,7 +12802,7 @@ self.__5_isPresented = isPresented
         
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._3(placement, prompt):
-            if #available(iOS 17.0,visionOS 1.0,macOS 14.0, *) {
+            if #available(visionOS 1.0,iOS 17.0,macOS 14.0, *) {
             let placement = placement as! SwiftUI.SearchFieldPlacement 
 let prompt = prompt as? TextReference
             __content._observeTextReference(prompt, on: element, in: context) { __content in
@@ -11789,7 +12814,7 @@ let prompt = prompt as? TextReference
         #endif
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._4(placement, prompt):
-            if #available(iOS 17.0,visionOS 1.0,macOS 14.0, *) {
+            if #available(visionOS 1.0,iOS 17.0,macOS 14.0, *) {
             let placement = placement as! SwiftUI.SearchFieldPlacement 
 let prompt = prompt as! SwiftUICore.LocalizedStringKey
             
@@ -11801,7 +12826,7 @@ let prompt = prompt as! SwiftUICore.LocalizedStringKey
         #endif
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._5(placement, prompt):
-            if #available(iOS 17.0,visionOS 1.0,macOS 14.0, *) {
+            if #available(visionOS 1.0,iOS 17.0,macOS 14.0, *) {
             let placement = placement as! SwiftUI.SearchFieldPlacement 
 let prompt = prompt as! AttributeReference<String>
             
@@ -11811,6 +12836,39 @@ let prompt = prompt as! AttributeReference<String>
                 
             } else { __content }
         #endif
+        
+        case let ._6(placement, prompt, suggestions):
+            
+            
+            __content._observeTextReference(prompt, on: element, in: context) { __content in
+            __content
+                .searchable(text: __6_text.projectedValue, placement: placement, prompt: prompt?.resolve(on: element, in: context), suggestions: { suggestions.resolve(on: element, in: context) })
+            }
+                
+            
+        
+        
+        case let ._7(placement, prompt, suggestions):
+            
+            
+            
+            __content
+                .searchable(text: __7_text.projectedValue, placement: placement, prompt: prompt, suggestions: { suggestions.resolve(on: element, in: context) })
+            
+                
+            
+        
+        
+        case let ._8(placement, prompt, suggestions):
+            
+            
+            
+            __content
+                .searchable(text: __8_text.projectedValue, placement: placement, prompt: prompt.resolve(on: element, in: context), suggestions: { suggestions.resolve(on: element, in: context) })
+            
+                
+            
+        
         }
     }
 }
@@ -11836,7 +12894,7 @@ struct _sectionActionsModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 15.0,iOS 18.0,visionOS 2.0, *)
+    @available(visionOS 2.0,macOS 15.0,iOS 18.0, *)
     init(content: ViewReference=ViewReference(value: [])) {
         self.value = ._0(content: content)
         
@@ -11849,7 +12907,7 @@ struct _sectionActionsModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(content):
-            if #available(macOS 15.0,iOS 18.0,visionOS 2.0, *) {
+            if #available(visionOS 2.0,macOS 15.0,iOS 18.0, *) {
             let content = content as! ViewReference
             
             __content
@@ -11883,7 +12941,7 @@ struct _selectionDisabledModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 10.0,macOS 14.0,iOS 17.0,visionOS 1.0,tvOS 17.0, *)
+    @available(watchOS 10.0,tvOS 17.0,visionOS 1.0,iOS 17.0,macOS 14.0, *)
     init(_ isDisabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(isDisabled: isDisabled)
         
@@ -11896,7 +12954,7 @@ struct _selectionDisabledModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(isDisabled):
-            if #available(watchOS 10.0,macOS 14.0,iOS 17.0,visionOS 1.0,tvOS 17.0, *) {
+            if #available(watchOS 10.0,tvOS 17.0,visionOS 1.0,iOS 17.0,macOS 14.0, *) {
             let isDisabled = isDisabled as! AttributeReference<Swift.Bool>
             
             __content
@@ -12049,7 +13107,7 @@ struct _simultaneousGestureModifier<R: RootRegistry>: ViewModifier {
     }
     
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 11.0,iOS 18.0,visionOS 2.0,tvOS 18.0,macOS 15.0, *)
+    @available(watchOS 11.0,visionOS 2.0,iOS 18.0,macOS 15.0,tvOS 18.0, *)
     init(_ gesture: _AnyGesture,name: AttributeReference<Swift.String>,isEnabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._2(gesture: gesture, name: name, isEnabled: isEnabled)
         
@@ -12084,7 +13142,7 @@ struct _simultaneousGestureModifier<R: RootRegistry>: ViewModifier {
         
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._2(gesture, name, isEnabled):
-            if #available(watchOS 11.0,iOS 18.0,visionOS 2.0,tvOS 18.0,macOS 15.0, *) {
+            if #available(watchOS 11.0,visionOS 2.0,iOS 18.0,macOS 15.0,tvOS 18.0, *) {
             let gesture = gesture as! _AnyGesture
 let name = name as! AttributeReference<Swift.String>
 let isEnabled = isEnabled as! AttributeReference<Swift.Bool>
@@ -12283,6 +13341,53 @@ struct _speechSpellsOutCharactersModifier<R: RootRegistry>: ViewModifier {
                 
             
         
+        }
+    }
+}
+@_documentation(visibility: public)
+@ParseableExpression
+struct _statusBarModifier<R: RootRegistry>: ViewModifier {
+    static var name: String { "statusBar" }
+
+    enum Value {
+        case _never
+        #if os(iOS) || os(visionOS)
+        indirect case _0(hidden: Any)
+        #endif
+    }
+
+    let value: Value
+
+    @ObservedElement private var element
+    @LiveContext<R> private var context
+    
+
+
+
+
+    #if os(iOS) || os(visionOS)
+    @available(visionOS 1.0,iOS 16.0, *)
+    init(hidden: AttributeReference<Swift.Bool>) {
+        self.value = ._0(hidden: hidden)
+        
+    }
+    #endif
+
+    func body(content __content: Content) -> some View {
+        switch value {
+        case ._never:
+            fatalError("unreachable")
+        #if os(iOS) || os(visionOS)
+        case let ._0(hidden):
+            if #available(visionOS 1.0,iOS 16.0, *) {
+            let hidden = hidden as! AttributeReference<Swift.Bool>
+            
+            __content
+                .statusBar(hidden: hidden.resolve(on: element, in: context))
+            
+                
+            } else { __content }
+        #endif
         }
     }
 }
@@ -12496,7 +13601,7 @@ struct _swipeActionsModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,macOS 12.0,watchOS 8.0,iOS 15.0, *)
+    @available(iOS 15.0,watchOS 8.0,visionOS 1.0,macOS 12.0, *)
     init(edge: SwiftUICore.HorizontalEdge = .trailing, allowsFullSwipe: AttributeReference<Swift.Bool> = .init(storage: .constant(true)), content: ViewReference=ViewReference(value: [])) {
         self.value = ._0(edge: edge, allowsFullSwipe: allowsFullSwipe, content: content)
         
@@ -12509,7 +13614,7 @@ struct _swipeActionsModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
         case let ._0(edge, allowsFullSwipe, content):
-            if #available(visionOS 1.0,macOS 12.0,watchOS 8.0,iOS 15.0, *) {
+            if #available(iOS 15.0,watchOS 8.0,visionOS 1.0,macOS 12.0, *) {
             let edge = edge as! SwiftUICore.HorizontalEdge 
 let allowsFullSwipe = allowsFullSwipe as! AttributeReference<Swift.Bool>
 let content = content as! ViewReference
@@ -12550,14 +13655,14 @@ struct _symbolEffectModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 10.0,visionOS 1.0,iOS 17.0,macOS 14.0,tvOS 17.0, *)
+    @available(tvOS 17.0,iOS 17.0,macOS 14.0,visionOS 1.0,watchOS 10.0, *)
     init(_ effect: AnyIndefiniteSymbolEffect,options: Symbols.SymbolEffectOptions = .default, isActive: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(effect: effect, options: options, isActive: isActive)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 10.0,visionOS 1.0,iOS 17.0,macOS 14.0,tvOS 17.0, *)
+    @available(tvOS 17.0,iOS 17.0,macOS 14.0,visionOS 1.0,watchOS 10.0, *)
     init(_ effect: AnyDiscreteSymbolEffect,options: Symbols.SymbolEffectOptions = .default, value: AttributeReference<String>) {
         self.value = ._1(effect: effect, options: options, value: value)
         
@@ -12570,7 +13675,7 @@ struct _symbolEffectModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(effect, options, isActive):
-            if #available(watchOS 10.0,visionOS 1.0,iOS 17.0,macOS 14.0,tvOS 17.0, *) {
+            if #available(tvOS 17.0,iOS 17.0,macOS 14.0,visionOS 1.0,watchOS 10.0, *) {
             let effect = effect as! AnyIndefiniteSymbolEffect
 let options = options as! Symbols.SymbolEffectOptions 
 let isActive = isActive as! AttributeReference<Swift.Bool>
@@ -12583,7 +13688,7 @@ let isActive = isActive as! AttributeReference<Swift.Bool>
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(effect, options, value):
-            if #available(watchOS 10.0,visionOS 1.0,iOS 17.0,macOS 14.0,tvOS 17.0, *) {
+            if #available(tvOS 17.0,iOS 17.0,macOS 14.0,visionOS 1.0,watchOS 10.0, *) {
             let effect = effect as! AnyDiscreteSymbolEffect
 let options = options as! Symbols.SymbolEffectOptions 
 let value = value as! AttributeReference<String>
@@ -12619,7 +13724,7 @@ struct _symbolEffectsRemovedModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 10.0,macOS 14.0,iOS 17.0,visionOS 1.0,tvOS 17.0, *)
+    @available(watchOS 10.0,tvOS 17.0,visionOS 1.0,iOS 17.0,macOS 14.0, *)
     init(_ isEnabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(isEnabled: isEnabled)
         
@@ -12632,7 +13737,7 @@ struct _symbolEffectsRemovedModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(isEnabled):
-            if #available(watchOS 10.0,macOS 14.0,iOS 17.0,visionOS 1.0,tvOS 17.0, *) {
+            if #available(watchOS 10.0,tvOS 17.0,visionOS 1.0,iOS 17.0,macOS 14.0, *) {
             let isEnabled = isEnabled as! AttributeReference<Swift.Bool>
             
             __content
@@ -12740,6 +13845,53 @@ struct _symbolVariantModifier<R: RootRegistry>: ViewModifier {
 }
 @_documentation(visibility: public)
 @ParseableExpression
+struct _tabItemModifier<R: RootRegistry>: ViewModifier {
+    static var name: String { "tabItem" }
+
+    enum Value {
+        case _never
+        
+        indirect case _0(label: ViewReference=ViewReference(value: []))
+        
+    }
+
+    let value: Value
+
+    @ObservedElement private var element
+    @LiveContext<R> private var context
+    
+
+
+
+
+    
+    
+    init(_ label: ViewReference=ViewReference(value: [])) {
+        self.value = ._0(label: label)
+        
+    }
+    
+
+    func body(content __content: Content) -> some View {
+        switch value {
+        case ._never:
+            fatalError("unreachable")
+        
+        case let ._0(label):
+            
+            
+            
+            __content
+                .tabItem({ label.resolve(on: element, in: context) })
+            
+                
+            
+        
+        }
+    }
+}
+@_documentation(visibility: public)
+@ParseableExpression
 struct _tabViewSidebarBottomBarModifier<R: RootRegistry>: ViewModifier {
     static var name: String { "tabViewSidebarBottomBar" }
 
@@ -12760,7 +13912,7 @@ struct _tabViewSidebarBottomBarModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 15.0,iOS 18.0,visionOS 2.0, *)
+    @available(visionOS 2.0,iOS 18.0,macOS 15.0, *)
     init(content: ViewReference=ViewReference(value: [])) {
         self.value = ._0(content: content)
         
@@ -12773,7 +13925,7 @@ struct _tabViewSidebarBottomBarModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(content):
-            if #available(macOS 15.0,iOS 18.0,visionOS 2.0, *) {
+            if #available(visionOS 2.0,iOS 18.0,macOS 15.0, *) {
             let content = content as! ViewReference
             
             __content
@@ -12807,7 +13959,7 @@ struct _tabViewSidebarFooterModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 15.0,iOS 18.0,visionOS 2.0, *)
+    @available(visionOS 2.0,iOS 18.0,macOS 15.0, *)
     init(content: ViewReference=ViewReference(value: [])) {
         self.value = ._0(content: content)
         
@@ -12820,7 +13972,7 @@ struct _tabViewSidebarFooterModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(content):
-            if #available(macOS 15.0,iOS 18.0,visionOS 2.0, *) {
+            if #available(visionOS 2.0,iOS 18.0,macOS 15.0, *) {
             let content = content as! ViewReference
             
             __content
@@ -12854,7 +14006,7 @@ struct _tabViewSidebarHeaderModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 15.0,iOS 18.0,visionOS 2.0, *)
+    @available(visionOS 2.0,iOS 18.0,macOS 15.0, *)
     init(content: ViewReference=ViewReference(value: [])) {
         self.value = ._0(content: content)
         
@@ -12867,7 +14019,7 @@ struct _tabViewSidebarHeaderModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(content):
-            if #available(macOS 15.0,iOS 18.0,visionOS 2.0, *) {
+            if #available(visionOS 2.0,iOS 18.0,macOS 15.0, *) {
             let content = content as! ViewReference
             
             __content
@@ -12948,7 +14100,7 @@ struct _tableStyleModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 12.0,iOS 16.0,visionOS 1.0, *)
+    @available(visionOS 1.0,macOS 12.0,iOS 16.0, *)
     init(_ style: AnyTableStyle) {
         self.value = ._0(style: style)
         
@@ -12961,7 +14113,7 @@ struct _tableStyleModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(style):
-            if #available(macOS 12.0,iOS 16.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,macOS 12.0,iOS 16.0, *) {
             let style = style as! AnyTableStyle
             
             __content
@@ -13042,7 +14194,7 @@ struct _textContentTypeModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(tvOS) || os(visionOS)
-    @available(visionOS 1.0,tvOS 13.0,iOS 13.0, *)
+    @available(tvOS 13.0,visionOS 1.0,iOS 13.0, *)
     init(_ textContentType: UIKit.UITextContentType?) {
         self.value = ._0(textContentType: textContentType)
         
@@ -13055,7 +14207,7 @@ struct _textContentTypeModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(tvOS) || os(visionOS)
         case let ._0(textContentType):
-            if #available(visionOS 1.0,tvOS 13.0,iOS 13.0, *) {
+            if #available(tvOS 13.0,visionOS 1.0,iOS 13.0, *) {
             let textContentType = textContentType as? UIKit.UITextContentType
             
             __content
@@ -13089,7 +14241,7 @@ struct _textEditorStyleModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 14.0,iOS 17.0,visionOS 1.0, *)
+    @available(visionOS 1.0,iOS 17.0,macOS 14.0, *)
     init(_ style: AnyTextEditorStyle) {
         self.value = ._0(style: style)
         
@@ -13102,7 +14254,7 @@ struct _textEditorStyleModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(style):
-            if #available(macOS 14.0,iOS 17.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,iOS 17.0,macOS 14.0, *) {
             let style = style as! AnyTextEditorStyle
             
             __content
@@ -13183,7 +14335,7 @@ struct _textInputAutocapitalizationModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,watchOS 8.0,tvOS 15.0,iOS 15.0, *)
+    @available(tvOS 15.0,iOS 15.0,visionOS 1.0,watchOS 8.0, *)
     init(_ autocapitalization: SwiftUI.TextInputAutocapitalization?) {
         self.value = ._0(autocapitalization: autocapitalization)
         
@@ -13196,7 +14348,7 @@ struct _textInputAutocapitalizationModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(autocapitalization):
-            if #available(visionOS 1.0,watchOS 8.0,tvOS 15.0,iOS 15.0, *) {
+            if #available(tvOS 15.0,iOS 15.0,visionOS 1.0,watchOS 8.0, *) {
             let autocapitalization = autocapitalization as? SwiftUI.TextInputAutocapitalization
             
             __content
@@ -13324,7 +14476,7 @@ struct _textSelectionModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(iOS 15.0,visionOS 1.0,macOS 12.0, *)
+    @available(iOS 15.0,macOS 12.0,visionOS 1.0, *)
     init(_ selectability: AnyTextSelectability) {
         self.value = ._0(selectability: selectability)
         
@@ -13337,7 +14489,7 @@ struct _textSelectionModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(selectability):
-            if #available(iOS 15.0,visionOS 1.0,macOS 12.0, *) {
+            if #available(iOS 15.0,macOS 12.0,visionOS 1.0, *) {
             let selectability = selectability as! AnyTextSelectability
             
             __content
@@ -13371,7 +14523,7 @@ struct _textSelectionAffinityModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 2.0,macOS 15.0,tvOS 18.0,iOS 18.0,watchOS 11.0, *)
+    @available(macOS 15.0,watchOS 11.0,visionOS 2.0,tvOS 18.0,iOS 18.0, *)
     init(_ affinity: SwiftUI.TextSelectionAffinity) {
         self.value = ._0(affinity: affinity)
         
@@ -13384,7 +14536,7 @@ struct _textSelectionAffinityModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(affinity):
-            if #available(visionOS 2.0,macOS 15.0,tvOS 18.0,iOS 18.0,watchOS 11.0, *) {
+            if #available(macOS 15.0,watchOS 11.0,visionOS 2.0,tvOS 18.0,iOS 18.0, *) {
             let affinity = affinity as! SwiftUI.TextSelectionAffinity
             
             __content
@@ -13520,14 +14672,17 @@ struct _toolbarModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
+        
+        indirect case _0(visibility: AttributeReference<SwiftUI.Visibility>,bars: SwiftUI.ToolbarPlacement)
+        
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-        indirect case _0(defaultItemKind: Any?)
+        indirect case _1(defaultItemKind: Any?)
         #endif
         
-        indirect case _2(content: ToolbarContentReference=ToolbarContentReference(value: []))
+        indirect case _3(content: ToolbarContentReference=ToolbarContentReference(value: []))
         
         
-        indirect case _3(id: AttributeReference<Swift.String>,content: CustomizableToolbarContentReference=CustomizableToolbarContentReference(value: []))
+        indirect case _4(id: AttributeReference<Swift.String>,content: CustomizableToolbarContentReference=CustomizableToolbarContentReference(value: []))
         
     }
 
@@ -13544,24 +14699,33 @@ struct _toolbarModifier<R: RootRegistry>: ViewModifier {
 
 
 
+
+
+    
+    
+    init(_ visibility: AttributeReference<SwiftUI.Visibility>,for bars: SwiftUI.ToolbarPlacement) {
+        self.value = ._0(visibility: visibility, bars: bars)
+        
+    }
+    
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 10.0,iOS 17.0,visionOS 1.0,tvOS 17.0,macOS 14.0, *)
+    @available(macOS 14.0,iOS 17.0,watchOS 10.0,visionOS 1.0,tvOS 17.0, *)
     init(removing defaultItemKind: SwiftUI.ToolbarDefaultItemKind?) {
-        self.value = ._0(defaultItemKind: defaultItemKind)
+        self.value = ._1(defaultItemKind: defaultItemKind)
         
     }
     #endif
     
     
     init(content: ToolbarContentReference=ToolbarContentReference(value: [])) {
-        self.value = ._2(content: content)
+        self.value = ._3(content: content)
         
     }
     
     
     
     init(id: AttributeReference<Swift.String>,content: CustomizableToolbarContentReference=CustomizableToolbarContentReference(value: [])) {
-        self.value = ._3(id: id, content: content)
+        self.value = ._4(id: id, content: content)
         
     }
     
@@ -13570,9 +14734,20 @@ struct _toolbarModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
+        
+        case let ._0(visibility, bars):
+            
+            
+            
+            __content
+                .toolbar(visibility.resolve(on: element, in: context), for: bars)
+            
+                
+            
+        
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-        case let ._0(defaultItemKind):
-            if #available(watchOS 10.0,iOS 17.0,visionOS 1.0,tvOS 17.0,macOS 14.0, *) {
+        case let ._1(defaultItemKind):
+            if #available(macOS 14.0,iOS 17.0,watchOS 10.0,visionOS 1.0,tvOS 17.0, *) {
             let defaultItemKind = defaultItemKind as? SwiftUI.ToolbarDefaultItemKind
             
             __content
@@ -13582,7 +14757,7 @@ struct _toolbarModifier<R: RootRegistry>: ViewModifier {
             } else { __content }
         #endif
         
-        case let ._2(content):
+        case let ._3(content):
             
             
             
@@ -13593,7 +14768,7 @@ struct _toolbarModifier<R: RootRegistry>: ViewModifier {
             
         
         
-        case let ._3(id, content):
+        case let ._4(id, content):
             
             
             
@@ -13616,6 +14791,9 @@ struct _toolbarBackgroundModifier<R: RootRegistry>: ViewModifier {
         
         indirect case _0(style: AnyShapeStyle.Resolvable,bars: SwiftUI.ToolbarPlacement)
         
+        
+        indirect case _1(visibility: AttributeReference<SwiftUI.Visibility>,bars: SwiftUI.ToolbarPlacement)
+        
     }
 
     let value: Value
@@ -13627,10 +14805,19 @@ struct _toolbarBackgroundModifier<R: RootRegistry>: ViewModifier {
 
 
 
+
+
     
     
     init(_ style: AnyShapeStyle.Resolvable,for bars: SwiftUI.ToolbarPlacement) {
         self.value = ._0(style: style, bars: bars)
+        
+    }
+    
+    
+    
+    init(_ visibility: AttributeReference<SwiftUI.Visibility>,for bars: SwiftUI.ToolbarPlacement) {
+        self.value = ._1(visibility: visibility, bars: bars)
         
     }
     
@@ -13646,6 +14833,17 @@ struct _toolbarBackgroundModifier<R: RootRegistry>: ViewModifier {
             
             __content
                 .toolbarBackground(style.resolve(on: element, in: context), for: bars)
+            
+                
+            
+        
+        
+        case let ._1(visibility, bars):
+            
+            
+            
+            __content
+                .toolbarBackground(visibility.resolve(on: element, in: context), for: bars)
             
                 
             
@@ -13675,7 +14873,7 @@ struct _toolbarBackgroundVisibilityModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 15.0,watchOS 11.0,tvOS 18.0,iOS 18.0,visionOS 2.0, *)
+    @available(watchOS 11.0,visionOS 2.0,iOS 18.0,macOS 15.0,tvOS 18.0, *)
     init(_ visibility: AttributeReference<SwiftUI.Visibility>,for bars: SwiftUI.ToolbarPlacement) {
         self.value = ._0(visibility: visibility, bars: bars)
         
@@ -13688,7 +14886,7 @@ struct _toolbarBackgroundVisibilityModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(visibility, bars):
-            if #available(macOS 15.0,watchOS 11.0,tvOS 18.0,iOS 18.0,visionOS 2.0, *) {
+            if #available(watchOS 11.0,visionOS 2.0,iOS 18.0,macOS 15.0,tvOS 18.0, *) {
             let visibility = visibility as! AttributeReference<SwiftUI.Visibility>
 let bars = bars as! SwiftUI.ToolbarPlacement
             
@@ -13864,7 +15062,7 @@ struct _toolbarTitleDisplayModeModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0,visionOS 1.0, *)
+    @available(macOS 14.0,watchOS 10.0,visionOS 1.0,tvOS 17.0,iOS 17.0, *)
     init(_ mode: SwiftUI.ToolbarTitleDisplayMode) {
         self.value = ._0(mode: mode)
         
@@ -13877,7 +15075,7 @@ struct _toolbarTitleDisplayModeModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(mode):
-            if #available(macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0,visionOS 1.0, *) {
+            if #available(macOS 14.0,watchOS 10.0,visionOS 1.0,tvOS 17.0,iOS 17.0, *) {
             let mode = mode as! SwiftUI.ToolbarTitleDisplayMode
             
             __content
@@ -13958,7 +15156,7 @@ struct _toolbarVisibilityModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 15.0,watchOS 11.0,tvOS 18.0,iOS 18.0,visionOS 2.0, *)
+    @available(iOS 18.0,watchOS 11.0,tvOS 18.0,visionOS 2.0,macOS 15.0, *)
     init(_ visibility: AttributeReference<SwiftUI.Visibility>,for bars: SwiftUI.ToolbarPlacement) {
         self.value = ._0(visibility: visibility, bars: bars)
         
@@ -13971,7 +15169,7 @@ struct _toolbarVisibilityModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(visibility, bars):
-            if #available(macOS 15.0,watchOS 11.0,tvOS 18.0,iOS 18.0,visionOS 2.0, *) {
+            if #available(iOS 18.0,watchOS 11.0,tvOS 18.0,visionOS 2.0,macOS 15.0, *) {
             let visibility = visibility as! AttributeReference<SwiftUI.Visibility>
 let bars = bars as! SwiftUI.ToolbarPlacement
             
@@ -14617,7 +15815,7 @@ struct _windowToolbarFullScreenVisibilityModifier<R: RootRegistry>: ViewModifier
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 15.0,watchOS 11.0,tvOS 18.0,iOS 18.0,visionOS 2.0, *)
+    @available(watchOS 11.0,macOS 15.0,visionOS 2.0,iOS 18.0,tvOS 18.0, *)
     init(_ visibility: SwiftUI.WindowToolbarFullScreenVisibility) {
         self.value = ._0(visibility: visibility)
         
@@ -14630,7 +15828,7 @@ struct _windowToolbarFullScreenVisibilityModifier<R: RootRegistry>: ViewModifier
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(visibility):
-            if #available(macOS 15.0,watchOS 11.0,tvOS 18.0,iOS 18.0,visionOS 2.0, *) {
+            if #available(watchOS 11.0,macOS 15.0,visionOS 2.0,iOS 18.0,tvOS 18.0, *) {
             let visibility = visibility as! SwiftUI.WindowToolbarFullScreenVisibility
             
             __content
@@ -14739,7 +15937,8 @@ struct _zIndexModifier<R: RootRegistry>: ViewModifier {
 
 extension BuiltinRegistry {
     enum _BuiltinModifierChunk0: ViewModifier {
-        indirect case accessibilityAction(_accessibilityActionModifier<R>)
+        indirect case accentColor(_accentColorModifier<R>)
+indirect case accessibilityAction(_accessibilityActionModifier<R>)
 indirect case accessibilityActions(_accessibilityActionsModifier<R>)
 indirect case accessibilityChildren(_accessibilityChildrenModifier<R>)
 indirect case accessibilityIgnoresInvertColors(_accessibilityIgnoresInvertColorsModifier<R>)
@@ -14751,12 +15950,13 @@ indirect case allowsTightening(_allowsTighteningModifier<R>)
 indirect case allowsWindowActivationEvents(_allowsWindowActivationEventsModifier<R>)
 indirect case animation(_animationModifier<R>)
 indirect case aspectRatio(_aspectRatioModifier<R>)
-indirect case autocorrectionDisabled(_autocorrectionDisabledModifier<R>)
-indirect case background(_backgroundModifier<R>)
+indirect case autocapitalization(_autocapitalizationModifier<R>)
         
         func body(content: Content) -> some View {
             switch self {
-            case let .accessibilityAction(modifier):
+            case let .accentColor(modifier):
+    content.modifier(modifier)
+case let .accessibilityAction(modifier):
     content.modifier(modifier)
 case let .accessibilityActions(modifier):
     content.modifier(modifier)
@@ -14780,9 +15980,7 @@ case let .animation(modifier):
     content.modifier(modifier)
 case let .aspectRatio(modifier):
     content.modifier(modifier)
-case let .autocorrectionDisabled(modifier):
-    content.modifier(modifier)
-case let .background(modifier):
+case let .autocapitalization(modifier):
     content.modifier(modifier)
             }
         }
@@ -14790,7 +15988,9 @@ case let .background(modifier):
 }
 extension BuiltinRegistry {
     enum _BuiltinModifierChunk1: ViewModifier {
-        indirect case backgroundStyle(_backgroundStyleModifier<R>)
+        indirect case autocorrectionDisabled(_autocorrectionDisabledModifier<R>)
+indirect case background(_backgroundModifier<R>)
+indirect case backgroundStyle(_backgroundStyleModifier<R>)
 indirect case badge(_badgeModifier<R>)
 indirect case badgeProminence(_badgeProminenceModifier<R>)
 indirect case blendMode(_blendModeModifier<R>)
@@ -14802,12 +16002,14 @@ indirect case buttonStyle(_buttonStyleModifier<R>)
 indirect case clipShape(_clipShapeModifier<R>)
 indirect case clipped(_clippedModifier<R>)
 indirect case colorInvert(_colorInvertModifier<R>)
-indirect case colorMultiply(_colorMultiplyModifier<R>)
-indirect case compositingGroup(_compositingGroupModifier<R>)
         
         func body(content: Content) -> some View {
             switch self {
-            case let .backgroundStyle(modifier):
+            case let .autocorrectionDisabled(modifier):
+    content.modifier(modifier)
+case let .background(modifier):
+    content.modifier(modifier)
+case let .backgroundStyle(modifier):
     content.modifier(modifier)
 case let .badge(modifier):
     content.modifier(modifier)
@@ -14831,17 +16033,16 @@ case let .clipped(modifier):
     content.modifier(modifier)
 case let .colorInvert(modifier):
     content.modifier(modifier)
-case let .colorMultiply(modifier):
-    content.modifier(modifier)
-case let .compositingGroup(modifier):
-    content.modifier(modifier)
             }
         }
     }
 }
 extension BuiltinRegistry {
     enum _BuiltinModifierChunk2: ViewModifier {
-        indirect case confirmationDialog(_confirmationDialogModifier<R>)
+        indirect case colorMultiply(_colorMultiplyModifier<R>)
+indirect case colorScheme(_colorSchemeModifier<R>)
+indirect case compositingGroup(_compositingGroupModifier<R>)
+indirect case confirmationDialog(_confirmationDialogModifier<R>)
 indirect case containerRelativeFrame(_containerRelativeFrameModifier<R>)
 indirect case containerShape(_containerShapeModifier<R>)
 indirect case contentMargins(_contentMarginsModifier<R>)
@@ -14852,13 +16053,16 @@ indirect case contrast(_contrastModifier<R>)
 indirect case controlGroupStyle(_controlGroupStyleModifier<R>)
 indirect case controlSize(_controlSizeModifier<R>)
 indirect case coordinateSpace(_coordinateSpaceModifier<R>)
-indirect case datePickerStyle(_datePickerStyleModifier<R>)
-indirect case defaultAdaptableTabBarPlacement(_defaultAdaptableTabBarPlacementModifier<R>)
-indirect case defaultHoverEffect(_defaultHoverEffectModifier<R>)
         
         func body(content: Content) -> some View {
             switch self {
-            case let .confirmationDialog(modifier):
+            case let .colorMultiply(modifier):
+    content.modifier(modifier)
+case let .colorScheme(modifier):
+    content.modifier(modifier)
+case let .compositingGroup(modifier):
+    content.modifier(modifier)
+case let .confirmationDialog(modifier):
     content.modifier(modifier)
 case let .containerRelativeFrame(modifier):
     content.modifier(modifier)
@@ -14880,36 +16084,38 @@ case let .controlSize(modifier):
     content.modifier(modifier)
 case let .coordinateSpace(modifier):
     content.modifier(modifier)
-case let .datePickerStyle(modifier):
-    content.modifier(modifier)
-case let .defaultAdaptableTabBarPlacement(modifier):
-    content.modifier(modifier)
-case let .defaultHoverEffect(modifier):
-    content.modifier(modifier)
             }
         }
     }
 }
 extension BuiltinRegistry {
     enum _BuiltinModifierChunk3: ViewModifier {
-        indirect case defaultScrollAnchor(_defaultScrollAnchorModifier<R>)
+        indirect case cornerRadius(_cornerRadiusModifier<R>)
+indirect case datePickerStyle(_datePickerStyleModifier<R>)
+indirect case defaultAdaptableTabBarPlacement(_defaultAdaptableTabBarPlacementModifier<R>)
+indirect case defaultHoverEffect(_defaultHoverEffectModifier<R>)
+indirect case defaultScrollAnchor(_defaultScrollAnchorModifier<R>)
 indirect case defaultWheelPickerItemHeight(_defaultWheelPickerItemHeightModifier<R>)
 indirect case defersSystemGestures(_defersSystemGesturesModifier<R>)
 indirect case deleteDisabled(_deleteDisabledModifier<R>)
 indirect case dialogSuppressionToggle(_dialogSuppressionToggleModifier<R>)
 indirect case digitalCrownAccessory(_digitalCrownAccessoryModifier<R>)
+indirect case disableAutocorrection(_disableAutocorrectionModifier<R>)
 indirect case disabled(_disabledModifier<R>)
+indirect case disclosureGroupStyle(_disclosureGroupStyleModifier<R>)
 indirect case dismissalConfirmationDialog(_dismissalConfirmationDialogModifier<R>)
-indirect case drawingGroup(_drawingGroupModifier<R>)
-indirect case dynamicTypeSize(_dynamicTypeSizeModifier<R>)
-indirect case fileDialogCustomizationID(_fileDialogCustomizationIDModifier<R>)
-indirect case fileDialogImportsUnresolvedAliases(_fileDialogImportsUnresolvedAliasesModifier<R>)
-indirect case findDisabled(_findDisabledModifier<R>)
-indirect case findNavigator(_findNavigatorModifier<R>)
         
         func body(content: Content) -> some View {
             switch self {
-            case let .defaultScrollAnchor(modifier):
+            case let .cornerRadius(modifier):
+    content.modifier(modifier)
+case let .datePickerStyle(modifier):
+    content.modifier(modifier)
+case let .defaultAdaptableTabBarPlacement(modifier):
+    content.modifier(modifier)
+case let .defaultHoverEffect(modifier):
+    content.modifier(modifier)
+case let .defaultScrollAnchor(modifier):
     content.modifier(modifier)
 case let .defaultWheelPickerItemHeight(modifier):
     content.modifier(modifier)
@@ -14921,13 +16127,42 @@ case let .dialogSuppressionToggle(modifier):
     content.modifier(modifier)
 case let .digitalCrownAccessory(modifier):
     content.modifier(modifier)
+case let .disableAutocorrection(modifier):
+    content.modifier(modifier)
 case let .disabled(modifier):
+    content.modifier(modifier)
+case let .disclosureGroupStyle(modifier):
     content.modifier(modifier)
 case let .dismissalConfirmationDialog(modifier):
     content.modifier(modifier)
-case let .drawingGroup(modifier):
+            }
+        }
+    }
+}
+extension BuiltinRegistry {
+    enum _BuiltinModifierChunk4: ViewModifier {
+        indirect case drawingGroup(_drawingGroupModifier<R>)
+indirect case dynamicTypeSize(_dynamicTypeSizeModifier<R>)
+indirect case edgesIgnoringSafeArea(_edgesIgnoringSafeAreaModifier<R>)
+indirect case fileDialogCustomizationID(_fileDialogCustomizationIDModifier<R>)
+indirect case fileDialogImportsUnresolvedAliases(_fileDialogImportsUnresolvedAliasesModifier<R>)
+indirect case findDisabled(_findDisabledModifier<R>)
+indirect case findNavigator(_findNavigatorModifier<R>)
+indirect case fixedSize(_fixedSizeModifier<R>)
+indirect case flipsForRightToLeftLayoutDirection(_flipsForRightToLeftLayoutDirectionModifier<R>)
+indirect case focusEffectDisabled(_focusEffectDisabledModifier<R>)
+indirect case focusSection(_focusSectionModifier<R>)
+indirect case focusable(_focusableModifier<R>)
+indirect case foregroundColor(_foregroundColorModifier<R>)
+indirect case formStyle(_formStyleModifier<R>)
+        
+        func body(content: Content) -> some View {
+            switch self {
+            case let .drawingGroup(modifier):
     content.modifier(modifier)
 case let .dynamicTypeSize(modifier):
+    content.modifier(modifier)
+case let .edgesIgnoringSafeArea(modifier):
     content.modifier(modifier)
 case let .fileDialogCustomizationID(modifier):
     content.modifier(modifier)
@@ -14937,30 +16172,7 @@ case let .findDisabled(modifier):
     content.modifier(modifier)
 case let .findNavigator(modifier):
     content.modifier(modifier)
-            }
-        }
-    }
-}
-extension BuiltinRegistry {
-    enum _BuiltinModifierChunk4: ViewModifier {
-        indirect case fixedSize(_fixedSizeModifier<R>)
-indirect case flipsForRightToLeftLayoutDirection(_flipsForRightToLeftLayoutDirectionModifier<R>)
-indirect case focusEffectDisabled(_focusEffectDisabledModifier<R>)
-indirect case focusSection(_focusSectionModifier<R>)
-indirect case focusable(_focusableModifier<R>)
-indirect case formStyle(_formStyleModifier<R>)
-indirect case frame(_frameModifier<R>)
-indirect case fullScreenCover(_fullScreenCoverModifier<R>)
-indirect case gaugeStyle(_gaugeStyleModifier<R>)
-indirect case geometryGroup(_geometryGroupModifier<R>)
-indirect case gesture(_gestureModifier<R>)
-indirect case glassBackgroundEffect(_glassBackgroundEffectModifier<R>)
-indirect case grayscale(_grayscaleModifier<R>)
-indirect case gridCellAnchor(_gridCellAnchorModifier<R>)
-        
-        func body(content: Content) -> some View {
-            switch self {
-            case let .fixedSize(modifier):
+case let .fixedSize(modifier):
     content.modifier(modifier)
 case let .flipsForRightToLeftLayoutDirection(modifier):
     content.modifier(modifier)
@@ -14970,9 +16182,34 @@ case let .focusSection(modifier):
     content.modifier(modifier)
 case let .focusable(modifier):
     content.modifier(modifier)
+case let .foregroundColor(modifier):
+    content.modifier(modifier)
 case let .formStyle(modifier):
     content.modifier(modifier)
-case let .frame(modifier):
+            }
+        }
+    }
+}
+extension BuiltinRegistry {
+    enum _BuiltinModifierChunk5: ViewModifier {
+        indirect case frame(_frameModifier<R>)
+indirect case fullScreenCover(_fullScreenCoverModifier<R>)
+indirect case gaugeStyle(_gaugeStyleModifier<R>)
+indirect case geometryGroup(_geometryGroupModifier<R>)
+indirect case gesture(_gestureModifier<R>)
+indirect case glassBackgroundEffect(_glassBackgroundEffectModifier<R>)
+indirect case grayscale(_grayscaleModifier<R>)
+indirect case gridCellAnchor(_gridCellAnchorModifier<R>)
+indirect case gridCellColumns(_gridCellColumnsModifier<R>)
+indirect case gridCellUnsizedAxes(_gridCellUnsizedAxesModifier<R>)
+indirect case gridColumnAlignment(_gridColumnAlignmentModifier<R>)
+indirect case groupBoxStyle(_groupBoxStyleModifier<R>)
+indirect case handGestureShortcut(_handGestureShortcutModifier<R>)
+indirect case handPointerBehavior(_handPointerBehaviorModifier<R>)
+        
+        func body(content: Content) -> some View {
+            switch self {
+            case let .frame(modifier):
     content.modifier(modifier)
 case let .fullScreenCover(modifier):
     content.modifier(modifier)
@@ -14988,30 +16225,7 @@ case let .grayscale(modifier):
     content.modifier(modifier)
 case let .gridCellAnchor(modifier):
     content.modifier(modifier)
-            }
-        }
-    }
-}
-extension BuiltinRegistry {
-    enum _BuiltinModifierChunk5: ViewModifier {
-        indirect case gridCellColumns(_gridCellColumnsModifier<R>)
-indirect case gridCellUnsizedAxes(_gridCellUnsizedAxesModifier<R>)
-indirect case gridColumnAlignment(_gridColumnAlignmentModifier<R>)
-indirect case groupBoxStyle(_groupBoxStyleModifier<R>)
-indirect case handGestureShortcut(_handGestureShortcutModifier<R>)
-indirect case handPointerBehavior(_handPointerBehaviorModifier<R>)
-indirect case headerProminence(_headerProminenceModifier<R>)
-indirect case help(_helpModifier<R>)
-indirect case hidden(_hiddenModifier<R>)
-indirect case highPriorityGesture(_highPriorityGestureModifier<R>)
-indirect case horizontalRadioGroupLayout(_horizontalRadioGroupLayoutModifier<R>)
-indirect case hoverEffect(_hoverEffectModifier<R>)
-indirect case hoverEffectDisabled(_hoverEffectDisabledModifier<R>)
-indirect case hoverEffectGroup(_hoverEffectGroupModifier<R>)
-        
-        func body(content: Content) -> some View {
-            switch self {
-            case let .gridCellColumns(modifier):
+case let .gridCellColumns(modifier):
     content.modifier(modifier)
 case let .gridCellUnsizedAxes(modifier):
     content.modifier(modifier)
@@ -15023,7 +16237,30 @@ case let .handGestureShortcut(modifier):
     content.modifier(modifier)
 case let .handPointerBehavior(modifier):
     content.modifier(modifier)
-case let .headerProminence(modifier):
+            }
+        }
+    }
+}
+extension BuiltinRegistry {
+    enum _BuiltinModifierChunk6: ViewModifier {
+        indirect case headerProminence(_headerProminenceModifier<R>)
+indirect case help(_helpModifier<R>)
+indirect case hidden(_hiddenModifier<R>)
+indirect case highPriorityGesture(_highPriorityGestureModifier<R>)
+indirect case horizontalRadioGroupLayout(_horizontalRadioGroupLayoutModifier<R>)
+indirect case hoverEffect(_hoverEffectModifier<R>)
+indirect case hoverEffectDisabled(_hoverEffectDisabledModifier<R>)
+indirect case hoverEffectGroup(_hoverEffectGroupModifier<R>)
+indirect case hueRotation(_hueRotationModifier<R>)
+indirect case ignoresSafeArea(_ignoresSafeAreaModifier<R>)
+indirect case imageScale(_imageScaleModifier<R>)
+indirect case immersiveEnvironmentPicker(_immersiveEnvironmentPickerModifier<R>)
+indirect case indexViewStyle(_indexViewStyleModifier<R>)
+indirect case inspector(_inspectorModifier<R>)
+        
+        func body(content: Content) -> some View {
+            switch self {
+            case let .headerProminence(modifier):
     content.modifier(modifier)
 case let .help(modifier):
     content.modifier(modifier)
@@ -15039,30 +16276,7 @@ case let .hoverEffectDisabled(modifier):
     content.modifier(modifier)
 case let .hoverEffectGroup(modifier):
     content.modifier(modifier)
-            }
-        }
-    }
-}
-extension BuiltinRegistry {
-    enum _BuiltinModifierChunk6: ViewModifier {
-        indirect case hueRotation(_hueRotationModifier<R>)
-indirect case ignoresSafeArea(_ignoresSafeAreaModifier<R>)
-indirect case imageScale(_imageScaleModifier<R>)
-indirect case immersiveEnvironmentPicker(_immersiveEnvironmentPickerModifier<R>)
-indirect case indexViewStyle(_indexViewStyleModifier<R>)
-indirect case inspector(_inspectorModifier<R>)
-indirect case inspectorColumnWidth(_inspectorColumnWidthModifier<R>)
-indirect case interactionActivityTrackingTag(_interactionActivityTrackingTagModifier<R>)
-indirect case interactiveDismissDisabled(_interactiveDismissDisabledModifier<R>)
-indirect case invalidatableContent(_invalidatableContentModifier<R>)
-indirect case keyboardShortcut(_keyboardShortcutModifier<R>)
-indirect case keyboardType(_keyboardTypeModifier<R>)
-indirect case labelStyle(_labelStyleModifier<R>)
-indirect case labeledContentStyle(_labeledContentStyleModifier<R>)
-        
-        func body(content: Content) -> some View {
-            switch self {
-            case let .hueRotation(modifier):
+case let .hueRotation(modifier):
     content.modifier(modifier)
 case let .ignoresSafeArea(modifier):
     content.modifier(modifier)
@@ -15074,7 +16288,30 @@ case let .indexViewStyle(modifier):
     content.modifier(modifier)
 case let .inspector(modifier):
     content.modifier(modifier)
-case let .inspectorColumnWidth(modifier):
+            }
+        }
+    }
+}
+extension BuiltinRegistry {
+    enum _BuiltinModifierChunk7: ViewModifier {
+        indirect case inspectorColumnWidth(_inspectorColumnWidthModifier<R>)
+indirect case interactionActivityTrackingTag(_interactionActivityTrackingTagModifier<R>)
+indirect case interactiveDismissDisabled(_interactiveDismissDisabledModifier<R>)
+indirect case invalidatableContent(_invalidatableContentModifier<R>)
+indirect case keyboardShortcut(_keyboardShortcutModifier<R>)
+indirect case keyboardType(_keyboardTypeModifier<R>)
+indirect case labelStyle(_labelStyleModifier<R>)
+indirect case labeledContentStyle(_labeledContentStyleModifier<R>)
+indirect case labelsHidden(_labelsHiddenModifier<R>)
+indirect case labelsVisibility(_labelsVisibilityModifier<R>)
+indirect case layoutPriority(_layoutPriorityModifier<R>)
+indirect case lineLimit(_lineLimitModifier<R>)
+indirect case lineSpacing(_lineSpacingModifier<R>)
+indirect case listItemTint(_listItemTintModifier<R>)
+        
+        func body(content: Content) -> some View {
+            switch self {
+            case let .inspectorColumnWidth(modifier):
     content.modifier(modifier)
 case let .interactionActivityTrackingTag(modifier):
     content.modifier(modifier)
@@ -15090,30 +16327,7 @@ case let .labelStyle(modifier):
     content.modifier(modifier)
 case let .labeledContentStyle(modifier):
     content.modifier(modifier)
-            }
-        }
-    }
-}
-extension BuiltinRegistry {
-    enum _BuiltinModifierChunk7: ViewModifier {
-        indirect case labelsHidden(_labelsHiddenModifier<R>)
-indirect case labelsVisibility(_labelsVisibilityModifier<R>)
-indirect case layoutPriority(_layoutPriorityModifier<R>)
-indirect case lineLimit(_lineLimitModifier<R>)
-indirect case lineSpacing(_lineSpacingModifier<R>)
-indirect case listItemTint(_listItemTintModifier<R>)
-indirect case listRowBackground(_listRowBackgroundModifier<R>)
-indirect case listRowHoverEffect(_listRowHoverEffectModifier<R>)
-indirect case listRowHoverEffectDisabled(_listRowHoverEffectDisabledModifier<R>)
-indirect case listRowInsets(_listRowInsetsModifier<R>)
-indirect case listRowSeparator(_listRowSeparatorModifier<R>)
-indirect case listRowSeparatorTint(_listRowSeparatorTintModifier<R>)
-indirect case listRowSpacing(_listRowSpacingModifier<R>)
-indirect case listSectionSeparator(_listSectionSeparatorModifier<R>)
-        
-        func body(content: Content) -> some View {
-            switch self {
-            case let .labelsHidden(modifier):
+case let .labelsHidden(modifier):
     content.modifier(modifier)
 case let .labelsVisibility(modifier):
     content.modifier(modifier)
@@ -15125,13 +16339,38 @@ case let .lineSpacing(modifier):
     content.modifier(modifier)
 case let .listItemTint(modifier):
     content.modifier(modifier)
-case let .listRowBackground(modifier):
+            }
+        }
+    }
+}
+extension BuiltinRegistry {
+    enum _BuiltinModifierChunk8: ViewModifier {
+        indirect case listRowBackground(_listRowBackgroundModifier<R>)
+indirect case listRowHoverEffect(_listRowHoverEffectModifier<R>)
+indirect case listRowHoverEffectDisabled(_listRowHoverEffectDisabledModifier<R>)
+indirect case listRowInsets(_listRowInsetsModifier<R>)
+indirect case listRowPlatterColor(_listRowPlatterColorModifier<R>)
+indirect case listRowSeparator(_listRowSeparatorModifier<R>)
+indirect case listRowSeparatorTint(_listRowSeparatorTintModifier<R>)
+indirect case listRowSpacing(_listRowSpacingModifier<R>)
+indirect case listSectionSeparator(_listSectionSeparatorModifier<R>)
+indirect case listSectionSeparatorTint(_listSectionSeparatorTintModifier<R>)
+indirect case listSectionSpacing(_listSectionSpacingModifier<R>)
+indirect case listStyle(_listStyleModifier<R>)
+indirect case luminanceToAlpha(_luminanceToAlphaModifier<R>)
+indirect case materialActiveAppearance(_materialActiveAppearanceModifier<R>)
+        
+        func body(content: Content) -> some View {
+            switch self {
+            case let .listRowBackground(modifier):
     content.modifier(modifier)
 case let .listRowHoverEffect(modifier):
     content.modifier(modifier)
 case let .listRowHoverEffectDisabled(modifier):
     content.modifier(modifier)
 case let .listRowInsets(modifier):
+    content.modifier(modifier)
+case let .listRowPlatterColor(modifier):
     content.modifier(modifier)
 case let .listRowSeparator(modifier):
     content.modifier(modifier)
@@ -15141,30 +16380,7 @@ case let .listRowSpacing(modifier):
     content.modifier(modifier)
 case let .listSectionSeparator(modifier):
     content.modifier(modifier)
-            }
-        }
-    }
-}
-extension BuiltinRegistry {
-    enum _BuiltinModifierChunk8: ViewModifier {
-        indirect case listSectionSeparatorTint(_listSectionSeparatorTintModifier<R>)
-indirect case listSectionSpacing(_listSectionSpacingModifier<R>)
-indirect case listStyle(_listStyleModifier<R>)
-indirect case luminanceToAlpha(_luminanceToAlphaModifier<R>)
-indirect case materialActiveAppearance(_materialActiveAppearanceModifier<R>)
-indirect case menuIndicator(_menuIndicatorModifier<R>)
-indirect case menuOrder(_menuOrderModifier<R>)
-indirect case menuStyle(_menuStyleModifier<R>)
-indirect case minimumScaleFactor(_minimumScaleFactorModifier<R>)
-indirect case modifierKeyAlternate(_modifierKeyAlternateModifier<R>)
-indirect case moveDisabled(_moveDisabledModifier<R>)
-indirect case multilineTextAlignment(_multilineTextAlignmentModifier<R>)
-indirect case navigationBarBackButtonHidden(_navigationBarBackButtonHiddenModifier<R>)
-indirect case navigationBarTitleDisplayMode(_navigationBarTitleDisplayModeModifier<R>)
-        
-        func body(content: Content) -> some View {
-            switch self {
-            case let .listSectionSeparatorTint(modifier):
+case let .listSectionSeparatorTint(modifier):
     content.modifier(modifier)
 case let .listSectionSpacing(modifier):
     content.modifier(modifier)
@@ -15173,6 +16389,31 @@ case let .listStyle(modifier):
 case let .luminanceToAlpha(modifier):
     content.modifier(modifier)
 case let .materialActiveAppearance(modifier):
+    content.modifier(modifier)
+            }
+        }
+    }
+}
+extension BuiltinRegistry {
+    enum _BuiltinModifierChunk9: ViewModifier {
+        indirect case menuButtonStyle(_menuButtonStyleModifier<R>)
+indirect case menuIndicator(_menuIndicatorModifier<R>)
+indirect case menuOrder(_menuOrderModifier<R>)
+indirect case menuStyle(_menuStyleModifier<R>)
+indirect case minimumScaleFactor(_minimumScaleFactorModifier<R>)
+indirect case modifierKeyAlternate(_modifierKeyAlternateModifier<R>)
+indirect case moveDisabled(_moveDisabledModifier<R>)
+indirect case multilineTextAlignment(_multilineTextAlignmentModifier<R>)
+indirect case navigationBarBackButtonHidden(_navigationBarBackButtonHiddenModifier<R>)
+indirect case navigationBarHidden(_navigationBarHiddenModifier<R>)
+indirect case navigationBarItems(_navigationBarItemsModifier<R>)
+indirect case navigationBarTitle(_navigationBarTitleModifier<R>)
+indirect case navigationBarTitleDisplayMode(_navigationBarTitleDisplayModeModifier<R>)
+indirect case navigationDestination(_navigationDestinationModifier<R>)
+        
+        func body(content: Content) -> some View {
+            switch self {
+            case let .menuButtonStyle(modifier):
     content.modifier(modifier)
 case let .menuIndicator(modifier):
     content.modifier(modifier)
@@ -15190,19 +16431,27 @@ case let .multilineTextAlignment(modifier):
     content.modifier(modifier)
 case let .navigationBarBackButtonHidden(modifier):
     content.modifier(modifier)
+case let .navigationBarHidden(modifier):
+    content.modifier(modifier)
+case let .navigationBarItems(modifier):
+    content.modifier(modifier)
+case let .navigationBarTitle(modifier):
+    content.modifier(modifier)
 case let .navigationBarTitleDisplayMode(modifier):
+    content.modifier(modifier)
+case let .navigationDestination(modifier):
     content.modifier(modifier)
             }
         }
     }
 }
 extension BuiltinRegistry {
-    enum _BuiltinModifierChunk9: ViewModifier {
-        indirect case navigationDestination(_navigationDestinationModifier<R>)
-indirect case navigationSplitViewColumnWidth(_navigationSplitViewColumnWidthModifier<R>)
+    enum _BuiltinModifierChunk10: ViewModifier {
+        indirect case navigationSplitViewColumnWidth(_navigationSplitViewColumnWidthModifier<R>)
 indirect case navigationSplitViewStyle(_navigationSplitViewStyleModifier<R>)
 indirect case navigationSubtitle(_navigationSubtitleModifier<R>)
 indirect case navigationTitle(_navigationTitleModifier<R>)
+indirect case navigationViewStyle(_navigationViewStyleModifier<R>)
 indirect case offset(_offsetModifier<R>)
 indirect case onAppear(_onAppearModifier<R>)
 indirect case onDeleteCommand(_onDeleteCommandModifier<R>)
@@ -15215,15 +16464,15 @@ indirect case onLongTouchGesture(_onLongTouchGestureModifier<R>)
         
         func body(content: Content) -> some View {
             switch self {
-            case let .navigationDestination(modifier):
-    content.modifier(modifier)
-case let .navigationSplitViewColumnWidth(modifier):
+            case let .navigationSplitViewColumnWidth(modifier):
     content.modifier(modifier)
 case let .navigationSplitViewStyle(modifier):
     content.modifier(modifier)
 case let .navigationSubtitle(modifier):
     content.modifier(modifier)
 case let .navigationTitle(modifier):
+    content.modifier(modifier)
+case let .navigationViewStyle(modifier):
     content.modifier(modifier)
 case let .offset(modifier):
     content.modifier(modifier)
@@ -15248,7 +16497,7 @@ case let .onLongTouchGesture(modifier):
     }
 }
 extension BuiltinRegistry {
-    enum _BuiltinModifierChunk10: ViewModifier {
+    enum _BuiltinModifierChunk11: ViewModifier {
         indirect case onModifierKeysChanged(_onModifierKeysChangedModifier<R>)
 indirect case onMoveCommand(_onMoveCommandModifier<R>)
 indirect case onPencilDoubleTap(_onPencilDoubleTapModifier<R>)
@@ -15299,7 +16548,7 @@ case let .padding3D(modifier):
     }
 }
 extension BuiltinRegistry {
-    enum _BuiltinModifierChunk11: ViewModifier {
+    enum _BuiltinModifierChunk12: ViewModifier {
         indirect case persistentSystemOverlays(_persistentSystemOverlaysModifier<R>)
 indirect case pickerStyle(_pickerStyleModifier<R>)
 indirect case pointerStyle(_pointerStyleModifier<R>)
@@ -15350,7 +16599,7 @@ case let .presentationDragIndicator(modifier):
     }
 }
 extension BuiltinRegistry {
-    enum _BuiltinModifierChunk12: ViewModifier {
+    enum _BuiltinModifierChunk13: ViewModifier {
         indirect case presentationSizing(_presentationSizingModifier<R>)
 indirect case previewDisplayName(_previewDisplayNameModifier<R>)
 indirect case privacySensitive(_privacySensitiveModifier<R>)
@@ -15401,7 +16650,7 @@ case let .scaleEffect(modifier):
     }
 }
 extension BuiltinRegistry {
-    enum _BuiltinModifierChunk13: ViewModifier {
+    enum _BuiltinModifierChunk14: ViewModifier {
         indirect case scaledToFill(_scaledToFillModifier<R>)
 indirect case scaledToFit(_scaledToFitModifier<R>)
 indirect case scenePadding(_scenePaddingModifier<R>)
@@ -15452,7 +16701,7 @@ case let .searchDictationBehavior(modifier):
     }
 }
 extension BuiltinRegistry {
-    enum _BuiltinModifierChunk14: ViewModifier {
+    enum _BuiltinModifierChunk15: ViewModifier {
         indirect case searchPresentationToolbarBehavior(_searchPresentationToolbarBehaviorModifier<R>)
 indirect case searchSuggestions(_searchSuggestionsModifier<R>)
 indirect case searchable(_searchableModifier<R>)
@@ -15465,8 +16714,8 @@ indirect case speechAdjustedPitch(_speechAdjustedPitchModifier<R>)
 indirect case speechAlwaysIncludesPunctuation(_speechAlwaysIncludesPunctuationModifier<R>)
 indirect case speechAnnouncementsQueued(_speechAnnouncementsQueuedModifier<R>)
 indirect case speechSpellsOutCharacters(_speechSpellsOutCharactersModifier<R>)
+indirect case statusBar(_statusBarModifier<R>)
 indirect case statusBarHidden(_statusBarHiddenModifier<R>)
-indirect case submitLabel(_submitLabelModifier<R>)
         
         func body(content: Content) -> some View {
             switch self {
@@ -15494,34 +16743,36 @@ case let .speechAnnouncementsQueued(modifier):
     content.modifier(modifier)
 case let .speechSpellsOutCharacters(modifier):
     content.modifier(modifier)
-case let .statusBarHidden(modifier):
+case let .statusBar(modifier):
     content.modifier(modifier)
-case let .submitLabel(modifier):
+case let .statusBarHidden(modifier):
     content.modifier(modifier)
             }
         }
     }
 }
 extension BuiltinRegistry {
-    enum _BuiltinModifierChunk15: ViewModifier {
-        indirect case submitScope(_submitScopeModifier<R>)
+    enum _BuiltinModifierChunk16: ViewModifier {
+        indirect case submitLabel(_submitLabelModifier<R>)
+indirect case submitScope(_submitScopeModifier<R>)
 indirect case supportedVolumeViewpoints(_supportedVolumeViewpointsModifier<R>)
 indirect case swipeActions(_swipeActionsModifier<R>)
 indirect case symbolEffect(_symbolEffectModifier<R>)
 indirect case symbolEffectsRemoved(_symbolEffectsRemovedModifier<R>)
 indirect case symbolRenderingMode(_symbolRenderingModeModifier<R>)
 indirect case symbolVariant(_symbolVariantModifier<R>)
+indirect case tabItem(_tabItemModifier<R>)
 indirect case tabViewSidebarBottomBar(_tabViewSidebarBottomBarModifier<R>)
 indirect case tabViewSidebarFooter(_tabViewSidebarFooterModifier<R>)
 indirect case tabViewSidebarHeader(_tabViewSidebarHeaderModifier<R>)
 indirect case tabViewStyle(_tabViewStyleModifier<R>)
 indirect case tableStyle(_tableStyleModifier<R>)
-indirect case textCase(_textCaseModifier<R>)
-indirect case textContentType(_textContentTypeModifier<R>)
         
         func body(content: Content) -> some View {
             switch self {
-            case let .submitScope(modifier):
+            case let .submitLabel(modifier):
+    content.modifier(modifier)
+case let .submitScope(modifier):
     content.modifier(modifier)
 case let .supportedVolumeViewpoints(modifier):
     content.modifier(modifier)
@@ -15535,6 +16786,8 @@ case let .symbolRenderingMode(modifier):
     content.modifier(modifier)
 case let .symbolVariant(modifier):
     content.modifier(modifier)
+case let .tabItem(modifier):
+    content.modifier(modifier)
 case let .tabViewSidebarBottomBar(modifier):
     content.modifier(modifier)
 case let .tabViewSidebarFooter(modifier):
@@ -15545,17 +16798,15 @@ case let .tabViewStyle(modifier):
     content.modifier(modifier)
 case let .tableStyle(modifier):
     content.modifier(modifier)
-case let .textCase(modifier):
-    content.modifier(modifier)
-case let .textContentType(modifier):
-    content.modifier(modifier)
             }
         }
     }
 }
 extension BuiltinRegistry {
-    enum _BuiltinModifierChunk16: ViewModifier {
-        indirect case textEditorStyle(_textEditorStyleModifier<R>)
+    enum _BuiltinModifierChunk17: ViewModifier {
+        indirect case textCase(_textCaseModifier<R>)
+indirect case textContentType(_textContentTypeModifier<R>)
+indirect case textEditorStyle(_textEditorStyleModifier<R>)
 indirect case textFieldStyle(_textFieldStyleModifier<R>)
 indirect case textInputAutocapitalization(_textInputAutocapitalizationModifier<R>)
 indirect case textInputCompletion(_textInputCompletionModifier<R>)
@@ -15567,12 +16818,14 @@ indirect case toggleStyle(_toggleStyleModifier<R>)
 indirect case toolbar(_toolbarModifier<R>)
 indirect case toolbarBackground(_toolbarBackgroundModifier<R>)
 indirect case toolbarBackgroundVisibility(_toolbarBackgroundVisibilityModifier<R>)
-indirect case toolbarColorScheme(_toolbarColorSchemeModifier<R>)
-indirect case toolbarItemHidden(_toolbarItemHiddenModifier<R>)
         
         func body(content: Content) -> some View {
             switch self {
-            case let .textEditorStyle(modifier):
+            case let .textCase(modifier):
+    content.modifier(modifier)
+case let .textContentType(modifier):
+    content.modifier(modifier)
+case let .textEditorStyle(modifier):
     content.modifier(modifier)
 case let .textFieldStyle(modifier):
     content.modifier(modifier)
@@ -15596,17 +16849,15 @@ case let .toolbarBackground(modifier):
     content.modifier(modifier)
 case let .toolbarBackgroundVisibility(modifier):
     content.modifier(modifier)
-case let .toolbarColorScheme(modifier):
-    content.modifier(modifier)
-case let .toolbarItemHidden(modifier):
-    content.modifier(modifier)
             }
         }
     }
 }
 extension BuiltinRegistry {
-    enum _BuiltinModifierChunk17: ViewModifier {
-        indirect case toolbarRole(_toolbarRoleModifier<R>)
+    enum _BuiltinModifierChunk18: ViewModifier {
+        indirect case toolbarColorScheme(_toolbarColorSchemeModifier<R>)
+indirect case toolbarItemHidden(_toolbarItemHiddenModifier<R>)
+indirect case toolbarRole(_toolbarRoleModifier<R>)
 indirect case toolbarTitleDisplayMode(_toolbarTitleDisplayModeModifier<R>)
 indirect case toolbarTitleMenu(_toolbarTitleMenuModifier<R>)
 indirect case toolbarVisibility(_toolbarVisibilityModifier<R>)
@@ -15618,12 +16869,14 @@ indirect case transition(_transitionModifier<R>)
 indirect case truncationMode(_truncationModeModifier<R>)
 indirect case unredacted(_unredactedModifier<R>)
 indirect case upperLimbVisibility(_upperLimbVisibilityModifier<R>)
-indirect case volumeBaseplateVisibility(_volumeBaseplateVisibilityModifier<R>)
-indirect case windowDismissBehavior(_windowDismissBehaviorModifier<R>)
         
         func body(content: Content) -> some View {
             switch self {
-            case let .toolbarRole(modifier):
+            case let .toolbarColorScheme(modifier):
+    content.modifier(modifier)
+case let .toolbarItemHidden(modifier):
+    content.modifier(modifier)
+case let .toolbarRole(modifier):
     content.modifier(modifier)
 case let .toolbarTitleDisplayMode(modifier):
     content.modifier(modifier)
@@ -15647,17 +16900,15 @@ case let .unredacted(modifier):
     content.modifier(modifier)
 case let .upperLimbVisibility(modifier):
     content.modifier(modifier)
-case let .volumeBaseplateVisibility(modifier):
-    content.modifier(modifier)
-case let .windowDismissBehavior(modifier):
-    content.modifier(modifier)
             }
         }
     }
 }
 extension BuiltinRegistry {
-    enum _BuiltinModifierChunk18: ViewModifier {
-        indirect case windowFullScreenBehavior(_windowFullScreenBehaviorModifier<R>)
+    enum _BuiltinModifierChunk19: ViewModifier {
+        indirect case volumeBaseplateVisibility(_volumeBaseplateVisibilityModifier<R>)
+indirect case windowDismissBehavior(_windowDismissBehaviorModifier<R>)
+indirect case windowFullScreenBehavior(_windowFullScreenBehaviorModifier<R>)
 indirect case windowMinimizeBehavior(_windowMinimizeBehaviorModifier<R>)
 indirect case windowResizeBehavior(_windowResizeBehaviorModifier<R>)
 indirect case windowToolbarFullScreenVisibility(_windowToolbarFullScreenVisibilityModifier<R>)
@@ -15666,7 +16917,11 @@ indirect case zIndex(_zIndexModifier<R>)
         
         func body(content: Content) -> some View {
             switch self {
-            case let .windowFullScreenBehavior(modifier):
+            case let .volumeBaseplateVisibility(modifier):
+    content.modifier(modifier)
+case let .windowDismissBehavior(modifier):
+    content.modifier(modifier)
+case let .windowFullScreenBehavior(modifier):
     content.modifier(modifier)
 case let .windowMinimizeBehavior(modifier):
     content.modifier(modifier)
@@ -15703,18 +16958,19 @@ indirect case chunk15(_BuiltinModifierChunk15)
 indirect case chunk16(_BuiltinModifierChunk16)
 indirect case chunk17(_BuiltinModifierChunk17)
 indirect case chunk18(_BuiltinModifierChunk18)
-        indirect case _SearchCompletionModifier(LiveViewNative._SearchCompletionModifier<R>)
-indirect case _PerspectiveRotationEffectModifier(LiveViewNative._PerspectiveRotationEffectModifier<R>)
-indirect case _SearchScopesModifier(LiveViewNative._SearchScopesModifier<R>)
-indirect case _MatchedGeometryEffectModifier(LiveViewNative._MatchedGeometryEffectModifier<R>)
-indirect case _Rotation3DEffectModifier(LiveViewNative._Rotation3DEffectModifier<R>)
-indirect case _PresentationDetentsModifier(LiveViewNative._PresentationDetentsModifier)
-indirect case _MatchedTransitionSourceModifier(LiveViewNative._MatchedTransitionSourceModifier<R>)
-indirect case _OnSubmitModifier(LiveViewNative._OnSubmitModifier)
-indirect case _FocusScopeModifier(LiveViewNative._FocusScopeModifier<R>)
+indirect case chunk19(_BuiltinModifierChunk19)
+        indirect case _OnSubmitModifier(LiveViewNative._OnSubmitModifier)
 indirect case _NavigationTransitionModifier(LiveViewNative._NavigationTransitionModifier<R>)
-indirect case _PrefersDefaultFocusModifier(LiveViewNative._PrefersDefaultFocusModifier<R>)
+indirect case _MatchedTransitionSourceModifier(LiveViewNative._MatchedTransitionSourceModifier<R>)
+indirect case _FocusScopeModifier(LiveViewNative._FocusScopeModifier<R>)
+indirect case _SearchScopesModifier(LiveViewNative._SearchScopesModifier<R>)
+indirect case _PresentationDetentsModifier(LiveViewNative._PresentationDetentsModifier)
+indirect case _Rotation3DEffectModifier(LiveViewNative._Rotation3DEffectModifier<R>)
 indirect case _MaskModifier(LiveViewNative._MaskModifier<R>)
+indirect case _PerspectiveRotationEffectModifier(LiveViewNative._PerspectiveRotationEffectModifier<R>)
+indirect case _MatchedGeometryEffectModifier(LiveViewNative._MatchedGeometryEffectModifier<R>)
+indirect case _PrefersDefaultFocusModifier(LiveViewNative._PrefersDefaultFocusModifier<R>)
+indirect case _SearchCompletionModifier(LiveViewNative._SearchCompletionModifier<R>)
         indirect case _customRegistryModifier(R.CustomModifier)
         indirect case _anyTextModifier(_AnyTextModifier<R>)
         indirect case _anyImageModifier(_AnyImageModifier<R>)
@@ -15761,29 +17017,31 @@ case let .chunk17(chunk):
     content.modifier(chunk)
 case let .chunk18(chunk):
     content.modifier(chunk)
-            case let ._SearchCompletionModifier(modifier):
-    content.modifier(modifier)
-case let ._PerspectiveRotationEffectModifier(modifier):
-    content.modifier(modifier)
-case let ._SearchScopesModifier(modifier):
-    content.modifier(modifier)
-case let ._MatchedGeometryEffectModifier(modifier):
-    content.modifier(modifier)
-case let ._Rotation3DEffectModifier(modifier):
-    content.modifier(modifier)
-case let ._PresentationDetentsModifier(modifier):
-    content.modifier(modifier)
-case let ._MatchedTransitionSourceModifier(modifier):
-    content.modifier(modifier)
-case let ._OnSubmitModifier(modifier):
-    content.modifier(modifier)
-case let ._FocusScopeModifier(modifier):
+case let .chunk19(chunk):
+    content.modifier(chunk)
+            case let ._OnSubmitModifier(modifier):
     content.modifier(modifier)
 case let ._NavigationTransitionModifier(modifier):
     content.modifier(modifier)
-case let ._PrefersDefaultFocusModifier(modifier):
+case let ._MatchedTransitionSourceModifier(modifier):
+    content.modifier(modifier)
+case let ._FocusScopeModifier(modifier):
+    content.modifier(modifier)
+case let ._SearchScopesModifier(modifier):
+    content.modifier(modifier)
+case let ._PresentationDetentsModifier(modifier):
+    content.modifier(modifier)
+case let ._Rotation3DEffectModifier(modifier):
     content.modifier(modifier)
 case let ._MaskModifier(modifier):
+    content.modifier(modifier)
+case let ._PerspectiveRotationEffectModifier(modifier):
+    content.modifier(modifier)
+case let ._MatchedGeometryEffectModifier(modifier):
+    content.modifier(modifier)
+case let ._PrefersDefaultFocusModifier(modifier):
+    content.modifier(modifier)
+case let ._SearchCompletionModifier(modifier):
     content.modifier(modifier)
             case let ._customRegistryModifier(modifier):
                 content.modifier(modifier)
@@ -15810,7 +17068,8 @@ case let ._MaskModifier(modifier):
             
             func parse(_ input: inout Substring.UTF8View) throws -> Output {
                 let parsers = [
-                    _accessibilityActionModifier<R>.name: _accessibilityActionModifier<R>.parser(in: context).map({ Output.chunk0(.accessibilityAction($0)) }).eraseToAnyParser(),
+                    _accentColorModifier<R>.name: _accentColorModifier<R>.parser(in: context).map({ Output.chunk0(.accentColor($0)) }).eraseToAnyParser(),
+_accessibilityActionModifier<R>.name: _accessibilityActionModifier<R>.parser(in: context).map({ Output.chunk0(.accessibilityAction($0)) }).eraseToAnyParser(),
 _accessibilityActionsModifier<R>.name: _accessibilityActionsModifier<R>.parser(in: context).map({ Output.chunk0(.accessibilityActions($0)) }).eraseToAnyParser(),
 _accessibilityChildrenModifier<R>.name: _accessibilityChildrenModifier<R>.parser(in: context).map({ Output.chunk0(.accessibilityChildren($0)) }).eraseToAnyParser(),
 _accessibilityIgnoresInvertColorsModifier<R>.name: _accessibilityIgnoresInvertColorsModifier<R>.parser(in: context).map({ Output.chunk0(.accessibilityIgnoresInvertColors($0)) }).eraseToAnyParser(),
@@ -15822,8 +17081,9 @@ _allowsTighteningModifier<R>.name: _allowsTighteningModifier<R>.parser(in: conte
 _allowsWindowActivationEventsModifier<R>.name: _allowsWindowActivationEventsModifier<R>.parser(in: context).map({ Output.chunk0(.allowsWindowActivationEvents($0)) }).eraseToAnyParser(),
 _animationModifier<R>.name: _animationModifier<R>.parser(in: context).map({ Output.chunk0(.animation($0)) }).eraseToAnyParser(),
 _aspectRatioModifier<R>.name: _aspectRatioModifier<R>.parser(in: context).map({ Output.chunk0(.aspectRatio($0)) }).eraseToAnyParser(),
-_autocorrectionDisabledModifier<R>.name: _autocorrectionDisabledModifier<R>.parser(in: context).map({ Output.chunk0(.autocorrectionDisabled($0)) }).eraseToAnyParser(),
-_backgroundModifier<R>.name: _backgroundModifier<R>.parser(in: context).map({ Output.chunk0(.background($0)) }).eraseToAnyParser(),
+_autocapitalizationModifier<R>.name: _autocapitalizationModifier<R>.parser(in: context).map({ Output.chunk0(.autocapitalization($0)) }).eraseToAnyParser(),
+_autocorrectionDisabledModifier<R>.name: _autocorrectionDisabledModifier<R>.parser(in: context).map({ Output.chunk1(.autocorrectionDisabled($0)) }).eraseToAnyParser(),
+_backgroundModifier<R>.name: _backgroundModifier<R>.parser(in: context).map({ Output.chunk1(.background($0)) }).eraseToAnyParser(),
 _backgroundStyleModifier<R>.name: _backgroundStyleModifier<R>.parser(in: context).map({ Output.chunk1(.backgroundStyle($0)) }).eraseToAnyParser(),
 _badgeModifier<R>.name: _badgeModifier<R>.parser(in: context).map({ Output.chunk1(.badge($0)) }).eraseToAnyParser(),
 _badgeProminenceModifier<R>.name: _badgeProminenceModifier<R>.parser(in: context).map({ Output.chunk1(.badgeProminence($0)) }).eraseToAnyParser(),
@@ -15836,8 +17096,9 @@ _buttonStyleModifier<R>.name: _buttonStyleModifier<R>.parser(in: context).map({ 
 _clipShapeModifier<R>.name: _clipShapeModifier<R>.parser(in: context).map({ Output.chunk1(.clipShape($0)) }).eraseToAnyParser(),
 _clippedModifier<R>.name: _clippedModifier<R>.parser(in: context).map({ Output.chunk1(.clipped($0)) }).eraseToAnyParser(),
 _colorInvertModifier<R>.name: _colorInvertModifier<R>.parser(in: context).map({ Output.chunk1(.colorInvert($0)) }).eraseToAnyParser(),
-_colorMultiplyModifier<R>.name: _colorMultiplyModifier<R>.parser(in: context).map({ Output.chunk1(.colorMultiply($0)) }).eraseToAnyParser(),
-_compositingGroupModifier<R>.name: _compositingGroupModifier<R>.parser(in: context).map({ Output.chunk1(.compositingGroup($0)) }).eraseToAnyParser(),
+_colorMultiplyModifier<R>.name: _colorMultiplyModifier<R>.parser(in: context).map({ Output.chunk2(.colorMultiply($0)) }).eraseToAnyParser(),
+_colorSchemeModifier<R>.name: _colorSchemeModifier<R>.parser(in: context).map({ Output.chunk2(.colorScheme($0)) }).eraseToAnyParser(),
+_compositingGroupModifier<R>.name: _compositingGroupModifier<R>.parser(in: context).map({ Output.chunk2(.compositingGroup($0)) }).eraseToAnyParser(),
 _confirmationDialogModifier<R>.name: _confirmationDialogModifier<R>.parser(in: context).map({ Output.chunk2(.confirmationDialog($0)) }).eraseToAnyParser(),
 _containerRelativeFrameModifier<R>.name: _containerRelativeFrameModifier<R>.parser(in: context).map({ Output.chunk2(.containerRelativeFrame($0)) }).eraseToAnyParser(),
 _containerShapeModifier<R>.name: _containerShapeModifier<R>.parser(in: context).map({ Output.chunk2(.containerShape($0)) }).eraseToAnyParser(),
@@ -15849,237 +17110,250 @@ _contrastModifier<R>.name: _contrastModifier<R>.parser(in: context).map({ Output
 _controlGroupStyleModifier<R>.name: _controlGroupStyleModifier<R>.parser(in: context).map({ Output.chunk2(.controlGroupStyle($0)) }).eraseToAnyParser(),
 _controlSizeModifier<R>.name: _controlSizeModifier<R>.parser(in: context).map({ Output.chunk2(.controlSize($0)) }).eraseToAnyParser(),
 _coordinateSpaceModifier<R>.name: _coordinateSpaceModifier<R>.parser(in: context).map({ Output.chunk2(.coordinateSpace($0)) }).eraseToAnyParser(),
-_datePickerStyleModifier<R>.name: _datePickerStyleModifier<R>.parser(in: context).map({ Output.chunk2(.datePickerStyle($0)) }).eraseToAnyParser(),
-_defaultAdaptableTabBarPlacementModifier<R>.name: _defaultAdaptableTabBarPlacementModifier<R>.parser(in: context).map({ Output.chunk2(.defaultAdaptableTabBarPlacement($0)) }).eraseToAnyParser(),
-_defaultHoverEffectModifier<R>.name: _defaultHoverEffectModifier<R>.parser(in: context).map({ Output.chunk2(.defaultHoverEffect($0)) }).eraseToAnyParser(),
+_cornerRadiusModifier<R>.name: _cornerRadiusModifier<R>.parser(in: context).map({ Output.chunk3(.cornerRadius($0)) }).eraseToAnyParser(),
+_datePickerStyleModifier<R>.name: _datePickerStyleModifier<R>.parser(in: context).map({ Output.chunk3(.datePickerStyle($0)) }).eraseToAnyParser(),
+_defaultAdaptableTabBarPlacementModifier<R>.name: _defaultAdaptableTabBarPlacementModifier<R>.parser(in: context).map({ Output.chunk3(.defaultAdaptableTabBarPlacement($0)) }).eraseToAnyParser(),
+_defaultHoverEffectModifier<R>.name: _defaultHoverEffectModifier<R>.parser(in: context).map({ Output.chunk3(.defaultHoverEffect($0)) }).eraseToAnyParser(),
 _defaultScrollAnchorModifier<R>.name: _defaultScrollAnchorModifier<R>.parser(in: context).map({ Output.chunk3(.defaultScrollAnchor($0)) }).eraseToAnyParser(),
 _defaultWheelPickerItemHeightModifier<R>.name: _defaultWheelPickerItemHeightModifier<R>.parser(in: context).map({ Output.chunk3(.defaultWheelPickerItemHeight($0)) }).eraseToAnyParser(),
 _defersSystemGesturesModifier<R>.name: _defersSystemGesturesModifier<R>.parser(in: context).map({ Output.chunk3(.defersSystemGestures($0)) }).eraseToAnyParser(),
 _deleteDisabledModifier<R>.name: _deleteDisabledModifier<R>.parser(in: context).map({ Output.chunk3(.deleteDisabled($0)) }).eraseToAnyParser(),
 _dialogSuppressionToggleModifier<R>.name: _dialogSuppressionToggleModifier<R>.parser(in: context).map({ Output.chunk3(.dialogSuppressionToggle($0)) }).eraseToAnyParser(),
 _digitalCrownAccessoryModifier<R>.name: _digitalCrownAccessoryModifier<R>.parser(in: context).map({ Output.chunk3(.digitalCrownAccessory($0)) }).eraseToAnyParser(),
+_disableAutocorrectionModifier<R>.name: _disableAutocorrectionModifier<R>.parser(in: context).map({ Output.chunk3(.disableAutocorrection($0)) }).eraseToAnyParser(),
 _disabledModifier<R>.name: _disabledModifier<R>.parser(in: context).map({ Output.chunk3(.disabled($0)) }).eraseToAnyParser(),
+_disclosureGroupStyleModifier<R>.name: _disclosureGroupStyleModifier<R>.parser(in: context).map({ Output.chunk3(.disclosureGroupStyle($0)) }).eraseToAnyParser(),
 _dismissalConfirmationDialogModifier<R>.name: _dismissalConfirmationDialogModifier<R>.parser(in: context).map({ Output.chunk3(.dismissalConfirmationDialog($0)) }).eraseToAnyParser(),
-_drawingGroupModifier<R>.name: _drawingGroupModifier<R>.parser(in: context).map({ Output.chunk3(.drawingGroup($0)) }).eraseToAnyParser(),
-_dynamicTypeSizeModifier<R>.name: _dynamicTypeSizeModifier<R>.parser(in: context).map({ Output.chunk3(.dynamicTypeSize($0)) }).eraseToAnyParser(),
-_fileDialogCustomizationIDModifier<R>.name: _fileDialogCustomizationIDModifier<R>.parser(in: context).map({ Output.chunk3(.fileDialogCustomizationID($0)) }).eraseToAnyParser(),
-_fileDialogImportsUnresolvedAliasesModifier<R>.name: _fileDialogImportsUnresolvedAliasesModifier<R>.parser(in: context).map({ Output.chunk3(.fileDialogImportsUnresolvedAliases($0)) }).eraseToAnyParser(),
-_findDisabledModifier<R>.name: _findDisabledModifier<R>.parser(in: context).map({ Output.chunk3(.findDisabled($0)) }).eraseToAnyParser(),
-_findNavigatorModifier<R>.name: _findNavigatorModifier<R>.parser(in: context).map({ Output.chunk3(.findNavigator($0)) }).eraseToAnyParser(),
+_drawingGroupModifier<R>.name: _drawingGroupModifier<R>.parser(in: context).map({ Output.chunk4(.drawingGroup($0)) }).eraseToAnyParser(),
+_dynamicTypeSizeModifier<R>.name: _dynamicTypeSizeModifier<R>.parser(in: context).map({ Output.chunk4(.dynamicTypeSize($0)) }).eraseToAnyParser(),
+_edgesIgnoringSafeAreaModifier<R>.name: _edgesIgnoringSafeAreaModifier<R>.parser(in: context).map({ Output.chunk4(.edgesIgnoringSafeArea($0)) }).eraseToAnyParser(),
+_fileDialogCustomizationIDModifier<R>.name: _fileDialogCustomizationIDModifier<R>.parser(in: context).map({ Output.chunk4(.fileDialogCustomizationID($0)) }).eraseToAnyParser(),
+_fileDialogImportsUnresolvedAliasesModifier<R>.name: _fileDialogImportsUnresolvedAliasesModifier<R>.parser(in: context).map({ Output.chunk4(.fileDialogImportsUnresolvedAliases($0)) }).eraseToAnyParser(),
+_findDisabledModifier<R>.name: _findDisabledModifier<R>.parser(in: context).map({ Output.chunk4(.findDisabled($0)) }).eraseToAnyParser(),
+_findNavigatorModifier<R>.name: _findNavigatorModifier<R>.parser(in: context).map({ Output.chunk4(.findNavigator($0)) }).eraseToAnyParser(),
 _fixedSizeModifier<R>.name: _fixedSizeModifier<R>.parser(in: context).map({ Output.chunk4(.fixedSize($0)) }).eraseToAnyParser(),
 _flipsForRightToLeftLayoutDirectionModifier<R>.name: _flipsForRightToLeftLayoutDirectionModifier<R>.parser(in: context).map({ Output.chunk4(.flipsForRightToLeftLayoutDirection($0)) }).eraseToAnyParser(),
 _focusEffectDisabledModifier<R>.name: _focusEffectDisabledModifier<R>.parser(in: context).map({ Output.chunk4(.focusEffectDisabled($0)) }).eraseToAnyParser(),
 _focusSectionModifier<R>.name: _focusSectionModifier<R>.parser(in: context).map({ Output.chunk4(.focusSection($0)) }).eraseToAnyParser(),
 _focusableModifier<R>.name: _focusableModifier<R>.parser(in: context).map({ Output.chunk4(.focusable($0)) }).eraseToAnyParser(),
+_foregroundColorModifier<R>.name: _foregroundColorModifier<R>.parser(in: context).map({ Output.chunk4(.foregroundColor($0)) }).eraseToAnyParser(),
 _formStyleModifier<R>.name: _formStyleModifier<R>.parser(in: context).map({ Output.chunk4(.formStyle($0)) }).eraseToAnyParser(),
-_frameModifier<R>.name: _frameModifier<R>.parser(in: context).map({ Output.chunk4(.frame($0)) }).eraseToAnyParser(),
-_fullScreenCoverModifier<R>.name: _fullScreenCoverModifier<R>.parser(in: context).map({ Output.chunk4(.fullScreenCover($0)) }).eraseToAnyParser(),
-_gaugeStyleModifier<R>.name: _gaugeStyleModifier<R>.parser(in: context).map({ Output.chunk4(.gaugeStyle($0)) }).eraseToAnyParser(),
-_geometryGroupModifier<R>.name: _geometryGroupModifier<R>.parser(in: context).map({ Output.chunk4(.geometryGroup($0)) }).eraseToAnyParser(),
-_gestureModifier<R>.name: _gestureModifier<R>.parser(in: context).map({ Output.chunk4(.gesture($0)) }).eraseToAnyParser(),
-_glassBackgroundEffectModifier<R>.name: _glassBackgroundEffectModifier<R>.parser(in: context).map({ Output.chunk4(.glassBackgroundEffect($0)) }).eraseToAnyParser(),
-_grayscaleModifier<R>.name: _grayscaleModifier<R>.parser(in: context).map({ Output.chunk4(.grayscale($0)) }).eraseToAnyParser(),
-_gridCellAnchorModifier<R>.name: _gridCellAnchorModifier<R>.parser(in: context).map({ Output.chunk4(.gridCellAnchor($0)) }).eraseToAnyParser(),
+_frameModifier<R>.name: _frameModifier<R>.parser(in: context).map({ Output.chunk5(.frame($0)) }).eraseToAnyParser(),
+_fullScreenCoverModifier<R>.name: _fullScreenCoverModifier<R>.parser(in: context).map({ Output.chunk5(.fullScreenCover($0)) }).eraseToAnyParser(),
+_gaugeStyleModifier<R>.name: _gaugeStyleModifier<R>.parser(in: context).map({ Output.chunk5(.gaugeStyle($0)) }).eraseToAnyParser(),
+_geometryGroupModifier<R>.name: _geometryGroupModifier<R>.parser(in: context).map({ Output.chunk5(.geometryGroup($0)) }).eraseToAnyParser(),
+_gestureModifier<R>.name: _gestureModifier<R>.parser(in: context).map({ Output.chunk5(.gesture($0)) }).eraseToAnyParser(),
+_glassBackgroundEffectModifier<R>.name: _glassBackgroundEffectModifier<R>.parser(in: context).map({ Output.chunk5(.glassBackgroundEffect($0)) }).eraseToAnyParser(),
+_grayscaleModifier<R>.name: _grayscaleModifier<R>.parser(in: context).map({ Output.chunk5(.grayscale($0)) }).eraseToAnyParser(),
+_gridCellAnchorModifier<R>.name: _gridCellAnchorModifier<R>.parser(in: context).map({ Output.chunk5(.gridCellAnchor($0)) }).eraseToAnyParser(),
 _gridCellColumnsModifier<R>.name: _gridCellColumnsModifier<R>.parser(in: context).map({ Output.chunk5(.gridCellColumns($0)) }).eraseToAnyParser(),
 _gridCellUnsizedAxesModifier<R>.name: _gridCellUnsizedAxesModifier<R>.parser(in: context).map({ Output.chunk5(.gridCellUnsizedAxes($0)) }).eraseToAnyParser(),
 _gridColumnAlignmentModifier<R>.name: _gridColumnAlignmentModifier<R>.parser(in: context).map({ Output.chunk5(.gridColumnAlignment($0)) }).eraseToAnyParser(),
 _groupBoxStyleModifier<R>.name: _groupBoxStyleModifier<R>.parser(in: context).map({ Output.chunk5(.groupBoxStyle($0)) }).eraseToAnyParser(),
 _handGestureShortcutModifier<R>.name: _handGestureShortcutModifier<R>.parser(in: context).map({ Output.chunk5(.handGestureShortcut($0)) }).eraseToAnyParser(),
 _handPointerBehaviorModifier<R>.name: _handPointerBehaviorModifier<R>.parser(in: context).map({ Output.chunk5(.handPointerBehavior($0)) }).eraseToAnyParser(),
-_headerProminenceModifier<R>.name: _headerProminenceModifier<R>.parser(in: context).map({ Output.chunk5(.headerProminence($0)) }).eraseToAnyParser(),
-_helpModifier<R>.name: _helpModifier<R>.parser(in: context).map({ Output.chunk5(.help($0)) }).eraseToAnyParser(),
-_hiddenModifier<R>.name: _hiddenModifier<R>.parser(in: context).map({ Output.chunk5(.hidden($0)) }).eraseToAnyParser(),
-_highPriorityGestureModifier<R>.name: _highPriorityGestureModifier<R>.parser(in: context).map({ Output.chunk5(.highPriorityGesture($0)) }).eraseToAnyParser(),
-_horizontalRadioGroupLayoutModifier<R>.name: _horizontalRadioGroupLayoutModifier<R>.parser(in: context).map({ Output.chunk5(.horizontalRadioGroupLayout($0)) }).eraseToAnyParser(),
-_hoverEffectModifier<R>.name: _hoverEffectModifier<R>.parser(in: context).map({ Output.chunk5(.hoverEffect($0)) }).eraseToAnyParser(),
-_hoverEffectDisabledModifier<R>.name: _hoverEffectDisabledModifier<R>.parser(in: context).map({ Output.chunk5(.hoverEffectDisabled($0)) }).eraseToAnyParser(),
-_hoverEffectGroupModifier<R>.name: _hoverEffectGroupModifier<R>.parser(in: context).map({ Output.chunk5(.hoverEffectGroup($0)) }).eraseToAnyParser(),
+_headerProminenceModifier<R>.name: _headerProminenceModifier<R>.parser(in: context).map({ Output.chunk6(.headerProminence($0)) }).eraseToAnyParser(),
+_helpModifier<R>.name: _helpModifier<R>.parser(in: context).map({ Output.chunk6(.help($0)) }).eraseToAnyParser(),
+_hiddenModifier<R>.name: _hiddenModifier<R>.parser(in: context).map({ Output.chunk6(.hidden($0)) }).eraseToAnyParser(),
+_highPriorityGestureModifier<R>.name: _highPriorityGestureModifier<R>.parser(in: context).map({ Output.chunk6(.highPriorityGesture($0)) }).eraseToAnyParser(),
+_horizontalRadioGroupLayoutModifier<R>.name: _horizontalRadioGroupLayoutModifier<R>.parser(in: context).map({ Output.chunk6(.horizontalRadioGroupLayout($0)) }).eraseToAnyParser(),
+_hoverEffectModifier<R>.name: _hoverEffectModifier<R>.parser(in: context).map({ Output.chunk6(.hoverEffect($0)) }).eraseToAnyParser(),
+_hoverEffectDisabledModifier<R>.name: _hoverEffectDisabledModifier<R>.parser(in: context).map({ Output.chunk6(.hoverEffectDisabled($0)) }).eraseToAnyParser(),
+_hoverEffectGroupModifier<R>.name: _hoverEffectGroupModifier<R>.parser(in: context).map({ Output.chunk6(.hoverEffectGroup($0)) }).eraseToAnyParser(),
 _hueRotationModifier<R>.name: _hueRotationModifier<R>.parser(in: context).map({ Output.chunk6(.hueRotation($0)) }).eraseToAnyParser(),
 _ignoresSafeAreaModifier<R>.name: _ignoresSafeAreaModifier<R>.parser(in: context).map({ Output.chunk6(.ignoresSafeArea($0)) }).eraseToAnyParser(),
 _imageScaleModifier<R>.name: _imageScaleModifier<R>.parser(in: context).map({ Output.chunk6(.imageScale($0)) }).eraseToAnyParser(),
 _immersiveEnvironmentPickerModifier<R>.name: _immersiveEnvironmentPickerModifier<R>.parser(in: context).map({ Output.chunk6(.immersiveEnvironmentPicker($0)) }).eraseToAnyParser(),
 _indexViewStyleModifier<R>.name: _indexViewStyleModifier<R>.parser(in: context).map({ Output.chunk6(.indexViewStyle($0)) }).eraseToAnyParser(),
 _inspectorModifier<R>.name: _inspectorModifier<R>.parser(in: context).map({ Output.chunk6(.inspector($0)) }).eraseToAnyParser(),
-_inspectorColumnWidthModifier<R>.name: _inspectorColumnWidthModifier<R>.parser(in: context).map({ Output.chunk6(.inspectorColumnWidth($0)) }).eraseToAnyParser(),
-_interactionActivityTrackingTagModifier<R>.name: _interactionActivityTrackingTagModifier<R>.parser(in: context).map({ Output.chunk6(.interactionActivityTrackingTag($0)) }).eraseToAnyParser(),
-_interactiveDismissDisabledModifier<R>.name: _interactiveDismissDisabledModifier<R>.parser(in: context).map({ Output.chunk6(.interactiveDismissDisabled($0)) }).eraseToAnyParser(),
-_invalidatableContentModifier<R>.name: _invalidatableContentModifier<R>.parser(in: context).map({ Output.chunk6(.invalidatableContent($0)) }).eraseToAnyParser(),
-_keyboardShortcutModifier<R>.name: _keyboardShortcutModifier<R>.parser(in: context).map({ Output.chunk6(.keyboardShortcut($0)) }).eraseToAnyParser(),
-_keyboardTypeModifier<R>.name: _keyboardTypeModifier<R>.parser(in: context).map({ Output.chunk6(.keyboardType($0)) }).eraseToAnyParser(),
-_labelStyleModifier<R>.name: _labelStyleModifier<R>.parser(in: context).map({ Output.chunk6(.labelStyle($0)) }).eraseToAnyParser(),
-_labeledContentStyleModifier<R>.name: _labeledContentStyleModifier<R>.parser(in: context).map({ Output.chunk6(.labeledContentStyle($0)) }).eraseToAnyParser(),
+_inspectorColumnWidthModifier<R>.name: _inspectorColumnWidthModifier<R>.parser(in: context).map({ Output.chunk7(.inspectorColumnWidth($0)) }).eraseToAnyParser(),
+_interactionActivityTrackingTagModifier<R>.name: _interactionActivityTrackingTagModifier<R>.parser(in: context).map({ Output.chunk7(.interactionActivityTrackingTag($0)) }).eraseToAnyParser(),
+_interactiveDismissDisabledModifier<R>.name: _interactiveDismissDisabledModifier<R>.parser(in: context).map({ Output.chunk7(.interactiveDismissDisabled($0)) }).eraseToAnyParser(),
+_invalidatableContentModifier<R>.name: _invalidatableContentModifier<R>.parser(in: context).map({ Output.chunk7(.invalidatableContent($0)) }).eraseToAnyParser(),
+_keyboardShortcutModifier<R>.name: _keyboardShortcutModifier<R>.parser(in: context).map({ Output.chunk7(.keyboardShortcut($0)) }).eraseToAnyParser(),
+_keyboardTypeModifier<R>.name: _keyboardTypeModifier<R>.parser(in: context).map({ Output.chunk7(.keyboardType($0)) }).eraseToAnyParser(),
+_labelStyleModifier<R>.name: _labelStyleModifier<R>.parser(in: context).map({ Output.chunk7(.labelStyle($0)) }).eraseToAnyParser(),
+_labeledContentStyleModifier<R>.name: _labeledContentStyleModifier<R>.parser(in: context).map({ Output.chunk7(.labeledContentStyle($0)) }).eraseToAnyParser(),
 _labelsHiddenModifier<R>.name: _labelsHiddenModifier<R>.parser(in: context).map({ Output.chunk7(.labelsHidden($0)) }).eraseToAnyParser(),
 _labelsVisibilityModifier<R>.name: _labelsVisibilityModifier<R>.parser(in: context).map({ Output.chunk7(.labelsVisibility($0)) }).eraseToAnyParser(),
 _layoutPriorityModifier<R>.name: _layoutPriorityModifier<R>.parser(in: context).map({ Output.chunk7(.layoutPriority($0)) }).eraseToAnyParser(),
 _lineLimitModifier<R>.name: _lineLimitModifier<R>.parser(in: context).map({ Output.chunk7(.lineLimit($0)) }).eraseToAnyParser(),
 _lineSpacingModifier<R>.name: _lineSpacingModifier<R>.parser(in: context).map({ Output.chunk7(.lineSpacing($0)) }).eraseToAnyParser(),
 _listItemTintModifier<R>.name: _listItemTintModifier<R>.parser(in: context).map({ Output.chunk7(.listItemTint($0)) }).eraseToAnyParser(),
-_listRowBackgroundModifier<R>.name: _listRowBackgroundModifier<R>.parser(in: context).map({ Output.chunk7(.listRowBackground($0)) }).eraseToAnyParser(),
-_listRowHoverEffectModifier<R>.name: _listRowHoverEffectModifier<R>.parser(in: context).map({ Output.chunk7(.listRowHoverEffect($0)) }).eraseToAnyParser(),
-_listRowHoverEffectDisabledModifier<R>.name: _listRowHoverEffectDisabledModifier<R>.parser(in: context).map({ Output.chunk7(.listRowHoverEffectDisabled($0)) }).eraseToAnyParser(),
-_listRowInsetsModifier<R>.name: _listRowInsetsModifier<R>.parser(in: context).map({ Output.chunk7(.listRowInsets($0)) }).eraseToAnyParser(),
-_listRowSeparatorModifier<R>.name: _listRowSeparatorModifier<R>.parser(in: context).map({ Output.chunk7(.listRowSeparator($0)) }).eraseToAnyParser(),
-_listRowSeparatorTintModifier<R>.name: _listRowSeparatorTintModifier<R>.parser(in: context).map({ Output.chunk7(.listRowSeparatorTint($0)) }).eraseToAnyParser(),
-_listRowSpacingModifier<R>.name: _listRowSpacingModifier<R>.parser(in: context).map({ Output.chunk7(.listRowSpacing($0)) }).eraseToAnyParser(),
-_listSectionSeparatorModifier<R>.name: _listSectionSeparatorModifier<R>.parser(in: context).map({ Output.chunk7(.listSectionSeparator($0)) }).eraseToAnyParser(),
+_listRowBackgroundModifier<R>.name: _listRowBackgroundModifier<R>.parser(in: context).map({ Output.chunk8(.listRowBackground($0)) }).eraseToAnyParser(),
+_listRowHoverEffectModifier<R>.name: _listRowHoverEffectModifier<R>.parser(in: context).map({ Output.chunk8(.listRowHoverEffect($0)) }).eraseToAnyParser(),
+_listRowHoverEffectDisabledModifier<R>.name: _listRowHoverEffectDisabledModifier<R>.parser(in: context).map({ Output.chunk8(.listRowHoverEffectDisabled($0)) }).eraseToAnyParser(),
+_listRowInsetsModifier<R>.name: _listRowInsetsModifier<R>.parser(in: context).map({ Output.chunk8(.listRowInsets($0)) }).eraseToAnyParser(),
+_listRowPlatterColorModifier<R>.name: _listRowPlatterColorModifier<R>.parser(in: context).map({ Output.chunk8(.listRowPlatterColor($0)) }).eraseToAnyParser(),
+_listRowSeparatorModifier<R>.name: _listRowSeparatorModifier<R>.parser(in: context).map({ Output.chunk8(.listRowSeparator($0)) }).eraseToAnyParser(),
+_listRowSeparatorTintModifier<R>.name: _listRowSeparatorTintModifier<R>.parser(in: context).map({ Output.chunk8(.listRowSeparatorTint($0)) }).eraseToAnyParser(),
+_listRowSpacingModifier<R>.name: _listRowSpacingModifier<R>.parser(in: context).map({ Output.chunk8(.listRowSpacing($0)) }).eraseToAnyParser(),
+_listSectionSeparatorModifier<R>.name: _listSectionSeparatorModifier<R>.parser(in: context).map({ Output.chunk8(.listSectionSeparator($0)) }).eraseToAnyParser(),
 _listSectionSeparatorTintModifier<R>.name: _listSectionSeparatorTintModifier<R>.parser(in: context).map({ Output.chunk8(.listSectionSeparatorTint($0)) }).eraseToAnyParser(),
 _listSectionSpacingModifier<R>.name: _listSectionSpacingModifier<R>.parser(in: context).map({ Output.chunk8(.listSectionSpacing($0)) }).eraseToAnyParser(),
 _listStyleModifier<R>.name: _listStyleModifier<R>.parser(in: context).map({ Output.chunk8(.listStyle($0)) }).eraseToAnyParser(),
 _luminanceToAlphaModifier<R>.name: _luminanceToAlphaModifier<R>.parser(in: context).map({ Output.chunk8(.luminanceToAlpha($0)) }).eraseToAnyParser(),
 _materialActiveAppearanceModifier<R>.name: _materialActiveAppearanceModifier<R>.parser(in: context).map({ Output.chunk8(.materialActiveAppearance($0)) }).eraseToAnyParser(),
-_menuIndicatorModifier<R>.name: _menuIndicatorModifier<R>.parser(in: context).map({ Output.chunk8(.menuIndicator($0)) }).eraseToAnyParser(),
-_menuOrderModifier<R>.name: _menuOrderModifier<R>.parser(in: context).map({ Output.chunk8(.menuOrder($0)) }).eraseToAnyParser(),
-_menuStyleModifier<R>.name: _menuStyleModifier<R>.parser(in: context).map({ Output.chunk8(.menuStyle($0)) }).eraseToAnyParser(),
-_minimumScaleFactorModifier<R>.name: _minimumScaleFactorModifier<R>.parser(in: context).map({ Output.chunk8(.minimumScaleFactor($0)) }).eraseToAnyParser(),
-_modifierKeyAlternateModifier<R>.name: _modifierKeyAlternateModifier<R>.parser(in: context).map({ Output.chunk8(.modifierKeyAlternate($0)) }).eraseToAnyParser(),
-_moveDisabledModifier<R>.name: _moveDisabledModifier<R>.parser(in: context).map({ Output.chunk8(.moveDisabled($0)) }).eraseToAnyParser(),
-_multilineTextAlignmentModifier<R>.name: _multilineTextAlignmentModifier<R>.parser(in: context).map({ Output.chunk8(.multilineTextAlignment($0)) }).eraseToAnyParser(),
-_navigationBarBackButtonHiddenModifier<R>.name: _navigationBarBackButtonHiddenModifier<R>.parser(in: context).map({ Output.chunk8(.navigationBarBackButtonHidden($0)) }).eraseToAnyParser(),
-_navigationBarTitleDisplayModeModifier<R>.name: _navigationBarTitleDisplayModeModifier<R>.parser(in: context).map({ Output.chunk8(.navigationBarTitleDisplayMode($0)) }).eraseToAnyParser(),
+_menuButtonStyleModifier<R>.name: _menuButtonStyleModifier<R>.parser(in: context).map({ Output.chunk9(.menuButtonStyle($0)) }).eraseToAnyParser(),
+_menuIndicatorModifier<R>.name: _menuIndicatorModifier<R>.parser(in: context).map({ Output.chunk9(.menuIndicator($0)) }).eraseToAnyParser(),
+_menuOrderModifier<R>.name: _menuOrderModifier<R>.parser(in: context).map({ Output.chunk9(.menuOrder($0)) }).eraseToAnyParser(),
+_menuStyleModifier<R>.name: _menuStyleModifier<R>.parser(in: context).map({ Output.chunk9(.menuStyle($0)) }).eraseToAnyParser(),
+_minimumScaleFactorModifier<R>.name: _minimumScaleFactorModifier<R>.parser(in: context).map({ Output.chunk9(.minimumScaleFactor($0)) }).eraseToAnyParser(),
+_modifierKeyAlternateModifier<R>.name: _modifierKeyAlternateModifier<R>.parser(in: context).map({ Output.chunk9(.modifierKeyAlternate($0)) }).eraseToAnyParser(),
+_moveDisabledModifier<R>.name: _moveDisabledModifier<R>.parser(in: context).map({ Output.chunk9(.moveDisabled($0)) }).eraseToAnyParser(),
+_multilineTextAlignmentModifier<R>.name: _multilineTextAlignmentModifier<R>.parser(in: context).map({ Output.chunk9(.multilineTextAlignment($0)) }).eraseToAnyParser(),
+_navigationBarBackButtonHiddenModifier<R>.name: _navigationBarBackButtonHiddenModifier<R>.parser(in: context).map({ Output.chunk9(.navigationBarBackButtonHidden($0)) }).eraseToAnyParser(),
+_navigationBarHiddenModifier<R>.name: _navigationBarHiddenModifier<R>.parser(in: context).map({ Output.chunk9(.navigationBarHidden($0)) }).eraseToAnyParser(),
+_navigationBarItemsModifier<R>.name: _navigationBarItemsModifier<R>.parser(in: context).map({ Output.chunk9(.navigationBarItems($0)) }).eraseToAnyParser(),
+_navigationBarTitleModifier<R>.name: _navigationBarTitleModifier<R>.parser(in: context).map({ Output.chunk9(.navigationBarTitle($0)) }).eraseToAnyParser(),
+_navigationBarTitleDisplayModeModifier<R>.name: _navigationBarTitleDisplayModeModifier<R>.parser(in: context).map({ Output.chunk9(.navigationBarTitleDisplayMode($0)) }).eraseToAnyParser(),
 _navigationDestinationModifier<R>.name: _navigationDestinationModifier<R>.parser(in: context).map({ Output.chunk9(.navigationDestination($0)) }).eraseToAnyParser(),
-_navigationSplitViewColumnWidthModifier<R>.name: _navigationSplitViewColumnWidthModifier<R>.parser(in: context).map({ Output.chunk9(.navigationSplitViewColumnWidth($0)) }).eraseToAnyParser(),
-_navigationSplitViewStyleModifier<R>.name: _navigationSplitViewStyleModifier<R>.parser(in: context).map({ Output.chunk9(.navigationSplitViewStyle($0)) }).eraseToAnyParser(),
-_navigationSubtitleModifier<R>.name: _navigationSubtitleModifier<R>.parser(in: context).map({ Output.chunk9(.navigationSubtitle($0)) }).eraseToAnyParser(),
-_navigationTitleModifier<R>.name: _navigationTitleModifier<R>.parser(in: context).map({ Output.chunk9(.navigationTitle($0)) }).eraseToAnyParser(),
-_offsetModifier<R>.name: _offsetModifier<R>.parser(in: context).map({ Output.chunk9(.offset($0)) }).eraseToAnyParser(),
-_onAppearModifier<R>.name: _onAppearModifier<R>.parser(in: context).map({ Output.chunk9(.onAppear($0)) }).eraseToAnyParser(),
-_onDeleteCommandModifier<R>.name: _onDeleteCommandModifier<R>.parser(in: context).map({ Output.chunk9(.onDeleteCommand($0)) }).eraseToAnyParser(),
-_onDisappearModifier<R>.name: _onDisappearModifier<R>.parser(in: context).map({ Output.chunk9(.onDisappear($0)) }).eraseToAnyParser(),
-_onExitCommandModifier<R>.name: _onExitCommandModifier<R>.parser(in: context).map({ Output.chunk9(.onExitCommand($0)) }).eraseToAnyParser(),
-_onHoverModifier<R>.name: _onHoverModifier<R>.parser(in: context).map({ Output.chunk9(.onHover($0)) }).eraseToAnyParser(),
-_onImmersionChangeModifier<R>.name: _onImmersionChangeModifier<R>.parser(in: context).map({ Output.chunk9(.onImmersionChange($0)) }).eraseToAnyParser(),
-_onLongPressGestureModifier<R>.name: _onLongPressGestureModifier<R>.parser(in: context).map({ Output.chunk9(.onLongPressGesture($0)) }).eraseToAnyParser(),
-_onLongTouchGestureModifier<R>.name: _onLongTouchGestureModifier<R>.parser(in: context).map({ Output.chunk9(.onLongTouchGesture($0)) }).eraseToAnyParser(),
-_onModifierKeysChangedModifier<R>.name: _onModifierKeysChangedModifier<R>.parser(in: context).map({ Output.chunk10(.onModifierKeysChanged($0)) }).eraseToAnyParser(),
-_onMoveCommandModifier<R>.name: _onMoveCommandModifier<R>.parser(in: context).map({ Output.chunk10(.onMoveCommand($0)) }).eraseToAnyParser(),
-_onPencilDoubleTapModifier<R>.name: _onPencilDoubleTapModifier<R>.parser(in: context).map({ Output.chunk10(.onPencilDoubleTap($0)) }).eraseToAnyParser(),
-_onPencilSqueezeModifier<R>.name: _onPencilSqueezeModifier<R>.parser(in: context).map({ Output.chunk10(.onPencilSqueeze($0)) }).eraseToAnyParser(),
-_onPlayPauseCommandModifier<R>.name: _onPlayPauseCommandModifier<R>.parser(in: context).map({ Output.chunk10(.onPlayPauseCommand($0)) }).eraseToAnyParser(),
-_onScrollPhaseChangeModifier<R>.name: _onScrollPhaseChangeModifier<R>.parser(in: context).map({ Output.chunk10(.onScrollPhaseChange($0)) }).eraseToAnyParser(),
-_onScrollVisibilityChangeModifier<R>.name: _onScrollVisibilityChangeModifier<R>.parser(in: context).map({ Output.chunk10(.onScrollVisibilityChange($0)) }).eraseToAnyParser(),
-_onTapGestureModifier<R>.name: _onTapGestureModifier<R>.parser(in: context).map({ Output.chunk10(.onTapGesture($0)) }).eraseToAnyParser(),
-_onVolumeViewpointChangeModifier<R>.name: _onVolumeViewpointChangeModifier<R>.parser(in: context).map({ Output.chunk10(.onVolumeViewpointChange($0)) }).eraseToAnyParser(),
-_opacityModifier<R>.name: _opacityModifier<R>.parser(in: context).map({ Output.chunk10(.opacity($0)) }).eraseToAnyParser(),
-_ornamentModifier<R>.name: _ornamentModifier<R>.parser(in: context).map({ Output.chunk10(.ornament($0)) }).eraseToAnyParser(),
-_overlayModifier<R>.name: _overlayModifier<R>.parser(in: context).map({ Output.chunk10(.overlay($0)) }).eraseToAnyParser(),
-_paddingModifier<R>.name: _paddingModifier<R>.parser(in: context).map({ Output.chunk10(.padding($0)) }).eraseToAnyParser(),
-_padding3DModifier<R>.name: _padding3DModifier<R>.parser(in: context).map({ Output.chunk10(.padding3D($0)) }).eraseToAnyParser(),
-_persistentSystemOverlaysModifier<R>.name: _persistentSystemOverlaysModifier<R>.parser(in: context).map({ Output.chunk11(.persistentSystemOverlays($0)) }).eraseToAnyParser(),
-_pickerStyleModifier<R>.name: _pickerStyleModifier<R>.parser(in: context).map({ Output.chunk11(.pickerStyle($0)) }).eraseToAnyParser(),
-_pointerStyleModifier<R>.name: _pointerStyleModifier<R>.parser(in: context).map({ Output.chunk11(.pointerStyle($0)) }).eraseToAnyParser(),
-_pointerVisibilityModifier<R>.name: _pointerVisibilityModifier<R>.parser(in: context).map({ Output.chunk11(.pointerVisibility($0)) }).eraseToAnyParser(),
-_popoverModifier<R>.name: _popoverModifier<R>.parser(in: context).map({ Output.chunk11(.popover($0)) }).eraseToAnyParser(),
-_positionModifier<R>.name: _positionModifier<R>.parser(in: context).map({ Output.chunk11(.position($0)) }).eraseToAnyParser(),
-_preferredColorSchemeModifier<R>.name: _preferredColorSchemeModifier<R>.parser(in: context).map({ Output.chunk11(.preferredColorScheme($0)) }).eraseToAnyParser(),
-_preferredSurroundingsEffectModifier<R>.name: _preferredSurroundingsEffectModifier<R>.parser(in: context).map({ Output.chunk11(.preferredSurroundingsEffect($0)) }).eraseToAnyParser(),
-_presentationBackgroundModifier<R>.name: _presentationBackgroundModifier<R>.parser(in: context).map({ Output.chunk11(.presentationBackground($0)) }).eraseToAnyParser(),
-_presentationBackgroundInteractionModifier<R>.name: _presentationBackgroundInteractionModifier<R>.parser(in: context).map({ Output.chunk11(.presentationBackgroundInteraction($0)) }).eraseToAnyParser(),
-_presentationCompactAdaptationModifier<R>.name: _presentationCompactAdaptationModifier<R>.parser(in: context).map({ Output.chunk11(.presentationCompactAdaptation($0)) }).eraseToAnyParser(),
-_presentationContentInteractionModifier<R>.name: _presentationContentInteractionModifier<R>.parser(in: context).map({ Output.chunk11(.presentationContentInteraction($0)) }).eraseToAnyParser(),
-_presentationCornerRadiusModifier<R>.name: _presentationCornerRadiusModifier<R>.parser(in: context).map({ Output.chunk11(.presentationCornerRadius($0)) }).eraseToAnyParser(),
-_presentationDragIndicatorModifier<R>.name: _presentationDragIndicatorModifier<R>.parser(in: context).map({ Output.chunk11(.presentationDragIndicator($0)) }).eraseToAnyParser(),
-_presentationSizingModifier<R>.name: _presentationSizingModifier<R>.parser(in: context).map({ Output.chunk12(.presentationSizing($0)) }).eraseToAnyParser(),
-_previewDisplayNameModifier<R>.name: _previewDisplayNameModifier<R>.parser(in: context).map({ Output.chunk12(.previewDisplayName($0)) }).eraseToAnyParser(),
-_privacySensitiveModifier<R>.name: _privacySensitiveModifier<R>.parser(in: context).map({ Output.chunk12(.privacySensitive($0)) }).eraseToAnyParser(),
-_progressViewStyleModifier<R>.name: _progressViewStyleModifier<R>.parser(in: context).map({ Output.chunk12(.progressViewStyle($0)) }).eraseToAnyParser(),
-_projectionEffectModifier<R>.name: _projectionEffectModifier<R>.parser(in: context).map({ Output.chunk12(.projectionEffect($0)) }).eraseToAnyParser(),
-_redactedModifier<R>.name: _redactedModifier<R>.parser(in: context).map({ Output.chunk12(.redacted($0)) }).eraseToAnyParser(),
-_refreshableModifier<R>.name: _refreshableModifier<R>.parser(in: context).map({ Output.chunk12(.refreshable($0)) }).eraseToAnyParser(),
-_renameActionModifier<R>.name: _renameActionModifier<R>.parser(in: context).map({ Output.chunk12(.renameAction($0)) }).eraseToAnyParser(),
-_replaceDisabledModifier<R>.name: _replaceDisabledModifier<R>.parser(in: context).map({ Output.chunk12(.replaceDisabled($0)) }).eraseToAnyParser(),
-_rotationEffectModifier<R>.name: _rotationEffectModifier<R>.parser(in: context).map({ Output.chunk12(.rotationEffect($0)) }).eraseToAnyParser(),
-_safeAreaInsetModifier<R>.name: _safeAreaInsetModifier<R>.parser(in: context).map({ Output.chunk12(.safeAreaInset($0)) }).eraseToAnyParser(),
-_safeAreaPaddingModifier<R>.name: _safeAreaPaddingModifier<R>.parser(in: context).map({ Output.chunk12(.safeAreaPadding($0)) }).eraseToAnyParser(),
-_saturationModifier<R>.name: _saturationModifier<R>.parser(in: context).map({ Output.chunk12(.saturation($0)) }).eraseToAnyParser(),
-_scaleEffectModifier<R>.name: _scaleEffectModifier<R>.parser(in: context).map({ Output.chunk12(.scaleEffect($0)) }).eraseToAnyParser(),
-_scaledToFillModifier<R>.name: _scaledToFillModifier<R>.parser(in: context).map({ Output.chunk13(.scaledToFill($0)) }).eraseToAnyParser(),
-_scaledToFitModifier<R>.name: _scaledToFitModifier<R>.parser(in: context).map({ Output.chunk13(.scaledToFit($0)) }).eraseToAnyParser(),
-_scenePaddingModifier<R>.name: _scenePaddingModifier<R>.parser(in: context).map({ Output.chunk13(.scenePadding($0)) }).eraseToAnyParser(),
-_scrollBounceBehaviorModifier<R>.name: _scrollBounceBehaviorModifier<R>.parser(in: context).map({ Output.chunk13(.scrollBounceBehavior($0)) }).eraseToAnyParser(),
-_scrollClipDisabledModifier<R>.name: _scrollClipDisabledModifier<R>.parser(in: context).map({ Output.chunk13(.scrollClipDisabled($0)) }).eraseToAnyParser(),
-_scrollContentBackgroundModifier<R>.name: _scrollContentBackgroundModifier<R>.parser(in: context).map({ Output.chunk13(.scrollContentBackground($0)) }).eraseToAnyParser(),
-_scrollDisabledModifier<R>.name: _scrollDisabledModifier<R>.parser(in: context).map({ Output.chunk13(.scrollDisabled($0)) }).eraseToAnyParser(),
-_scrollDismissesKeyboardModifier<R>.name: _scrollDismissesKeyboardModifier<R>.parser(in: context).map({ Output.chunk13(.scrollDismissesKeyboard($0)) }).eraseToAnyParser(),
-_scrollIndicatorsModifier<R>.name: _scrollIndicatorsModifier<R>.parser(in: context).map({ Output.chunk13(.scrollIndicators($0)) }).eraseToAnyParser(),
-_scrollIndicatorsFlashModifier<R>.name: _scrollIndicatorsFlashModifier<R>.parser(in: context).map({ Output.chunk13(.scrollIndicatorsFlash($0)) }).eraseToAnyParser(),
-_scrollPositionModifier<R>.name: _scrollPositionModifier<R>.parser(in: context).map({ Output.chunk13(.scrollPosition($0)) }).eraseToAnyParser(),
-_scrollTargetBehaviorModifier<R>.name: _scrollTargetBehaviorModifier<R>.parser(in: context).map({ Output.chunk13(.scrollTargetBehavior($0)) }).eraseToAnyParser(),
-_scrollTargetLayoutModifier<R>.name: _scrollTargetLayoutModifier<R>.parser(in: context).map({ Output.chunk13(.scrollTargetLayout($0)) }).eraseToAnyParser(),
-_searchDictationBehaviorModifier<R>.name: _searchDictationBehaviorModifier<R>.parser(in: context).map({ Output.chunk13(.searchDictationBehavior($0)) }).eraseToAnyParser(),
-_searchPresentationToolbarBehaviorModifier<R>.name: _searchPresentationToolbarBehaviorModifier<R>.parser(in: context).map({ Output.chunk14(.searchPresentationToolbarBehavior($0)) }).eraseToAnyParser(),
-_searchSuggestionsModifier<R>.name: _searchSuggestionsModifier<R>.parser(in: context).map({ Output.chunk14(.searchSuggestions($0)) }).eraseToAnyParser(),
-_searchableModifier<R>.name: _searchableModifier<R>.parser(in: context).map({ Output.chunk14(.searchable($0)) }).eraseToAnyParser(),
-_sectionActionsModifier<R>.name: _sectionActionsModifier<R>.parser(in: context).map({ Output.chunk14(.sectionActions($0)) }).eraseToAnyParser(),
-_selectionDisabledModifier<R>.name: _selectionDisabledModifier<R>.parser(in: context).map({ Output.chunk14(.selectionDisabled($0)) }).eraseToAnyParser(),
-_shadowModifier<R>.name: _shadowModifier<R>.parser(in: context).map({ Output.chunk14(.shadow($0)) }).eraseToAnyParser(),
-_sheetModifier<R>.name: _sheetModifier<R>.parser(in: context).map({ Output.chunk14(.sheet($0)) }).eraseToAnyParser(),
-_simultaneousGestureModifier<R>.name: _simultaneousGestureModifier<R>.parser(in: context).map({ Output.chunk14(.simultaneousGesture($0)) }).eraseToAnyParser(),
-_speechAdjustedPitchModifier<R>.name: _speechAdjustedPitchModifier<R>.parser(in: context).map({ Output.chunk14(.speechAdjustedPitch($0)) }).eraseToAnyParser(),
-_speechAlwaysIncludesPunctuationModifier<R>.name: _speechAlwaysIncludesPunctuationModifier<R>.parser(in: context).map({ Output.chunk14(.speechAlwaysIncludesPunctuation($0)) }).eraseToAnyParser(),
-_speechAnnouncementsQueuedModifier<R>.name: _speechAnnouncementsQueuedModifier<R>.parser(in: context).map({ Output.chunk14(.speechAnnouncementsQueued($0)) }).eraseToAnyParser(),
-_speechSpellsOutCharactersModifier<R>.name: _speechSpellsOutCharactersModifier<R>.parser(in: context).map({ Output.chunk14(.speechSpellsOutCharacters($0)) }).eraseToAnyParser(),
-_statusBarHiddenModifier<R>.name: _statusBarHiddenModifier<R>.parser(in: context).map({ Output.chunk14(.statusBarHidden($0)) }).eraseToAnyParser(),
-_submitLabelModifier<R>.name: _submitLabelModifier<R>.parser(in: context).map({ Output.chunk14(.submitLabel($0)) }).eraseToAnyParser(),
-_submitScopeModifier<R>.name: _submitScopeModifier<R>.parser(in: context).map({ Output.chunk15(.submitScope($0)) }).eraseToAnyParser(),
-_supportedVolumeViewpointsModifier<R>.name: _supportedVolumeViewpointsModifier<R>.parser(in: context).map({ Output.chunk15(.supportedVolumeViewpoints($0)) }).eraseToAnyParser(),
-_swipeActionsModifier<R>.name: _swipeActionsModifier<R>.parser(in: context).map({ Output.chunk15(.swipeActions($0)) }).eraseToAnyParser(),
-_symbolEffectModifier<R>.name: _symbolEffectModifier<R>.parser(in: context).map({ Output.chunk15(.symbolEffect($0)) }).eraseToAnyParser(),
-_symbolEffectsRemovedModifier<R>.name: _symbolEffectsRemovedModifier<R>.parser(in: context).map({ Output.chunk15(.symbolEffectsRemoved($0)) }).eraseToAnyParser(),
-_symbolRenderingModeModifier<R>.name: _symbolRenderingModeModifier<R>.parser(in: context).map({ Output.chunk15(.symbolRenderingMode($0)) }).eraseToAnyParser(),
-_symbolVariantModifier<R>.name: _symbolVariantModifier<R>.parser(in: context).map({ Output.chunk15(.symbolVariant($0)) }).eraseToAnyParser(),
-_tabViewSidebarBottomBarModifier<R>.name: _tabViewSidebarBottomBarModifier<R>.parser(in: context).map({ Output.chunk15(.tabViewSidebarBottomBar($0)) }).eraseToAnyParser(),
-_tabViewSidebarFooterModifier<R>.name: _tabViewSidebarFooterModifier<R>.parser(in: context).map({ Output.chunk15(.tabViewSidebarFooter($0)) }).eraseToAnyParser(),
-_tabViewSidebarHeaderModifier<R>.name: _tabViewSidebarHeaderModifier<R>.parser(in: context).map({ Output.chunk15(.tabViewSidebarHeader($0)) }).eraseToAnyParser(),
-_tabViewStyleModifier<R>.name: _tabViewStyleModifier<R>.parser(in: context).map({ Output.chunk15(.tabViewStyle($0)) }).eraseToAnyParser(),
-_tableStyleModifier<R>.name: _tableStyleModifier<R>.parser(in: context).map({ Output.chunk15(.tableStyle($0)) }).eraseToAnyParser(),
-_textCaseModifier<R>.name: _textCaseModifier<R>.parser(in: context).map({ Output.chunk15(.textCase($0)) }).eraseToAnyParser(),
-_textContentTypeModifier<R>.name: _textContentTypeModifier<R>.parser(in: context).map({ Output.chunk15(.textContentType($0)) }).eraseToAnyParser(),
-_textEditorStyleModifier<R>.name: _textEditorStyleModifier<R>.parser(in: context).map({ Output.chunk16(.textEditorStyle($0)) }).eraseToAnyParser(),
-_textFieldStyleModifier<R>.name: _textFieldStyleModifier<R>.parser(in: context).map({ Output.chunk16(.textFieldStyle($0)) }).eraseToAnyParser(),
-_textInputAutocapitalizationModifier<R>.name: _textInputAutocapitalizationModifier<R>.parser(in: context).map({ Output.chunk16(.textInputAutocapitalization($0)) }).eraseToAnyParser(),
-_textInputCompletionModifier<R>.name: _textInputCompletionModifier<R>.parser(in: context).map({ Output.chunk16(.textInputCompletion($0)) }).eraseToAnyParser(),
-_textInputSuggestionsModifier<R>.name: _textInputSuggestionsModifier<R>.parser(in: context).map({ Output.chunk16(.textInputSuggestions($0)) }).eraseToAnyParser(),
-_textSelectionModifier<R>.name: _textSelectionModifier<R>.parser(in: context).map({ Output.chunk16(.textSelection($0)) }).eraseToAnyParser(),
-_textSelectionAffinityModifier<R>.name: _textSelectionAffinityModifier<R>.parser(in: context).map({ Output.chunk16(.textSelectionAffinity($0)) }).eraseToAnyParser(),
-_tintModifier<R>.name: _tintModifier<R>.parser(in: context).map({ Output.chunk16(.tint($0)) }).eraseToAnyParser(),
-_toggleStyleModifier<R>.name: _toggleStyleModifier<R>.parser(in: context).map({ Output.chunk16(.toggleStyle($0)) }).eraseToAnyParser(),
-_toolbarModifier<R>.name: _toolbarModifier<R>.parser(in: context).map({ Output.chunk16(.toolbar($0)) }).eraseToAnyParser(),
-_toolbarBackgroundModifier<R>.name: _toolbarBackgroundModifier<R>.parser(in: context).map({ Output.chunk16(.toolbarBackground($0)) }).eraseToAnyParser(),
-_toolbarBackgroundVisibilityModifier<R>.name: _toolbarBackgroundVisibilityModifier<R>.parser(in: context).map({ Output.chunk16(.toolbarBackgroundVisibility($0)) }).eraseToAnyParser(),
-_toolbarColorSchemeModifier<R>.name: _toolbarColorSchemeModifier<R>.parser(in: context).map({ Output.chunk16(.toolbarColorScheme($0)) }).eraseToAnyParser(),
-_toolbarItemHiddenModifier<R>.name: _toolbarItemHiddenModifier<R>.parser(in: context).map({ Output.chunk16(.toolbarItemHidden($0)) }).eraseToAnyParser(),
-_toolbarRoleModifier<R>.name: _toolbarRoleModifier<R>.parser(in: context).map({ Output.chunk17(.toolbarRole($0)) }).eraseToAnyParser(),
-_toolbarTitleDisplayModeModifier<R>.name: _toolbarTitleDisplayModeModifier<R>.parser(in: context).map({ Output.chunk17(.toolbarTitleDisplayMode($0)) }).eraseToAnyParser(),
-_toolbarTitleMenuModifier<R>.name: _toolbarTitleMenuModifier<R>.parser(in: context).map({ Output.chunk17(.toolbarTitleMenu($0)) }).eraseToAnyParser(),
-_toolbarVisibilityModifier<R>.name: _toolbarVisibilityModifier<R>.parser(in: context).map({ Output.chunk17(.toolbarVisibility($0)) }).eraseToAnyParser(),
-_touchBarCustomizationLabelModifier<R>.name: _touchBarCustomizationLabelModifier<R>.parser(in: context).map({ Output.chunk17(.touchBarCustomizationLabel($0)) }).eraseToAnyParser(),
-_touchBarItemPrincipalModifier<R>.name: _touchBarItemPrincipalModifier<R>.parser(in: context).map({ Output.chunk17(.touchBarItemPrincipal($0)) }).eraseToAnyParser(),
-_transform3DEffectModifier<R>.name: _transform3DEffectModifier<R>.parser(in: context).map({ Output.chunk17(.transform3DEffect($0)) }).eraseToAnyParser(),
-_transformEffectModifier<R>.name: _transformEffectModifier<R>.parser(in: context).map({ Output.chunk17(.transformEffect($0)) }).eraseToAnyParser(),
-_transitionModifier<R>.name: _transitionModifier<R>.parser(in: context).map({ Output.chunk17(.transition($0)) }).eraseToAnyParser(),
-_truncationModeModifier<R>.name: _truncationModeModifier<R>.parser(in: context).map({ Output.chunk17(.truncationMode($0)) }).eraseToAnyParser(),
-_unredactedModifier<R>.name: _unredactedModifier<R>.parser(in: context).map({ Output.chunk17(.unredacted($0)) }).eraseToAnyParser(),
-_upperLimbVisibilityModifier<R>.name: _upperLimbVisibilityModifier<R>.parser(in: context).map({ Output.chunk17(.upperLimbVisibility($0)) }).eraseToAnyParser(),
-_volumeBaseplateVisibilityModifier<R>.name: _volumeBaseplateVisibilityModifier<R>.parser(in: context).map({ Output.chunk17(.volumeBaseplateVisibility($0)) }).eraseToAnyParser(),
-_windowDismissBehaviorModifier<R>.name: _windowDismissBehaviorModifier<R>.parser(in: context).map({ Output.chunk17(.windowDismissBehavior($0)) }).eraseToAnyParser(),
-_windowFullScreenBehaviorModifier<R>.name: _windowFullScreenBehaviorModifier<R>.parser(in: context).map({ Output.chunk18(.windowFullScreenBehavior($0)) }).eraseToAnyParser(),
-_windowMinimizeBehaviorModifier<R>.name: _windowMinimizeBehaviorModifier<R>.parser(in: context).map({ Output.chunk18(.windowMinimizeBehavior($0)) }).eraseToAnyParser(),
-_windowResizeBehaviorModifier<R>.name: _windowResizeBehaviorModifier<R>.parser(in: context).map({ Output.chunk18(.windowResizeBehavior($0)) }).eraseToAnyParser(),
-_windowToolbarFullScreenVisibilityModifier<R>.name: _windowToolbarFullScreenVisibilityModifier<R>.parser(in: context).map({ Output.chunk18(.windowToolbarFullScreenVisibility($0)) }).eraseToAnyParser(),
-_writingToolsBehaviorModifier<R>.name: _writingToolsBehaviorModifier<R>.parser(in: context).map({ Output.chunk18(.writingToolsBehavior($0)) }).eraseToAnyParser(),
-_zIndexModifier<R>.name: _zIndexModifier<R>.parser(in: context).map({ Output.chunk18(.zIndex($0)) }).eraseToAnyParser(),
-                    LiveViewNative._SearchCompletionModifier<R>.name: LiveViewNative._SearchCompletionModifier<R>.parser(in: context).map(Output._SearchCompletionModifier).eraseToAnyParser(),
-LiveViewNative._PerspectiveRotationEffectModifier<R>.name: LiveViewNative._PerspectiveRotationEffectModifier<R>.parser(in: context).map(Output._PerspectiveRotationEffectModifier).eraseToAnyParser(),
-LiveViewNative._SearchScopesModifier<R>.name: LiveViewNative._SearchScopesModifier<R>.parser(in: context).map(Output._SearchScopesModifier).eraseToAnyParser(),
-LiveViewNative._MatchedGeometryEffectModifier<R>.name: LiveViewNative._MatchedGeometryEffectModifier<R>.parser(in: context).map(Output._MatchedGeometryEffectModifier).eraseToAnyParser(),
-LiveViewNative._Rotation3DEffectModifier<R>.name: LiveViewNative._Rotation3DEffectModifier<R>.parser(in: context).map(Output._Rotation3DEffectModifier).eraseToAnyParser(),
-LiveViewNative._PresentationDetentsModifier.name: LiveViewNative._PresentationDetentsModifier.parser(in: context).map(Output._PresentationDetentsModifier).eraseToAnyParser(),
-LiveViewNative._MatchedTransitionSourceModifier<R>.name: LiveViewNative._MatchedTransitionSourceModifier<R>.parser(in: context).map(Output._MatchedTransitionSourceModifier).eraseToAnyParser(),
-LiveViewNative._OnSubmitModifier.name: LiveViewNative._OnSubmitModifier.parser(in: context).map(Output._OnSubmitModifier).eraseToAnyParser(),
-LiveViewNative._FocusScopeModifier<R>.name: LiveViewNative._FocusScopeModifier<R>.parser(in: context).map(Output._FocusScopeModifier).eraseToAnyParser(),
+_navigationSplitViewColumnWidthModifier<R>.name: _navigationSplitViewColumnWidthModifier<R>.parser(in: context).map({ Output.chunk10(.navigationSplitViewColumnWidth($0)) }).eraseToAnyParser(),
+_navigationSplitViewStyleModifier<R>.name: _navigationSplitViewStyleModifier<R>.parser(in: context).map({ Output.chunk10(.navigationSplitViewStyle($0)) }).eraseToAnyParser(),
+_navigationSubtitleModifier<R>.name: _navigationSubtitleModifier<R>.parser(in: context).map({ Output.chunk10(.navigationSubtitle($0)) }).eraseToAnyParser(),
+_navigationTitleModifier<R>.name: _navigationTitleModifier<R>.parser(in: context).map({ Output.chunk10(.navigationTitle($0)) }).eraseToAnyParser(),
+_navigationViewStyleModifier<R>.name: _navigationViewStyleModifier<R>.parser(in: context).map({ Output.chunk10(.navigationViewStyle($0)) }).eraseToAnyParser(),
+_offsetModifier<R>.name: _offsetModifier<R>.parser(in: context).map({ Output.chunk10(.offset($0)) }).eraseToAnyParser(),
+_onAppearModifier<R>.name: _onAppearModifier<R>.parser(in: context).map({ Output.chunk10(.onAppear($0)) }).eraseToAnyParser(),
+_onDeleteCommandModifier<R>.name: _onDeleteCommandModifier<R>.parser(in: context).map({ Output.chunk10(.onDeleteCommand($0)) }).eraseToAnyParser(),
+_onDisappearModifier<R>.name: _onDisappearModifier<R>.parser(in: context).map({ Output.chunk10(.onDisappear($0)) }).eraseToAnyParser(),
+_onExitCommandModifier<R>.name: _onExitCommandModifier<R>.parser(in: context).map({ Output.chunk10(.onExitCommand($0)) }).eraseToAnyParser(),
+_onHoverModifier<R>.name: _onHoverModifier<R>.parser(in: context).map({ Output.chunk10(.onHover($0)) }).eraseToAnyParser(),
+_onImmersionChangeModifier<R>.name: _onImmersionChangeModifier<R>.parser(in: context).map({ Output.chunk10(.onImmersionChange($0)) }).eraseToAnyParser(),
+_onLongPressGestureModifier<R>.name: _onLongPressGestureModifier<R>.parser(in: context).map({ Output.chunk10(.onLongPressGesture($0)) }).eraseToAnyParser(),
+_onLongTouchGestureModifier<R>.name: _onLongTouchGestureModifier<R>.parser(in: context).map({ Output.chunk10(.onLongTouchGesture($0)) }).eraseToAnyParser(),
+_onModifierKeysChangedModifier<R>.name: _onModifierKeysChangedModifier<R>.parser(in: context).map({ Output.chunk11(.onModifierKeysChanged($0)) }).eraseToAnyParser(),
+_onMoveCommandModifier<R>.name: _onMoveCommandModifier<R>.parser(in: context).map({ Output.chunk11(.onMoveCommand($0)) }).eraseToAnyParser(),
+_onPencilDoubleTapModifier<R>.name: _onPencilDoubleTapModifier<R>.parser(in: context).map({ Output.chunk11(.onPencilDoubleTap($0)) }).eraseToAnyParser(),
+_onPencilSqueezeModifier<R>.name: _onPencilSqueezeModifier<R>.parser(in: context).map({ Output.chunk11(.onPencilSqueeze($0)) }).eraseToAnyParser(),
+_onPlayPauseCommandModifier<R>.name: _onPlayPauseCommandModifier<R>.parser(in: context).map({ Output.chunk11(.onPlayPauseCommand($0)) }).eraseToAnyParser(),
+_onScrollPhaseChangeModifier<R>.name: _onScrollPhaseChangeModifier<R>.parser(in: context).map({ Output.chunk11(.onScrollPhaseChange($0)) }).eraseToAnyParser(),
+_onScrollVisibilityChangeModifier<R>.name: _onScrollVisibilityChangeModifier<R>.parser(in: context).map({ Output.chunk11(.onScrollVisibilityChange($0)) }).eraseToAnyParser(),
+_onTapGestureModifier<R>.name: _onTapGestureModifier<R>.parser(in: context).map({ Output.chunk11(.onTapGesture($0)) }).eraseToAnyParser(),
+_onVolumeViewpointChangeModifier<R>.name: _onVolumeViewpointChangeModifier<R>.parser(in: context).map({ Output.chunk11(.onVolumeViewpointChange($0)) }).eraseToAnyParser(),
+_opacityModifier<R>.name: _opacityModifier<R>.parser(in: context).map({ Output.chunk11(.opacity($0)) }).eraseToAnyParser(),
+_ornamentModifier<R>.name: _ornamentModifier<R>.parser(in: context).map({ Output.chunk11(.ornament($0)) }).eraseToAnyParser(),
+_overlayModifier<R>.name: _overlayModifier<R>.parser(in: context).map({ Output.chunk11(.overlay($0)) }).eraseToAnyParser(),
+_paddingModifier<R>.name: _paddingModifier<R>.parser(in: context).map({ Output.chunk11(.padding($0)) }).eraseToAnyParser(),
+_padding3DModifier<R>.name: _padding3DModifier<R>.parser(in: context).map({ Output.chunk11(.padding3D($0)) }).eraseToAnyParser(),
+_persistentSystemOverlaysModifier<R>.name: _persistentSystemOverlaysModifier<R>.parser(in: context).map({ Output.chunk12(.persistentSystemOverlays($0)) }).eraseToAnyParser(),
+_pickerStyleModifier<R>.name: _pickerStyleModifier<R>.parser(in: context).map({ Output.chunk12(.pickerStyle($0)) }).eraseToAnyParser(),
+_pointerStyleModifier<R>.name: _pointerStyleModifier<R>.parser(in: context).map({ Output.chunk12(.pointerStyle($0)) }).eraseToAnyParser(),
+_pointerVisibilityModifier<R>.name: _pointerVisibilityModifier<R>.parser(in: context).map({ Output.chunk12(.pointerVisibility($0)) }).eraseToAnyParser(),
+_popoverModifier<R>.name: _popoverModifier<R>.parser(in: context).map({ Output.chunk12(.popover($0)) }).eraseToAnyParser(),
+_positionModifier<R>.name: _positionModifier<R>.parser(in: context).map({ Output.chunk12(.position($0)) }).eraseToAnyParser(),
+_preferredColorSchemeModifier<R>.name: _preferredColorSchemeModifier<R>.parser(in: context).map({ Output.chunk12(.preferredColorScheme($0)) }).eraseToAnyParser(),
+_preferredSurroundingsEffectModifier<R>.name: _preferredSurroundingsEffectModifier<R>.parser(in: context).map({ Output.chunk12(.preferredSurroundingsEffect($0)) }).eraseToAnyParser(),
+_presentationBackgroundModifier<R>.name: _presentationBackgroundModifier<R>.parser(in: context).map({ Output.chunk12(.presentationBackground($0)) }).eraseToAnyParser(),
+_presentationBackgroundInteractionModifier<R>.name: _presentationBackgroundInteractionModifier<R>.parser(in: context).map({ Output.chunk12(.presentationBackgroundInteraction($0)) }).eraseToAnyParser(),
+_presentationCompactAdaptationModifier<R>.name: _presentationCompactAdaptationModifier<R>.parser(in: context).map({ Output.chunk12(.presentationCompactAdaptation($0)) }).eraseToAnyParser(),
+_presentationContentInteractionModifier<R>.name: _presentationContentInteractionModifier<R>.parser(in: context).map({ Output.chunk12(.presentationContentInteraction($0)) }).eraseToAnyParser(),
+_presentationCornerRadiusModifier<R>.name: _presentationCornerRadiusModifier<R>.parser(in: context).map({ Output.chunk12(.presentationCornerRadius($0)) }).eraseToAnyParser(),
+_presentationDragIndicatorModifier<R>.name: _presentationDragIndicatorModifier<R>.parser(in: context).map({ Output.chunk12(.presentationDragIndicator($0)) }).eraseToAnyParser(),
+_presentationSizingModifier<R>.name: _presentationSizingModifier<R>.parser(in: context).map({ Output.chunk13(.presentationSizing($0)) }).eraseToAnyParser(),
+_previewDisplayNameModifier<R>.name: _previewDisplayNameModifier<R>.parser(in: context).map({ Output.chunk13(.previewDisplayName($0)) }).eraseToAnyParser(),
+_privacySensitiveModifier<R>.name: _privacySensitiveModifier<R>.parser(in: context).map({ Output.chunk13(.privacySensitive($0)) }).eraseToAnyParser(),
+_progressViewStyleModifier<R>.name: _progressViewStyleModifier<R>.parser(in: context).map({ Output.chunk13(.progressViewStyle($0)) }).eraseToAnyParser(),
+_projectionEffectModifier<R>.name: _projectionEffectModifier<R>.parser(in: context).map({ Output.chunk13(.projectionEffect($0)) }).eraseToAnyParser(),
+_redactedModifier<R>.name: _redactedModifier<R>.parser(in: context).map({ Output.chunk13(.redacted($0)) }).eraseToAnyParser(),
+_refreshableModifier<R>.name: _refreshableModifier<R>.parser(in: context).map({ Output.chunk13(.refreshable($0)) }).eraseToAnyParser(),
+_renameActionModifier<R>.name: _renameActionModifier<R>.parser(in: context).map({ Output.chunk13(.renameAction($0)) }).eraseToAnyParser(),
+_replaceDisabledModifier<R>.name: _replaceDisabledModifier<R>.parser(in: context).map({ Output.chunk13(.replaceDisabled($0)) }).eraseToAnyParser(),
+_rotationEffectModifier<R>.name: _rotationEffectModifier<R>.parser(in: context).map({ Output.chunk13(.rotationEffect($0)) }).eraseToAnyParser(),
+_safeAreaInsetModifier<R>.name: _safeAreaInsetModifier<R>.parser(in: context).map({ Output.chunk13(.safeAreaInset($0)) }).eraseToAnyParser(),
+_safeAreaPaddingModifier<R>.name: _safeAreaPaddingModifier<R>.parser(in: context).map({ Output.chunk13(.safeAreaPadding($0)) }).eraseToAnyParser(),
+_saturationModifier<R>.name: _saturationModifier<R>.parser(in: context).map({ Output.chunk13(.saturation($0)) }).eraseToAnyParser(),
+_scaleEffectModifier<R>.name: _scaleEffectModifier<R>.parser(in: context).map({ Output.chunk13(.scaleEffect($0)) }).eraseToAnyParser(),
+_scaledToFillModifier<R>.name: _scaledToFillModifier<R>.parser(in: context).map({ Output.chunk14(.scaledToFill($0)) }).eraseToAnyParser(),
+_scaledToFitModifier<R>.name: _scaledToFitModifier<R>.parser(in: context).map({ Output.chunk14(.scaledToFit($0)) }).eraseToAnyParser(),
+_scenePaddingModifier<R>.name: _scenePaddingModifier<R>.parser(in: context).map({ Output.chunk14(.scenePadding($0)) }).eraseToAnyParser(),
+_scrollBounceBehaviorModifier<R>.name: _scrollBounceBehaviorModifier<R>.parser(in: context).map({ Output.chunk14(.scrollBounceBehavior($0)) }).eraseToAnyParser(),
+_scrollClipDisabledModifier<R>.name: _scrollClipDisabledModifier<R>.parser(in: context).map({ Output.chunk14(.scrollClipDisabled($0)) }).eraseToAnyParser(),
+_scrollContentBackgroundModifier<R>.name: _scrollContentBackgroundModifier<R>.parser(in: context).map({ Output.chunk14(.scrollContentBackground($0)) }).eraseToAnyParser(),
+_scrollDisabledModifier<R>.name: _scrollDisabledModifier<R>.parser(in: context).map({ Output.chunk14(.scrollDisabled($0)) }).eraseToAnyParser(),
+_scrollDismissesKeyboardModifier<R>.name: _scrollDismissesKeyboardModifier<R>.parser(in: context).map({ Output.chunk14(.scrollDismissesKeyboard($0)) }).eraseToAnyParser(),
+_scrollIndicatorsModifier<R>.name: _scrollIndicatorsModifier<R>.parser(in: context).map({ Output.chunk14(.scrollIndicators($0)) }).eraseToAnyParser(),
+_scrollIndicatorsFlashModifier<R>.name: _scrollIndicatorsFlashModifier<R>.parser(in: context).map({ Output.chunk14(.scrollIndicatorsFlash($0)) }).eraseToAnyParser(),
+_scrollPositionModifier<R>.name: _scrollPositionModifier<R>.parser(in: context).map({ Output.chunk14(.scrollPosition($0)) }).eraseToAnyParser(),
+_scrollTargetBehaviorModifier<R>.name: _scrollTargetBehaviorModifier<R>.parser(in: context).map({ Output.chunk14(.scrollTargetBehavior($0)) }).eraseToAnyParser(),
+_scrollTargetLayoutModifier<R>.name: _scrollTargetLayoutModifier<R>.parser(in: context).map({ Output.chunk14(.scrollTargetLayout($0)) }).eraseToAnyParser(),
+_searchDictationBehaviorModifier<R>.name: _searchDictationBehaviorModifier<R>.parser(in: context).map({ Output.chunk14(.searchDictationBehavior($0)) }).eraseToAnyParser(),
+_searchPresentationToolbarBehaviorModifier<R>.name: _searchPresentationToolbarBehaviorModifier<R>.parser(in: context).map({ Output.chunk15(.searchPresentationToolbarBehavior($0)) }).eraseToAnyParser(),
+_searchSuggestionsModifier<R>.name: _searchSuggestionsModifier<R>.parser(in: context).map({ Output.chunk15(.searchSuggestions($0)) }).eraseToAnyParser(),
+_searchableModifier<R>.name: _searchableModifier<R>.parser(in: context).map({ Output.chunk15(.searchable($0)) }).eraseToAnyParser(),
+_sectionActionsModifier<R>.name: _sectionActionsModifier<R>.parser(in: context).map({ Output.chunk15(.sectionActions($0)) }).eraseToAnyParser(),
+_selectionDisabledModifier<R>.name: _selectionDisabledModifier<R>.parser(in: context).map({ Output.chunk15(.selectionDisabled($0)) }).eraseToAnyParser(),
+_shadowModifier<R>.name: _shadowModifier<R>.parser(in: context).map({ Output.chunk15(.shadow($0)) }).eraseToAnyParser(),
+_sheetModifier<R>.name: _sheetModifier<R>.parser(in: context).map({ Output.chunk15(.sheet($0)) }).eraseToAnyParser(),
+_simultaneousGestureModifier<R>.name: _simultaneousGestureModifier<R>.parser(in: context).map({ Output.chunk15(.simultaneousGesture($0)) }).eraseToAnyParser(),
+_speechAdjustedPitchModifier<R>.name: _speechAdjustedPitchModifier<R>.parser(in: context).map({ Output.chunk15(.speechAdjustedPitch($0)) }).eraseToAnyParser(),
+_speechAlwaysIncludesPunctuationModifier<R>.name: _speechAlwaysIncludesPunctuationModifier<R>.parser(in: context).map({ Output.chunk15(.speechAlwaysIncludesPunctuation($0)) }).eraseToAnyParser(),
+_speechAnnouncementsQueuedModifier<R>.name: _speechAnnouncementsQueuedModifier<R>.parser(in: context).map({ Output.chunk15(.speechAnnouncementsQueued($0)) }).eraseToAnyParser(),
+_speechSpellsOutCharactersModifier<R>.name: _speechSpellsOutCharactersModifier<R>.parser(in: context).map({ Output.chunk15(.speechSpellsOutCharacters($0)) }).eraseToAnyParser(),
+_statusBarModifier<R>.name: _statusBarModifier<R>.parser(in: context).map({ Output.chunk15(.statusBar($0)) }).eraseToAnyParser(),
+_statusBarHiddenModifier<R>.name: _statusBarHiddenModifier<R>.parser(in: context).map({ Output.chunk15(.statusBarHidden($0)) }).eraseToAnyParser(),
+_submitLabelModifier<R>.name: _submitLabelModifier<R>.parser(in: context).map({ Output.chunk16(.submitLabel($0)) }).eraseToAnyParser(),
+_submitScopeModifier<R>.name: _submitScopeModifier<R>.parser(in: context).map({ Output.chunk16(.submitScope($0)) }).eraseToAnyParser(),
+_supportedVolumeViewpointsModifier<R>.name: _supportedVolumeViewpointsModifier<R>.parser(in: context).map({ Output.chunk16(.supportedVolumeViewpoints($0)) }).eraseToAnyParser(),
+_swipeActionsModifier<R>.name: _swipeActionsModifier<R>.parser(in: context).map({ Output.chunk16(.swipeActions($0)) }).eraseToAnyParser(),
+_symbolEffectModifier<R>.name: _symbolEffectModifier<R>.parser(in: context).map({ Output.chunk16(.symbolEffect($0)) }).eraseToAnyParser(),
+_symbolEffectsRemovedModifier<R>.name: _symbolEffectsRemovedModifier<R>.parser(in: context).map({ Output.chunk16(.symbolEffectsRemoved($0)) }).eraseToAnyParser(),
+_symbolRenderingModeModifier<R>.name: _symbolRenderingModeModifier<R>.parser(in: context).map({ Output.chunk16(.symbolRenderingMode($0)) }).eraseToAnyParser(),
+_symbolVariantModifier<R>.name: _symbolVariantModifier<R>.parser(in: context).map({ Output.chunk16(.symbolVariant($0)) }).eraseToAnyParser(),
+_tabItemModifier<R>.name: _tabItemModifier<R>.parser(in: context).map({ Output.chunk16(.tabItem($0)) }).eraseToAnyParser(),
+_tabViewSidebarBottomBarModifier<R>.name: _tabViewSidebarBottomBarModifier<R>.parser(in: context).map({ Output.chunk16(.tabViewSidebarBottomBar($0)) }).eraseToAnyParser(),
+_tabViewSidebarFooterModifier<R>.name: _tabViewSidebarFooterModifier<R>.parser(in: context).map({ Output.chunk16(.tabViewSidebarFooter($0)) }).eraseToAnyParser(),
+_tabViewSidebarHeaderModifier<R>.name: _tabViewSidebarHeaderModifier<R>.parser(in: context).map({ Output.chunk16(.tabViewSidebarHeader($0)) }).eraseToAnyParser(),
+_tabViewStyleModifier<R>.name: _tabViewStyleModifier<R>.parser(in: context).map({ Output.chunk16(.tabViewStyle($0)) }).eraseToAnyParser(),
+_tableStyleModifier<R>.name: _tableStyleModifier<R>.parser(in: context).map({ Output.chunk16(.tableStyle($0)) }).eraseToAnyParser(),
+_textCaseModifier<R>.name: _textCaseModifier<R>.parser(in: context).map({ Output.chunk17(.textCase($0)) }).eraseToAnyParser(),
+_textContentTypeModifier<R>.name: _textContentTypeModifier<R>.parser(in: context).map({ Output.chunk17(.textContentType($0)) }).eraseToAnyParser(),
+_textEditorStyleModifier<R>.name: _textEditorStyleModifier<R>.parser(in: context).map({ Output.chunk17(.textEditorStyle($0)) }).eraseToAnyParser(),
+_textFieldStyleModifier<R>.name: _textFieldStyleModifier<R>.parser(in: context).map({ Output.chunk17(.textFieldStyle($0)) }).eraseToAnyParser(),
+_textInputAutocapitalizationModifier<R>.name: _textInputAutocapitalizationModifier<R>.parser(in: context).map({ Output.chunk17(.textInputAutocapitalization($0)) }).eraseToAnyParser(),
+_textInputCompletionModifier<R>.name: _textInputCompletionModifier<R>.parser(in: context).map({ Output.chunk17(.textInputCompletion($0)) }).eraseToAnyParser(),
+_textInputSuggestionsModifier<R>.name: _textInputSuggestionsModifier<R>.parser(in: context).map({ Output.chunk17(.textInputSuggestions($0)) }).eraseToAnyParser(),
+_textSelectionModifier<R>.name: _textSelectionModifier<R>.parser(in: context).map({ Output.chunk17(.textSelection($0)) }).eraseToAnyParser(),
+_textSelectionAffinityModifier<R>.name: _textSelectionAffinityModifier<R>.parser(in: context).map({ Output.chunk17(.textSelectionAffinity($0)) }).eraseToAnyParser(),
+_tintModifier<R>.name: _tintModifier<R>.parser(in: context).map({ Output.chunk17(.tint($0)) }).eraseToAnyParser(),
+_toggleStyleModifier<R>.name: _toggleStyleModifier<R>.parser(in: context).map({ Output.chunk17(.toggleStyle($0)) }).eraseToAnyParser(),
+_toolbarModifier<R>.name: _toolbarModifier<R>.parser(in: context).map({ Output.chunk17(.toolbar($0)) }).eraseToAnyParser(),
+_toolbarBackgroundModifier<R>.name: _toolbarBackgroundModifier<R>.parser(in: context).map({ Output.chunk17(.toolbarBackground($0)) }).eraseToAnyParser(),
+_toolbarBackgroundVisibilityModifier<R>.name: _toolbarBackgroundVisibilityModifier<R>.parser(in: context).map({ Output.chunk17(.toolbarBackgroundVisibility($0)) }).eraseToAnyParser(),
+_toolbarColorSchemeModifier<R>.name: _toolbarColorSchemeModifier<R>.parser(in: context).map({ Output.chunk18(.toolbarColorScheme($0)) }).eraseToAnyParser(),
+_toolbarItemHiddenModifier<R>.name: _toolbarItemHiddenModifier<R>.parser(in: context).map({ Output.chunk18(.toolbarItemHidden($0)) }).eraseToAnyParser(),
+_toolbarRoleModifier<R>.name: _toolbarRoleModifier<R>.parser(in: context).map({ Output.chunk18(.toolbarRole($0)) }).eraseToAnyParser(),
+_toolbarTitleDisplayModeModifier<R>.name: _toolbarTitleDisplayModeModifier<R>.parser(in: context).map({ Output.chunk18(.toolbarTitleDisplayMode($0)) }).eraseToAnyParser(),
+_toolbarTitleMenuModifier<R>.name: _toolbarTitleMenuModifier<R>.parser(in: context).map({ Output.chunk18(.toolbarTitleMenu($0)) }).eraseToAnyParser(),
+_toolbarVisibilityModifier<R>.name: _toolbarVisibilityModifier<R>.parser(in: context).map({ Output.chunk18(.toolbarVisibility($0)) }).eraseToAnyParser(),
+_touchBarCustomizationLabelModifier<R>.name: _touchBarCustomizationLabelModifier<R>.parser(in: context).map({ Output.chunk18(.touchBarCustomizationLabel($0)) }).eraseToAnyParser(),
+_touchBarItemPrincipalModifier<R>.name: _touchBarItemPrincipalModifier<R>.parser(in: context).map({ Output.chunk18(.touchBarItemPrincipal($0)) }).eraseToAnyParser(),
+_transform3DEffectModifier<R>.name: _transform3DEffectModifier<R>.parser(in: context).map({ Output.chunk18(.transform3DEffect($0)) }).eraseToAnyParser(),
+_transformEffectModifier<R>.name: _transformEffectModifier<R>.parser(in: context).map({ Output.chunk18(.transformEffect($0)) }).eraseToAnyParser(),
+_transitionModifier<R>.name: _transitionModifier<R>.parser(in: context).map({ Output.chunk18(.transition($0)) }).eraseToAnyParser(),
+_truncationModeModifier<R>.name: _truncationModeModifier<R>.parser(in: context).map({ Output.chunk18(.truncationMode($0)) }).eraseToAnyParser(),
+_unredactedModifier<R>.name: _unredactedModifier<R>.parser(in: context).map({ Output.chunk18(.unredacted($0)) }).eraseToAnyParser(),
+_upperLimbVisibilityModifier<R>.name: _upperLimbVisibilityModifier<R>.parser(in: context).map({ Output.chunk18(.upperLimbVisibility($0)) }).eraseToAnyParser(),
+_volumeBaseplateVisibilityModifier<R>.name: _volumeBaseplateVisibilityModifier<R>.parser(in: context).map({ Output.chunk19(.volumeBaseplateVisibility($0)) }).eraseToAnyParser(),
+_windowDismissBehaviorModifier<R>.name: _windowDismissBehaviorModifier<R>.parser(in: context).map({ Output.chunk19(.windowDismissBehavior($0)) }).eraseToAnyParser(),
+_windowFullScreenBehaviorModifier<R>.name: _windowFullScreenBehaviorModifier<R>.parser(in: context).map({ Output.chunk19(.windowFullScreenBehavior($0)) }).eraseToAnyParser(),
+_windowMinimizeBehaviorModifier<R>.name: _windowMinimizeBehaviorModifier<R>.parser(in: context).map({ Output.chunk19(.windowMinimizeBehavior($0)) }).eraseToAnyParser(),
+_windowResizeBehaviorModifier<R>.name: _windowResizeBehaviorModifier<R>.parser(in: context).map({ Output.chunk19(.windowResizeBehavior($0)) }).eraseToAnyParser(),
+_windowToolbarFullScreenVisibilityModifier<R>.name: _windowToolbarFullScreenVisibilityModifier<R>.parser(in: context).map({ Output.chunk19(.windowToolbarFullScreenVisibility($0)) }).eraseToAnyParser(),
+_writingToolsBehaviorModifier<R>.name: _writingToolsBehaviorModifier<R>.parser(in: context).map({ Output.chunk19(.writingToolsBehavior($0)) }).eraseToAnyParser(),
+_zIndexModifier<R>.name: _zIndexModifier<R>.parser(in: context).map({ Output.chunk19(.zIndex($0)) }).eraseToAnyParser(),
+                    LiveViewNative._OnSubmitModifier.name: LiveViewNative._OnSubmitModifier.parser(in: context).map(Output._OnSubmitModifier).eraseToAnyParser(),
 LiveViewNative._NavigationTransitionModifier<R>.name: LiveViewNative._NavigationTransitionModifier<R>.parser(in: context).map(Output._NavigationTransitionModifier).eraseToAnyParser(),
-LiveViewNative._PrefersDefaultFocusModifier<R>.name: LiveViewNative._PrefersDefaultFocusModifier<R>.parser(in: context).map(Output._PrefersDefaultFocusModifier).eraseToAnyParser(),
+LiveViewNative._MatchedTransitionSourceModifier<R>.name: LiveViewNative._MatchedTransitionSourceModifier<R>.parser(in: context).map(Output._MatchedTransitionSourceModifier).eraseToAnyParser(),
+LiveViewNative._FocusScopeModifier<R>.name: LiveViewNative._FocusScopeModifier<R>.parser(in: context).map(Output._FocusScopeModifier).eraseToAnyParser(),
+LiveViewNative._SearchScopesModifier<R>.name: LiveViewNative._SearchScopesModifier<R>.parser(in: context).map(Output._SearchScopesModifier).eraseToAnyParser(),
+LiveViewNative._PresentationDetentsModifier.name: LiveViewNative._PresentationDetentsModifier.parser(in: context).map(Output._PresentationDetentsModifier).eraseToAnyParser(),
+LiveViewNative._Rotation3DEffectModifier<R>.name: LiveViewNative._Rotation3DEffectModifier<R>.parser(in: context).map(Output._Rotation3DEffectModifier).eraseToAnyParser(),
 LiveViewNative._MaskModifier<R>.name: LiveViewNative._MaskModifier<R>.parser(in: context).map(Output._MaskModifier).eraseToAnyParser(),
+LiveViewNative._PerspectiveRotationEffectModifier<R>.name: LiveViewNative._PerspectiveRotationEffectModifier<R>.parser(in: context).map(Output._PerspectiveRotationEffectModifier).eraseToAnyParser(),
+LiveViewNative._MatchedGeometryEffectModifier<R>.name: LiveViewNative._MatchedGeometryEffectModifier<R>.parser(in: context).map(Output._MatchedGeometryEffectModifier).eraseToAnyParser(),
+LiveViewNative._PrefersDefaultFocusModifier<R>.name: LiveViewNative._PrefersDefaultFocusModifier<R>.parser(in: context).map(Output._PrefersDefaultFocusModifier).eraseToAnyParser(),
+LiveViewNative._SearchCompletionModifier<R>.name: LiveViewNative._SearchCompletionModifier<R>.parser(in: context).map(Output._SearchCompletionModifier).eraseToAnyParser(),
                 ]
 
                 let deprecations = [
@@ -16275,7 +17549,7 @@ ConstantAtomLiteral("content").map({ () -> Self in
 /// * `.tabBar`
 /// * `.sidebar`
 @_documentation(visibility: public)
-@available(watchOS 11.0,iOS 18.0,tvOS 18.0,visionOS 2.0,macOS 15.0, *)
+@available(iOS 18.0,visionOS 2.0,watchOS 11.0,macOS 15.0,tvOS 18.0, *)
 extension AdaptableTabBarPlacement: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -16393,7 +17667,7 @@ ConstantAtomLiteral("vertical").map({ () -> Self in
 /// * `.standard`
 /// * `.increased`
 @_documentation(visibility: public)
-@available(macOS 14.0,iOS 17.0,visionOS 1.0, *)
+@available(visionOS 1.0,macOS 14.0,iOS 17.0, *)
 extension BadgeProminence: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -16621,7 +17895,7 @@ ConstantAtomLiteral("plusLighter").map({ () -> Self in
 /// * `.enabled`
 /// * `.disabled`
 @_documentation(visibility: public)
-@available(watchOS 10.0,iOS 17.0,tvOS 17.0,visionOS 1.0,macOS 14.0, *)
+@available(iOS 17.0,visionOS 1.0,watchOS 10.0,macOS 14.0,tvOS 17.0, *)
 extension ButtonRepeatBehavior: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -16740,35 +18014,35 @@ ConstantAtomLiteral("dark").map({ () -> Self in
 /// * `.navigationSplitView`
 /// * `.window`
 @_documentation(visibility: public)
-@available(iOS 17.0,tvOS 17.0,watchOS 10.0,macOS 14.0,visionOS 1.0, *)
+@available(visionOS 1.0,tvOS 17.0,iOS 17.0,watchOS 10.0,macOS 14.0, *)
 extension ContainerBackgroundPlacement: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             #if os(watchOS)
 ConstantAtomLiteral("tabView").map({ () -> Self in
-if #available(iOS 17.0,tvOS 17.0,watchOS 10.0,macOS 14.0, *) {
+if #available(tvOS 17.0,iOS 17.0,watchOS 10.0,macOS 14.0, *) {
     return Self.tabView
 } else { fatalError("'tabView' is not available in this OS version") }
 })
 #endif
 #if os(iOS) || os(watchOS)
 ConstantAtomLiteral("navigation").map({ () -> Self in
-if #available(iOS 18.0,tvOS 17.0,watchOS 10.0,macOS 14.0, *) {
+if #available(tvOS 17.0,iOS 18.0,watchOS 10.0,macOS 14.0, *) {
     return Self.navigation
 } else { fatalError("'navigation' is not available in this OS version") }
 })
 #endif
 #if os(iOS) || os(watchOS)
 ConstantAtomLiteral("navigationSplitView").map({ () -> Self in
-if #available(iOS 18.0,tvOS 17.0,watchOS 11.0,macOS 14.0, *) {
+if #available(tvOS 17.0,iOS 18.0,watchOS 11.0,macOS 14.0, *) {
     return Self.navigationSplitView
 } else { fatalError("'navigationSplitView' is not available in this OS version") }
 })
 #endif
 #if os(macOS)
 ConstantAtomLiteral("window").map({ () -> Self in
-if #available(iOS 17.0,tvOS 17.0,watchOS 10.0,macOS 15.0, *) {
+if #available(tvOS 17.0,iOS 17.0,watchOS 10.0,macOS 15.0, *) {
     return Self.window
 } else { fatalError("'window' is not available in this OS version") }
 })
@@ -16789,7 +18063,7 @@ if #available(iOS 17.0,tvOS 17.0,watchOS 10.0,macOS 15.0, *) {
 /// * `.scrollContent`
 /// * `.scrollIndicators`
 @_documentation(visibility: public)
-@available(macOS 14.0,watchOS 10.0,visionOS 1.0,iOS 17.0,tvOS 17.0, *)
+@available(visionOS 1.0,tvOS 17.0,iOS 17.0,watchOS 10.0,macOS 14.0, *)
 extension ContentMarginPlacement: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -16848,35 +18122,35 @@ ConstantAtomLiteral("interaction").map({ () -> Self in
 
 #if os(iOS) || os(macOS) || os(visionOS)
 ConstantAtomLiteral("dragPreview").map({ () -> Self in
-if #available(watchOS 8.0,visionOS 1.0,macOS 12.0,iOS 15.0,tvOS 15.0, *) {
+if #available(visionOS 1.0,tvOS 15.0,iOS 15.0,macOS 12.0,watchOS 8.0, *) {
     return Self.dragPreview
 } else { fatalError("'dragPreview' is not available in this OS version") }
 })
 #endif
 #if os(iOS) || os(tvOS) || os(visionOS)
 ConstantAtomLiteral("contextMenuPreview").map({ () -> Self in
-if #available(watchOS 8.0,visionOS 1.0,macOS 12.0,iOS 15.0,tvOS 17.0, *) {
+if #available(visionOS 1.0,tvOS 17.0,iOS 15.0,macOS 12.0,watchOS 8.0, *) {
     return Self.contextMenuPreview
 } else { fatalError("'contextMenuPreview' is not available in this OS version") }
 })
 #endif
 #if os(iOS) || os(tvOS) || os(visionOS)
 ConstantAtomLiteral("hoverEffect").map({ () -> Self in
-if #available(watchOS 8.0,visionOS 1.0,macOS 12.0,iOS 15.0,tvOS 18.0, *) {
+if #available(visionOS 1.0,tvOS 18.0,iOS 15.0,macOS 12.0,watchOS 8.0, *) {
     return Self.hoverEffect
 } else { fatalError("'hoverEffect' is not available in this OS version") }
 })
 #endif
 #if os(macOS) || os(watchOS)
 ConstantAtomLiteral("focusEffect").map({ () -> Self in
-if #available(watchOS 8.0,macOS 12.0,iOS 15.0,tvOS 15.0, *) {
+if #available(tvOS 15.0,iOS 15.0,macOS 12.0,watchOS 8.0, *) {
     return Self.focusEffect
 } else { fatalError("'focusEffect' is not available in this OS version") }
 })
 #endif
 #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
 ConstantAtomLiteral("accessibility").map({ () -> Self in
-if #available(iOS 17.0,tvOS 17.0,watchOS 10.0,macOS 14.0,visionOS 1.0, *) {
+if #available(tvOS 17.0,visionOS 1.0,macOS 14.0,iOS 17.0,watchOS 10.0, *) {
     return Self.accessibility
 } else { fatalError("'accessibility' is not available in this OS version") }
 })
@@ -16899,7 +18173,7 @@ if #available(iOS 17.0,tvOS 17.0,watchOS 10.0,macOS 14.0,visionOS 1.0, *) {
 /// * `.large`
 /// * `.extraLarge`
 @_documentation(visibility: public)
-@available(iOS 15.0,watchOS 9.0,macOS 10.15,visionOS 1.0, *)
+@available(visionOS 1.0,macOS 10.15,watchOS 9.0,iOS 15.0, *)
 extension ControlSize: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -16927,14 +18201,14 @@ ConstantAtomLiteral("regular").map({ () -> Self in
 #endif
 #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
 ConstantAtomLiteral("large").map({ () -> Self in
-if #available(iOS 15.0,watchOS 9.0,macOS 11.0,visionOS 1.0, *) {
+if #available(visionOS 1.0,macOS 11.0,watchOS 9.0,iOS 15.0, *) {
     return Self.large
 } else { fatalError("'large' is not available in this OS version") }
 })
 #endif
 #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
 ConstantAtomLiteral("extraLarge").map({ () -> Self in
-if #available(iOS 17.0,watchOS 10.0,macOS 14.0,visionOS 1.0, *) {
+if #available(visionOS 1.0,macOS 14.0,watchOS 10.0,iOS 17.0, *) {
     return Self.extraLarge
 } else { fatalError("'extraLarge' is not available in this OS version") }
 })
@@ -16989,7 +18263,7 @@ ConstantAtomLiteral("userInitiated").map({ () -> Self in
 /// * `.critical`
 /// * `.standard`
 @_documentation(visibility: public)
-@available(iOS 17.0,tvOS 17.0,watchOS 10.0,macOS 13.0,visionOS 1.0, *)
+@available(visionOS 1.0,tvOS 17.0,iOS 17.0,watchOS 10.0,macOS 13.0, *)
 extension DialogSeverity: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -17010,7 +18284,7 @@ ConstantAtomLiteral("critical").map({ () -> Self in
 #endif
 #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
 ConstantAtomLiteral("standard").map({ () -> Self in
-if #available(iOS 17.0,tvOS 17.0,watchOS 10.0,macOS 14.0,visionOS 1.0, *) {
+if #available(visionOS 1.0,tvOS 17.0,iOS 17.0,watchOS 10.0,macOS 14.0, *) {
     return Self.standard
 } else { fatalError("'standard' is not available in this OS version") }
 })
@@ -17181,7 +18455,7 @@ ConstantAtomLiteral("all").map({ () -> Self in
 /// * `.includeHiddenFiles`
 /// * `.displayFileExtensions`
 @_documentation(visibility: public)
-@available(iOS 17.0,visionOS 1.0,macOS 14.0, *)
+@available(visionOS 1.0,macOS 14.0,iOS 17.0, *)
 extension FileDialogBrowserOptions: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -17223,7 +18497,7 @@ ConstantAtomLiteral("displayFileExtensions").map({ () -> Self in
 /// * `.edit`
 /// * `.automatic`
 @_documentation(visibility: public)
-@available(watchOS 10.0,iOS 17.0,tvOS 17.0,visionOS 1.0,macOS 14.0, *)
+@available(iOS 17.0,visionOS 1.0,watchOS 10.0,macOS 14.0,tvOS 17.0, *)
 extension FocusInteractions: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -17482,14 +18756,14 @@ extension HorizontalAlignment: ParseableModifierValue {
             OneOf {
             #if os(iOS) || os(macOS) || os(visionOS)
 ConstantAtomLiteral("listRowSeparatorLeading").map({ () -> Self in
-if #available(iOS 16.0,visionOS 1.0,macOS 13.0, *) {
+if #available(visionOS 1.0,macOS 13.0,iOS 16.0, *) {
     return Self.listRowSeparatorLeading
 } else { fatalError("'listRowSeparatorLeading' is not available in this OS version") }
 })
 #endif
 #if os(iOS) || os(macOS) || os(visionOS)
 ConstantAtomLiteral("listRowSeparatorTrailing").map({ () -> Self in
-if #available(iOS 16.0,visionOS 1.0,macOS 13.0, *) {
+if #available(visionOS 1.0,macOS 13.0,iOS 16.0, *) {
     return Self.listRowSeparatorTrailing
 } else { fatalError("'listRowSeparatorTrailing' is not available in this OS version") }
 })
@@ -17530,7 +18804,7 @@ ConstantAtomLiteral("trailing").map({ () -> Self in
 /// * `.leading`
 /// * `.trailing`
 @_documentation(visibility: public)
-@available(watchOS 11.0,visionOS 2.0,macOS 15.0,iOS 18.0,tvOS 18.0, *)
+@available(visionOS 2.0,tvOS 18.0,iOS 18.0,macOS 15.0,watchOS 11.0, *)
 extension HorizontalDirection: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -17599,7 +18873,7 @@ ConstantAtomLiteral("trailing").map({ () -> Self in
 /// * `.highlight`
 /// * `.lift`
 @_documentation(visibility: public)
-@available(iOS 13.4,visionOS 1.0,tvOS 16.0, *)
+@available(tvOS 16.0,visionOS 1.0,iOS 13.4, *)
 extension HoverEffect: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -17613,7 +18887,7 @@ ConstantAtomLiteral("automatic").map({ () -> Self in
 #endif
 #if os(iOS) || os(tvOS) || os(visionOS)
 ConstantAtomLiteral("highlight").map({ () -> Self in
-if #available(iOS 13.4,visionOS 1.0,tvOS 17.0, *) {
+if #available(tvOS 17.0,visionOS 1.0,iOS 13.4, *) {
     return Self.highlight
 } else { fatalError("'highlight' is not available in this OS version") }
 })
@@ -17640,7 +18914,7 @@ ConstantAtomLiteral("lift").map({ () -> Self in
 /// * `.defaultAction`
 /// * `.cancelAction`
 @_documentation(visibility: public)
-@available(macOS 11.0,iOS 14.0,visionOS 1.0, *)
+@available(visionOS 1.0,macOS 11.0,iOS 14.0, *)
 extension KeyboardShortcut: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -17731,7 +19005,7 @@ ConstantAtomLiteral("automatic").map({ () -> Self in
 
 #if os(iOS) || os(visionOS)
 ConstantAtomLiteral("priority").map({ () -> Self in
-if #available(macOS 13.0,watchOS 9.0,visionOS 1.0,iOS 16.0,tvOS 16.0, *) {
+if #available(watchOS 9.0,iOS 16.0,macOS 13.0,tvOS 16.0,visionOS 1.0, *) {
     return Self.priority
 } else { fatalError("'priority' is not available in this OS version") }
 })
@@ -17761,7 +19035,7 @@ ConstantAtomLiteral("fixed").map({ () -> Self in
 /// * `.sheet`
 /// * `.fullScreenCover`
 @_documentation(visibility: public)
-@available(iOS 16.4,tvOS 16.4,watchOS 9.4,macOS 13.3,visionOS 1.0, *)
+@available(visionOS 1.0,tvOS 16.4,iOS 16.4,watchOS 9.4,macOS 13.3, *)
 extension PresentationAdaptation: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -17817,7 +19091,7 @@ ConstantAtomLiteral("fullScreenCover").map({ () -> Self in
 /// * `.resizes`
 /// * `.scrolls`
 @_documentation(visibility: public)
-@available(watchOS 9.4,iOS 16.4,tvOS 16.4,visionOS 1.0,macOS 13.3, *)
+@available(iOS 16.4,visionOS 1.0,watchOS 9.4,macOS 13.3,tvOS 16.4, *)
 extension PresentationContentInteraction: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -17914,7 +19188,7 @@ ConstantAtomLiteral("privacy").map({ () -> Self in
 
 #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
 ConstantAtomLiteral("invalidated").map({ () -> Self in
-if #available(iOS 17.0,tvOS 17.0,watchOS 10.0,macOS 14.0,visionOS 1.0, *) {
+if #available(tvOS 17.0,visionOS 1.0,macOS 14.0,iOS 17.0,watchOS 10.0, *) {
     return Self.invalidated
 } else { fatalError("'invalidated' is not available in this OS version") }
 })
@@ -18024,7 +19298,7 @@ ConstantAtomLiteral("minimum").map({ () -> Self in
 
 #if os(watchOS)
 ConstantAtomLiteral("navigationBar").map({ () -> Self in
-if #available(tvOS 16.0,iOS 16.0,macOS 13.0,watchOS 9.0, *) {
+if #available(watchOS 9.0,macOS 13.0,iOS 16.0,tvOS 16.0, *) {
     return Self.navigationBar
 } else { fatalError("'navigationBar' is not available in this OS version") }
 })
@@ -18045,7 +19319,7 @@ if #available(tvOS 16.0,iOS 16.0,macOS 13.0,watchOS 9.0, *) {
 /// * `.sizeChanges`
 /// * `.alignment`
 @_documentation(visibility: public)
-@available(iOS 18.0,tvOS 18.0,watchOS 11.0,macOS 15.0,visionOS 2.0, *)
+@available(visionOS 2.0,tvOS 18.0,iOS 18.0,watchOS 11.0,macOS 15.0, *)
 extension ScrollAnchorRole: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -18087,7 +19361,7 @@ ConstantAtomLiteral("alignment").map({ () -> Self in
 /// * `.always`
 /// * `.basedOnSize`
 @_documentation(visibility: public)
-@available(iOS 16.4,tvOS 16.4,watchOS 9.4,macOS 13.3,visionOS 1.0, *)
+@available(visionOS 1.0,tvOS 16.4,iOS 16.4,watchOS 9.4,macOS 13.3, *)
 extension ScrollBounceBehavior: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -18130,7 +19404,7 @@ ConstantAtomLiteral("basedOnSize").map({ () -> Self in
 /// * `.interactively`
 /// * `.never`
 @_documentation(visibility: public)
-@available(iOS 16.0,tvOS 16.0,watchOS 9.0,macOS 13.0, *)
+@available(tvOS 16.0,iOS 16.0,watchOS 9.0,macOS 13.0, *)
 extension ScrollDismissesKeyboardMode: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -18229,7 +19503,7 @@ ConstantAtomLiteral("never").map({ () -> Self in
 /// * `.enabled`
 /// * `.disabled`
 @_documentation(visibility: public)
-@available(iOS 18.0,tvOS 18.0,watchOS 11.0,macOS 15.0,visionOS 2.0, *)
+@available(visionOS 2.0,tvOS 18.0,iOS 18.0,watchOS 11.0,macOS 15.0, *)
 extension ScrollInputBehavior: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -18271,7 +19545,7 @@ ConstantAtomLiteral("disabled").map({ () -> Self in
 /// * `.onTextEntry`
 /// * `.onSearchPresentation`
 @_documentation(visibility: public)
-@available(macOS 13.3,watchOS 9.4,visionOS 1.0,iOS 16.4,tvOS 16.4, *)
+@available(watchOS 9.4,iOS 16.4,macOS 13.3,tvOS 16.4,visionOS 1.0, *)
 extension SearchScopeActivation: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -18355,7 +19629,7 @@ ConstantAtomLiteral("content").map({ () -> Self in
 /// * `.enabled`
 /// * `.disabled`
 @_documentation(visibility: public)
-@available(visionOS 1.0,tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0, *)
+@available(iOS 17.0,visionOS 1.0,watchOS 10.0,macOS 14.0,tvOS 17.0, *)
 extension SpringLoadingBehavior: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -18521,7 +19795,7 @@ ConstantAtomLiteral("search").map({ () -> Self in
 /// * `.upstream`
 /// * `.downstream`
 @_documentation(visibility: public)
-@available(iOS 18.0,tvOS 18.0,watchOS 11.0,macOS 15.0,visionOS 2.0, *)
+@available(visionOS 2.0,tvOS 18.0,iOS 18.0,watchOS 11.0,macOS 15.0, *)
 extension TextSelectionAffinity: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -18562,7 +19836,7 @@ ConstantAtomLiteral("downstream").map({ () -> Self in
 /// * `.sidebarToggle`
 /// * `.title`
 @_documentation(visibility: public)
-@available(iOS 17.0,tvOS 17.0,watchOS 10.0,macOS 14.0,visionOS 1.0, *)
+@available(visionOS 1.0,tvOS 17.0,iOS 17.0,watchOS 10.0,macOS 14.0, *)
 extension ToolbarDefaultItemKind: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -18576,7 +19850,7 @@ ConstantAtomLiteral("sidebarToggle").map({ () -> Self in
 #endif
 #if os(iOS) || os(macOS) || os(visionOS)
 ConstantAtomLiteral("title").map({ () -> Self in
-if #available(iOS 18.0,tvOS 17.0,watchOS 10.0,macOS 15.0,visionOS 2.0, *) {
+if #available(visionOS 2.0,tvOS 17.0,iOS 18.0,watchOS 10.0,macOS 15.0, *) {
     return Self.title
 } else { fatalError("'title' is not available in this OS version") }
 })
@@ -18612,21 +19886,21 @@ ConstantAtomLiteral("automatic").map({ () -> Self in
 
 #if os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
 ConstantAtomLiteral("navigationStack").map({ () -> Self in
-if #available(watchOS 9.0,iOS 16.0,tvOS 16.0,visionOS 1.0,macOS 13.0, *) {
+if #available(iOS 16.0,visionOS 1.0,watchOS 9.0,macOS 13.0,tvOS 16.0, *) {
     return Self.navigationStack
 } else { fatalError("'navigationStack' is not available in this OS version") }
 })
 #endif
 #if os(iOS) || os(visionOS)
 ConstantAtomLiteral("browser").map({ () -> Self in
-if #available(watchOS 9.0,iOS 16.0,tvOS 16.0,visionOS 1.0,macOS 13.0, *) {
+if #available(iOS 16.0,visionOS 1.0,watchOS 9.0,macOS 13.0,tvOS 16.0, *) {
     return Self.browser
 } else { fatalError("'browser' is not available in this OS version") }
 })
 #endif
 #if os(iOS) || os(macOS) || os(visionOS)
 ConstantAtomLiteral("editor").map({ () -> Self in
-if #available(watchOS 9.0,iOS 16.0,tvOS 16.0,visionOS 1.0,macOS 13.0, *) {
+if #available(iOS 16.0,visionOS 1.0,watchOS 9.0,macOS 13.0,tvOS 16.0, *) {
     return Self.editor
 } else { fatalError("'editor' is not available in this OS version") }
 })
@@ -18648,7 +19922,7 @@ if #available(watchOS 9.0,iOS 16.0,tvOS 16.0,visionOS 1.0,macOS 13.0, *) {
 /// * `.inlineLarge`
 /// * `.inline`
 @_documentation(visibility: public)
-@available(iOS 17.0,tvOS 17.0,watchOS 10.0,macOS 14.0,visionOS 1.0, *)
+@available(visionOS 1.0,tvOS 17.0,iOS 17.0,watchOS 10.0,macOS 14.0, *)
 extension ToolbarTitleDisplayMode: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -18754,7 +20028,7 @@ ConstantAtomLiteral("lastTextBaseline").map({ () -> Self in
 /// * `.up`
 /// * `.down`
 @_documentation(visibility: public)
-@available(watchOS 11.0,visionOS 2.0,macOS 15.0,iOS 18.0,tvOS 18.0, *)
+@available(visionOS 2.0,tvOS 18.0,iOS 18.0,macOS 15.0,watchOS 11.0, *)
 extension VerticalDirection: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -18907,7 +20181,7 @@ ConstantAtomLiteral("disabled").map({ () -> Self in
 /// * `.visible`
 /// * `.onHover`
 @_documentation(visibility: public)
-@available(macOS 15.0,watchOS 11.0,visionOS 2.0,iOS 18.0,tvOS 18.0, *)
+@available(visionOS 2.0,tvOS 18.0,iOS 18.0,watchOS 11.0,macOS 15.0, *)
 extension WindowToolbarFullScreenVisibility: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -18950,7 +20224,7 @@ ConstantAtomLiteral("onHover").map({ () -> Self in
 /// * `.limited`
 /// * `.disabled`
 @_documentation(visibility: public)
-@available(iOS 18.0,macOS 15.0, *)
+@available(macOS 15.0,iOS 18.0, *)
 extension WritingToolsBehavior: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {

--- a/Sources/ModifierGenerator/FunctionParameterSyntax+isViewBuilder.swift
+++ b/Sources/ModifierGenerator/FunctionParameterSyntax+isViewBuilder.swift
@@ -61,4 +61,12 @@ extension FunctionParameterSyntax {
     var isUIGestureRecognizerRepresentable: Bool {
         self.type.as(SomeOrAnyTypeSyntax.self)?.constraint.as(IdentifierTypeSyntax.self)?.name.text == "UIGestureRecognizerRepresentable"
     }
+    
+    var isContextMenu: Bool {
+        (self.type.as(OptionalTypeSyntax.self)?.wrappedType ?? self.type).as(MemberTypeSyntax.self)?.name.text == "ContextMenu"
+    }
+    
+    var isCoordinateSpace: Bool {
+        (self.type.as(OptionalTypeSyntax.self)?.wrappedType ?? self.type).as(MemberTypeSyntax.self)?.name.text == "CoordinateSpace"
+    }
 }

--- a/Sources/ModifierGenerator/ModifierGenerator.swift
+++ b/Sources/ModifierGenerator/ModifierGenerator.swift
@@ -137,6 +137,8 @@ struct ModifierGenerator: ParsableCommand {
         "textRenderer",
         
         "tabViewCustomization",
+        
+        "menuButtonStyle",
 
         // manually implemented due to argument order edge cases
         "searchScopes",

--- a/Sources/ModifierGenerator/ModifierGenerator.swift
+++ b/Sources/ModifierGenerator/ModifierGenerator.swift
@@ -271,6 +271,14 @@ struct ModifierGenerator: ParsableCommand {
             if parameter.isUIGestureRecognizerRepresentable {
                 return false
             }
+            
+            if parameter.isContextMenu {
+                return false
+            }
+            
+            if parameter.isCoordinateSpace {
+                return false
+            }
         }
         return true
     }

--- a/Sources/ModifierGenerator/Visitors/ModifierVisitor.swift
+++ b/Sources/ModifierGenerator/Visitors/ModifierVisitor.swift
@@ -79,7 +79,6 @@ final class ModifierVisitor: SyntaxVisitor {
 
         let nodeAvailabilityAttributes = node.attributes.compactMap({ $0.as(AttributeSyntax.self)?.arguments?.as(AvailabilityArgumentListSyntax.self) })
 
-        // if all platforms mark this symbol as deprecated, exclude it.
         let isDeprecated = !nodeAvailabilityAttributes.isEmpty && nodeAvailabilityAttributes.allSatisfy({
             $0.contains(where: {
                 $0.argument.as(AvailabilityLabeledArgumentSyntax.self)?.label.tokenKind == .keyword(.deprecated)
@@ -106,6 +105,7 @@ final class ModifierVisitor: SyntaxVisitor {
                     $0.argument.as(AvailabilityLabeledArgumentSyntax.self)?.label.tokenKind == .keyword(.deprecated)
                 })
             })
+            self.modifiers[decl.name.trimmed.text, default: []].append((decl, availability: Self.availability(node.attributes, decl.attributes)))
             if isMemberDeprecated || isDeprecated {
                 // extract the deprecation message.
                 self.deprecations[decl.name.trimmed.text] = (isMemberDeprecated ? memberAvailabilityAttributes : nodeAvailabilityAttributes)
@@ -128,8 +128,6 @@ final class ModifierVisitor: SyntaxVisitor {
                             }
                         }).first
                     }).first ?? #""This symbol is unavailable and will have no effect""#
-            } else {
-                self.modifiers[decl.name.trimmed.text, default: []].append((decl, availability: Self.availability(node.attributes, decl.attributes)))
             }
         }
 


### PR DESCRIPTION
This adds the new `sidebarAdaptable` TabViewStyle, and support for the `TabContentBuilder`.

```heex
<TabView phx-change="tab-changed" style="tabViewStyle(.sidebarAdaptable)">
    <VStack tag="/" style='tabItem(:item)'>
        <Label template="item" systemImage="1.circle">Tab 1</Label>
        Tab Content 1
    </VStack>
    <VStack tag="/detail/red" style='tabItem(:item)'>
        <Label template="item" systemImage="2.circle">Tab 2</Label>
        Tab Content 2
    </VStack>
</TabView>
```