### PR TITLE
`List` scroll restoration

### DIFF
--- a/Sources/LiveViewNative/Coordinators/LiveSessionCoordinator.swift
+++ b/Sources/LiveViewNative/Coordinators/LiveSessionCoordinator.swift
@@ -71,6 +71,23 @@ public class LiveSessionCoordinator<R: RootRegistry>: ObservableObject {
     
     private var reconnectAttempts = 0
     
+    /// Positions for `<ScrollView>` elements with an explicit ID.
+    ///
+    /// These positions are used for scroll restoration on back navigation.
+    ///
+    /// ``ScrollRestorationModifier`` gets and sets the values in this dictionary.
+    ///
+    /// The dictionary has the following structure:
+    ///
+    /// ```
+    /// [<Route Index>: [<ScrollView ID>: <Scroll Offset>]]
+    /// ```
+    internal var scrollPositions: [Int:[String:AnyScrollPosition]] = [:]
+    enum AnyScrollPosition {
+        case id(String)
+        case offset(CGFloat)
+    }
+    
     public convenience init(_ host: some LiveViewHost, config: LiveSessionConfiguration = .init(), customRegistryType: R.Type = R.self) {
         self.init(host.url, config: config, customRegistryType: customRegistryType)
     }

--- a/Sources/LiveViewNative/Live/LiveElement.swift
+++ b/Sources/LiveViewNative/Live/LiveElement.swift
@@ -157,6 +157,14 @@ public extension _LiveElementTracked {
     var childNodes: [LiveViewNativeCore.Node] {
         _element.children
     }
+    
+    func childNodes(in template: Template, default includeDefault: Bool = false) -> [LiveViewNativeCore.Node] {
+        _element.children.filter {
+            $0.attributes.contains(where: {
+                $0 == template
+            }) || (includeDefault && !$0.attributes.contains(where: { $0.name.namespace == nil && $0.name.name == "template" }))
+        }
+    }
 }
 
 /// A value passed to the `template` attribute, used for filtering children.

--- a/Sources/LiveViewNative/ViewTree.swift
+++ b/Sources/LiveViewNative/ViewTree.swift
@@ -279,7 +279,7 @@ extension View {
     }
 }
 
-private enum ForEachElement: Identifiable {
+enum ForEachElement: Identifiable {
     case keyed(Node, id: String)
     case unkeyed(Node)
     

--- a/Sources/LiveViewNative/Views/Layout Containers/Collection Containers/Section.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Collection Containers/Section.swift
@@ -61,7 +61,20 @@ struct Section<Root: RootRegistry>: View {
     
     public var body: some View {
         SwiftUI.Section {
-            $liveElement.children(in: "content", default: true)
+            let elements = $liveElement.childNodes(in: "content", default: true)
+                .map { (node) -> ForEachElement in
+                    if let element = node.asElement(),
+                       let id = element.attributeValue(for: .init(name: "id"))
+                    {
+                        return .keyed(node, id: id)
+                    } else {
+                        return .unkeyed(node)
+                    }
+                }
+            ForEach(elements) { childNode in
+                ViewTreeBuilder<Root>.NodeView(node: childNode.node, context: $liveElement.context.storage)
+                    .trackListItemScrollOffset(id: childNode.id)
+            }
         } header: {
             $liveElement.children(in: "header")
         } footer: {
@@ -70,5 +83,6 @@ struct Section<Root: RootRegistry>: View {
         #if os(macOS)
             .collapsible(collapsible)
         #endif
+        
     }
 }


### PR DESCRIPTION
This enables scroll restoration for `List`.

Restoration happens automatically when the `List` element has an `id` attribute.

```html
<List id="my-list">
  ...
</List>
```

https://github.com/user-attachments/assets/fb3c0d96-3d8b-49aa-84bb-48db12fa55fc
