### PR TITLE
fix: phx-change on form sends all form data

### DIFF
--- a/Tests/LiveViewNativeTests/FormModelTests.swift
+++ b/Tests/LiveViewNativeTests/FormModelTests.swift
@@ -1,0 +1,47 @@
+//
+//  File.swift
+//  
+//
+//  Created by Adam Woods on 9/7/2024.
+//
+
+import XCTest
+import LiveViewNativeCore
+@_spi(LiveForm) @testable import LiveViewNative
+
+class FormModelTests: XCTestCase {
+    func testFormChangeEvent() async throws {
+        let expectation = XCTestExpectation(description: "Send a form change event.")
+        
+        func pushEvent(type: String, event: String, value: Any, target: Int? = nil) async throws -> Void {
+            XCTAssertEqual(type, "form")
+            XCTAssertEqual(event, "validate")
+            
+            let expectedQuery = URLComponents(string: "http://localhost/?b=2&c=3&a=1&_target=a")?.queryItems?.sorted(by: {$0.name < $1.name})
+            let actualQuery = URLComponents(string: "http://localhost/?\(value as! String)")?.queryItems?.sorted(by: {$0.name < $1.name})
+            XCTAssertEqual(expectedQuery, actualQuery)
+            XCTAssertNil(target)
+
+            expectation.fulfill()
+        }
+        
+        let formModel = FormModel(elementID: "test-form")
+        formModel.setInitialValue("1", forName: "a")
+        formModel.setInitialValue("2", forName: "b")
+        formModel.setInitialValue("3", forName: "c")
+        formModel.pushEventImpl = pushEvent
+        
+        // Associate the formModel with a form
+        let document = try LiveViewNativeCore.Document.parse("""
+            <Form phx-change="validate"></Form>
+        """)
+        let element = document[document.root()].children().first?.asElement()
+        formModel.updateFromElement(element!) { }
+        
+        // Emulate a sending a change event from the form itself (no event)
+        try await formModel.sendChangeEvent("2", for: "a", event: nil)
+        
+        await fulfillment(of: [expectation])
+    }
+}
+

--- a/Tests/LiveViewNativeTests/FormModelTests.swift
+++ b/Tests/LiveViewNativeTests/FormModelTests.swift
@@ -1,5 +1,5 @@
 //
-//  File.swift
+//  FormModelTests.swift
 //  
 //
 //  Created by Adam Woods on 9/7/2024.
@@ -38,10 +38,9 @@ class FormModelTests: XCTestCase {
         let element = document[document.root()].children().first?.asElement()
         formModel.updateFromElement(element!) { }
         
-        // Emulate a sending a change event from the form itself (no event)
+        // Emulate sending a change event from the form itself (no event)
         try await formModel.sendChangeEvent("2", for: "a", event: nil)
         
         await fulfillment(of: [expectation])
     }
 }
-


### PR DESCRIPTION
Ran into the same issue as https://github.com/liveview-native/liveview-native-live-form/issues/16 so thought i'd take a shot at fixing it.

Unit testing was not as simple as I'd hoped, and I ran into issues with Views being required to use environment values. Hence only one of the paths is tested.

### `phx-change="validate"` on the form
```bash
Swift:

[debug] HANDLE EVENT "validate" in SaturnWeb.Idine.CheckoutLive
  Parameters: %{"_target" => ["payment", "add_loyalty_card"], "payment" => %{"add_loyalty_card" => "true", "payment_type" => "2"}}
[debug] Replied in 400µs


Web:

[debug] HANDLE EVENT "validate" in SaturnWeb.Idine.CheckoutLive
  Parameters: %{"_csrf_token" => "DAdXDCskLwJnfCU_BiQLLAIxJTAkDUEMcn1jMnWG09MqqaCi0rUWWzqK", "_target" => ["payment", "add_loyalty_card"], "payment" => %{"add_loyalty_card" => "true", "payment_type" => "2"}}
[debug] Replied in 366µs
```

### `phx-change="validateElement"` on the form input element
```bash
Swift:

[debug] HANDLE EVENT "validateElement" in SaturnWeb.Idine.CheckoutLive
  Parameters: %{"_target" => ["payment", "payment_type"], "payment" => %{"payment_type" => "2"}}
[debug] Replied in 363µs


Web:

[debug] HANDLE EVENT "validateElement" in SaturnWeb.Idine.CheckoutLive
  Parameters: %{"_target" => ["payment", "payment_type"], "payment" => %{"payment_type" => "2"}}
[debug] Replied in 1ms
```