### PR TITLE
Expose `navigationPath`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           sudo xcode-select --switch /Applications/Xcode_15.4.app
       - uses: irgaly/xcode-cache@v1
         with:
-          key: xcode-cache-deriveddata-${{ github.workflow }}-${{ github.sha }}
+          key: xcode-cache-deriveddata-${{ github.workflow }}
           restore-keys: xcode-cache-deriveddata-${{ github.workflow }}-
       - name: Run tests on iOS Simulator
         shell: bash

--- a/Sources/LiveViewNative/Coordinators/LiveNavigationEntry.swift
+++ b/Sources/LiveViewNative/Coordinators/LiveNavigationEntry.swift
@@ -7,15 +7,15 @@
 
 import Foundation
 
-struct LiveNavigationEntry<R: RootRegistry>: Hashable {
-    let url: URL
-    let coordinator: LiveViewCoordinator<R>
+public struct LiveNavigationEntry<R: RootRegistry>: Hashable {
+    public let url: URL
+    public let coordinator: LiveViewCoordinator<R>
     
-    static func == (lhs: Self, rhs: Self) -> Bool {
+    public static func == (lhs: Self, rhs: Self) -> Bool {
         lhs.url == rhs.url && lhs.coordinator === rhs.coordinator
     }
     
-    func hash(into hasher: inout Hasher) {
+    public func hash(into hasher: inout Hasher) {
         hasher.combine(url)
         hasher.combine(ObjectIdentifier(coordinator))
     }

--- a/Sources/LiveViewNative/Coordinators/LiveSessionCoordinator.swift
+++ b/Sources/LiveViewNative/Coordinators/LiveSessionCoordinator.swift
@@ -39,7 +39,7 @@ public class LiveSessionCoordinator<R: RootRegistry>: ObservableObject {
     public private(set) var url: URL
     
     /// The current navigation path this live view is rendering.
-    @Published public private(set) var navigationPath = [LiveNavigationEntry<R>]()
+    @Published public internal(set) var navigationPath = [LiveNavigationEntry<R>]()
     
     internal let configuration: LiveSessionConfiguration
     

--- a/Sources/LiveViewNative/Coordinators/LiveSessionCoordinator.swift
+++ b/Sources/LiveViewNative/Coordinators/LiveSessionCoordinator.swift
@@ -38,7 +38,8 @@ public class LiveSessionCoordinator<R: RootRegistry>: ObservableObject {
     /// The current URL this live view is connected to.
     public private(set) var url: URL
     
-    @Published var navigationPath = [LiveNavigationEntry<R>]()
+    /// The current navigation path this live view is rendering.
+    @Published public private(set) var navigationPath = [LiveNavigationEntry<R>]()
     
     internal let configuration: LiveSessionConfiguration
     


### PR DESCRIPTION
This makes the `LiveSessionCoordinator.navigationPath` public for read-only access.

With this addition, you can now check what URL is currently being displayed, and access the `LiveViewCoordinator` for that navigation path.

In the future, this API could be expanded to allow writing for more advanced client-side navigation.