### PR TITLE
Update flash component to dismiss properly on macOS

### DIFF
--- a/priv/templates/lvn.swiftui.gen/core_components.ex
+++ b/priv/templates/lvn.swiftui.gen/core_components.ex
@@ -341,11 +341,9 @@ defmodule <%= inspect context.web_module %>.CoreComponents.<%= inspect context.m
       presented={msg != nil}
       id={@id}
       {@rest}
-      phx-change="lv:clear-flash"
-      phx-value-key={@kind}
     >
       <Text template="message"><%%= msg %></Text>
-      <Button template="actions">Ok</Button>
+      <Button template="actions" phx-click="lv:clear-flash" phx-value-key={@kind}>OK</Button>
     </VStack>
     """
   end


### PR DESCRIPTION
This updates the `flash` component to send the `lv:clear-flash` in response to the button click, instead of the alert dismissal. The dismissal event is sent on iOS, but not macOS. This new solution will work on all platforms.

It should also send the `key`, which the `phx-change` approach likely missed.