### PR TITLE
Add nested keys to `_interface` for l10n and i18n

### DIFF
--- a/Sources/LiveViewNative/Coordinators/LiveSessionCoordinator.swift
+++ b/Sources/LiveViewNative/Coordinators/LiveSessionCoordinator.swift
@@ -529,8 +529,8 @@ extension LiveSessionCoordinator {
             "os": getOSName(),
             "os_version": getOSVersion(),
             "target": getTarget(),
-            "localization": getLocalization(),
-            "internationalization": getInternationalization()
+            "l10n": getLocalization(),
+            "i18n": getInternationalization()
         ]
     }
     


### PR DESCRIPTION
Closes #1379 

The params sent to the server now look like this:

```ex
%{
  "_format" => "swiftui",
  "_interface" => %{
    "app_build" => "1",
    "app_version" => "1.0",
    "bundle_id" => "com.example.app",
    "internationalization" => %{
      "time_zone" => "America/New_York"
    },
    "localization" => %{
      "locale" => "en_US"
    },
    "os" => "iOS",
    "os_version" => "18.0",
    "target" => "ios"
  }
}
```

Note the addition of the `internationalization` and `localization` keys.