### PR TITLE
Update generated modifiers for Xcode 15.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `Stylesheet` type made public
 
 ### Changed
-- `Stylesheet` type made public
 - Code-generated modifiers updated for Xcode 15.4
 
 ## Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- `Stylesheet` type made public
+- Code-generated modifiers updated for Xcode 15.4
 
 ## Fixed
 

--- a/Sources/LiveViewNative/Stylesheets/Stylesheet.swift
+++ b/Sources/LiveViewNative/Stylesheets/Stylesheet.swift
@@ -5,7 +5,10 @@ import OSLog
 
 private let logger = Logger(subsystem: "LiveViewNative", category: "Stylesheet")
 
-struct Stylesheet<R: RootRegistry> {
+/// A type that stores a map between classes and an array of modifiers.
+///
+/// The raw content of the stylesheet is retained so it can re-parsed in a different context.
+public struct Stylesheet<R: RootRegistry> {
     let content: [String]
     let classes: [String:[BuiltinRegistry<R>.BuiltinModifier]]
     
@@ -25,7 +28,7 @@ struct Stylesheet<R: RootRegistry> {
 }
 
 extension Stylesheet: AttributeDecodable {
-    init(from attribute: LiveViewNativeCore.Attribute?, on element: ElementNode) throws {
+    public init(from attribute: LiveViewNativeCore.Attribute?, on element: ElementNode) throws {
         guard let value = attribute?.value
         else { throw AttributeDecodingError.missingAttribute(Self.self) }
         do {

--- a/Sources/LiveViewNative/_GeneratedModifiers.swift
+++ b/Sources/LiveViewNative/_GeneratedModifiers.swift
@@ -1021,21 +1021,21 @@ struct _badgeModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(visionOS 1.0,macOS 12.0,iOS 15.0, *)
+    @available(iOS 15.0,macOS 12.0,visionOS 1.0, *)
     init(_ count: AttributeReference<Swift.Int>) {
         self.value = ._0(count: count)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(visionOS 1.0,macOS 12.0,iOS 15.0, *)
+    @available(iOS 15.0,macOS 12.0,visionOS 1.0, *)
     init(_ label: TextReference?) {
         self.value = ._1(label: label)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(visionOS 1.0,macOS 12.0,iOS 15.0, *)
+    @available(iOS 15.0,macOS 12.0,visionOS 1.0, *)
     init(_ key: SwiftUI.LocalizedStringKey?) {
         self.value = ._2(key: key)
         
@@ -1055,7 +1055,7 @@ struct _badgeModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(count):
-            if #available(visionOS 1.0,macOS 12.0,iOS 15.0, *) {
+            if #available(iOS 15.0,macOS 12.0,visionOS 1.0, *) {
             let count = count as! AttributeReference<Swift.Int>
             
             __content
@@ -1066,7 +1066,7 @@ struct _badgeModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._1(label):
-            if #available(visionOS 1.0,macOS 12.0,iOS 15.0, *) {
+            if #available(iOS 15.0,macOS 12.0,visionOS 1.0, *) {
             let label = label as? TextReference
             __content._observeTextReference(label, on: element, in: context) { __content in
             __content
@@ -1077,7 +1077,7 @@ struct _badgeModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._2(key):
-            if #available(visionOS 1.0,macOS 12.0,iOS 15.0, *) {
+            if #available(iOS 15.0,macOS 12.0,visionOS 1.0, *) {
             let key = key as? SwiftUI.LocalizedStringKey
             
             __content
@@ -1122,7 +1122,7 @@ struct _badgeProminenceModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 14.0,iOS 17.0,visionOS 1.0, *)
+    @available(iOS 17.0,macOS 14.0,visionOS 1.0, *)
     init(_ prominence: SwiftUI.BadgeProminence) {
         self.value = ._0(prominence: prominence)
         
@@ -1135,7 +1135,7 @@ struct _badgeProminenceModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(prominence):
-            if #available(macOS 14.0,iOS 17.0,visionOS 1.0, *) {
+            if #available(iOS 17.0,macOS 14.0,visionOS 1.0, *) {
             let prominence = prominence as! SwiftUI.BadgeProminence
             
             __content
@@ -1876,14 +1876,14 @@ struct _containerRelativeFrameModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 10.0,macOS 14.0,tvOS 17.0,iOS 17.0,visionOS 1.0, *)
+    @available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0,visionOS 1.0, *)
     init(_ axes: SwiftUI.Axis.Set,alignment: AttributeReference<SwiftUI.Alignment> = .init(storage: .constant(.center)) ) {
         self.value = ._0(axes: axes, alignment: alignment)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(iOS 17.0,tvOS 17.0,macOS 14.0,watchOS 10.0,visionOS 1.0, *)
+    @available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0,visionOS 1.0, *)
     init(_ axes: SwiftUI.Axis.Set,count: AttributeReference<Swift.Int>,span: AttributeReference<Swift.Int> = .init(storage: .constant(1)), spacing: AttributeReference<CoreFoundation.CGFloat>,alignment: AttributeReference<SwiftUI.Alignment> = .init(storage: .constant(.center)) ) {
         self.value = ._1(axes: axes, count: count, span: span, spacing: spacing, alignment: alignment)
         
@@ -1896,7 +1896,7 @@ struct _containerRelativeFrameModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(axes, alignment):
-            if #available(watchOS 10.0,macOS 14.0,tvOS 17.0,iOS 17.0,visionOS 1.0, *) {
+            if #available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0,visionOS 1.0, *) {
             let axes = axes as! SwiftUI.Axis.Set
 let alignment = alignment as! AttributeReference<SwiftUI.Alignment>
             
@@ -1908,7 +1908,7 @@ let alignment = alignment as! AttributeReference<SwiftUI.Alignment>
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(axes, count, span, spacing, alignment):
-            if #available(iOS 17.0,tvOS 17.0,macOS 14.0,watchOS 10.0,visionOS 1.0, *) {
+            if #available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0,visionOS 1.0, *) {
             let axes = axes as! SwiftUI.Axis.Set
 let count = count as! AttributeReference<Swift.Int>
 let span = span as! AttributeReference<Swift.Int>
@@ -2003,21 +2003,21 @@ struct _contentMarginsModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(tvOS 17.0,visionOS 1.0,watchOS 10.0,macOS 14.0,iOS 17.0, *)
+    @available(watchOS 10.0,tvOS 17.0,iOS 17.0,macOS 14.0,visionOS 1.0, *)
     init(_ edges: SwiftUI.Edge.Set = .all, _ insets: SwiftUI.EdgeInsets,for placement: SwiftUI.ContentMarginPlacement = .automatic ) {
         self.value = ._0(edges: edges, insets: insets, placement: placement)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(tvOS 17.0,visionOS 1.0,watchOS 10.0,macOS 14.0,iOS 17.0, *)
+    @available(watchOS 10.0,tvOS 17.0,iOS 17.0,macOS 14.0,visionOS 1.0, *)
     init(_ edges: SwiftUI.Edge.Set = .all, _ length: AttributeReference<CoreFoundation.CGFloat?>?,for placement: SwiftUI.ContentMarginPlacement = .automatic ) {
         self.value = ._1(edges: edges, length: length, placement: placement)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 10.0,iOS 17.0,visionOS 1.0,macOS 14.0,tvOS 17.0, *)
+    @available(watchOS 10.0,tvOS 17.0,iOS 17.0,macOS 14.0,visionOS 1.0, *)
     init(_ length: AttributeReference<CoreFoundation.CGFloat>,for placement: SwiftUI.ContentMarginPlacement = .automatic ) {
         self.value = ._2(length: length, placement: placement)
         
@@ -2030,7 +2030,7 @@ struct _contentMarginsModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(edges, insets, placement):
-            if #available(tvOS 17.0,visionOS 1.0,watchOS 10.0,macOS 14.0,iOS 17.0, *) {
+            if #available(watchOS 10.0,tvOS 17.0,iOS 17.0,macOS 14.0,visionOS 1.0, *) {
             let edges = edges as! SwiftUI.Edge.Set 
 let insets = insets as! SwiftUI.EdgeInsets
 let placement = placement as! SwiftUI.ContentMarginPlacement 
@@ -2043,7 +2043,7 @@ let placement = placement as! SwiftUI.ContentMarginPlacement
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(edges, length, placement):
-            if #available(tvOS 17.0,visionOS 1.0,watchOS 10.0,macOS 14.0,iOS 17.0, *) {
+            if #available(watchOS 10.0,tvOS 17.0,iOS 17.0,macOS 14.0,visionOS 1.0, *) {
             let edges = edges as! SwiftUI.Edge.Set 
 let length = length as? AttributeReference<CoreFoundation.CGFloat?>
 let placement = placement as! SwiftUI.ContentMarginPlacement 
@@ -2056,7 +2056,7 @@ let placement = placement as! SwiftUI.ContentMarginPlacement
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._2(length, placement):
-            if #available(watchOS 10.0,iOS 17.0,visionOS 1.0,macOS 14.0,tvOS 17.0, *) {
+            if #available(watchOS 10.0,tvOS 17.0,iOS 17.0,macOS 14.0,visionOS 1.0, *) {
             let length = length as! AttributeReference<CoreFoundation.CGFloat>
 let placement = placement as! SwiftUI.ContentMarginPlacement 
             
@@ -2220,7 +2220,7 @@ struct _contextMenuModifier<R: RootRegistry>: ViewModifier {
     }
     
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS)
-    @available(iOS 16.0,visionOS 1.0,macOS 13.0,tvOS 16.0, *)
+    @available(iOS 16.0,visionOS 1.0,tvOS 16.0,macOS 13.0, *)
     init(menuItems: ViewReference=ViewReference(value: []),preview: ViewReference=ViewReference(value: [])) {
         self.value = ._1(menuItems: menuItems, preview: preview)
         
@@ -2244,7 +2244,7 @@ struct _contextMenuModifier<R: RootRegistry>: ViewModifier {
         
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS)
         case let ._1(menuItems, preview):
-            if #available(iOS 16.0,visionOS 1.0,macOS 13.0,tvOS 16.0, *) {
+            if #available(iOS 16.0,visionOS 1.0,tvOS 16.0,macOS 13.0, *) {
             let menuItems = menuItems as! ViewReference
 let preview = preview as! ViewReference
             
@@ -2326,7 +2326,7 @@ struct _controlGroupStyleModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS)
-    @available(tvOS 17.0,iOS 15.0,macOS 12.0,visionOS 1.0, *)
+    @available(visionOS 1.0,tvOS 17.0,macOS 12.0,iOS 15.0, *)
     init(_ style: AnyControlGroupStyle) {
         self.value = ._0(style: style)
         
@@ -2339,7 +2339,7 @@ struct _controlGroupStyleModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS)
         case let ._0(style):
-            if #available(tvOS 17.0,iOS 15.0,macOS 12.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,tvOS 17.0,macOS 12.0,iOS 15.0, *) {
             let style = style as! AnyControlGroupStyle
             
             __content
@@ -2373,7 +2373,7 @@ struct _controlSizeModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 9.0,macOS 10.15,iOS 15.0,visionOS 1.0, *)
+    @available(iOS 15.0,watchOS 9.0,macOS 10.15,visionOS 1.0, *)
     init(_ controlSize: SwiftUI.ControlSize) {
         self.value = ._0(controlSize: controlSize)
         
@@ -2386,7 +2386,7 @@ struct _controlSizeModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
         case let ._0(controlSize):
-            if #available(watchOS 9.0,macOS 10.15,iOS 15.0,visionOS 1.0, *) {
+            if #available(iOS 15.0,watchOS 9.0,macOS 10.15,visionOS 1.0, *) {
             let controlSize = controlSize as! SwiftUI.ControlSize
             
             __content
@@ -2420,7 +2420,7 @@ struct _coordinateSpaceModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 10.0,macOS 14.0,tvOS 17.0,iOS 17.0,visionOS 1.0, *)
+    @available(watchOS 10.0,tvOS 17.0,iOS 17.0,macOS 14.0,visionOS 1.0, *)
     init(_ name: SwiftUI.NamedCoordinateSpace) {
         self.value = ._0(name: name)
         
@@ -2433,7 +2433,7 @@ struct _coordinateSpaceModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(name):
-            if #available(watchOS 10.0,macOS 14.0,tvOS 17.0,iOS 17.0,visionOS 1.0, *) {
+            if #available(watchOS 10.0,tvOS 17.0,iOS 17.0,macOS 14.0,visionOS 1.0, *) {
             let name = name as! SwiftUI.NamedCoordinateSpace
             
             __content
@@ -2467,7 +2467,7 @@ struct _datePickerStyleModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 10.0,visionOS 1.0,iOS 13.0,macOS 10.15, *)
+    @available(visionOS 1.0,macOS 10.15,iOS 13.0,watchOS 10.0, *)
     init(_ style: AnyDatePickerStyle) {
         self.value = ._0(style: style)
         
@@ -2480,7 +2480,7 @@ struct _datePickerStyleModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
         case let ._0(style):
-            if #available(watchOS 10.0,visionOS 1.0,iOS 13.0,macOS 10.15, *) {
+            if #available(visionOS 1.0,macOS 10.15,iOS 13.0,watchOS 10.0, *) {
             let style = style as! AnyDatePickerStyle
             
             __content
@@ -2499,7 +2499,7 @@ struct _defaultHoverEffectModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(tvOS) || os(visionOS) || os(xrOS)
+        #if os(iOS) || os(tvOS) || os(visionOS)
         indirect case _0(effect: Any?)
         #endif
     }
@@ -2513,8 +2513,8 @@ struct _defaultHoverEffectModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(tvOS) || os(visionOS) || os(xrOS)
-    @available(xrOS 1.0,iOS 17.0,tvOS 17.0,visionOS 1.0, *)
+    #if os(iOS) || os(tvOS) || os(visionOS)
+    @available(tvOS 17.0,iOS 17.0,visionOS 1.0, *)
     init(_ effect: SwiftUI.HoverEffect?) {
         self.value = ._0(effect: effect)
         
@@ -2525,9 +2525,9 @@ struct _defaultHoverEffectModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(tvOS) || os(visionOS) || os(xrOS)
+        #if os(iOS) || os(tvOS) || os(visionOS)
         case let ._0(effect):
-            if #available(xrOS 1.0,iOS 17.0,tvOS 17.0,visionOS 1.0, *) {
+            if #available(tvOS 17.0,iOS 17.0,visionOS 1.0, *) {
             let effect = effect as? SwiftUI.HoverEffect
             
             __content
@@ -2561,7 +2561,7 @@ struct _defaultScrollAnchorModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 10.0,iOS 17.0,visionOS 1.0,macOS 14.0,tvOS 17.0, *)
+    @available(iOS 17.0,watchOS 10.0,tvOS 17.0,macOS 14.0,visionOS 1.0, *)
     init(_ anchor: AttributeReference<SwiftUI.UnitPoint?>?) {
         self.value = ._0(anchor: anchor)
         
@@ -2574,7 +2574,7 @@ struct _defaultScrollAnchorModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(anchor):
-            if #available(watchOS 10.0,iOS 17.0,visionOS 1.0,macOS 14.0,tvOS 17.0, *) {
+            if #available(iOS 17.0,watchOS 10.0,tvOS 17.0,macOS 14.0,visionOS 1.0, *) {
             let anchor = anchor as? AttributeReference<SwiftUI.UnitPoint?>
             
             __content
@@ -2640,7 +2640,7 @@ struct _defersSystemGesturesModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(visionOS)
+        #if os(iOS)
         indirect case _0(edges: Any)
         #endif
     }
@@ -2654,8 +2654,8 @@ struct _defersSystemGesturesModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(visionOS)
-    @available(iOS 16.0,visionOS 1.0, *)
+    #if os(iOS)
+    @available(iOS 16.0, *)
     init(on edges: SwiftUI.Edge.Set) {
         self.value = ._0(edges: edges)
         
@@ -2666,9 +2666,9 @@ struct _defersSystemGesturesModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(visionOS)
+        #if os(iOS)
         case let ._0(edges):
-            if #available(iOS 16.0,visionOS 1.0, *) {
+            if #available(iOS 16.0, *) {
             let edges = edges as! SwiftUI.Edge.Set
             
             __content
@@ -2764,28 +2764,28 @@ struct _dialogSuppressionToggleModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,watchOS 10.0,tvOS 17.0,iOS 17.0,macOS 14.0, *)
+    @available(watchOS 10.0,tvOS 17.0,iOS 17.0,macOS 14.0,visionOS 1.0, *)
     init(_ titleKey: SwiftUI.LocalizedStringKey,isSuppressed: ChangeTracked<Swift.Bool>) {
         self.value = ._0(titleKey: titleKey)
         self.__0_isSuppressed = isSuppressed
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,iOS 17.0,tvOS 17.0,macOS 14.0,watchOS 10.0, *)
+    @available(watchOS 10.0,tvOS 17.0,iOS 17.0,macOS 14.0,visionOS 1.0, *)
     init(_ title: AttributeReference<String>,isSuppressed: ChangeTracked<Swift.Bool>) {
         self.value = ._1(title: title)
         self.__1_isSuppressed = isSuppressed
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(iOS 17.0,tvOS 17.0,watchOS 10.0,macOS 14.0,visionOS 1.0, *)
+    @available(watchOS 10.0,tvOS 17.0,iOS 17.0,macOS 14.0,visionOS 1.0, *)
     init(_ label: TextReference,isSuppressed: ChangeTracked<Swift.Bool>) {
         self.value = ._2(label: label)
         self.__2_isSuppressed = isSuppressed
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(iOS 17.0,tvOS 17.0,watchOS 10.0,macOS 14.0,visionOS 1.0, *)
+    @available(watchOS 10.0,tvOS 17.0,iOS 17.0,macOS 14.0,visionOS 1.0, *)
     init(isSuppressed: ChangeTracked<Swift.Bool>) {
         self.value = ._3
         self.__3_isSuppressed = isSuppressed
@@ -2798,7 +2798,7 @@ struct _dialogSuppressionToggleModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(titleKey):
-            if #available(visionOS 1.0,watchOS 10.0,tvOS 17.0,iOS 17.0,macOS 14.0, *) {
+            if #available(watchOS 10.0,tvOS 17.0,iOS 17.0,macOS 14.0,visionOS 1.0, *) {
             let titleKey = titleKey as! SwiftUI.LocalizedStringKey
             
             __content
@@ -2809,7 +2809,7 @@ struct _dialogSuppressionToggleModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(title):
-            if #available(visionOS 1.0,iOS 17.0,tvOS 17.0,macOS 14.0,watchOS 10.0, *) {
+            if #available(watchOS 10.0,tvOS 17.0,iOS 17.0,macOS 14.0,visionOS 1.0, *) {
             let title = title as! AttributeReference<String>
             
             __content
@@ -2820,7 +2820,7 @@ struct _dialogSuppressionToggleModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._2(label):
-            if #available(iOS 17.0,tvOS 17.0,watchOS 10.0,macOS 14.0,visionOS 1.0, *) {
+            if #available(watchOS 10.0,tvOS 17.0,iOS 17.0,macOS 14.0,visionOS 1.0, *) {
             let label = label as! TextReference
             __content._observeTextReference(label, on: element, in: context) { __content in
             __content
@@ -2831,7 +2831,7 @@ struct _dialogSuppressionToggleModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case ._3:
-            if #available(iOS 17.0,tvOS 17.0,watchOS 10.0,macOS 14.0,visionOS 1.0, *) {
+            if #available(watchOS 10.0,tvOS 17.0,iOS 17.0,macOS 14.0,visionOS 1.0, *) {
             
             
             __content
@@ -2850,10 +2850,10 @@ struct _digitalCrownAccessoryModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(visionOS) || os(watchOS)
+        #if os(watchOS)
         indirect case _0(content: Any)
         #endif
-        #if os(visionOS) || os(watchOS)
+        #if os(watchOS)
         indirect case _1(visibility: Any)
         #endif
     }
@@ -2869,15 +2869,15 @@ struct _digitalCrownAccessoryModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(visionOS) || os(watchOS)
-    @available(watchOS 9.0,visionOS 1.0, *)
+    #if os(watchOS)
+    @available(watchOS 9.0, *)
     init(content: ViewReference=ViewReference(value: [])) {
         self.value = ._0(content: content)
         
     }
     #endif
-    #if os(visionOS) || os(watchOS)
-    @available(watchOS 9.0,visionOS 1.0, *)
+    #if os(watchOS)
+    @available(watchOS 9.0, *)
     init(_ visibility: AttributeReference<SwiftUI.Visibility>) {
         self.value = ._1(visibility: visibility)
         
@@ -2888,9 +2888,9 @@ struct _digitalCrownAccessoryModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(visionOS) || os(watchOS)
+        #if os(watchOS)
         case let ._0(content):
-            if #available(watchOS 9.0,visionOS 1.0, *) {
+            if #available(watchOS 9.0, *) {
             let content = content as! ViewReference
             
             __content
@@ -2899,9 +2899,9 @@ struct _digitalCrownAccessoryModifier<R: RootRegistry>: ViewModifier {
                 
             } else { __content }
         #endif
-        #if os(visionOS) || os(watchOS)
+        #if os(watchOS)
         case let ._1(visibility):
-            if #available(watchOS 9.0,visionOS 1.0, *) {
+            if #available(watchOS 9.0, *) {
             let visibility = visibility as! AttributeReference<SwiftUI.Visibility>
             
             __content
@@ -3099,7 +3099,7 @@ struct _fileDialogCustomizationIDModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(iOS 17.0,macOS 14.0,visionOS 1.0, *)
+    @available(iOS 17.0,visionOS 1.0,macOS 14.0, *)
     init(_ id: AttributeReference<Swift.String>) {
         self.value = ._0(id: id)
         
@@ -3112,7 +3112,7 @@ struct _fileDialogCustomizationIDModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(id):
-            if #available(iOS 17.0,macOS 14.0,visionOS 1.0, *) {
+            if #available(iOS 17.0,visionOS 1.0,macOS 14.0, *) {
             let id = id as! AttributeReference<Swift.String>
             
             __content
@@ -3146,7 +3146,7 @@ struct _fileDialogImportsUnresolvedAliasesModifier<R: RootRegistry>: ViewModifie
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(visionOS 1.0,macOS 14.0,iOS 17.0, *)
+    @available(iOS 17.0,visionOS 1.0,macOS 14.0, *)
     init(_ imports: AttributeReference<Swift.Bool>) {
         self.value = ._0(imports: imports)
         
@@ -3159,7 +3159,7 @@ struct _fileDialogImportsUnresolvedAliasesModifier<R: RootRegistry>: ViewModifie
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(imports):
-            if #available(visionOS 1.0,macOS 14.0,iOS 17.0, *) {
+            if #available(iOS 17.0,visionOS 1.0,macOS 14.0, *) {
             let imports = imports as! AttributeReference<Swift.Bool>
             
             __content
@@ -3404,7 +3404,7 @@ struct _focusEffectDisabledModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(iOS 17.0,watchOS 10.0,tvOS 17.0,visionOS 1.0,macOS 14.0, *)
+    @available(visionOS 1.0,macOS 14.0,tvOS 17.0,iOS 17.0,watchOS 10.0, *)
     init(_ disabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(disabled: disabled)
         
@@ -3417,7 +3417,7 @@ struct _focusEffectDisabledModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(disabled):
-            if #available(iOS 17.0,watchOS 10.0,tvOS 17.0,visionOS 1.0,macOS 14.0, *) {
+            if #available(visionOS 1.0,macOS 14.0,tvOS 17.0,iOS 17.0,watchOS 10.0, *) {
             let disabled = disabled as! AttributeReference<Swift.Bool>
             
             __content
@@ -3436,7 +3436,7 @@ struct _focusSectionModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(macOS) || os(tvOS) || os(visionOS)
+        #if os(macOS) || os(tvOS)
          case _0
         #endif
     }
@@ -3450,8 +3450,8 @@ struct _focusSectionModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(macOS) || os(tvOS) || os(visionOS)
-    @available(visionOS 1.0,macOS 13.0,tvOS 15.0, *)
+    #if os(macOS) || os(tvOS)
+    @available(tvOS 15.0,macOS 13.0, *)
     init() {
         self.value = ._0
         
@@ -3462,9 +3462,9 @@ struct _focusSectionModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(macOS) || os(tvOS) || os(visionOS)
+        #if os(macOS) || os(tvOS)
         case ._0:
-            if #available(visionOS 1.0,macOS 13.0,tvOS 15.0, *) {
+            if #available(tvOS 15.0,macOS 13.0, *) {
             
             
             __content
@@ -3503,14 +3503,14 @@ struct _focusableModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 12.0,visionOS 1.0,watchOS 8.0,tvOS 15.0,iOS 17.0, *)
+    @available(visionOS 1.0,macOS 12.0,tvOS 15.0,iOS 17.0,watchOS 8.0, *)
     init(_ isFocusable: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(isFocusable: isFocusable)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 14.0,visionOS 1.0,watchOS 10.0,tvOS 17.0,iOS 17.0, *)
+    @available(visionOS 1.0,macOS 14.0,tvOS 17.0,iOS 17.0,watchOS 10.0, *)
     init(_ isFocusable: AttributeReference<Swift.Bool> = .init(storage: .constant(true)), interactions: SwiftUI.FocusInteractions) {
         self.value = ._1(isFocusable: isFocusable, interactions: interactions)
         
@@ -3523,7 +3523,7 @@ struct _focusableModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(isFocusable):
-            if #available(macOS 12.0,visionOS 1.0,watchOS 8.0,tvOS 15.0,iOS 17.0, *) {
+            if #available(visionOS 1.0,macOS 12.0,tvOS 15.0,iOS 17.0,watchOS 8.0, *) {
             let isFocusable = isFocusable as! AttributeReference<Swift.Bool>
             
             __content
@@ -3534,7 +3534,7 @@ struct _focusableModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(isFocusable, interactions):
-            if #available(macOS 14.0,visionOS 1.0,watchOS 10.0,tvOS 17.0,iOS 17.0, *) {
+            if #available(visionOS 1.0,macOS 14.0,tvOS 17.0,iOS 17.0,watchOS 10.0, *) {
             let isFocusable = isFocusable as! AttributeReference<Swift.Bool>
 let interactions = interactions as! SwiftUI.FocusInteractions
             
@@ -3601,10 +3601,10 @@ struct _frameModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(visionOS) || os(xrOS)
+        #if os(visionOS)
         indirect case _0(depth: Any?,alignment: Any)
         #endif
-        #if os(visionOS) || os(xrOS)
+        #if os(visionOS)
         indirect case _1(minDepth: Any?, idealDepth: Any?, maxDepth: Any?, alignment: Any)
         #endif
         
@@ -3635,15 +3635,15 @@ struct _frameModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(visionOS) || os(xrOS)
-    @available(xrOS 1.0,visionOS 1.0, *)
+    #if os(visionOS)
+    @available(visionOS 1.0, *)
     init(depth: AttributeReference<CoreFoundation.CGFloat?>?,alignment: SwiftUI.DepthAlignment = .center ) {
         self.value = ._0(depth: depth, alignment: alignment)
         
     }
     #endif
-    #if os(visionOS) || os(xrOS)
-    @available(visionOS 1.0,xrOS 1.0, *)
+    #if os(visionOS)
+    @available(visionOS 1.0, *)
     init(minDepth: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), idealDepth: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), maxDepth: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), alignment: SwiftUI.DepthAlignment = .center ) {
         self.value = ._1(minDepth: minDepth, idealDepth: idealDepth, maxDepth: maxDepth, alignment: alignment)
         
@@ -3675,9 +3675,9 @@ struct _frameModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(visionOS) || os(xrOS)
+        #if os(visionOS)
         case let ._0(depth, alignment):
-            if #available(xrOS 1.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0, *) {
             let depth = depth as? AttributeReference<CoreFoundation.CGFloat?>
 let alignment = alignment as! SwiftUI.DepthAlignment 
             
@@ -3687,9 +3687,9 @@ let alignment = alignment as! SwiftUI.DepthAlignment
                 
             } else { __content }
         #endif
-        #if os(visionOS) || os(xrOS)
+        #if os(visionOS)
         case let ._1(minDepth, idealDepth, maxDepth, alignment):
-            if #available(visionOS 1.0,xrOS 1.0, *) {
+            if #available(visionOS 1.0, *) {
             let minDepth = minDepth as? AttributeReference<CoreFoundation.CGFloat?>
 let idealDepth = idealDepth as? AttributeReference<CoreFoundation.CGFloat?>
 let maxDepth = maxDepth as? AttributeReference<CoreFoundation.CGFloat?>
@@ -3759,7 +3759,7 @@ struct _fullScreenCoverModifier<R: RootRegistry>: ViewModifier {
 @Event private var _0_onDismiss__0: Event.EventHandler
 
     #if os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(tvOS 14.0,visionOS 1.0,iOS 14.0,watchOS 7.0, *)
+    @available(watchOS 7.0,tvOS 14.0,iOS 14.0,visionOS 1.0, *)
     init(isPresented: ChangeTracked<Swift.Bool>,onDismiss onDismiss__0: Event=Event(), content: ViewReference=ViewReference(value: [])) {
         self.value = ._0(content: content)
         self.__0_isPresented = isPresented
@@ -3773,7 +3773,7 @@ self.__0_onDismiss__0 = onDismiss__0
             fatalError("unreachable")
         #if os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(content):
-            if #available(tvOS 14.0,visionOS 1.0,iOS 14.0,watchOS 7.0, *) {
+            if #available(watchOS 7.0,tvOS 14.0,iOS 14.0,visionOS 1.0, *) {
             let content = content as! ViewReference
             
             __content
@@ -3807,7 +3807,7 @@ struct _gaugeStyleModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 7.0,macOS 13.0,iOS 16.0,visionOS 1.0, *)
+    @available(iOS 16.0,watchOS 7.0,macOS 13.0,visionOS 1.0, *)
     init(_ style: AnyGaugeStyle) {
         self.value = ._0(style: style)
         
@@ -3820,7 +3820,7 @@ struct _gaugeStyleModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
         case let ._0(style):
-            if #available(watchOS 7.0,macOS 13.0,iOS 16.0,visionOS 1.0, *) {
+            if #available(iOS 16.0,watchOS 7.0,macOS 13.0,visionOS 1.0, *) {
             let style = style as! AnyGaugeStyle
             
             __content
@@ -3854,7 +3854,7 @@ struct _geometryGroupModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 10.0,iOS 17.0,visionOS 1.0,macOS 14.0,tvOS 17.0, *)
+    @available(iOS 17.0,watchOS 10.0,tvOS 17.0,macOS 14.0,visionOS 1.0, *)
     init() {
         self.value = ._0
         
@@ -3867,7 +3867,7 @@ struct _geometryGroupModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case ._0:
-            if #available(watchOS 10.0,iOS 17.0,visionOS 1.0,macOS 14.0,tvOS 17.0, *) {
+            if #available(iOS 17.0,watchOS 10.0,tvOS 17.0,macOS 14.0,visionOS 1.0, *) {
             
             
             __content
@@ -3933,10 +3933,10 @@ struct _glassBackgroundEffectModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(visionOS) || os(xrOS)
+        #if os(visionOS)
         indirect case _0(displayMode: Any)
         #endif
-        #if os(visionOS) || os(xrOS)
+        #if os(visionOS)
         indirect case _1(shape: Any,displayMode: Any)
         #endif
     }
@@ -3952,15 +3952,15 @@ struct _glassBackgroundEffectModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(visionOS) || os(xrOS)
-    @available(xrOS 1.0,visionOS 1.0, *)
+    #if os(visionOS)
+    @available(visionOS 1.0, *)
     init(displayMode: SwiftUI.GlassBackgroundDisplayMode = .always ) {
         self.value = ._0(displayMode: displayMode)
         
     }
     #endif
-    #if os(visionOS) || os(xrOS)
-    @available(xrOS 1.0,visionOS 1.0, *)
+    #if os(visionOS)
+    @available(visionOS 1.0, *)
     init(in shape: AnyInsettableShape,displayMode: SwiftUI.GlassBackgroundDisplayMode = .always ) {
         self.value = ._1(shape: shape, displayMode: displayMode)
         
@@ -3971,9 +3971,9 @@ struct _glassBackgroundEffectModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(visionOS) || os(xrOS)
+        #if os(visionOS)
         case let ._0(displayMode):
-            if #available(xrOS 1.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0, *) {
             let displayMode = displayMode as! SwiftUI.GlassBackgroundDisplayMode 
             
             __content
@@ -3982,9 +3982,9 @@ struct _glassBackgroundEffectModifier<R: RootRegistry>: ViewModifier {
                 
             } else { __content }
         #endif
-        #if os(visionOS) || os(xrOS)
+        #if os(visionOS)
         case let ._1(shape, displayMode):
-            if #available(xrOS 1.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0, *) {
             let shape = shape as! AnyInsettableShape
 let displayMode = displayMode as! SwiftUI.GlassBackgroundDisplayMode 
             
@@ -4254,7 +4254,7 @@ struct _groupBoxStyleModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(visionOS 1.0,iOS 14.0,macOS 11.0, *)
+    @available(iOS 14.0,macOS 11.0,visionOS 1.0, *)
     init(_ style: AnyGroupBoxStyle) {
         self.value = ._0(style: style)
         
@@ -4267,7 +4267,7 @@ struct _groupBoxStyleModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(style):
-            if #available(visionOS 1.0,iOS 14.0,macOS 11.0, *) {
+            if #available(iOS 14.0,macOS 11.0,visionOS 1.0, *) {
             let style = style as! AnyGroupBoxStyle
             
             __content
@@ -4520,7 +4520,7 @@ struct _horizontalRadioGroupLayoutModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(macOS) || os(visionOS)
+        #if os(macOS)
          case _0
         #endif
     }
@@ -4534,8 +4534,8 @@ struct _horizontalRadioGroupLayoutModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(macOS) || os(visionOS)
-    @available(visionOS 1.0,macOS 10.15, *)
+    #if os(macOS)
+    @available(macOS 10.15, *)
     init() {
         self.value = ._0
         
@@ -4546,9 +4546,9 @@ struct _horizontalRadioGroupLayoutModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(macOS) || os(visionOS)
+        #if os(macOS)
         case ._0:
-            if #available(visionOS 1.0,macOS 10.15, *) {
+            if #available(macOS 10.15, *) {
             
             
             __content
@@ -4567,10 +4567,10 @@ struct _hoverEffectModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(tvOS) || os(visionOS) || os(xrOS)
+        #if os(iOS) || os(tvOS) || os(visionOS)
         indirect case _0(effect: Any)
         #endif
-        #if os(iOS) || os(tvOS) || os(visionOS) || os(xrOS)
+        #if os(iOS) || os(tvOS) || os(visionOS)
         indirect case _1(effect: Any, isEnabled: Any)
         #endif
     }
@@ -4586,15 +4586,15 @@ struct _hoverEffectModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(tvOS) || os(visionOS) || os(xrOS)
-    @available(xrOS 1.0,iOS 13.4,tvOS 16.0,visionOS 1.0, *)
+    #if os(iOS) || os(tvOS) || os(visionOS)
+    @available(tvOS 16.0,iOS 13.4,visionOS 1.0, *)
     init(_ effect: SwiftUI.HoverEffect = .automatic ) {
         self.value = ._0(effect: effect)
         
     }
     #endif
-    #if os(iOS) || os(tvOS) || os(visionOS) || os(xrOS)
-    @available(xrOS 1.0,iOS 17.0,tvOS 17.0,visionOS 1.0, *)
+    #if os(iOS) || os(tvOS) || os(visionOS)
+    @available(tvOS 17.0,iOS 17.0,visionOS 1.0, *)
     init(_ effect: SwiftUI.HoverEffect = .automatic, isEnabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._1(effect: effect, isEnabled: isEnabled)
         
@@ -4605,9 +4605,9 @@ struct _hoverEffectModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(tvOS) || os(visionOS) || os(xrOS)
+        #if os(iOS) || os(tvOS) || os(visionOS)
         case let ._0(effect):
-            if #available(xrOS 1.0,iOS 13.4,tvOS 16.0,visionOS 1.0, *) {
+            if #available(tvOS 16.0,iOS 13.4,visionOS 1.0, *) {
             let effect = effect as! SwiftUI.HoverEffect 
             
             __content
@@ -4616,9 +4616,9 @@ struct _hoverEffectModifier<R: RootRegistry>: ViewModifier {
                 
             } else { __content }
         #endif
-        #if os(iOS) || os(tvOS) || os(visionOS) || os(xrOS)
+        #if os(iOS) || os(tvOS) || os(visionOS)
         case let ._1(effect, isEnabled):
-            if #available(xrOS 1.0,iOS 17.0,tvOS 17.0,visionOS 1.0, *) {
+            if #available(tvOS 17.0,iOS 17.0,visionOS 1.0, *) {
             let effect = effect as! SwiftUI.HoverEffect 
 let isEnabled = isEnabled as! AttributeReference<Swift.Bool>
             
@@ -4638,7 +4638,7 @@ struct _hoverEffectDisabledModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(tvOS) || os(visionOS) || os(xrOS)
+        #if os(iOS) || os(tvOS) || os(visionOS)
         indirect case _0(disabled: Any)
         #endif
     }
@@ -4652,8 +4652,8 @@ struct _hoverEffectDisabledModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(tvOS) || os(visionOS) || os(xrOS)
-    @available(tvOS 17.0,visionOS 1.0,iOS 17.0,xrOS 1.0, *)
+    #if os(iOS) || os(tvOS) || os(visionOS)
+    @available(tvOS 17.0,iOS 17.0,visionOS 1.0, *)
     init(_ disabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(disabled: disabled)
         
@@ -4664,9 +4664,9 @@ struct _hoverEffectDisabledModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(tvOS) || os(visionOS) || os(xrOS)
+        #if os(iOS) || os(tvOS) || os(visionOS)
         case let ._0(disabled):
-            if #available(tvOS 17.0,visionOS 1.0,iOS 17.0,xrOS 1.0, *) {
+            if #available(tvOS 17.0,iOS 17.0,visionOS 1.0, *) {
             let disabled = disabled as! AttributeReference<Swift.Bool>
             
             __content
@@ -4873,7 +4873,7 @@ struct _inspectorModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(macOS) || os(visionOS)
+        #if os(iOS) || os(macOS)
         indirect case _0(content: Any)
         #endif
     }
@@ -4887,8 +4887,8 @@ struct _inspectorModifier<R: RootRegistry>: ViewModifier {
 @ChangeTracked private var _0_isPresented: Swift.Bool
 
 
-    #if os(iOS) || os(macOS) || os(visionOS)
-    @available(visionOS 1.0,iOS 17.0,macOS 14.0, *)
+    #if os(iOS) || os(macOS)
+    @available(iOS 17.0,macOS 14.0, *)
     init(isPresented: ChangeTracked<Swift.Bool>,content: ViewReference=ViewReference(value: [])) {
         self.value = ._0(content: content)
         self.__0_isPresented = isPresented
@@ -4899,9 +4899,9 @@ struct _inspectorModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(macOS) || os(visionOS)
+        #if os(iOS) || os(macOS)
         case let ._0(content):
-            if #available(visionOS 1.0,iOS 17.0,macOS 14.0, *) {
+            if #available(iOS 17.0,macOS 14.0, *) {
             let content = content as! ViewReference
             
             __content
@@ -4920,10 +4920,10 @@ struct _inspectorColumnWidthModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(macOS) || os(visionOS)
+        #if os(iOS) || os(macOS)
         indirect case _0(min: Any?, ideal: Any,max: Any?)
         #endif
-        #if os(iOS) || os(macOS) || os(visionOS)
+        #if os(iOS) || os(macOS)
         indirect case _1(width: Any)
         #endif
     }
@@ -4939,15 +4939,15 @@ struct _inspectorColumnWidthModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(macOS) || os(visionOS)
-    @available(visionOS 1.0,iOS 17.0,macOS 14.0, *)
+    #if os(iOS) || os(macOS)
+    @available(iOS 17.0,macOS 14.0, *)
     init(min: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), ideal: AttributeReference<CoreFoundation.CGFloat>,max: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)) ) {
         self.value = ._0(min: min, ideal: ideal, max: max)
         
     }
     #endif
-    #if os(iOS) || os(macOS) || os(visionOS)
-    @available(visionOS 1.0,macOS 14.0,iOS 17.0, *)
+    #if os(iOS) || os(macOS)
+    @available(iOS 17.0,macOS 14.0, *)
     init(_ width: AttributeReference<CoreFoundation.CGFloat>) {
         self.value = ._1(width: width)
         
@@ -4958,9 +4958,9 @@ struct _inspectorColumnWidthModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(macOS) || os(visionOS)
+        #if os(iOS) || os(macOS)
         case let ._0(min, ideal, max):
-            if #available(visionOS 1.0,iOS 17.0,macOS 14.0, *) {
+            if #available(iOS 17.0,macOS 14.0, *) {
             let min = min as? AttributeReference<CoreFoundation.CGFloat?>
 let ideal = ideal as! AttributeReference<CoreFoundation.CGFloat>
 let max = max as? AttributeReference<CoreFoundation.CGFloat?>
@@ -4971,9 +4971,9 @@ let max = max as? AttributeReference<CoreFoundation.CGFloat?>
                 
             } else { __content }
         #endif
-        #if os(iOS) || os(macOS) || os(visionOS)
+        #if os(iOS) || os(macOS)
         case let ._1(width):
-            if #available(visionOS 1.0,macOS 14.0,iOS 17.0, *) {
+            if #available(iOS 17.0,macOS 14.0, *) {
             let width = width as! AttributeReference<CoreFoundation.CGFloat>
             
             __content
@@ -5101,7 +5101,7 @@ struct _invalidatableContentModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(tvOS 17.0,visionOS 1.0,watchOS 10.0,macOS 14.0,iOS 17.0, *)
+    @available(watchOS 10.0,visionOS 1.0,iOS 17.0,tvOS 17.0,macOS 14.0, *)
     init(_ invalidatable: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(invalidatable: invalidatable)
         
@@ -5114,7 +5114,7 @@ struct _invalidatableContentModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(invalidatable):
-            if #available(tvOS 17.0,visionOS 1.0,watchOS 10.0,macOS 14.0,iOS 17.0, *) {
+            if #available(watchOS 10.0,visionOS 1.0,iOS 17.0,tvOS 17.0,macOS 14.0, *) {
             let invalidatable = invalidatable as! AttributeReference<Swift.Bool>
             
             __content
@@ -5170,14 +5170,14 @@ struct _keyboardShortcutModifier<R: RootRegistry>: ViewModifier {
     }
     #endif
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(visionOS 1.0,iOS 14.0,macOS 11.0, *)
+    @available(iOS 14.0,macOS 11.0,visionOS 1.0, *)
     init(_ shortcut: SwiftUI.KeyboardShortcut) {
         self.value = ._1(shortcut: shortcut)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(visionOS 1.0,iOS 15.4,macOS 12.3, *)
+    @available(iOS 15.4,macOS 12.3,visionOS 1.0, *)
     init(_ shortcut: SwiftUI.KeyboardShortcut?) {
         self.value = ._2(shortcut: shortcut)
         
@@ -5209,7 +5209,7 @@ let modifiers = modifiers as! SwiftUI.EventModifiers
         #endif
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._1(shortcut):
-            if #available(visionOS 1.0,iOS 14.0,macOS 11.0, *) {
+            if #available(iOS 14.0,macOS 11.0,visionOS 1.0, *) {
             let shortcut = shortcut as! SwiftUI.KeyboardShortcut
             
             __content
@@ -5220,7 +5220,7 @@ let modifiers = modifiers as! SwiftUI.EventModifiers
         #endif
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._2(shortcut):
-            if #available(visionOS 1.0,iOS 15.4,macOS 12.3, *) {
+            if #available(iOS 15.4,macOS 12.3,visionOS 1.0, *) {
             let shortcut = shortcut as? SwiftUI.KeyboardShortcut
             
             __content
@@ -5267,7 +5267,7 @@ struct _keyboardTypeModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(tvOS) || os(visionOS)
-    @available(tvOS 13.0,iOS 13.0,visionOS 1.0, *)
+    @available(iOS 13.0,tvOS 13.0,visionOS 1.0, *)
     init(_ type: UIKit.UIKeyboardType) {
         self.value = ._0(type: type)
         
@@ -5280,7 +5280,7 @@ struct _keyboardTypeModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(tvOS) || os(visionOS)
         case let ._0(type):
-            if #available(tvOS 13.0,iOS 13.0,visionOS 1.0, *) {
+            if #available(iOS 13.0,tvOS 13.0,visionOS 1.0, *) {
             let type = type as! UIKit.UIKeyboardType
             
             __content
@@ -5790,7 +5790,7 @@ struct _listRowHoverEffectModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(visionOS) || os(xrOS)
+        #if os(visionOS)
         indirect case _0(effect: Any?)
         #endif
     }
@@ -5804,8 +5804,8 @@ struct _listRowHoverEffectModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(visionOS) || os(xrOS)
-    @available(visionOS 1.0,xrOS 1.0, *)
+    #if os(visionOS)
+    @available(visionOS 1.0, *)
     init(_ effect: SwiftUI.HoverEffect?) {
         self.value = ._0(effect: effect)
         
@@ -5816,9 +5816,9 @@ struct _listRowHoverEffectModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(visionOS) || os(xrOS)
+        #if os(visionOS)
         case let ._0(effect):
-            if #available(visionOS 1.0,xrOS 1.0, *) {
+            if #available(visionOS 1.0, *) {
             let effect = effect as? SwiftUI.HoverEffect
             
             __content
@@ -5837,7 +5837,7 @@ struct _listRowHoverEffectDisabledModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(visionOS) || os(xrOS)
+        #if os(visionOS)
         indirect case _0(disabled: Any)
         #endif
     }
@@ -5851,8 +5851,8 @@ struct _listRowHoverEffectDisabledModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(visionOS) || os(xrOS)
-    @available(visionOS 1.0,xrOS 1.0, *)
+    #if os(visionOS)
+    @available(visionOS 1.0, *)
     init(_ disabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(disabled: disabled)
         
@@ -5863,9 +5863,9 @@ struct _listRowHoverEffectDisabledModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(visionOS) || os(xrOS)
+        #if os(visionOS)
         case let ._0(disabled):
-            if #available(visionOS 1.0,xrOS 1.0, *) {
+            if #available(visionOS 1.0, *) {
             let disabled = disabled as! AttributeReference<Swift.Bool>
             
             __content
@@ -5946,7 +5946,7 @@ struct _listRowSeparatorModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(visionOS 1.0,macOS 13.0,iOS 15.0, *)
+    @available(iOS 15.0,visionOS 1.0,macOS 13.0, *)
     init(_ visibility: AttributeReference<SwiftUI.Visibility>,edges: SwiftUI.VerticalEdge.Set = .all ) {
         self.value = ._0(visibility: visibility, edges: edges)
         
@@ -5959,7 +5959,7 @@ struct _listRowSeparatorModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(visibility, edges):
-            if #available(visionOS 1.0,macOS 13.0,iOS 15.0, *) {
+            if #available(iOS 15.0,visionOS 1.0,macOS 13.0, *) {
             let visibility = visibility as! AttributeReference<SwiftUI.Visibility>
 let edges = edges as! SwiftUI.VerticalEdge.Set 
             
@@ -5994,7 +5994,7 @@ struct _listRowSeparatorTintModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(visionOS 1.0,macOS 13.0,iOS 15.0, *)
+    @available(iOS 15.0,visionOS 1.0,macOS 13.0, *)
     init(_ color: Color.Resolvable?,edges: SwiftUI.VerticalEdge.Set = .all ) {
         self.value = ._0(color: color, edges: edges)
         
@@ -6007,7 +6007,7 @@ struct _listRowSeparatorTintModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(color, edges):
-            if #available(visionOS 1.0,macOS 13.0,iOS 15.0, *) {
+            if #available(iOS 15.0,visionOS 1.0,macOS 13.0, *) {
             let color = color as? Color.Resolvable
 let edges = edges as! SwiftUI.VerticalEdge.Set 
             
@@ -6042,7 +6042,7 @@ struct _listRowSpacingModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(visionOS)
-    @available(iOS 15.0,visionOS 1.0, *)
+    @available(visionOS 1.0,iOS 15.0, *)
     init(_ spacing: AttributeReference<CoreFoundation.CGFloat?>?) {
         self.value = ._0(spacing: spacing)
         
@@ -6055,7 +6055,7 @@ struct _listRowSpacingModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(visionOS)
         case let ._0(spacing):
-            if #available(iOS 15.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,iOS 15.0, *) {
             let spacing = spacing as? AttributeReference<CoreFoundation.CGFloat?>
             
             __content
@@ -6089,7 +6089,7 @@ struct _listSectionSeparatorModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(visionOS 1.0,iOS 15.0,macOS 13.0, *)
+    @available(iOS 15.0,visionOS 1.0,macOS 13.0, *)
     init(_ visibility: AttributeReference<SwiftUI.Visibility>,edges: SwiftUI.VerticalEdge.Set = .all ) {
         self.value = ._0(visibility: visibility, edges: edges)
         
@@ -6102,7 +6102,7 @@ struct _listSectionSeparatorModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(visibility, edges):
-            if #available(visionOS 1.0,iOS 15.0,macOS 13.0, *) {
+            if #available(iOS 15.0,visionOS 1.0,macOS 13.0, *) {
             let visibility = visibility as! AttributeReference<SwiftUI.Visibility>
 let edges = edges as! SwiftUI.VerticalEdge.Set 
             
@@ -6137,7 +6137,7 @@ struct _listSectionSeparatorTintModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(visionOS 1.0,iOS 15.0,macOS 13.0, *)
+    @available(iOS 15.0,visionOS 1.0,macOS 13.0, *)
     init(_ color: Color.Resolvable?,edges: SwiftUI.VerticalEdge.Set = .all ) {
         self.value = ._0(color: color, edges: edges)
         
@@ -6150,7 +6150,7 @@ struct _listSectionSeparatorTintModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(color, edges):
-            if #available(visionOS 1.0,iOS 15.0,macOS 13.0, *) {
+            if #available(iOS 15.0,visionOS 1.0,macOS 13.0, *) {
             let color = color as? Color.Resolvable
 let edges = edges as! SwiftUI.VerticalEdge.Set 
             
@@ -6349,7 +6349,7 @@ struct _menuIndicatorModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS)
-    @available(macOS 12.0,iOS 15.0,visionOS 1.0,tvOS 17.0, *)
+    @available(iOS 15.0,macOS 12.0,tvOS 17.0,visionOS 1.0, *)
     init(_ visibility: AttributeReference<SwiftUI.Visibility>) {
         self.value = ._0(visibility: visibility)
         
@@ -6362,7 +6362,7 @@ struct _menuIndicatorModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS)
         case let ._0(visibility):
-            if #available(macOS 12.0,iOS 15.0,visionOS 1.0,tvOS 17.0, *) {
+            if #available(iOS 15.0,macOS 12.0,tvOS 17.0,visionOS 1.0, *) {
             let visibility = visibility as! AttributeReference<SwiftUI.Visibility>
             
             __content
@@ -6443,7 +6443,7 @@ struct _menuStyleModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS)
-    @available(iOS 14.0,macOS 11.0,tvOS 17.0,visionOS 1.0, *)
+    @available(visionOS 1.0,tvOS 17.0,macOS 11.0,iOS 14.0, *)
     init(_ style: AnyMenuStyle) {
         self.value = ._0(style: style)
         
@@ -6456,7 +6456,7 @@ struct _menuStyleModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS)
         case let ._0(style):
-            if #available(iOS 14.0,macOS 11.0,tvOS 17.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,tvOS 17.0,macOS 11.0,iOS 14.0, *) {
             let style = style as! AnyMenuStyle
             
             __content
@@ -6874,13 +6874,13 @@ struct _navigationSubtitleModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(macOS) || os(visionOS) || targetEnvironment(macCatalyst)
+        #if os(macOS) || targetEnvironment(macCatalyst)
         indirect case _0(subtitle: Any)
         #endif
-        #if os(macOS) || os(visionOS) || targetEnvironment(macCatalyst)
+        #if os(macOS) || targetEnvironment(macCatalyst)
         indirect case _1(subtitleKey: Any)
         #endif
-        #if os(macOS) || os(visionOS) || targetEnvironment(macCatalyst)
+        #if os(macOS) || targetEnvironment(macCatalyst)
         indirect case _2(subtitle: Any)
         #endif
     }
@@ -6898,22 +6898,22 @@ struct _navigationSubtitleModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(macOS) || os(visionOS) || targetEnvironment(macCatalyst)
-    @available(visionOS 1.0,macCatalyst 14.0,macOS 11.0, *)
+    #if os(macOS) || targetEnvironment(macCatalyst)
+    @available(macCatalyst 14.0,macOS 11.0, *)
     init(_ subtitle: TextReference) {
         self.value = ._0(subtitle: subtitle)
         
     }
     #endif
-    #if os(macOS) || os(visionOS) || targetEnvironment(macCatalyst)
-    @available(visionOS 1.0,macCatalyst 14.0,macOS 11.0, *)
+    #if os(macOS) || targetEnvironment(macCatalyst)
+    @available(macCatalyst 14.0,macOS 11.0, *)
     init(_ subtitleKey: SwiftUI.LocalizedStringKey) {
         self.value = ._1(subtitleKey: subtitleKey)
         
     }
     #endif
-    #if os(macOS) || os(visionOS) || targetEnvironment(macCatalyst)
-    @available(visionOS 1.0,macCatalyst 14.0,macOS 11.0, *)
+    #if os(macOS) || targetEnvironment(macCatalyst)
+    @available(macCatalyst 14.0,macOS 11.0, *)
     init(_ subtitle: AttributeReference<String>) {
         self.value = ._2(subtitle: subtitle)
         
@@ -6924,9 +6924,9 @@ struct _navigationSubtitleModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(macOS) || os(visionOS) || targetEnvironment(macCatalyst)
+        #if os(macOS) || targetEnvironment(macCatalyst)
         case let ._0(subtitle):
-            if #available(visionOS 1.0,macCatalyst 14.0,macOS 11.0, *) {
+            if #available(macCatalyst 14.0,macOS 11.0, *) {
             let subtitle = subtitle as! TextReference
             __content._observeTextReference(subtitle, on: element, in: context) { __content in
             __content
@@ -6935,9 +6935,9 @@ struct _navigationSubtitleModifier<R: RootRegistry>: ViewModifier {
                 
             } else { __content }
         #endif
-        #if os(macOS) || os(visionOS) || targetEnvironment(macCatalyst)
+        #if os(macOS) || targetEnvironment(macCatalyst)
         case let ._1(subtitleKey):
-            if #available(visionOS 1.0,macCatalyst 14.0,macOS 11.0, *) {
+            if #available(macCatalyst 14.0,macOS 11.0, *) {
             let subtitleKey = subtitleKey as! SwiftUI.LocalizedStringKey
             
             __content
@@ -6946,9 +6946,9 @@ struct _navigationSubtitleModifier<R: RootRegistry>: ViewModifier {
                 
             } else { __content }
         #endif
-        #if os(macOS) || os(visionOS) || targetEnvironment(macCatalyst)
+        #if os(macOS) || targetEnvironment(macCatalyst)
         case let ._2(subtitle):
-            if #available(visionOS 1.0,macCatalyst 14.0,macOS 11.0, *) {
+            if #available(macCatalyst 14.0,macOS 11.0, *) {
             let subtitle = subtitle as! AttributeReference<String>
             
             __content
@@ -6976,7 +6976,7 @@ struct _navigationTitleModifier<R: RootRegistry>: ViewModifier {
         
         indirect case _2(title: AttributeReference<String>)
         
-        #if os(visionOS) || os(watchOS)
+        #if os(watchOS)
         indirect case _3(title: Any)
         #endif
         
@@ -7022,8 +7022,8 @@ struct _navigationTitleModifier<R: RootRegistry>: ViewModifier {
         
     }
     
-    #if os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,iOS 14.0,tvOS 14.0,macOS 11.0,watchOS 7.0, *)
+    #if os(watchOS)
+    @available(tvOS 14.0,iOS 14.0,macOS 11.0,watchOS 7.0, *)
     init(_ title: ViewReference=ViewReference(value: [])) {
         self.value = ._3(title: title)
         
@@ -7074,9 +7074,9 @@ struct _navigationTitleModifier<R: RootRegistry>: ViewModifier {
                 
             
         
-        #if os(visionOS) || os(watchOS)
+        #if os(watchOS)
         case let ._3(title):
-            if #available(visionOS 1.0,iOS 14.0,tvOS 14.0,macOS 11.0,watchOS 7.0, *) {
+            if #available(tvOS 14.0,iOS 14.0,macOS 11.0,watchOS 7.0, *) {
             let title = title as! ViewReference
             
             __content
@@ -7112,7 +7112,7 @@ struct _offsetModifier<R: RootRegistry>: ViewModifier {
         
         indirect case _1(x: AttributeReference<CoreFoundation.CGFloat> = .init(storage: .constant(0)), y: AttributeReference<CoreFoundation.CGFloat> = .init(storage: .constant(0)) )
         
-        #if os(visionOS) || os(xrOS)
+        #if os(visionOS)
         indirect case _2(z: Any)
         #endif
     }
@@ -7144,8 +7144,8 @@ struct _offsetModifier<R: RootRegistry>: ViewModifier {
         
     }
     
-    #if os(visionOS) || os(xrOS)
-    @available(visionOS 1.0,xrOS 1.0, *)
+    #if os(visionOS)
+    @available(visionOS 1.0, *)
     init(z: AttributeReference<CoreFoundation.CGFloat>) {
         self.value = ._2(z: z)
         
@@ -7178,9 +7178,9 @@ struct _offsetModifier<R: RootRegistry>: ViewModifier {
                 
             
         
-        #if os(visionOS) || os(xrOS)
+        #if os(visionOS)
         case let ._2(z):
-            if #available(visionOS 1.0,xrOS 1.0, *) {
+            if #available(visionOS 1.0, *) {
             let z = z as! AttributeReference<CoreFoundation.CGFloat>
             
             __content
@@ -7246,7 +7246,7 @@ struct _onDeleteCommandModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(macOS) || os(visionOS)
+        #if os(macOS)
          case _0
         #endif
     }
@@ -7260,8 +7260,8 @@ struct _onDeleteCommandModifier<R: RootRegistry>: ViewModifier {
 
 @Event private var _0_action__0: Event.EventHandler
 
-    #if os(macOS) || os(visionOS)
-    @available(visionOS 1.0,tvOS 13.0,macOS 10.15, *)
+    #if os(macOS)
+    @available(tvOS 13.0,macOS 10.15, *)
     init(perform action__0: Event=Event()) {
         self.value = ._0
         self.__0_action__0 = action__0
@@ -7272,9 +7272,9 @@ struct _onDeleteCommandModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(macOS) || os(visionOS)
+        #if os(macOS)
         case ._0:
-            if #available(visionOS 1.0,tvOS 13.0,macOS 10.15, *) {
+            if #available(tvOS 13.0,macOS 10.15, *) {
             
             
             __content
@@ -7340,7 +7340,7 @@ struct _onExitCommandModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(macOS) || os(tvOS) || os(visionOS)
+        #if os(macOS) || os(tvOS)
          case _0
         #endif
     }
@@ -7354,8 +7354,8 @@ struct _onExitCommandModifier<R: RootRegistry>: ViewModifier {
 
 @Event private var _0_action__0: Event.EventHandler
 
-    #if os(macOS) || os(tvOS) || os(visionOS)
-    @available(visionOS 1.0,tvOS 13.0,macOS 10.15, *)
+    #if os(macOS) || os(tvOS)
+    @available(tvOS 13.0,macOS 10.15, *)
     init(perform action__0: Event=Event()) {
         self.value = ._0
         self.__0_action__0 = action__0
@@ -7366,9 +7366,9 @@ struct _onExitCommandModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(macOS) || os(tvOS) || os(visionOS)
+        #if os(macOS) || os(tvOS)
         case ._0:
-            if #available(visionOS 1.0,tvOS 13.0,macOS 10.15, *) {
+            if #available(tvOS 13.0,macOS 10.15, *) {
             
             
             __content
@@ -7402,7 +7402,7 @@ struct _onHoverModifier<R: RootRegistry>: ViewModifier {
 @Event private var _0_action__1: Event.EventHandler
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(iOS 13.4,macOS 10.15,visionOS 1.0, *)
+    @available(iOS 13.4,visionOS 1.0,macOS 10.15, *)
     init(perform action__1: Event) {
         self.value = ._0
         self.__0_action__1 = action__1
@@ -7415,7 +7415,7 @@ struct _onHoverModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case ._0:
-            if #available(iOS 13.4,macOS 10.15,visionOS 1.0, *) {
+            if #available(iOS 13.4,visionOS 1.0,macOS 10.15, *) {
             
             
             __content
@@ -7437,7 +7437,7 @@ struct _onLongPressGestureModifier<R: RootRegistry>: ViewModifier {
         #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
         indirect case _0(minimumDuration: Any, maximumDistance: Any)
         #endif
-        #if os(tvOS) || os(visionOS)
+        #if os(tvOS)
         indirect case _1(minimumDuration: Any)
         #endif
     }
@@ -7456,15 +7456,15 @@ struct _onLongPressGestureModifier<R: RootRegistry>: ViewModifier {
 @Event private var _1_onPressingChanged__1: Event.EventHandler
 
     #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
-    @available(iOS 13.0,visionOS 1.0,macOS 10.15,watchOS 6.0,tvOS 14.0, *)
+    @available(watchOS 6.0,macOS 10.15,tvOS 14.0,visionOS 1.0,iOS 13.0, *)
     init(minimumDuration: AttributeReference<Swift.Double> = .init(storage: .constant(0.5)), maximumDistance: AttributeReference<CoreFoundation.CGFloat> = .init(storage: .constant(10)), perform action__0: Event,onPressingChanged onPressingChanged__1: Event=Event() ) {
         self.value = ._0(minimumDuration: minimumDuration, maximumDistance: maximumDistance)
         self.__0_action__0 = action__0
 self.__0_onPressingChanged__1 = onPressingChanged__1
     }
     #endif
-    #if os(tvOS) || os(visionOS)
-    @available(watchOS 6.0,tvOS 14.0,iOS 13.0,macOS 10.15,visionOS 1.0, *)
+    #if os(tvOS)
+    @available(watchOS 6.0,macOS 10.15,tvOS 14.0,iOS 13.0, *)
     init(minimumDuration: AttributeReference<Swift.Double> = .init(storage: .constant(0.5)), perform action__0: Event,onPressingChanged onPressingChanged__1: Event=Event() ) {
         self.value = ._1(minimumDuration: minimumDuration)
         self.__1_action__0 = action__0
@@ -7478,7 +7478,7 @@ self.__1_onPressingChanged__1 = onPressingChanged__1
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
         case let ._0(minimumDuration, maximumDistance):
-            if #available(iOS 13.0,visionOS 1.0,macOS 10.15,watchOS 6.0,tvOS 14.0, *) {
+            if #available(watchOS 6.0,macOS 10.15,tvOS 14.0,visionOS 1.0,iOS 13.0, *) {
             let minimumDuration = minimumDuration as! AttributeReference<Swift.Double>
 let maximumDistance = maximumDistance as! AttributeReference<CoreFoundation.CGFloat>
             
@@ -7488,9 +7488,9 @@ let maximumDistance = maximumDistance as! AttributeReference<CoreFoundation.CGFl
                 
             } else { __content }
         #endif
-        #if os(tvOS) || os(visionOS)
+        #if os(tvOS)
         case let ._1(minimumDuration):
-            if #available(watchOS 6.0,tvOS 14.0,iOS 13.0,macOS 10.15,visionOS 1.0, *) {
+            if #available(watchOS 6.0,macOS 10.15,tvOS 14.0,iOS 13.0, *) {
             let minimumDuration = minimumDuration as! AttributeReference<Swift.Double>
             
             __content
@@ -7509,7 +7509,7 @@ struct _onLongTouchGestureModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(tvOS) || os(visionOS)
+        #if os(tvOS)
         indirect case _0(minimumDuration: Any)
         #endif
     }
@@ -7524,8 +7524,8 @@ struct _onLongTouchGestureModifier<R: RootRegistry>: ViewModifier {
 @Event private var _0_action__0: Event.EventHandler
 @Event private var _0_onTouchingChanged__1: Event.EventHandler
 
-    #if os(tvOS) || os(visionOS)
-    @available(tvOS 16.0,visionOS 1.0, *)
+    #if os(tvOS)
+    @available(tvOS 16.0, *)
     init(minimumDuration: AttributeReference<Swift.Double> = .init(storage: .constant(0.5)), perform action__0: Event,onTouchingChanged onTouchingChanged__1: Event=Event() ) {
         self.value = ._0(minimumDuration: minimumDuration)
         self.__0_action__0 = action__0
@@ -7537,9 +7537,9 @@ self.__0_onTouchingChanged__1 = onTouchingChanged__1
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(tvOS) || os(visionOS)
+        #if os(tvOS)
         case let ._0(minimumDuration):
-            if #available(tvOS 16.0,visionOS 1.0, *) {
+            if #available(tvOS 16.0, *) {
             let minimumDuration = minimumDuration as! AttributeReference<Swift.Double>
             
             __content
@@ -7558,7 +7558,7 @@ struct _onMoveCommandModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(macOS) || os(tvOS) || os(visionOS)
+        #if os(macOS) || os(tvOS)
          case _0
         #endif
     }
@@ -7572,8 +7572,8 @@ struct _onMoveCommandModifier<R: RootRegistry>: ViewModifier {
 
 @Event private var _0_action__1: Event.EventHandler
 
-    #if os(macOS) || os(tvOS) || os(visionOS)
-    @available(visionOS 1.0,tvOS 13.0,macOS 10.15, *)
+    #if os(macOS) || os(tvOS)
+    @available(tvOS 13.0,macOS 10.15, *)
     init(perform action__1: Event=Event()) {
         self.value = ._0
         self.__0_action__1 = action__1
@@ -7584,9 +7584,9 @@ struct _onMoveCommandModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(macOS) || os(tvOS) || os(visionOS)
+        #if os(macOS) || os(tvOS)
         case ._0:
-            if #available(visionOS 1.0,tvOS 13.0,macOS 10.15, *) {
+            if #available(tvOS 13.0,macOS 10.15, *) {
             
             
             __content
@@ -7605,7 +7605,7 @@ struct _onPlayPauseCommandModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(tvOS) || os(visionOS)
+        #if os(tvOS)
          case _0
         #endif
     }
@@ -7619,8 +7619,8 @@ struct _onPlayPauseCommandModifier<R: RootRegistry>: ViewModifier {
 
 @Event private var _0_action__0: Event.EventHandler
 
-    #if os(tvOS) || os(visionOS)
-    @available(visionOS 1.0,tvOS 13.0,macOS 10.15, *)
+    #if os(tvOS)
+    @available(tvOS 13.0,macOS 10.15, *)
     init(perform action__0: Event=Event()) {
         self.value = ._0
         self.__0_action__0 = action__0
@@ -7631,9 +7631,9 @@ struct _onPlayPauseCommandModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(tvOS) || os(visionOS)
+        #if os(tvOS)
         case ._0:
-            if #available(visionOS 1.0,tvOS 13.0,macOS 10.15, *) {
+            if #available(tvOS 13.0,macOS 10.15, *) {
             
             
             __content
@@ -7679,7 +7679,7 @@ struct _onTapGestureModifier<R: RootRegistry>: ViewModifier {
     }
     
     #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 10.0,iOS 17.0,visionOS 1.0,macOS 14.0, *)
+    @available(visionOS 1.0,macOS 14.0,iOS 17.0,watchOS 10.0, *)
     init(count: AttributeReference<Swift.Int> = .init(storage: .constant(1)), coordinateSpace: AnyCoordinateSpaceProtocol = .local, perform action__1: Event) {
         self.value = ._1(count: count, coordinateSpace: coordinateSpace)
         self.__1_action__1 = action__1
@@ -7703,7 +7703,7 @@ struct _onTapGestureModifier<R: RootRegistry>: ViewModifier {
         
         #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
         case let ._1(count, coordinateSpace):
-            if #available(watchOS 10.0,iOS 17.0,visionOS 1.0,macOS 14.0, *) {
+            if #available(visionOS 1.0,macOS 14.0,iOS 17.0,watchOS 10.0, *) {
             let count = count as! AttributeReference<Swift.Int>
 let coordinateSpace = coordinateSpace as! AnyCoordinateSpaceProtocol 
             
@@ -7770,7 +7770,7 @@ struct _ornamentModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(visionOS) || os(xrOS)
+        #if os(visionOS)
         indirect case _0(visibility: Any, attachmentAnchor: Any,contentAlignment: Any, ornament: Any)
         #endif
     }
@@ -7784,8 +7784,8 @@ struct _ornamentModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(visionOS) || os(xrOS)
-    @available(xrOS 1.0,visionOS 1.0, *)
+    #if os(visionOS)
+    @available(visionOS 1.0, *)
     init(visibility: AttributeReference<SwiftUI.Visibility> = .init(storage: .constant(.automatic)), attachmentAnchor: SwiftUI.OrnamentAttachmentAnchor,contentAlignment: AttributeReference<SwiftUI.Alignment> = .init(storage: .constant(.center)), ornament: ViewReference=ViewReference(value: [])) {
         self.value = ._0(visibility: visibility, attachmentAnchor: attachmentAnchor, contentAlignment: contentAlignment, ornament: ornament)
         
@@ -7796,9 +7796,9 @@ struct _ornamentModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(visionOS) || os(xrOS)
+        #if os(visionOS)
         case let ._0(visibility, attachmentAnchor, contentAlignment, ornament):
-            if #available(xrOS 1.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0, *) {
             let visibility = visibility as! AttributeReference<SwiftUI.Visibility>
 let attachmentAnchor = attachmentAnchor as! SwiftUI.OrnamentAttachmentAnchor
 let contentAlignment = contentAlignment as! AttributeReference<SwiftUI.Alignment>
@@ -8006,13 +8006,13 @@ struct _padding3DModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(visionOS) || os(xrOS)
+        #if os(visionOS)
         indirect case _0(insets: Any)
         #endif
-        #if os(visionOS) || os(xrOS)
+        #if os(visionOS)
         indirect case _1(edges: Any, length: Any?)
         #endif
-        #if os(visionOS) || os(xrOS)
+        #if os(visionOS)
         indirect case _2(length: Any)
         #endif
     }
@@ -8030,22 +8030,22 @@ struct _padding3DModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(visionOS) || os(xrOS)
-    @available(visionOS 1.0,xrOS 1.0, *)
+    #if os(visionOS)
+    @available(visionOS 1.0, *)
     init(_ insets: SwiftUI.EdgeInsets3D) {
         self.value = ._0(insets: insets)
         
     }
     #endif
-    #if os(visionOS) || os(xrOS)
-    @available(visionOS 1.0,xrOS 1.0, *)
+    #if os(visionOS)
+    @available(visionOS 1.0, *)
     init(_ edges: SwiftUI.Edge3D.Set = .all, _ length: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)) ) {
         self.value = ._1(edges: edges, length: length)
         
     }
     #endif
-    #if os(visionOS) || os(xrOS)
-    @available(visionOS 1.0,xrOS 1.0, *)
+    #if os(visionOS)
+    @available(visionOS 1.0, *)
     init(_ length: AttributeReference<CoreFoundation.CGFloat>) {
         self.value = ._2(length: length)
         
@@ -8056,9 +8056,9 @@ struct _padding3DModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(visionOS) || os(xrOS)
+        #if os(visionOS)
         case let ._0(insets):
-            if #available(visionOS 1.0,xrOS 1.0, *) {
+            if #available(visionOS 1.0, *) {
             let insets = insets as! SwiftUI.EdgeInsets3D
             
             __content
@@ -8067,9 +8067,9 @@ struct _padding3DModifier<R: RootRegistry>: ViewModifier {
                 
             } else { __content }
         #endif
-        #if os(visionOS) || os(xrOS)
+        #if os(visionOS)
         case let ._1(edges, length):
-            if #available(visionOS 1.0,xrOS 1.0, *) {
+            if #available(visionOS 1.0, *) {
             let edges = edges as! SwiftUI.Edge3D.Set 
 let length = length as? AttributeReference<CoreFoundation.CGFloat?>
             
@@ -8079,9 +8079,9 @@ let length = length as? AttributeReference<CoreFoundation.CGFloat?>
                 
             } else { __content }
         #endif
-        #if os(visionOS) || os(xrOS)
+        #if os(visionOS)
         case let ._2(length):
-            if #available(visionOS 1.0,xrOS 1.0, *) {
+            if #available(visionOS 1.0, *) {
             let length = length as! AttributeReference<CoreFoundation.CGFloat>
             
             __content
@@ -8360,7 +8360,7 @@ struct _preferredSurroundingsEffectModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(visionOS) || os(xrOS)
+        #if os(visionOS)
         indirect case _0(effect: Any?)
         #endif
     }
@@ -8374,8 +8374,8 @@ struct _preferredSurroundingsEffectModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(visionOS) || os(xrOS)
-    @available(xrOS 1.0,visionOS 1.0, *)
+    #if os(visionOS)
+    @available(visionOS 1.0, *)
     init(_ effect: SwiftUI.SurroundingsEffect?) {
         self.value = ._0(effect: effect)
         
@@ -8386,9 +8386,9 @@ struct _preferredSurroundingsEffectModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(visionOS) || os(xrOS)
+        #if os(visionOS)
         case let ._0(effect):
-            if #available(xrOS 1.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0, *) {
             let effect = effect as? SwiftUI.SurroundingsEffect
             
             __content
@@ -8427,14 +8427,14 @@ struct _presentationBackgroundModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,tvOS 16.4,watchOS 9.4,iOS 16.4,macOS 13.3, *)
+    @available(visionOS 1.0,macOS 13.3,tvOS 16.4,iOS 16.4,watchOS 9.4, *)
     init(_ style: AnyShapeStyle.Resolvable) {
         self.value = ._0(style: style)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(iOS 16.4,watchOS 9.4,tvOS 16.4,visionOS 1.0,macOS 13.3, *)
+    @available(visionOS 1.0,macOS 13.3,tvOS 16.4,iOS 16.4,watchOS 9.4, *)
     init(alignment: AttributeReference<SwiftUI.Alignment> = .init(storage: .constant(.center)), content: ViewReference=ViewReference(value: [])) {
         self.value = ._1(alignment: alignment, content: content)
         
@@ -8447,7 +8447,7 @@ struct _presentationBackgroundModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(style):
-            if #available(visionOS 1.0,tvOS 16.4,watchOS 9.4,iOS 16.4,macOS 13.3, *) {
+            if #available(visionOS 1.0,macOS 13.3,tvOS 16.4,iOS 16.4,watchOS 9.4, *) {
             let style = style as! AnyShapeStyle.Resolvable
             
             __content
@@ -8458,7 +8458,7 @@ struct _presentationBackgroundModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(alignment, content):
-            if #available(iOS 16.4,watchOS 9.4,tvOS 16.4,visionOS 1.0,macOS 13.3, *) {
+            if #available(visionOS 1.0,macOS 13.3,tvOS 16.4,iOS 16.4,watchOS 9.4, *) {
             let alignment = alignment as! AttributeReference<SwiftUI.Alignment>
 let content = content as! ViewReference
             
@@ -8493,7 +8493,7 @@ struct _presentationBackgroundInteractionModifier<R: RootRegistry>: ViewModifier
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 9.4,iOS 16.4,visionOS 1.0,macOS 13.3,tvOS 16.4, *)
+    @available(visionOS 1.0,macOS 13.3,tvOS 16.4,iOS 16.4,watchOS 9.4, *)
     init(_ interaction: SwiftUI.PresentationBackgroundInteraction) {
         self.value = ._0(interaction: interaction)
         
@@ -8506,7 +8506,7 @@ struct _presentationBackgroundInteractionModifier<R: RootRegistry>: ViewModifier
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(interaction):
-            if #available(watchOS 9.4,iOS 16.4,visionOS 1.0,macOS 13.3,tvOS 16.4, *) {
+            if #available(visionOS 1.0,macOS 13.3,tvOS 16.4,iOS 16.4,watchOS 9.4, *) {
             let interaction = interaction as! SwiftUI.PresentationBackgroundInteraction
             
             __content
@@ -8545,14 +8545,14 @@ struct _presentationCompactAdaptationModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 9.4,iOS 16.4,visionOS 1.0,macOS 13.3,tvOS 16.4, *)
+    @available(visionOS 1.0,macOS 13.3,tvOS 16.4,iOS 16.4,watchOS 9.4, *)
     init(_ adaptation: SwiftUI.PresentationAdaptation) {
         self.value = ._0(adaptation: adaptation)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(macOS 13.3,visionOS 1.0,watchOS 9.4,tvOS 16.4,iOS 16.4, *)
+    @available(visionOS 1.0,macOS 13.3,tvOS 16.4,iOS 16.4,watchOS 9.4, *)
     init(horizontal horizontalAdaptation: SwiftUI.PresentationAdaptation,vertical verticalAdaptation: SwiftUI.PresentationAdaptation) {
         self.value = ._1(horizontalAdaptation: horizontalAdaptation, verticalAdaptation: verticalAdaptation)
         
@@ -8565,7 +8565,7 @@ struct _presentationCompactAdaptationModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(adaptation):
-            if #available(watchOS 9.4,iOS 16.4,visionOS 1.0,macOS 13.3,tvOS 16.4, *) {
+            if #available(visionOS 1.0,macOS 13.3,tvOS 16.4,iOS 16.4,watchOS 9.4, *) {
             let adaptation = adaptation as! SwiftUI.PresentationAdaptation
             
             __content
@@ -8576,7 +8576,7 @@ struct _presentationCompactAdaptationModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(horizontalAdaptation, verticalAdaptation):
-            if #available(macOS 13.3,visionOS 1.0,watchOS 9.4,tvOS 16.4,iOS 16.4, *) {
+            if #available(visionOS 1.0,macOS 13.3,tvOS 16.4,iOS 16.4,watchOS 9.4, *) {
             let horizontalAdaptation = horizontalAdaptation as! SwiftUI.PresentationAdaptation
 let verticalAdaptation = verticalAdaptation as! SwiftUI.PresentationAdaptation
             
@@ -8611,7 +8611,7 @@ struct _presentationContentInteractionModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(iOS 16.4,watchOS 9.4,tvOS 16.4,visionOS 1.0,macOS 13.3, *)
+    @available(visionOS 1.0,macOS 13.3,tvOS 16.4,iOS 16.4,watchOS 9.4, *)
     init(_ behavior: SwiftUI.PresentationContentInteraction) {
         self.value = ._0(behavior: behavior)
         
@@ -8624,7 +8624,7 @@ struct _presentationContentInteractionModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(behavior):
-            if #available(iOS 16.4,watchOS 9.4,tvOS 16.4,visionOS 1.0,macOS 13.3, *) {
+            if #available(visionOS 1.0,macOS 13.3,tvOS 16.4,iOS 16.4,watchOS 9.4, *) {
             let behavior = behavior as! SwiftUI.PresentationContentInteraction
             
             __content
@@ -8658,7 +8658,7 @@ struct _presentationCornerRadiusModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 9.4,iOS 16.4,visionOS 1.0,macOS 13.3,tvOS 16.4, *)
+    @available(visionOS 1.0,macOS 13.3,tvOS 16.4,iOS 16.4,watchOS 9.4, *)
     init(_ cornerRadius: AttributeReference<CoreFoundation.CGFloat?>?) {
         self.value = ._0(cornerRadius: cornerRadius)
         
@@ -8671,7 +8671,7 @@ struct _presentationCornerRadiusModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(cornerRadius):
-            if #available(watchOS 9.4,iOS 16.4,visionOS 1.0,macOS 13.3,tvOS 16.4, *) {
+            if #available(visionOS 1.0,macOS 13.3,tvOS 16.4,iOS 16.4,watchOS 9.4, *) {
             let cornerRadius = cornerRadius as? AttributeReference<CoreFoundation.CGFloat?>
             
             __content
@@ -9255,21 +9255,21 @@ struct _safeAreaPaddingModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(tvOS 17.0,visionOS 1.0,watchOS 10.0,macOS 14.0,iOS 17.0, *)
+    @available(watchOS 10.0,tvOS 17.0,iOS 17.0,macOS 14.0,visionOS 1.0, *)
     init(_ insets: SwiftUI.EdgeInsets) {
         self.value = ._0(insets: insets)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(tvOS 17.0,visionOS 1.0,watchOS 10.0,macOS 14.0,iOS 17.0, *)
+    @available(watchOS 10.0,tvOS 17.0,iOS 17.0,macOS 14.0,visionOS 1.0, *)
     init(_ edges: SwiftUI.Edge.Set = .all, _ length: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)) ) {
         self.value = ._1(edges: edges, length: length)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(tvOS 17.0,visionOS 1.0,watchOS 10.0,macOS 14.0,iOS 17.0, *)
+    @available(watchOS 10.0,tvOS 17.0,iOS 17.0,macOS 14.0,visionOS 1.0, *)
     init(_ length: AttributeReference<CoreFoundation.CGFloat>) {
         self.value = ._2(length: length)
         
@@ -9282,7 +9282,7 @@ struct _safeAreaPaddingModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(insets):
-            if #available(tvOS 17.0,visionOS 1.0,watchOS 10.0,macOS 14.0,iOS 17.0, *) {
+            if #available(watchOS 10.0,tvOS 17.0,iOS 17.0,macOS 14.0,visionOS 1.0, *) {
             let insets = insets as! SwiftUI.EdgeInsets
             
             __content
@@ -9293,7 +9293,7 @@ struct _safeAreaPaddingModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(edges, length):
-            if #available(tvOS 17.0,visionOS 1.0,watchOS 10.0,macOS 14.0,iOS 17.0, *) {
+            if #available(watchOS 10.0,tvOS 17.0,iOS 17.0,macOS 14.0,visionOS 1.0, *) {
             let edges = edges as! SwiftUI.Edge.Set 
 let length = length as? AttributeReference<CoreFoundation.CGFloat?>
             
@@ -9305,7 +9305,7 @@ let length = length as? AttributeReference<CoreFoundation.CGFloat?>
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._2(length):
-            if #available(tvOS 17.0,visionOS 1.0,watchOS 10.0,macOS 14.0,iOS 17.0, *) {
+            if #available(watchOS 10.0,tvOS 17.0,iOS 17.0,macOS 14.0,visionOS 1.0, *) {
             let length = length as! AttributeReference<CoreFoundation.CGFloat>
             
             __content
@@ -9380,13 +9380,13 @@ struct _scaleEffectModifier<R: RootRegistry>: ViewModifier {
         
         indirect case _2(x: AttributeReference<CoreFoundation.CGFloat> = .init(storage: .constant(1.0)), y: AttributeReference<CoreFoundation.CGFloat> = .init(storage: .constant(1.0)), anchor: AttributeReference<SwiftUI.UnitPoint> = .init(storage: .constant(.center)) )
         
-        #if os(visionOS) || os(xrOS)
+        #if os(visionOS)
         indirect case _3(scale: Any,anchor: Any)
         #endif
-        #if os(visionOS) || os(xrOS)
+        #if os(visionOS)
         indirect case _4(s: Any,anchor: Any)
         #endif
-        #if os(visionOS) || os(xrOS)
+        #if os(visionOS)
         indirect case _5(x: Any, y: Any, z: Any, anchor: Any)
         #endif
     }
@@ -9431,22 +9431,22 @@ struct _scaleEffectModifier<R: RootRegistry>: ViewModifier {
         
     }
     
-    #if os(visionOS) || os(xrOS)
-    @available(xrOS 1.0,visionOS 1.0, *)
+    #if os(visionOS)
+    @available(visionOS 1.0, *)
     init(_ scale: Spatial.Size3D,anchor: SwiftUI.UnitPoint3D = .center ) {
         self.value = ._3(scale: scale, anchor: anchor)
         
     }
     #endif
-    #if os(visionOS) || os(xrOS)
-    @available(xrOS 1.0,visionOS 1.0, *)
+    #if os(visionOS)
+    @available(visionOS 1.0, *)
     init(_ s: AttributeReference<CoreFoundation.CGFloat>,anchor: SwiftUI.UnitPoint3D = .center ) {
         self.value = ._4(s: s, anchor: anchor)
         
     }
     #endif
-    #if os(visionOS) || os(xrOS)
-    @available(visionOS 1.0,xrOS 1.0, *)
+    #if os(visionOS)
+    @available(visionOS 1.0, *)
     init(x: AttributeReference<CoreFoundation.CGFloat> = .init(storage: .constant(1.0)), y: AttributeReference<CoreFoundation.CGFloat> = .init(storage: .constant(1.0)), z: AttributeReference<CoreFoundation.CGFloat> = .init(storage: .constant(1.0)), anchor: SwiftUI.UnitPoint3D = .center ) {
         self.value = ._5(x: x, y: y, z: z, anchor: anchor)
         
@@ -9490,9 +9490,9 @@ struct _scaleEffectModifier<R: RootRegistry>: ViewModifier {
                 
             
         
-        #if os(visionOS) || os(xrOS)
+        #if os(visionOS)
         case let ._3(scale, anchor):
-            if #available(xrOS 1.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0, *) {
             let scale = scale as! Spatial.Size3D
 let anchor = anchor as! SwiftUI.UnitPoint3D 
             
@@ -9502,9 +9502,9 @@ let anchor = anchor as! SwiftUI.UnitPoint3D
                 
             } else { __content }
         #endif
-        #if os(visionOS) || os(xrOS)
+        #if os(visionOS)
         case let ._4(s, anchor):
-            if #available(xrOS 1.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0, *) {
             let s = s as! AttributeReference<CoreFoundation.CGFloat>
 let anchor = anchor as! SwiftUI.UnitPoint3D 
             
@@ -9514,9 +9514,9 @@ let anchor = anchor as! SwiftUI.UnitPoint3D
                 
             } else { __content }
         #endif
-        #if os(visionOS) || os(xrOS)
+        #if os(visionOS)
         case let ._5(x, y, z, anchor):
-            if #available(visionOS 1.0,xrOS 1.0, *) {
+            if #available(visionOS 1.0, *) {
             let x = x as! AttributeReference<CoreFoundation.CGFloat>
 let y = y as! AttributeReference<CoreFoundation.CGFloat>
 let z = z as! AttributeReference<CoreFoundation.CGFloat>
@@ -9717,7 +9717,7 @@ struct _scrollBounceBehaviorModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(iOS 16.4,tvOS 16.4,macOS 13.3,watchOS 9.4,visionOS 1.0, *)
+    @available(iOS 16.4,watchOS 9.4,tvOS 16.4,macOS 13.3,visionOS 1.0, *)
     init(_ behavior: SwiftUI.ScrollBounceBehavior,axes: SwiftUI.Axis.Set = [.vertical] ) {
         self.value = ._0(behavior: behavior, axes: axes)
         
@@ -9730,7 +9730,7 @@ struct _scrollBounceBehaviorModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(behavior, axes):
-            if #available(iOS 16.4,tvOS 16.4,macOS 13.3,watchOS 9.4,visionOS 1.0, *) {
+            if #available(iOS 16.4,watchOS 9.4,tvOS 16.4,macOS 13.3,visionOS 1.0, *) {
             let behavior = behavior as! SwiftUI.ScrollBounceBehavior
 let axes = axes as! SwiftUI.Axis.Set 
             
@@ -9765,7 +9765,7 @@ struct _scrollClipDisabledModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(tvOS 17.0,visionOS 1.0,macOS 14.0,iOS 17.0,watchOS 10.0, *)
+    @available(iOS 17.0,watchOS 10.0,tvOS 17.0,macOS 14.0,visionOS 1.0, *)
     init(_ disabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(disabled: disabled)
         
@@ -9778,7 +9778,7 @@ struct _scrollClipDisabledModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(disabled):
-            if #available(tvOS 17.0,visionOS 1.0,macOS 14.0,iOS 17.0,watchOS 10.0, *) {
+            if #available(iOS 17.0,watchOS 10.0,tvOS 17.0,macOS 14.0,visionOS 1.0, *) {
             let disabled = disabled as! AttributeReference<Swift.Bool>
             
             __content
@@ -9812,7 +9812,7 @@ struct _scrollContentBackgroundModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,watchOS 9.0,macOS 13.0,iOS 16.0, *)
+    @available(visionOS 1.0,macOS 13.0,iOS 16.0,watchOS 9.0, *)
     init(_ visibility: AttributeReference<SwiftUI.Visibility>) {
         self.value = ._0(visibility: visibility)
         
@@ -9825,7 +9825,7 @@ struct _scrollContentBackgroundModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
         case let ._0(visibility):
-            if #available(visionOS 1.0,watchOS 9.0,macOS 13.0,iOS 16.0, *) {
+            if #available(visionOS 1.0,macOS 13.0,iOS 16.0,watchOS 9.0, *) {
             let visibility = visibility as! AttributeReference<SwiftUI.Visibility>
             
             __content
@@ -9891,7 +9891,7 @@ struct _scrollDismissesKeyboardModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
         indirect case _0(mode: Any)
         #endif
     }
@@ -9905,8 +9905,8 @@ struct _scrollDismissesKeyboardModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(iOS 16.0,tvOS 16.0,watchOS 9.0,macOS 13.0,visionOS 1.0, *)
+    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+    @available(iOS 16.0,watchOS 9.0,tvOS 16.0,macOS 13.0, *)
     init(_ mode: SwiftUI.ScrollDismissesKeyboardMode) {
         self.value = ._0(mode: mode)
         
@@ -9917,9 +9917,9 @@ struct _scrollDismissesKeyboardModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
         case let ._0(mode):
-            if #available(iOS 16.0,tvOS 16.0,watchOS 9.0,macOS 13.0,visionOS 1.0, *) {
+            if #available(iOS 16.0,watchOS 9.0,tvOS 16.0,macOS 13.0, *) {
             let mode = mode as! SwiftUI.ScrollDismissesKeyboardMode
             
             __content
@@ -10005,14 +10005,14 @@ struct _scrollIndicatorsFlashModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(tvOS 17.0,visionOS 1.0,macOS 14.0,iOS 17.0,watchOS 10.0, *)
+    @available(iOS 17.0,watchOS 10.0,tvOS 17.0,macOS 14.0,visionOS 1.0, *)
     init(trigger value: AttributeReference<String>) {
         self.value = ._0(value: value)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(tvOS 17.0,visionOS 1.0,macOS 14.0,iOS 17.0,watchOS 10.0, *)
+    @available(iOS 17.0,watchOS 10.0,tvOS 17.0,macOS 14.0,visionOS 1.0, *)
     init(onAppear: AttributeReference<Swift.Bool>) {
         self.value = ._1(onAppear: onAppear)
         
@@ -10025,7 +10025,7 @@ struct _scrollIndicatorsFlashModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(value):
-            if #available(tvOS 17.0,visionOS 1.0,macOS 14.0,iOS 17.0,watchOS 10.0, *) {
+            if #available(iOS 17.0,watchOS 10.0,tvOS 17.0,macOS 14.0,visionOS 1.0, *) {
             let value = value as! AttributeReference<String>
             
             __content
@@ -10036,7 +10036,7 @@ struct _scrollIndicatorsFlashModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(onAppear):
-            if #available(tvOS 17.0,visionOS 1.0,macOS 14.0,iOS 17.0,watchOS 10.0, *) {
+            if #available(iOS 17.0,watchOS 10.0,tvOS 17.0,macOS 14.0,visionOS 1.0, *) {
             let onAppear = onAppear as! AttributeReference<Swift.Bool>
             
             __content
@@ -10070,7 +10070,7 @@ struct _scrollPositionModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(tvOS 17.0,macOS 14.0,iOS 17.0,watchOS 10.0,visionOS 1.0, *)
+    @available(watchOS 10.0,tvOS 17.0,iOS 17.0,macOS 14.0,visionOS 1.0, *)
     init(id: ChangeTracked<String?>,anchor: AttributeReference<SwiftUI.UnitPoint?>? = .init(storage: .constant(nil)) ) {
         self.value = ._0(anchor: anchor)
         self.__0_id = id
@@ -10083,7 +10083,7 @@ struct _scrollPositionModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(anchor):
-            if #available(tvOS 17.0,macOS 14.0,iOS 17.0,watchOS 10.0,visionOS 1.0, *) {
+            if #available(watchOS 10.0,tvOS 17.0,iOS 17.0,macOS 14.0,visionOS 1.0, *) {
             let anchor = anchor as? AttributeReference<SwiftUI.UnitPoint?>
             
             __content
@@ -10117,7 +10117,7 @@ struct _scrollTargetBehaviorModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(tvOS 17.0,visionOS 1.0,watchOS 10.0,macOS 14.0,iOS 17.0, *)
+    @available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0,visionOS 1.0, *)
     init(_ behavior: AnyScrollTargetBehavior) {
         self.value = ._0(behavior: behavior)
         
@@ -10130,7 +10130,7 @@ struct _scrollTargetBehaviorModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(behavior):
-            if #available(tvOS 17.0,visionOS 1.0,watchOS 10.0,macOS 14.0,iOS 17.0, *) {
+            if #available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0,visionOS 1.0, *) {
             let behavior = behavior as! AnyScrollTargetBehavior
             
             __content
@@ -10164,7 +10164,7 @@ struct _scrollTargetLayoutModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,watchOS 10.0,tvOS 17.0,iOS 17.0,macOS 14.0, *)
+    @available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0,visionOS 1.0, *)
     init(isEnabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(isEnabled: isEnabled)
         
@@ -10177,7 +10177,7 @@ struct _scrollTargetLayoutModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(isEnabled):
-            if #available(visionOS 1.0,watchOS 10.0,tvOS 17.0,iOS 17.0,macOS 14.0, *) {
+            if #available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0,visionOS 1.0, *) {
             let isEnabled = isEnabled as! AttributeReference<Swift.Bool>
             
             __content
@@ -10196,7 +10196,7 @@ struct _searchDictationBehaviorModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(visionOS) || os(xrOS)
+        #if os(iOS) || os(visionOS)
         indirect case _0(dictationBehavior: Any)
         #endif
     }
@@ -10210,8 +10210,8 @@ struct _searchDictationBehaviorModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(visionOS) || os(xrOS)
-    @available(visionOS 1.0,iOS 17.0,xrOS 1.0, *)
+    #if os(iOS) || os(visionOS)
+    @available(iOS 17.0,visionOS 1.0, *)
     init(_ dictationBehavior: SwiftUI.TextInputDictationBehavior) {
         self.value = ._0(dictationBehavior: dictationBehavior)
         
@@ -10222,9 +10222,9 @@ struct _searchDictationBehaviorModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(visionOS) || os(xrOS)
+        #if os(iOS) || os(visionOS)
         case let ._0(dictationBehavior):
-            if #available(visionOS 1.0,iOS 17.0,xrOS 1.0, *) {
+            if #available(iOS 17.0,visionOS 1.0, *) {
             let dictationBehavior = dictationBehavior as! SwiftUI.TextInputDictationBehavior
             
             __content
@@ -10258,7 +10258,7 @@ struct _searchPresentationToolbarBehaviorModifier<R: RootRegistry>: ViewModifier
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(iOS 17.1,tvOS 17.1,watchOS 10.1,macOS 14.1,visionOS 1.0, *)
+    @available(visionOS 1.0,tvOS 17.1,macOS 14.1,iOS 17.1,watchOS 10.1, *)
     init(_ behavior: SwiftUI.SearchPresentationToolbarBehavior) {
         self.value = ._0(behavior: behavior)
         
@@ -10271,7 +10271,7 @@ struct _searchPresentationToolbarBehaviorModifier<R: RootRegistry>: ViewModifier
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(behavior):
-            if #available(iOS 17.1,tvOS 17.1,watchOS 10.1,macOS 14.1,visionOS 1.0, *) {
+            if #available(visionOS 1.0,tvOS 17.1,macOS 14.1,iOS 17.1,watchOS 10.1, *) {
             let behavior = behavior as! SwiftUI.SearchPresentationToolbarBehavior
             
             __content
@@ -10424,7 +10424,7 @@ struct _searchableModifier<R: RootRegistry>: ViewModifier {
     }
     
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 14.0,iOS 17.0,visionOS 1.0, *)
+    @available(iOS 17.0,macOS 14.0,visionOS 1.0, *)
     init(text: ChangeTracked<Swift.String>,isPresented: ChangeTracked<Swift.Bool>,placement: SwiftUI.SearchFieldPlacement = .automatic, prompt: TextReference? = nil ) {
         self.value = ._3(placement: placement, prompt: prompt)
         self.__3_text = text
@@ -10432,7 +10432,7 @@ self.__3_isPresented = isPresented
     }
     #endif
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(macOS 14.0,iOS 17.0,visionOS 1.0, *)
+    @available(iOS 17.0,macOS 14.0,visionOS 1.0, *)
     init(text: ChangeTracked<Swift.String>,isPresented: ChangeTracked<Swift.Bool>,placement: SwiftUI.SearchFieldPlacement = .automatic, prompt: SwiftUI.LocalizedStringKey) {
         self.value = ._4(placement: placement, prompt: prompt)
         self.__4_text = text
@@ -10440,7 +10440,7 @@ self.__4_isPresented = isPresented
     }
     #endif
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(visionOS 1.0,iOS 17.0,macOS 14.0, *)
+    @available(iOS 17.0,macOS 14.0,visionOS 1.0, *)
     init(text: ChangeTracked<Swift.String>,isPresented: ChangeTracked<Swift.Bool>,placement: SwiftUI.SearchFieldPlacement = .automatic, prompt: AttributeReference<String>) {
         self.value = ._5(placement: placement, prompt: prompt)
         self.__5_text = text
@@ -10487,7 +10487,7 @@ self.__5_isPresented = isPresented
         
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._3(placement, prompt):
-            if #available(macOS 14.0,iOS 17.0,visionOS 1.0, *) {
+            if #available(iOS 17.0,macOS 14.0,visionOS 1.0, *) {
             let placement = placement as! SwiftUI.SearchFieldPlacement 
 let prompt = prompt as? TextReference
             __content._observeTextReference(prompt, on: element, in: context) { __content in
@@ -10499,7 +10499,7 @@ let prompt = prompt as? TextReference
         #endif
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._4(placement, prompt):
-            if #available(macOS 14.0,iOS 17.0,visionOS 1.0, *) {
+            if #available(iOS 17.0,macOS 14.0,visionOS 1.0, *) {
             let placement = placement as! SwiftUI.SearchFieldPlacement 
 let prompt = prompt as! SwiftUI.LocalizedStringKey
             
@@ -10511,7 +10511,7 @@ let prompt = prompt as! SwiftUI.LocalizedStringKey
         #endif
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._5(placement, prompt):
-            if #available(visionOS 1.0,iOS 17.0,macOS 14.0, *) {
+            if #available(iOS 17.0,macOS 14.0,visionOS 1.0, *) {
             let placement = placement as! SwiftUI.SearchFieldPlacement 
 let prompt = prompt as! AttributeReference<String>
             
@@ -10546,7 +10546,7 @@ struct _selectionDisabledModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(iOS 17.0,tvOS 17.0,watchOS 10.0,macOS 14.0,visionOS 1.0, *)
+    @available(watchOS 10.0,visionOS 1.0,iOS 17.0,tvOS 17.0,macOS 14.0, *)
     init(_ isDisabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(isDisabled: isDisabled)
         
@@ -10559,7 +10559,7 @@ struct _selectionDisabledModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(isDisabled):
-            if #available(iOS 17.0,tvOS 17.0,watchOS 10.0,macOS 14.0,visionOS 1.0, *) {
+            if #available(watchOS 10.0,visionOS 1.0,iOS 17.0,tvOS 17.0,macOS 14.0, *) {
             let isDisabled = isDisabled as! AttributeReference<Swift.Bool>
             
             __content
@@ -11064,7 +11064,7 @@ struct _swipeActionsModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 8.0,macOS 12.0,iOS 15.0,visionOS 1.0, *)
+    @available(iOS 15.0,watchOS 8.0,macOS 12.0,visionOS 1.0, *)
     init(edge: SwiftUI.HorizontalEdge = .trailing, allowsFullSwipe: AttributeReference<Swift.Bool> = .init(storage: .constant(true)), content: ViewReference=ViewReference(value: [])) {
         self.value = ._0(edge: edge, allowsFullSwipe: allowsFullSwipe, content: content)
         
@@ -11077,7 +11077,7 @@ struct _swipeActionsModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
         case let ._0(edge, allowsFullSwipe, content):
-            if #available(watchOS 8.0,macOS 12.0,iOS 15.0,visionOS 1.0, *) {
+            if #available(iOS 15.0,watchOS 8.0,macOS 12.0,visionOS 1.0, *) {
             let edge = edge as! SwiftUI.HorizontalEdge 
 let allowsFullSwipe = allowsFullSwipe as! AttributeReference<Swift.Bool>
 let content = content as! ViewReference
@@ -11118,14 +11118,14 @@ struct _symbolEffectModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(iOS 17.0,tvOS 17.0,macOS 14.0,watchOS 10.0,visionOS 1.0, *)
+    @available(watchOS 10.0,tvOS 17.0,iOS 17.0,macOS 14.0,visionOS 1.0, *)
     init(_ effect: AnyIndefiniteSymbolEffect,options: Symbols.SymbolEffectOptions = .default, isActive: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(effect: effect, options: options, isActive: isActive)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(iOS 17.0,tvOS 17.0,macOS 14.0,watchOS 10.0,visionOS 1.0, *)
+    @available(watchOS 10.0,tvOS 17.0,iOS 17.0,macOS 14.0,visionOS 1.0, *)
     init(_ effect: AnyDiscreteSymbolEffect,options: Symbols.SymbolEffectOptions = .default, value: AttributeReference<String>) {
         self.value = ._1(effect: effect, options: options, value: value)
         
@@ -11138,7 +11138,7 @@ struct _symbolEffectModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(effect, options, isActive):
-            if #available(iOS 17.0,tvOS 17.0,macOS 14.0,watchOS 10.0,visionOS 1.0, *) {
+            if #available(watchOS 10.0,tvOS 17.0,iOS 17.0,macOS 14.0,visionOS 1.0, *) {
             let effect = effect as! AnyIndefiniteSymbolEffect
 let options = options as! Symbols.SymbolEffectOptions 
 let isActive = isActive as! AttributeReference<Swift.Bool>
@@ -11151,7 +11151,7 @@ let isActive = isActive as! AttributeReference<Swift.Bool>
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(effect, options, value):
-            if #available(iOS 17.0,tvOS 17.0,macOS 14.0,watchOS 10.0,visionOS 1.0, *) {
+            if #available(watchOS 10.0,tvOS 17.0,iOS 17.0,macOS 14.0,visionOS 1.0, *) {
             let effect = effect as! AnyDiscreteSymbolEffect
 let options = options as! Symbols.SymbolEffectOptions 
 let value = value as! AttributeReference<String>
@@ -11187,7 +11187,7 @@ struct _symbolEffectsRemovedModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(iOS 17.0,tvOS 17.0,watchOS 10.0,macOS 14.0,visionOS 1.0, *)
+    @available(watchOS 10.0,visionOS 1.0,iOS 17.0,tvOS 17.0,macOS 14.0, *)
     init(_ isEnabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(isEnabled: isEnabled)
         
@@ -11200,7 +11200,7 @@ struct _symbolEffectsRemovedModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(isEnabled):
-            if #available(iOS 17.0,tvOS 17.0,watchOS 10.0,macOS 14.0,visionOS 1.0, *) {
+            if #available(watchOS 10.0,visionOS 1.0,iOS 17.0,tvOS 17.0,macOS 14.0, *) {
             let isEnabled = isEnabled as! AttributeReference<Swift.Bool>
             
             __content
@@ -11548,7 +11548,7 @@ struct _textEditorStyleModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(iOS) || os(macOS) || os(visionOS) || os(xrOS)
+        #if os(iOS) || os(macOS) || os(visionOS)
         indirect case _0(style: Any)
         #endif
     }
@@ -11562,8 +11562,8 @@ struct _textEditorStyleModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(iOS) || os(macOS) || os(visionOS) || os(xrOS)
-    @available(iOS 17.0,xrOS 1.0,macOS 14.0,visionOS 1.0, *)
+    #if os(iOS) || os(macOS) || os(visionOS)
+    @available(iOS 17.0,macOS 14.0,visionOS 1.0, *)
     init(_ style: AnyTextEditorStyle) {
         self.value = ._0(style: style)
         
@@ -11574,9 +11574,9 @@ struct _textEditorStyleModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(iOS) || os(macOS) || os(visionOS) || os(xrOS)
+        #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(style):
-            if #available(iOS 17.0,xrOS 1.0,macOS 14.0,visionOS 1.0, *) {
+            if #available(iOS 17.0,macOS 14.0,visionOS 1.0, *) {
             let style = style as! AnyTextEditorStyle
             
             __content
@@ -11657,7 +11657,7 @@ struct _textInputAutocapitalizationModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(iOS 15.0,tvOS 15.0,watchOS 8.0,visionOS 1.0, *)
+    @available(watchOS 8.0,tvOS 15.0,iOS 15.0,visionOS 1.0, *)
     init(_ autocapitalization: SwiftUI.TextInputAutocapitalization?) {
         self.value = ._0(autocapitalization: autocapitalization)
         
@@ -11670,7 +11670,7 @@ struct _textInputAutocapitalizationModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(autocapitalization):
-            if #available(iOS 15.0,tvOS 15.0,watchOS 8.0,visionOS 1.0, *) {
+            if #available(watchOS 8.0,tvOS 15.0,iOS 15.0,visionOS 1.0, *) {
             let autocapitalization = autocapitalization as? SwiftUI.TextInputAutocapitalization
             
             __content
@@ -11704,7 +11704,7 @@ struct _textSelectionModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(visionOS 1.0,iOS 15.0,macOS 12.0, *)
+    @available(iOS 15.0,macOS 12.0,visionOS 1.0, *)
     init(_ selectability: AnyTextSelectability) {
         self.value = ._0(selectability: selectability)
         
@@ -11717,7 +11717,7 @@ struct _textSelectionModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(selectability):
-            if #available(visionOS 1.0,iOS 15.0,macOS 12.0, *) {
+            if #available(iOS 15.0,macOS 12.0,visionOS 1.0, *) {
             let selectability = selectability as! AnyTextSelectability
             
             __content
@@ -11890,7 +11890,7 @@ struct _toolbarModifier<R: RootRegistry>: ViewModifier {
     }
     
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 10.0,macOS 14.0,tvOS 17.0,iOS 17.0,visionOS 1.0, *)
+    @available(visionOS 1.0,tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0, *)
     init(removing defaultItemKind: SwiftUI.ToolbarDefaultItemKind?) {
         self.value = ._1(defaultItemKind: defaultItemKind)
         
@@ -11928,7 +11928,7 @@ struct _toolbarModifier<R: RootRegistry>: ViewModifier {
         
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(defaultItemKind):
-            if #available(watchOS 10.0,macOS 14.0,tvOS 17.0,iOS 17.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0, *) {
             let defaultItemKind = defaultItemKind as? SwiftUI.ToolbarDefaultItemKind
             
             __content
@@ -12148,7 +12148,7 @@ struct _toolbarTitleDisplayModeModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,tvOS 17.0,watchOS 10.0,iOS 17.0,macOS 14.0, *)
+    @available(visionOS 1.0,tvOS 17.0,macOS 14.0,iOS 17.0,watchOS 10.0, *)
     init(_ mode: SwiftUI.ToolbarTitleDisplayMode) {
         self.value = ._0(mode: mode)
         
@@ -12161,7 +12161,7 @@ struct _toolbarTitleDisplayModeModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(mode):
-            if #available(visionOS 1.0,tvOS 17.0,watchOS 10.0,iOS 17.0,macOS 14.0, *) {
+            if #available(visionOS 1.0,tvOS 17.0,macOS 14.0,iOS 17.0,watchOS 10.0, *) {
             let mode = mode as! SwiftUI.ToolbarTitleDisplayMode
             
             __content
@@ -12227,7 +12227,7 @@ struct _touchBarCustomizationLabelModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(macOS) || os(visionOS)
+        #if os(macOS)
         indirect case _0(label: Any)
         #endif
     }
@@ -12241,8 +12241,8 @@ struct _touchBarCustomizationLabelModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(macOS) || os(visionOS)
-    @available(visionOS 1.0,macOS 10.15, *)
+    #if os(macOS)
+    @available(macOS 10.15, *)
     init(_ label: TextReference) {
         self.value = ._0(label: label)
         
@@ -12253,9 +12253,9 @@ struct _touchBarCustomizationLabelModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(macOS) || os(visionOS)
+        #if os(macOS)
         case let ._0(label):
-            if #available(visionOS 1.0,macOS 10.15, *) {
+            if #available(macOS 10.15, *) {
             let label = label as! TextReference
             __content._observeTextReference(label, on: element, in: context) { __content in
             __content
@@ -12274,7 +12274,7 @@ struct _touchBarItemPrincipalModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(macOS) || os(visionOS)
+        #if os(macOS)
         indirect case _0(principal: Any)
         #endif
     }
@@ -12288,8 +12288,8 @@ struct _touchBarItemPrincipalModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(macOS) || os(visionOS)
-    @available(visionOS 1.0,macOS 10.15, *)
+    #if os(macOS)
+    @available(macOS 10.15, *)
     init(_ principal: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(principal: principal)
         
@@ -12300,9 +12300,9 @@ struct _touchBarItemPrincipalModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(macOS) || os(visionOS)
+        #if os(macOS)
         case let ._0(principal):
-            if #available(visionOS 1.0,macOS 10.15, *) {
+            if #available(macOS 10.15, *) {
             let principal = principal as! AttributeReference<Swift.Bool>
             
             __content
@@ -12321,7 +12321,7 @@ struct _transform3DEffectModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(visionOS) || os(xrOS)
+        #if os(visionOS)
         indirect case _0(transform: Any)
         #endif
     }
@@ -12335,8 +12335,8 @@ struct _transform3DEffectModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(visionOS) || os(xrOS)
-    @available(visionOS 1.0,xrOS 1.0, *)
+    #if os(visionOS)
+    @available(visionOS 1.0, *)
     init(_ transform: Spatial.AffineTransform3D) {
         self.value = ._0(transform: transform)
         
@@ -12347,9 +12347,9 @@ struct _transform3DEffectModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(visionOS) || os(xrOS)
+        #if os(visionOS)
         case let ._0(transform):
-            if #available(visionOS 1.0,xrOS 1.0, *) {
+            if #available(visionOS 1.0, *) {
             let transform = transform as! Spatial.AffineTransform3D
             
             __content
@@ -12556,7 +12556,7 @@ struct _upperLimbVisibilityModifier<R: RootRegistry>: ViewModifier {
 
     enum Value {
         case _never
-        #if os(visionOS) || os(xrOS)
+        #if os(visionOS)
         indirect case _0(preferredVisibility: Any)
         #endif
     }
@@ -12570,8 +12570,8 @@ struct _upperLimbVisibilityModifier<R: RootRegistry>: ViewModifier {
 
 
 
-    #if os(visionOS) || os(xrOS)
-    @available(xrOS 1.0,visionOS 1.0, *)
+    #if os(visionOS)
+    @available(visionOS 1.0, *)
     init(_ preferredVisibility: AttributeReference<SwiftUI.Visibility>) {
         self.value = ._0(preferredVisibility: preferredVisibility)
         
@@ -12582,9 +12582,9 @@ struct _upperLimbVisibilityModifier<R: RootRegistry>: ViewModifier {
         switch value {
         case ._never:
             fatalError("unreachable")
-        #if os(visionOS) || os(xrOS)
+        #if os(visionOS)
         case let ._0(preferredVisibility):
-            if #available(xrOS 1.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0, *) {
             let preferredVisibility = preferredVisibility as! AttributeReference<SwiftUI.Visibility>
             
             __content
@@ -13469,16 +13469,16 @@ indirect case chunk12(_BuiltinModifierChunk12)
 indirect case chunk13(_BuiltinModifierChunk13)
 indirect case chunk14(_BuiltinModifierChunk14)
 indirect case chunk15(_BuiltinModifierChunk15)
-        indirect case _SearchScopesModifier(LiveViewNative._SearchScopesModifier<R>)
-indirect case _FocusScopeModifier(LiveViewNative._FocusScopeModifier<R>)
-indirect case _SearchCompletionModifier(LiveViewNative._SearchCompletionModifier<R>)
+        indirect case _Rotation3DEffectModifier(LiveViewNative._Rotation3DEffectModifier<R>)
 indirect case _PrefersDefaultFocusModifier(LiveViewNative._PrefersDefaultFocusModifier<R>)
+indirect case _MaskModifier(LiveViewNative._MaskModifier<R>)
+indirect case _FocusScopeModifier(LiveViewNative._FocusScopeModifier<R>)
+indirect case _PerspectiveRotationEffectModifier(LiveViewNative._PerspectiveRotationEffectModifier<R>)
+indirect case _SearchScopesModifier(LiveViewNative._SearchScopesModifier<R>)
+indirect case _SearchCompletionModifier(LiveViewNative._SearchCompletionModifier<R>)
 indirect case _OnSubmitModifier(LiveViewNative._OnSubmitModifier)
 indirect case _MatchedGeometryEffectModifier(LiveViewNative._MatchedGeometryEffectModifier<R>)
-indirect case _PerspectiveRotationEffectModifier(LiveViewNative._PerspectiveRotationEffectModifier<R>)
-indirect case _MaskModifier(LiveViewNative._MaskModifier<R>)
 indirect case _PresentationDetentsModifier(LiveViewNative._PresentationDetentsModifier)
-indirect case _Rotation3DEffectModifier(LiveViewNative._Rotation3DEffectModifier<R>)
         indirect case _customRegistryModifier(R.CustomModifier)
         indirect case _anyTextModifier(_AnyTextModifier<R>)
         indirect case _anyImageModifier(_AnyImageModifier<R>)
@@ -13519,25 +13519,25 @@ case let .chunk14(chunk):
     content.modifier(chunk)
 case let .chunk15(chunk):
     content.modifier(chunk)
-            case let ._SearchScopesModifier(modifier):
+            case let ._Rotation3DEffectModifier(modifier):
+    content.modifier(modifier)
+case let ._PrefersDefaultFocusModifier(modifier):
+    content.modifier(modifier)
+case let ._MaskModifier(modifier):
     content.modifier(modifier)
 case let ._FocusScopeModifier(modifier):
     content.modifier(modifier)
-case let ._SearchCompletionModifier(modifier):
+case let ._PerspectiveRotationEffectModifier(modifier):
     content.modifier(modifier)
-case let ._PrefersDefaultFocusModifier(modifier):
+case let ._SearchScopesModifier(modifier):
+    content.modifier(modifier)
+case let ._SearchCompletionModifier(modifier):
     content.modifier(modifier)
 case let ._OnSubmitModifier(modifier):
     content.modifier(modifier)
 case let ._MatchedGeometryEffectModifier(modifier):
     content.modifier(modifier)
-case let ._PerspectiveRotationEffectModifier(modifier):
-    content.modifier(modifier)
-case let ._MaskModifier(modifier):
-    content.modifier(modifier)
 case let ._PresentationDetentsModifier(modifier):
-    content.modifier(modifier)
-case let ._Rotation3DEffectModifier(modifier):
     content.modifier(modifier)
             case let ._customRegistryModifier(modifier):
                 content.modifier(modifier)
@@ -13785,16 +13785,16 @@ _truncationModeModifier<R>.name: _truncationModeModifier<R>.parser(in: context).
 _unredactedModifier<R>.name: _unredactedModifier<R>.parser(in: context).map({ Output.chunk15(.unredacted($0)) }).eraseToAnyParser(),
 _upperLimbVisibilityModifier<R>.name: _upperLimbVisibilityModifier<R>.parser(in: context).map({ Output.chunk15(.upperLimbVisibility($0)) }).eraseToAnyParser(),
 _zIndexModifier<R>.name: _zIndexModifier<R>.parser(in: context).map({ Output.chunk15(.zIndex($0)) }).eraseToAnyParser(),
-                    LiveViewNative._SearchScopesModifier<R>.name: LiveViewNative._SearchScopesModifier<R>.parser(in: context).map(Output._SearchScopesModifier).eraseToAnyParser(),
-LiveViewNative._FocusScopeModifier<R>.name: LiveViewNative._FocusScopeModifier<R>.parser(in: context).map(Output._FocusScopeModifier).eraseToAnyParser(),
-LiveViewNative._SearchCompletionModifier<R>.name: LiveViewNative._SearchCompletionModifier<R>.parser(in: context).map(Output._SearchCompletionModifier).eraseToAnyParser(),
+                    LiveViewNative._Rotation3DEffectModifier<R>.name: LiveViewNative._Rotation3DEffectModifier<R>.parser(in: context).map(Output._Rotation3DEffectModifier).eraseToAnyParser(),
 LiveViewNative._PrefersDefaultFocusModifier<R>.name: LiveViewNative._PrefersDefaultFocusModifier<R>.parser(in: context).map(Output._PrefersDefaultFocusModifier).eraseToAnyParser(),
+LiveViewNative._MaskModifier<R>.name: LiveViewNative._MaskModifier<R>.parser(in: context).map(Output._MaskModifier).eraseToAnyParser(),
+LiveViewNative._FocusScopeModifier<R>.name: LiveViewNative._FocusScopeModifier<R>.parser(in: context).map(Output._FocusScopeModifier).eraseToAnyParser(),
+LiveViewNative._PerspectiveRotationEffectModifier<R>.name: LiveViewNative._PerspectiveRotationEffectModifier<R>.parser(in: context).map(Output._PerspectiveRotationEffectModifier).eraseToAnyParser(),
+LiveViewNative._SearchScopesModifier<R>.name: LiveViewNative._SearchScopesModifier<R>.parser(in: context).map(Output._SearchScopesModifier).eraseToAnyParser(),
+LiveViewNative._SearchCompletionModifier<R>.name: LiveViewNative._SearchCompletionModifier<R>.parser(in: context).map(Output._SearchCompletionModifier).eraseToAnyParser(),
 LiveViewNative._OnSubmitModifier.name: LiveViewNative._OnSubmitModifier.parser(in: context).map(Output._OnSubmitModifier).eraseToAnyParser(),
 LiveViewNative._MatchedGeometryEffectModifier<R>.name: LiveViewNative._MatchedGeometryEffectModifier<R>.parser(in: context).map(Output._MatchedGeometryEffectModifier).eraseToAnyParser(),
-LiveViewNative._PerspectiveRotationEffectModifier<R>.name: LiveViewNative._PerspectiveRotationEffectModifier<R>.parser(in: context).map(Output._PerspectiveRotationEffectModifier).eraseToAnyParser(),
-LiveViewNative._MaskModifier<R>.name: LiveViewNative._MaskModifier<R>.parser(in: context).map(Output._MaskModifier).eraseToAnyParser(),
 LiveViewNative._PresentationDetentsModifier.name: LiveViewNative._PresentationDetentsModifier.parser(in: context).map(Output._PresentationDetentsModifier).eraseToAnyParser(),
-LiveViewNative._Rotation3DEffectModifier<R>.name: LiveViewNative._Rotation3DEffectModifier<R>.parser(in: context).map(Output._Rotation3DEffectModifier).eraseToAnyParser(),
                 ]
 
                 let deprecations = [
@@ -13983,7 +13983,7 @@ ConstantAtomLiteral("content").map({ () -> Self in
     }
 }
 
-#if os(macOS) || os(visionOS)
+#if os(macOS)
 /// See [`SwiftUI.AlternatingRowBackgroundBehavior`](https://developer.apple.com/documentation/swiftui/AlternatingRowBackgroundBehavior) for more details.
 ///
 /// Possible values:
@@ -13991,13 +13991,13 @@ ConstantAtomLiteral("content").map({ () -> Self in
 /// * `.enabled`
 /// * `.disabled`
 @_documentation(visibility: public)
-@available(macOS 14.0,visionOS 1.0, *)
+@available(macOS 14.0, *)
 extension AlternatingRowBackgroundBehavior: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             ConstantAtomLiteral("automatic").map({ () -> Self in
-#if os(macOS) || os(visionOS)
+#if os(macOS)
 
     return Self.automatic
 
@@ -14006,7 +14006,7 @@ fatalError("'automatic' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("enabled").map({ () -> Self in
-#if os(macOS) || os(visionOS)
+#if os(macOS)
 
     return Self.enabled
 
@@ -14015,7 +14015,7 @@ fatalError("'enabled' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("disabled").map({ () -> Self in
-#if os(macOS) || os(visionOS)
+#if os(macOS)
 
     return Self.disabled
 
@@ -14071,7 +14071,7 @@ ConstantAtomLiteral("vertical").map({ () -> Self in
 /// * `.standard`
 /// * `.increased`
 @_documentation(visibility: public)
-@available(macOS 14.0,iOS 17.0,visionOS 1.0, *)
+@available(macOS 14.0,visionOS 1.0,iOS 17.0, *)
 extension BadgeProminence: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -14341,7 +14341,7 @@ ConstantAtomLiteral("plusLighter").map({ () -> Self in
 /// * `.enabled`
 /// * `.disabled`
 @_documentation(visibility: public)
-@available(iOS 17.0,watchOS 10.0,visionOS 1.0,macOS 14.0,tvOS 17.0, *)
+@available(iOS 17.0,macOS 14.0,watchOS 10.0,tvOS 17.0,visionOS 1.0, *)
 extension ButtonRepeatBehavior: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -14465,25 +14465,25 @@ ConstantAtomLiteral("dark").map({ () -> Self in
 /// * `.tabView`
 /// * `.navigation`
 @_documentation(visibility: public)
-@available(visionOS 1.0,watchOS 10.0,iOS 17.0,tvOS 17.0,macOS 14.0, *)
+@available(macOS 14.0,iOS 17.0,visionOS 1.0,tvOS 17.0,watchOS 10.0, *)
 extension ContainerBackgroundPlacement: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             ConstantAtomLiteral("tabView").map({ () -> Self in
-#if os(visionOS) || os(watchOS)
-
+#if os(watchOS)
+if #available(macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0, *) {
     return Self.tabView
-
+} else { fatalError("'tabView' is not available in this OS version") }
 #else
 fatalError("'tabView' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("navigation").map({ () -> Self in
-#if os(visionOS) || os(watchOS)
-
+#if os(watchOS)
+if #available(macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0, *) {
     return Self.navigation
-
+} else { fatalError("'navigation' is not available in this OS version") }
 #else
 fatalError("'navigation' is not available on this OS")
 #endif
@@ -14501,7 +14501,7 @@ fatalError("'navigation' is not available on this OS")
 /// * `.scrollContent`
 /// * `.scrollIndicators`
 @_documentation(visibility: public)
-@available(iOS 17.0,tvOS 17.0,watchOS 10.0,macOS 14.0,visionOS 1.0, *)
+@available(macOS 14.0,iOS 17.0,visionOS 1.0,tvOS 17.0,watchOS 10.0, *)
 extension ContentMarginPlacement: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -14565,7 +14565,7 @@ extension ContentShapeKinds: ParseableModifierValue {
 })
 ConstantAtomLiteral("dragPreview").map({ () -> Self in
 #if os(iOS) || os(macOS) || os(visionOS)
-if #available(watchOS 8.0,tvOS 15.0,macOS 12.0,iOS 15.0,visionOS 1.0, *) {
+if #available(watchOS 8.0,tvOS 15.0,iOS 15.0,visionOS 1.0,macOS 12.0, *) {
     return Self.dragPreview
 } else { fatalError("'dragPreview' is not available in this OS version") }
 #else
@@ -14574,7 +14574,7 @@ fatalError("'dragPreview' is not available on this OS")
 })
 ConstantAtomLiteral("contextMenuPreview").map({ () -> Self in
 #if os(iOS) || os(tvOS) || os(visionOS)
-if #available(watchOS 8.0,tvOS 17.0,macOS 12.0,iOS 15.0,visionOS 1.0, *) {
+if #available(watchOS 8.0,tvOS 17.0,iOS 15.0,visionOS 1.0,macOS 12.0, *) {
     return Self.contextMenuPreview
 } else { fatalError("'contextMenuPreview' is not available in this OS version") }
 #else
@@ -14583,7 +14583,7 @@ fatalError("'contextMenuPreview' is not available on this OS")
 })
 ConstantAtomLiteral("hoverEffect").map({ () -> Self in
 #if os(iOS) || os(visionOS)
-if #available(watchOS 8.0,tvOS 15.0,macOS 12.0,iOS 15.0,visionOS 1.0, *) {
+if #available(watchOS 8.0,tvOS 15.0,iOS 15.0,visionOS 1.0,macOS 12.0, *) {
     return Self.hoverEffect
 } else { fatalError("'hoverEffect' is not available in this OS version") }
 #else
@@ -14591,8 +14591,8 @@ fatalError("'hoverEffect' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("focusEffect").map({ () -> Self in
-#if os(macOS) || os(visionOS) || os(watchOS)
-if #available(watchOS 8.0,tvOS 15.0,macOS 12.0,iOS 15.0,visionOS 1.0, *) {
+#if os(macOS) || os(watchOS)
+if #available(watchOS 8.0,tvOS 15.0,iOS 15.0,macOS 12.0, *) {
     return Self.focusEffect
 } else { fatalError("'focusEffect' is not available in this OS version") }
 #else
@@ -14601,7 +14601,7 @@ fatalError("'focusEffect' is not available on this OS")
 })
 ConstantAtomLiteral("accessibility").map({ () -> Self in
 #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-if #available(macOS 14.0,visionOS 1.0,watchOS 10.0,tvOS 17.0,iOS 17.0, *) {
+if #available(macOS 14.0,watchOS 10.0,tvOS 17.0,visionOS 1.0,iOS 17.0, *) {
     return Self.accessibility
 } else { fatalError("'accessibility' is not available in this OS version") }
 #else
@@ -14623,7 +14623,7 @@ fatalError("'accessibility' is not available on this OS")
 /// * `.large`
 /// * `.extraLarge`
 @_documentation(visibility: public)
-@available(iOS 15.0,watchOS 9.0,macOS 10.15,visionOS 1.0, *)
+@available(visionOS 1.0,macOS 10.15,iOS 15.0,watchOS 9.0, *)
 extension ControlSize: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -14657,7 +14657,7 @@ fatalError("'regular' is not available on this OS")
 })
 ConstantAtomLiteral("large").map({ () -> Self in
 #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
-if #available(iOS 15.0,watchOS 9.0,macOS 11.0,visionOS 1.0, *) {
+if #available(visionOS 1.0,macOS 11.0,iOS 15.0,watchOS 9.0, *) {
     return Self.large
 } else { fatalError("'large' is not available in this OS version") }
 #else
@@ -14665,8 +14665,8 @@ fatalError("'large' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("extraLarge").map({ () -> Self in
-#if os(iOS) || os(macOS) || os(visionOS) || os(watchOS) || os(xrOS)
-if #available(iOS 17.0,watchOS 10.0,macOS 14.0,xrOS 1.0,visionOS 1.0, *) {
+#if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
+if #available(visionOS 1.0,macOS 14.0,iOS 17.0,watchOS 10.0, *) {
     return Self.extraLarge
 } else { fatalError("'extraLarge' is not available in this OS version") }
 #else
@@ -14721,7 +14721,7 @@ ConstantAtomLiteral("userInitiated").map({ () -> Self in
 /// * `.critical`
 /// * `.standard`
 @_documentation(visibility: public)
-@available(macOS 13.0,visionOS 1.0,watchOS 10.0,tvOS 17.0,iOS 17.0, *)
+@available(visionOS 1.0,iOS 17.0,tvOS 17.0,macOS 13.0,watchOS 10.0, *)
 extension DialogSeverity: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -14746,7 +14746,7 @@ fatalError("'critical' is not available on this OS")
 })
 ConstantAtomLiteral("standard").map({ () -> Self in
 #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-if #available(macOS 14.0,visionOS 1.0,watchOS 10.0,tvOS 17.0,iOS 17.0, *) {
+if #available(visionOS 1.0,iOS 17.0,tvOS 17.0,macOS 14.0,watchOS 10.0, *) {
     return Self.standard
 } else { fatalError("'standard' is not available in this OS version") }
 #else
@@ -14758,7 +14758,7 @@ fatalError("'standard' is not available on this OS")
     }
 }
 #endif
-#if os(visionOS) || os(watchOS)
+#if os(watchOS)
 /// See [`SwiftUI.DigitalCrownRotationalSensitivity`](https://developer.apple.com/documentation/swiftui/DigitalCrownRotationalSensitivity) for more details.
 ///
 /// Possible values:
@@ -14766,13 +14766,13 @@ fatalError("'standard' is not available on this OS")
 /// * `.medium`
 /// * `.high`
 @_documentation(visibility: public)
-@available(visionOS 1.0,watchOS 6.0, *)
+@available(watchOS 6.0, *)
 extension DigitalCrownRotationalSensitivity: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             ConstantAtomLiteral("low").map({ () -> Self in
-#if os(visionOS) || os(watchOS)
+#if os(watchOS)
 
     return Self.low
 
@@ -14781,7 +14781,7 @@ fatalError("'low' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("medium").map({ () -> Self in
-#if os(visionOS) || os(watchOS)
+#if os(watchOS)
 
     return Self.medium
 
@@ -14790,7 +14790,7 @@ fatalError("'medium' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("high").map({ () -> Self in
-#if os(visionOS) || os(watchOS)
+#if os(watchOS)
 
     return Self.high
 
@@ -14803,19 +14803,19 @@ fatalError("'high' is not available on this OS")
     }
 }
 #endif
-#if os(visionOS) || os(xrOS)
+#if os(visionOS)
 /// See [`SwiftUI.Edge3D`](https://developer.apple.com/documentation/swiftui/Edge3D) for more details.
 ///
 /// Possible values:
 /// * `.top`
 @_documentation(visibility: public)
-@available(xrOS 1.0,visionOS 1.0, *)
+@available(visionOS 1.0, *)
 extension Edge3D: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             ConstantAtomLiteral("top").map({ () -> Self in
-#if os(visionOS) || os(xrOS)
+#if os(visionOS)
 
     return Self.top
 
@@ -14931,7 +14931,7 @@ ConstantAtomLiteral("all").map({ () -> Self in
 /// * `.includeHiddenFiles`
 /// * `.displayFileExtensions`
 @_documentation(visibility: public)
-@available(macOS 14.0,iOS 17.0,visionOS 1.0, *)
+@available(macOS 14.0,visionOS 1.0,iOS 17.0, *)
 extension FileDialogBrowserOptions: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -14976,7 +14976,7 @@ fatalError("'displayFileExtensions' is not available on this OS")
 /// * `.edit`
 /// * `.automatic`
 @_documentation(visibility: public)
-@available(iOS 17.0,watchOS 10.0,visionOS 1.0,macOS 14.0,tvOS 17.0, *)
+@available(iOS 17.0,macOS 14.0,watchOS 10.0,tvOS 17.0,visionOS 1.0, *)
 extension FocusInteractions: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -15068,7 +15068,7 @@ ConstantAtomLiteral("all").map({ () -> Self in
     }
 }
 
-#if os(visionOS) || os(xrOS)
+#if os(visionOS)
 /// See [`SwiftUI.GlassBackgroundDisplayMode`](https://developer.apple.com/documentation/swiftui/GlassBackgroundDisplayMode) for more details.
 ///
 /// Possible values:
@@ -15076,13 +15076,13 @@ ConstantAtomLiteral("all").map({ () -> Self in
 /// * `.implicit`
 /// * `.never`
 @_documentation(visibility: public)
-@available(visionOS 1.0,xrOS 1.0, *)
+@available(visionOS 1.0, *)
 extension GlassBackgroundDisplayMode: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             ConstantAtomLiteral("always").map({ () -> Self in
-#if os(visionOS) || os(xrOS)
+#if os(visionOS)
 
     return Self.always
 
@@ -15091,7 +15091,7 @@ fatalError("'always' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("implicit").map({ () -> Self in
-#if os(visionOS) || os(xrOS)
+#if os(visionOS)
 
     return Self.implicit
 
@@ -15100,7 +15100,7 @@ fatalError("'implicit' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("never").map({ () -> Self in
-#if os(visionOS) || os(xrOS)
+#if os(visionOS)
 
     return Self.never
 
@@ -15157,7 +15157,7 @@ ConstantAtomLiteral("trailing").map({ () -> Self in
 })
 ConstantAtomLiteral("listRowSeparatorLeading").map({ () -> Self in
 #if os(iOS) || os(macOS) || os(visionOS)
-if #available(macOS 13.0,iOS 16.0,visionOS 1.0, *) {
+if #available(macOS 13.0,visionOS 1.0,iOS 16.0, *) {
     return Self.listRowSeparatorLeading
 } else { fatalError("'listRowSeparatorLeading' is not available in this OS version") }
 #else
@@ -15166,7 +15166,7 @@ fatalError("'listRowSeparatorLeading' is not available on this OS")
 })
 ConstantAtomLiteral("listRowSeparatorTrailing").map({ () -> Self in
 #if os(iOS) || os(macOS) || os(visionOS)
-if #available(macOS 13.0,iOS 16.0,visionOS 1.0, *) {
+if #available(macOS 13.0,visionOS 1.0,iOS 16.0, *) {
     return Self.listRowSeparatorTrailing
 } else { fatalError("'listRowSeparatorTrailing' is not available in this OS version") }
 #else
@@ -15221,7 +15221,7 @@ ConstantAtomLiteral("trailing").map({ () -> Self in
 /// * `.highlight`
 /// * `.lift`
 @_documentation(visibility: public)
-@available(visionOS 1.0,iOS 13.4,tvOS 16.0, *)
+@available(iOS 13.4,tvOS 16.0,visionOS 1.0, *)
 extension HoverEffect: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -15237,7 +15237,7 @@ fatalError("'automatic' is not available on this OS")
 })
 ConstantAtomLiteral("highlight").map({ () -> Self in
 #if os(iOS) || os(tvOS) || os(visionOS)
-if #available(visionOS 1.0,iOS 13.4,tvOS 17.0, *) {
+if #available(iOS 13.4,tvOS 17.0,visionOS 1.0, *) {
     return Self.highlight
 } else { fatalError("'highlight' is not available in this OS version") }
 #else
@@ -15362,7 +15362,7 @@ extension MenuOrder: ParseableModifierValue {
 })
 ConstantAtomLiteral("priority").map({ () -> Self in
 #if os(iOS) || os(visionOS)
-if #available(tvOS 16.0,watchOS 9.0,iOS 16.0,macOS 13.0,visionOS 1.0, *) {
+if #available(visionOS 1.0,watchOS 9.0,macOS 13.0,tvOS 16.0,iOS 16.0, *) {
     return Self.priority
 } else { fatalError("'priority' is not available in this OS version") }
 #else
@@ -15393,7 +15393,7 @@ ConstantAtomLiteral("fixed").map({ () -> Self in
 /// * `.sheet`
 /// * `.fullScreenCover`
 @_documentation(visibility: public)
-@available(watchOS 9.4,tvOS 16.4,iOS 16.4,visionOS 1.0,macOS 13.3, *)
+@available(iOS 16.4,macOS 13.3,watchOS 9.4,visionOS 1.0,tvOS 16.4, *)
 extension PresentationAdaptation: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -15456,7 +15456,7 @@ fatalError("'fullScreenCover' is not available on this OS")
 /// * `.resizes`
 /// * `.scrolls`
 @_documentation(visibility: public)
-@available(iOS 16.4,watchOS 9.4,visionOS 1.0,macOS 13.3,tvOS 16.4, *)
+@available(iOS 16.4,macOS 13.3,watchOS 9.4,tvOS 16.4,visionOS 1.0, *)
 extension PresentationContentInteraction: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -15561,7 +15561,7 @@ ConstantAtomLiteral("privacy").map({ () -> Self in
 })
 ConstantAtomLiteral("invalidated").map({ () -> Self in
 #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-if #available(watchOS 10.0,tvOS 17.0,macOS 14.0,iOS 17.0,visionOS 1.0, *) {
+if #available(tvOS 17.0,visionOS 1.0,watchOS 10.0,macOS 14.0,iOS 17.0, *) {
     return Self.invalidated
 } else { fatalError("'invalidated' is not available in this OS version") }
 #else
@@ -15675,8 +15675,8 @@ extension ScenePadding: ParseableModifierValue {
 
 })
 ConstantAtomLiteral("navigationBar").map({ () -> Self in
-#if os(visionOS) || os(watchOS)
-if #available(iOS 16.0,tvOS 16.0,watchOS 9.0,macOS 13.0,visionOS 1.0, *) {
+#if os(watchOS)
+if #available(macOS 13.0,iOS 16.0,tvOS 16.0,watchOS 9.0, *) {
     return Self.navigationBar
 } else { fatalError("'navigationBar' is not available in this OS version") }
 #else
@@ -15696,7 +15696,7 @@ fatalError("'navigationBar' is not available on this OS")
 /// * `.always`
 /// * `.basedOnSize`
 @_documentation(visibility: public)
-@available(watchOS 9.4,tvOS 16.4,macOS 13.3,iOS 16.4,visionOS 1.0, *)
+@available(macOS 13.3,iOS 16.4,visionOS 1.0,tvOS 16.4,watchOS 9.4, *)
 extension ScrollBounceBehavior: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -15733,7 +15733,7 @@ fatalError("'basedOnSize' is not available on this OS")
     }
 }
 #endif
-#if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
 /// See [`SwiftUI.ScrollDismissesKeyboardMode`](https://developer.apple.com/documentation/swiftui/ScrollDismissesKeyboardMode) for more details.
 ///
 /// Possible values:
@@ -15742,13 +15742,13 @@ fatalError("'basedOnSize' is not available on this OS")
 /// * `.interactively`
 /// * `.never`
 @_documentation(visibility: public)
-@available(watchOS 9.0,tvOS 16.0,macOS 13.0,iOS 16.0,visionOS 1.0, *)
+@available(macOS 13.0,iOS 16.0,tvOS 16.0,watchOS 9.0, *)
 extension ScrollDismissesKeyboardMode: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
             ConstantAtomLiteral("automatic").map({ () -> Self in
-#if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
 
     return Self.automatic
 
@@ -15757,7 +15757,7 @@ fatalError("'automatic' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("immediately").map({ () -> Self in
-#if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
 
     return Self.immediately
 
@@ -15766,7 +15766,7 @@ fatalError("'immediately' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("interactively").map({ () -> Self in
-#if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
 
     return Self.interactively
 
@@ -15775,7 +15775,7 @@ fatalError("'interactively' is not available on this OS")
 #endif
 })
 ConstantAtomLiteral("never").map({ () -> Self in
-#if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
 
     return Self.never
 
@@ -15851,7 +15851,7 @@ ConstantAtomLiteral("never").map({ () -> Self in
 /// * `.onTextEntry`
 /// * `.onSearchPresentation`
 @_documentation(visibility: public)
-@available(watchOS 9.4,tvOS 16.4,iOS 16.4,visionOS 1.0,macOS 13.3, *)
+@available(iOS 16.4,tvOS 16.4,macOS 13.3,watchOS 9.4,visionOS 1.0, *)
 extension SearchScopeActivation: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -15941,7 +15941,7 @@ ConstantAtomLiteral("content").map({ () -> Self in
 /// * `.enabled`
 /// * `.disabled`
 @_documentation(visibility: public)
-@available(tvOS 17.0,watchOS 10.0,iOS 17.0,macOS 14.0,visionOS 1.0, *)
+@available(visionOS 1.0,watchOS 10.0,macOS 14.0,tvOS 17.0,iOS 17.0, *)
 extension SpringLoadingBehavior: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -16124,7 +16124,7 @@ ConstantAtomLiteral("search").map({ () -> Self in
 /// Possible values:
 /// * `.sidebarToggle`
 @_documentation(visibility: public)
-@available(macOS 14.0,visionOS 1.0,watchOS 10.0,tvOS 17.0,iOS 17.0, *)
+@available(visionOS 1.0,iOS 17.0,tvOS 17.0,macOS 14.0,watchOS 10.0, *)
 extension ToolbarDefaultItemKind: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
@@ -16168,7 +16168,7 @@ extension ToolbarRole: ParseableModifierValue {
 })
 ConstantAtomLiteral("navigationStack").map({ () -> Self in
 #if os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
-if #available(iOS 16.0,watchOS 9.0,visionOS 1.0,macOS 13.0,tvOS 16.0, *) {
+if #available(iOS 16.0,macOS 13.0,watchOS 9.0,tvOS 16.0,visionOS 1.0, *) {
     return Self.navigationStack
 } else { fatalError("'navigationStack' is not available in this OS version") }
 #else
@@ -16177,7 +16177,7 @@ fatalError("'navigationStack' is not available on this OS")
 })
 ConstantAtomLiteral("browser").map({ () -> Self in
 #if os(iOS) || os(visionOS)
-if #available(iOS 16.0,watchOS 9.0,visionOS 1.0,macOS 13.0,tvOS 16.0, *) {
+if #available(iOS 16.0,macOS 13.0,watchOS 9.0,tvOS 16.0,visionOS 1.0, *) {
     return Self.browser
 } else { fatalError("'browser' is not available in this OS version") }
 #else
@@ -16186,7 +16186,7 @@ fatalError("'browser' is not available on this OS")
 })
 ConstantAtomLiteral("editor").map({ () -> Self in
 #if os(iOS) || os(macOS) || os(visionOS)
-if #available(iOS 16.0,watchOS 9.0,visionOS 1.0,macOS 13.0,tvOS 16.0, *) {
+if #available(iOS 16.0,macOS 13.0,watchOS 9.0,tvOS 16.0,visionOS 1.0, *) {
     return Self.editor
 } else { fatalError("'editor' is not available in this OS version") }
 #else
@@ -16207,7 +16207,7 @@ fatalError("'editor' is not available on this OS")
 /// * `.inlineLarge`
 /// * `.inline`
 @_documentation(visibility: public)
-@available(tvOS 17.0,iOS 17.0,watchOS 10.0,macOS 14.0,visionOS 1.0, *)
+@available(iOS 17.0,macOS 14.0,watchOS 10.0,visionOS 1.0,tvOS 17.0, *)
 extension ToolbarTitleDisplayMode: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {


### PR DESCRIPTION
The modifiers have been regenerated using Xcode 15.4.

Xcode 15.4 removed `xrOS` references from the `swiftinterface` file for SwiftUI, which fixes an issue with visionOS modifier compilation.

I've also made the `Stylesheet` type to fix a release mode linker error in RC 4.