### PR TITLE
Add access to `LiveContext` from `ContentBuilder`

### DIFF
--- a/Sources/LiveViewNative/Property Wrappers/Event.swift
+++ b/Sources/LiveViewNative/Property Wrappers/Event.swift
@@ -144,21 +144,21 @@ public struct Event: DynamicProperty, Decodable {
             if let debounce = debounce {
                 handlerTask = Task { [weak didSendSubject] in
                     for await event in channel.debounce(for: .milliseconds(debounce)) {
-                        try await coordinator?.pushEvent(event.0, event.1, event.2, event.3)
+                        _ = try await coordinator?.pushEvent(event.0, event.1, event.2, event.3)
                         didSendSubject?.send()
                     }
                 }
             } else if let throttle = throttle {
                 handlerTask = Task { [weak didSendSubject] in
                     for await event in channel.throttle(for: .milliseconds(throttle)) {
-                        try await coordinator?.pushEvent(event.0, event.1, event.2, event.3)
+                        _ = try await coordinator?.pushEvent(event.0, event.1, event.2, event.3)
                         didSendSubject?.send()
                     }
                 }
             } else {
                 handlerTask = Task { [weak didSendSubject] in
                     for await event in channel {
-                        try await coordinator?.pushEvent(event.0, event.1, event.2, event.3)
+                        _ = try await coordinator?.pushEvent(event.0, event.1, event.2, event.3)
                         didSendSubject?.send()
                     }
                 }

--- a/Sources/LiveViewNative/Property Wrappers/LiveContext.swift
+++ b/Sources/LiveViewNative/Property Wrappers/LiveContext.swift
@@ -32,8 +32,9 @@ public struct LiveContext<R: RootRegistry>: DynamicProperty {
         overrideGestureState ?? environmentGestureState
     }
     
+    internal let overrideStorage: LiveContextStorage<R>?
     var storage: LiveContextStorage<R> {
-        anyStorage as! LiveContextStorage<R>
+        overrideStorage ?? (anyStorage as! LiveContextStorage<R>)
     }
     
     /// The coordinator corresponding to the live view in which thie view is being constructed.
@@ -51,6 +52,11 @@ public struct LiveContext<R: RootRegistry>: DynamicProperty {
     }
     
     public init() {
+        self.overrideStorage = nil
+    }
+    
+    init(storage: LiveContextStorage<R>) {
+        self.overrideStorage = storage
     }
     
     /// Add an ``overrideGestureState`` to the context.

--- a/Sources/LiveViewNative/Protocols/ContentBuilder.swift
+++ b/Sources/LiveViewNative/Protocols/ContentBuilder.swift
@@ -327,15 +327,15 @@ public struct ContentBuilderContext<R: RootRegistry, Builder: ContentBuilder>: D
     public var wrappedValue: Value {
         Value(
             coordinatorEnvironment: coordinatorEnvironment,
-            context: context.storage,
-            stylesheet: stylesheet as! Stylesheet<R>,
+            context: LiveContext(storage: context.storage),
+            stylesheet: stylesheet as? Stylesheet<R>,
             resolvedStylesheet: stylesheetResolver.resolvedStylesheet
         )
     }
     
     public struct Value {
         let coordinatorEnvironment: CoordinatorEnvironment?
-        let context: LiveContextStorage<R>
+        public let context: LiveContext<R>
         let stylesheet: Stylesheet<R>?
         
         let resolvedStylesheet: [String:[BuilderModifierContainer<Builder>]]
@@ -545,7 +545,7 @@ public extension ContentBuilder {
     ) -> some View where C.Element == Node, C.Index == Int {
         ViewTreeBuilder().fromNodes(
             nodes,
-            context: context.context
+            context: context.context.storage
         )
         .environment(\.coordinatorEnvironment, context.coordinatorEnvironment)
         .environment(\.anyLiveContextStorage, context.context)
@@ -570,7 +570,7 @@ public extension ContentBuilder {
             ViewTreeBuilder().fromNodes(
                 element.children()
                     .filter({ $0.attributes.contains(where: { $0.name == "template" && $0.value == template }) }),
-                context: context.context
+                context: context.context.storage
             )
                 .environment(\.coordinatorEnvironment, context.coordinatorEnvironment)
                 .environment(\.anyLiveContextStorage, context.context)
@@ -578,7 +578,7 @@ public extension ContentBuilder {
             ViewTreeBuilder().fromNodes(
                 element.children()
                     .filter({ !$0.attributes.contains(where: { $0.name == "template" }) }),
-                context: context.context
+                context: context.context.storage
             )
                 .environment(\.coordinatorEnvironment, context.coordinatorEnvironment)
                 .environment(\.anyLiveContextStorage, context.context)
@@ -594,7 +594,7 @@ public extension ContentBuilder {
         ViewTreeBuilder().fromNodes(
             element.children()
                 .filter({ $0.attributes.contains(where: { $0.name == "template" && template.value.contains($0.value ?? "") }) }),
-            context: context.context
+            context: context.context.storage
         )
             .environment(\.coordinatorEnvironment, context.coordinatorEnvironment)
             .environment(\.anyLiveContextStorage, context.context)

--- a/Sources/LiveViewNative/ViewTree.swift
+++ b/Sources/LiveViewNative/ViewTree.swift
@@ -145,8 +145,9 @@ struct ClassModifiers<Root: RootRegistry>: DynamicProperty {
     @LiveElementIgnored
     var wrappedValue: ArraySlice<BuiltinRegistry<Root>.BuiltinModifier> {
         if _liveElement.isConstant {
-            let sheet = overrideStylesheet ?? (stylesheet as! Stylesheet<Root>)
             var result = ArraySlice<BuiltinRegistry<Root>.BuiltinModifier>()
+            guard let sheet = overrideStylesheet ?? (stylesheet as? Stylesheet<Root>)
+            else { return result }
             if let style,
                !style.isEmpty
             {
@@ -167,8 +168,9 @@ struct ClassModifiers<Root: RootRegistry>: DynamicProperty {
     var resolvedModifiers: ArraySlice<BuiltinRegistry<Root>.BuiltinModifier> = .init()
     
     mutating func update() {
-        let sheet = overrideStylesheet ?? (stylesheet as! Stylesheet<Root>)
         resolvedModifiers.removeAll()
+        guard let sheet = overrideStylesheet ?? (stylesheet as? Stylesheet<Root>)
+        else { return }
         if let style,
            !style.isEmpty
         {


### PR DESCRIPTION
This fixes instances in addon libraries where a blank (unusable) `LiveContext<R>()` had to be passed to resolve a stylesheet value.

https://github.com/liveview-native/liveview-native-swiftui-charts/blob/c612c5ac085fc61a33a4c3d097d09b0db9a2be7f/Sources/LiveViewNativeCharts/Modifiers/SymbolModifier.swift#L44

Instead, a valid `LiveContext` can be accessed from the `ContentBuilder` context, via `context.context`.

Addon libraries will need to be updated to make use of this new API.