### PR TITLE
Skip stylesheet parsing if `ContentBuilder` doesn't provide any modifiers

### DIFF
--- a/Sources/LiveViewNative/Protocols/ContentBuilder.swift
+++ b/Sources/LiveViewNative/Protocols/ContentBuilder.swift
@@ -376,9 +376,13 @@ public struct ContentBuilderContext<R: RootRegistry, Builder: ContentBuilder>: D
     static func resolveStylesheet(
         _ stylesheet: Stylesheet<R>
     ) throws -> [String:[BuilderModifierContainer<Builder>]] {
-        return try stylesheet.content.reduce(into: [:], {
-            $0.merge(try StylesheetParser<BuilderModifierContainer<Builder>>(context: .init()).parse($1.utf8), uniquingKeysWith: { $1 })
-        })
+        if Builder.ModifierType.self == EmptyContentModifier<Builder>.self {
+            return [:]
+        } else {
+            return try stylesheet.content.reduce(into: [:], {
+                $0.merge(try StylesheetParser<BuilderModifierContainer<Builder>>(context: .init()).parse($1.utf8), uniquingKeysWith: { $1 })
+            })
+        }
     }
 }
 


### PR DESCRIPTION
If a `ContentBuilder` uses the default `EmptyContentModifier` type, then it doesn't provide any modifiers that need to be parsed.

In this case, we can skip parsing the stylesheet for the additional modifiers to improve performance.