### PR TITLE
Automatic scroll restoration for `ScrollView`

### DIFF
--- a/Sources/LiveViewNative/Coordinators/LiveSessionCoordinator.swift
+++ b/Sources/LiveViewNative/Coordinators/LiveSessionCoordinator.swift
@@ -86,7 +86,7 @@ public class LiveSessionCoordinator<R: RootRegistry>: ObservableObject {
     internal var scrollPositions: [Int:[String:AnyScrollPosition]] = [:]
     enum AnyScrollPosition {
         case id(String)
-        case offset(CGFloat)
+        case offset(CGPoint)
     }
     
     public convenience init(_ host: some LiveViewHost, config: LiveSessionConfiguration = .init(), customRegistryType: R.Type = R.self) {
@@ -140,6 +140,9 @@ public class LiveSessionCoordinator<R: RootRegistry>: ObservableObject {
                     }
                     Task(priority: .userInitiated) {
                         try await next.last?.coordinator.connect(domValues: self.domValues, redirect: true)
+                        // reset the scroll positions for a freshly navigated route.
+                        // scroll restoration should only happen on back navigation.
+                        self.scrollPositions[next.count] = [:]
                     }
                 }
             }


### PR DESCRIPTION
Scroll restoration is now automatically provided for all `ScrollView` elements with an explicit `id` attribute.

```html
<ScrollView id="cookbook">
  ...
</ScrollView>
```

Scroll restoration only occurs on back navigation. It is also only available for the `ScrollView` element (not `List` or other scrolling containers)

> [!NOTE]
> Scroll restoration is only available for iOS 18 or later.

https://github.com/user-attachments/assets/dce871ae-d628-4145-9ab3-492971a087ae

