### PR TITLE
Add option to warn when missing semicolons

### DIFF
--- a/lib/live_view_native/swiftui/rules_parser.ex
+++ b/lib/live_view_native/swiftui/rules_parser.ex
@@ -11,6 +11,7 @@ defmodule LiveViewNative.SwiftUI.RulesParser do
     line = Keyword.get(opts, :line) || 1
     variable_context = Keyword.get(opts, :variable_context, Elixir)
     expect_semicolons? = Keyword.get(opts, :expect_semicolons?, false)
+    expect_semicolons? = true
 
     context =
       opts

--- a/lib/live_view_native/swiftui/rules_parser.ex
+++ b/lib/live_view_native/swiftui/rules_parser.ex
@@ -3,12 +3,14 @@ defmodule LiveViewNative.SwiftUI.RulesParser do
 
   alias LiveViewNative.SwiftUI.RulesParser.Modifiers
   alias LiveViewNative.SwiftUI.RulesParser.Parser
+  require Logger
 
   def parse(rules, opts \\ []) do
     file = Keyword.get(opts, :file) || ""
     module = Keyword.get(opts, :module) || ""
     line = Keyword.get(opts, :line) || 1
     variable_context = Keyword.get(opts, :variable_context, Elixir)
+    expect_semicolons? = Keyword.get(opts, :expect_semicolons?, false)
 
     context =
       opts
@@ -16,6 +18,7 @@ defmodule LiveViewNative.SwiftUI.RulesParser do
       |> Map.put_new(:file, file)
       |> Map.put_new(:source_line, line)
       |> Map.put_new(:module, module)
+      |> Map.put_new(:expect_semicolons?, expect_semicolons?)
       |> Map.put_new(
         :annotations,
         Application.get_env(:live_view_native_stylesheet, :annotations, false)
@@ -35,10 +38,12 @@ defmodule LiveViewNative.SwiftUI.RulesParser do
       |> Parser.error_from_result()
 
     case result do
-      {:ok, [output], _unconsumed = "", _context, _current_line_and_offset, _} ->
+      {:ok, [output], warnings} ->
+        log_warnings(warnings, file)
         output
 
-      {:ok, output, _unconsumed = "", _context, _current_line_and_offset, _} ->
+      {:ok, output, warnings} ->
+        log_warnings(warnings, file)
         output
 
       {:error, message, _unconsumed, _context, {line, _}, _} ->
@@ -46,6 +51,12 @@ defmodule LiveViewNative.SwiftUI.RulesParser do
           description: message,
           file: file,
           line: line
+    end
+  end
+
+  def log_warnings(warnings, file) do
+    for {message, {line, _}, _offset} <- warnings do
+      IO.warn(message, line: line, file: file)
     end
   end
 end

--- a/lib/live_view_native/swiftui/rules_parser/modifiers.ex
+++ b/lib/live_view_native/swiftui/rules_parser/modifiers.ex
@@ -283,6 +283,7 @@ defmodule LiveViewNative.SwiftUI.RulesParser.Modifiers do
     ignore_whitespace()
     |> concat(modifier_name())
     |> concat(modifier_brackets.(nested: false))
+    |> expect_semicolon_or_warn()
     |> post_traverse({PostProcessors, :to_function_call_ast, []}),
     export_combinator: true
   )

--- a/lib/live_view_native/swiftui/rules_parser/parser/context.ex
+++ b/lib/live_view_native/swiftui/rules_parser/parser/context.ex
@@ -8,6 +8,7 @@ defmodule LiveViewNative.SwiftUI.RulesParser.Parser.Context do
     source: "",
     source_lines: [],
     errors: [],
+    warnings: [],
     highlight_error: true,
     # Where in the code does the input start?
     # Useful for localizing errors when parsing sigil text
@@ -45,14 +46,14 @@ defmodule LiveViewNative.SwiftUI.RulesParser.Parser.Context do
     if is_frozen?(context) and not error.forced? do
       context
     else
-      path = [:context, Access.key(:errors)]
+      path =
+        if error.is_warning? do
+          [:context, Access.key(:warnings)]
+        else
+          [:context, Access.key(:errors)]
+        end
 
-      {_, context} =
-        get_and_update_in(context, path, fn
-          existing_errors -> {[error | existing_errors], [error | existing_errors]}
-        end)
-
-      context
+      update_in(context, path, &[error | &1])
     end
   end
 

--- a/lib/live_view_native/swiftui/rules_parser/parser/error.ex
+++ b/lib/live_view_native/swiftui/rules_parser/parser/error.ex
@@ -9,70 +9,64 @@ defmodule LiveViewNative.SwiftUI.RulesParser.Parser.Error do
     :line,
     :byte_offset,
     :error_message,
-    forced?: false
+    forced?: false,
+    is_warning?: false
   ])
 
   def put_error(
         rest,
         args,
         context,
-        _,
-        _,
+        {line, _offset},
+        byte_offset,
         error_message,
         opts \\ []
-      )
-
-  def put_error(
-        rest,
-        [] = arg,
-        context,
-        {line, _offset},
-        byte_offset,
-        error_message,
-        opts
       ) do
-    # IO.inspect({[], rest, error_message}, label: "error[0]")
+    # IO.inspect({args, rest, error_message}, label: "error[0]")
+
+    error = %__MODULE__{
+      incorrect_text: List.first(args, ""),
+      line: line,
+      byte_offset: byte_offset,
+      error_message: error_message,
+      show_incorrect_text?: Keyword.get(opts, :show_incorrect_text?, false),
+      forced?: Keyword.get(opts, :force_error?, false),
+      is_warning?: false
+    }
 
     context =
-      Context.put_new_error(context, rest, %__MODULE__{
-        incorrect_text: "",
-        line: line,
-        byte_offset: byte_offset,
-        error_message: error_message,
-        show_incorrect_text?: Keyword.get(opts, :show_incorrect_text?, false),
-        forced?: Keyword.get(opts, :force_error?, false)
-      })
+      case opts[:warning] do
+        true ->
+          # Always treat error as warning
+          Context.put_new_error(context, rest, %{error | is_warning?: true})
 
-    {rest, arg, context}
-  end
+        false ->
+          # Never treat error as warning
+          Context.put_new_error(context, rest, error)
 
-  def put_error(
-        rest,
-        [matched_text | _] = args,
-        context,
-        {line, _offset},
-        byte_offset,
-        error_message,
-        opts
-      ) do
-    # IO.inspect({matched_text, rest, error_message}, label: "error[0]")
+        nil ->
+          # Never treat error as warning
+          Context.put_new_error(context, rest, error)
 
-    context =
-      Context.put_new_error(context, rest, %__MODULE__{
-        incorrect_text: matched_text,
-        line: line,
-        byte_offset: byte_offset,
-        error_message: error_message,
-        show_incorrect_text?: Keyword.get(opts, :show_incorrect_text?, false),
-        forced?: Keyword.get(opts, :force_error?, false)
-      })
+        warning ->
+          # The error is an optional warning
+          # Only log the warning if value in `context[<key>]` is true
+          if get_in(context, [Access.key(warning)]) == true do
+            Context.put_new_error(context, rest, %{error | is_warning?: true})
+          else
+            context
+          end
+      end
 
     {rest, args, context}
   end
 
   def context_to_error_message(context) do
     [%__MODULE__{} = error | _] = Enum.reverse(context.errors)
+    context_to_error_message(context, error)
+  end
 
+  def context_to_error_message(context, %__MODULE__{} = error) do
     error_message = error.error_message
     line = error.line
     incorrect_text = error.incorrect_text
@@ -144,8 +138,15 @@ defmodule LiveViewNative.SwiftUI.RulesParser.Parser.Error do
         ""
       end
 
+    header =
+      if error.is_warning? do
+        ""
+      else
+        "Unsupported input:"
+      end
+
     message = """
-    Unsupported input:
+    #{header}
     #{line_spacer} |
     #{lines}
     #{line_spacer} |

--- a/lib/live_view_native/swiftui/rules_parser/tokens.ex
+++ b/lib/live_view_native/swiftui/rules_parser/tokens.ex
@@ -113,6 +113,19 @@ defmodule LiveViewNative.SwiftUI.RulesParser.Tokens do
     combinator |> ignore(optional(whitespace(min: 1)))
   end
 
+  def expect_semicolon_or_warn(combinator) do
+    combinator
+    |> concat(
+      ignore(string(";"))
+      |> expect(
+        warning: :expect_semicolons?,
+        error_message: "Expected a ‘;’",
+        error_parser: empty(),
+        show_incorrect_text?: false
+      )
+    )
+  end
+
   # @tuple_children [
   #   parsec(:nested_attribute),
   #   atom(),


### PR DESCRIPTION
Addresses #182

When calling the parser you can now specify that warnings be emitted on the console if semicolons are missing. When parsing using the `expect_semicolons?` option:

```elixir
RulesParser.parse(input, expect_semicolons?: true, ...opts)
```

The value would be false (or not set) in most places, but set to true when parsing the `style` attribute on elements.

TODO:
- [ ] Fix line in sheets
```elixir
```
