### PR TITLE
Fix stylesheet crash when enum case is unavailable

### DIFF
--- a/Sources/LiveViewNative/Views/Images/ImageView.swift
+++ b/Sources/LiveViewNative/Views/Images/ImageView.swift
@@ -131,7 +131,7 @@ struct ImageView<Root: RootRegistry>: View {
         if let labelNode = $liveElement.childNodes.first {
             switch labelNode.data {
             case let .element(element):
-                return Text<Root>(element: ElementNode(node: labelNode, data: element), overrideStylesheet: nil).body
+                return Text<Root>(element: ElementNode(node: labelNode, data: element), overrideStylesheet: _modifiers.overrideStylesheet).body
             case let .leaf(label):
                 return .init(label)
             case .root:

--- a/Sources/LiveViewNative/_GeneratedModifiers.swift
+++ b/Sources/LiveViewNative/_GeneratedModifiers.swift
@@ -1021,28 +1021,28 @@ struct _badgeModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(iOS 15.0,macOS 12.0,visionOS 1.0, *)
+    @available(macOS 12.0,visionOS 1.0,iOS 15.0, *)
     init(_ count: AttributeReference<Swift.Int>) {
         self.value = ._0(count: count)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(iOS 15.0,macOS 12.0,visionOS 1.0, *)
+    @available(macOS 12.0,visionOS 1.0,iOS 15.0, *)
     init(_ label: TextReference?) {
         self.value = ._1(label: label)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(iOS 15.0,macOS 12.0,visionOS 1.0, *)
+    @available(macOS 12.0,visionOS 1.0,iOS 15.0, *)
     init(_ key: SwiftUI.LocalizedStringKey?) {
         self.value = ._2(key: key)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(iOS 15.0,macOS 12.0,visionOS 1.0, *)
+    @available(macOS 12.0,visionOS 1.0,iOS 15.0, *)
     init(_ label: AttributeReference<String>) {
         self.value = ._3(label: label)
         
@@ -1055,7 +1055,7 @@ struct _badgeModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(count):
-            if #available(iOS 15.0,macOS 12.0,visionOS 1.0, *) {
+            if #available(macOS 12.0,visionOS 1.0,iOS 15.0, *) {
             let count = count as! AttributeReference<Swift.Int>
             
             __content
@@ -1066,7 +1066,7 @@ struct _badgeModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._1(label):
-            if #available(iOS 15.0,macOS 12.0,visionOS 1.0, *) {
+            if #available(macOS 12.0,visionOS 1.0,iOS 15.0, *) {
             let label = label as? TextReference
             __content._observeTextReference(label, on: element, in: context) { __content in
             __content
@@ -1077,7 +1077,7 @@ struct _badgeModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._2(key):
-            if #available(iOS 15.0,macOS 12.0,visionOS 1.0, *) {
+            if #available(macOS 12.0,visionOS 1.0,iOS 15.0, *) {
             let key = key as? SwiftUI.LocalizedStringKey
             
             __content
@@ -1088,7 +1088,7 @@ struct _badgeModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._3(label):
-            if #available(iOS 15.0,macOS 12.0,visionOS 1.0, *) {
+            if #available(macOS 12.0,visionOS 1.0,iOS 15.0, *) {
             let label = label as! AttributeReference<String>
             
             __content
@@ -1122,7 +1122,7 @@ struct _badgeProminenceModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(iOS 17.0,macOS 14.0,visionOS 1.0, *)
+    @available(macOS 14.0,visionOS 1.0,iOS 17.0, *)
     init(_ prominence: SwiftUI.BadgeProminence) {
         self.value = ._0(prominence: prominence)
         
@@ -1135,7 +1135,7 @@ struct _badgeProminenceModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(prominence):
-            if #available(iOS 17.0,macOS 14.0,visionOS 1.0, *) {
+            if #available(macOS 14.0,visionOS 1.0,iOS 17.0, *) {
             let prominence = prominence as! SwiftUI.BadgeProminence
             
             __content
@@ -1876,14 +1876,14 @@ struct _containerRelativeFrameModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0,visionOS 1.0, *)
+    @available(visionOS 1.0,macOS 14.0,watchOS 10.0,tvOS 17.0,iOS 17.0, *)
     init(_ axes: SwiftUI.Axis.Set,alignment: AttributeReference<SwiftUI.Alignment> = .init(storage: .constant(.center)) ) {
         self.value = ._0(axes: axes, alignment: alignment)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0,visionOS 1.0, *)
+    @available(visionOS 1.0,macOS 14.0,watchOS 10.0,tvOS 17.0,iOS 17.0, *)
     init(_ axes: SwiftUI.Axis.Set,count: AttributeReference<Swift.Int>,span: AttributeReference<Swift.Int> = .init(storage: .constant(1)), spacing: AttributeReference<CoreFoundation.CGFloat>,alignment: AttributeReference<SwiftUI.Alignment> = .init(storage: .constant(.center)) ) {
         self.value = ._1(axes: axes, count: count, span: span, spacing: spacing, alignment: alignment)
         
@@ -1896,7 +1896,7 @@ struct _containerRelativeFrameModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(axes, alignment):
-            if #available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,macOS 14.0,watchOS 10.0,tvOS 17.0,iOS 17.0, *) {
             let axes = axes as! SwiftUI.Axis.Set
 let alignment = alignment as! AttributeReference<SwiftUI.Alignment>
             
@@ -1908,7 +1908,7 @@ let alignment = alignment as! AttributeReference<SwiftUI.Alignment>
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(axes, count, span, spacing, alignment):
-            if #available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,macOS 14.0,watchOS 10.0,tvOS 17.0,iOS 17.0, *) {
             let axes = axes as! SwiftUI.Axis.Set
 let count = count as! AttributeReference<Swift.Int>
 let span = span as! AttributeReference<Swift.Int>
@@ -2003,21 +2003,21 @@ struct _contentMarginsModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 10.0,tvOS 17.0,iOS 17.0,macOS 14.0,visionOS 1.0, *)
+    @available(watchOS 10.0,macOS 14.0,visionOS 1.0,iOS 17.0,tvOS 17.0, *)
     init(_ edges: SwiftUI.Edge.Set = .all, _ insets: SwiftUI.EdgeInsets,for placement: SwiftUI.ContentMarginPlacement = .automatic ) {
         self.value = ._0(edges: edges, insets: insets, placement: placement)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 10.0,tvOS 17.0,iOS 17.0,macOS 14.0,visionOS 1.0, *)
+    @available(watchOS 10.0,macOS 14.0,visionOS 1.0,iOS 17.0,tvOS 17.0, *)
     init(_ edges: SwiftUI.Edge.Set = .all, _ length: AttributeReference<CoreFoundation.CGFloat?>?,for placement: SwiftUI.ContentMarginPlacement = .automatic ) {
         self.value = ._1(edges: edges, length: length, placement: placement)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 10.0,tvOS 17.0,iOS 17.0,macOS 14.0,visionOS 1.0, *)
+    @available(watchOS 10.0,macOS 14.0,visionOS 1.0,iOS 17.0,tvOS 17.0, *)
     init(_ length: AttributeReference<CoreFoundation.CGFloat>,for placement: SwiftUI.ContentMarginPlacement = .automatic ) {
         self.value = ._2(length: length, placement: placement)
         
@@ -2030,7 +2030,7 @@ struct _contentMarginsModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(edges, insets, placement):
-            if #available(watchOS 10.0,tvOS 17.0,iOS 17.0,macOS 14.0,visionOS 1.0, *) {
+            if #available(watchOS 10.0,macOS 14.0,visionOS 1.0,iOS 17.0,tvOS 17.0, *) {
             let edges = edges as! SwiftUI.Edge.Set 
 let insets = insets as! SwiftUI.EdgeInsets
 let placement = placement as! SwiftUI.ContentMarginPlacement 
@@ -2043,7 +2043,7 @@ let placement = placement as! SwiftUI.ContentMarginPlacement
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(edges, length, placement):
-            if #available(watchOS 10.0,tvOS 17.0,iOS 17.0,macOS 14.0,visionOS 1.0, *) {
+            if #available(watchOS 10.0,macOS 14.0,visionOS 1.0,iOS 17.0,tvOS 17.0, *) {
             let edges = edges as! SwiftUI.Edge.Set 
 let length = length as? AttributeReference<CoreFoundation.CGFloat?>
 let placement = placement as! SwiftUI.ContentMarginPlacement 
@@ -2056,7 +2056,7 @@ let placement = placement as! SwiftUI.ContentMarginPlacement
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._2(length, placement):
-            if #available(watchOS 10.0,tvOS 17.0,iOS 17.0,macOS 14.0,visionOS 1.0, *) {
+            if #available(watchOS 10.0,macOS 14.0,visionOS 1.0,iOS 17.0,tvOS 17.0, *) {
             let length = length as! AttributeReference<CoreFoundation.CGFloat>
 let placement = placement as! SwiftUI.ContentMarginPlacement 
             
@@ -2220,7 +2220,7 @@ struct _contextMenuModifier<R: RootRegistry>: ViewModifier {
     }
     
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS)
-    @available(iOS 16.0,visionOS 1.0,tvOS 16.0,macOS 13.0, *)
+    @available(iOS 16.0,tvOS 16.0,macOS 13.0,visionOS 1.0, *)
     init(menuItems: ViewReference=ViewReference(value: []),preview: ViewReference=ViewReference(value: [])) {
         self.value = ._1(menuItems: menuItems, preview: preview)
         
@@ -2244,7 +2244,7 @@ struct _contextMenuModifier<R: RootRegistry>: ViewModifier {
         
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS)
         case let ._1(menuItems, preview):
-            if #available(iOS 16.0,visionOS 1.0,tvOS 16.0,macOS 13.0, *) {
+            if #available(iOS 16.0,tvOS 16.0,macOS 13.0,visionOS 1.0, *) {
             let menuItems = menuItems as! ViewReference
 let preview = preview as! ViewReference
             
@@ -2326,7 +2326,7 @@ struct _controlGroupStyleModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS)
-    @available(visionOS 1.0,tvOS 17.0,macOS 12.0,iOS 15.0, *)
+    @available(macOS 12.0,iOS 15.0,visionOS 1.0,tvOS 17.0, *)
     init(_ style: AnyControlGroupStyle) {
         self.value = ._0(style: style)
         
@@ -2339,7 +2339,7 @@ struct _controlGroupStyleModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS)
         case let ._0(style):
-            if #available(visionOS 1.0,tvOS 17.0,macOS 12.0,iOS 15.0, *) {
+            if #available(macOS 12.0,iOS 15.0,visionOS 1.0,tvOS 17.0, *) {
             let style = style as! AnyControlGroupStyle
             
             __content
@@ -2420,7 +2420,7 @@ struct _coordinateSpaceModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 10.0,tvOS 17.0,iOS 17.0,macOS 14.0,visionOS 1.0, *)
+    @available(watchOS 10.0,macOS 14.0,visionOS 1.0,iOS 17.0,tvOS 17.0, *)
     init(_ name: SwiftUI.NamedCoordinateSpace) {
         self.value = ._0(name: name)
         
@@ -2433,7 +2433,7 @@ struct _coordinateSpaceModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(name):
-            if #available(watchOS 10.0,tvOS 17.0,iOS 17.0,macOS 14.0,visionOS 1.0, *) {
+            if #available(watchOS 10.0,macOS 14.0,visionOS 1.0,iOS 17.0,tvOS 17.0, *) {
             let name = name as! SwiftUI.NamedCoordinateSpace
             
             __content
@@ -2467,7 +2467,7 @@ struct _datePickerStyleModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,macOS 10.15,iOS 13.0,watchOS 10.0, *)
+    @available(macOS 10.15,iOS 13.0,visionOS 1.0,watchOS 10.0, *)
     init(_ style: AnyDatePickerStyle) {
         self.value = ._0(style: style)
         
@@ -2480,7 +2480,7 @@ struct _datePickerStyleModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
         case let ._0(style):
-            if #available(visionOS 1.0,macOS 10.15,iOS 13.0,watchOS 10.0, *) {
+            if #available(macOS 10.15,iOS 13.0,visionOS 1.0,watchOS 10.0, *) {
             let style = style as! AnyDatePickerStyle
             
             __content
@@ -2514,7 +2514,7 @@ struct _defaultHoverEffectModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(tvOS) || os(visionOS)
-    @available(tvOS 17.0,iOS 17.0,visionOS 1.0, *)
+    @available(tvOS 17.0,visionOS 1.0,iOS 17.0, *)
     init(_ effect: SwiftUI.HoverEffect?) {
         self.value = ._0(effect: effect)
         
@@ -2527,7 +2527,7 @@ struct _defaultHoverEffectModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(tvOS) || os(visionOS)
         case let ._0(effect):
-            if #available(tvOS 17.0,iOS 17.0,visionOS 1.0, *) {
+            if #available(tvOS 17.0,visionOS 1.0,iOS 17.0, *) {
             let effect = effect as? SwiftUI.HoverEffect
             
             __content
@@ -2561,7 +2561,7 @@ struct _defaultScrollAnchorModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(iOS 17.0,watchOS 10.0,tvOS 17.0,macOS 14.0,visionOS 1.0, *)
+    @available(tvOS 17.0,iOS 17.0,watchOS 10.0,visionOS 1.0,macOS 14.0, *)
     init(_ anchor: AttributeReference<SwiftUI.UnitPoint?>?) {
         self.value = ._0(anchor: anchor)
         
@@ -2574,7 +2574,7 @@ struct _defaultScrollAnchorModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(anchor):
-            if #available(iOS 17.0,watchOS 10.0,tvOS 17.0,macOS 14.0,visionOS 1.0, *) {
+            if #available(tvOS 17.0,iOS 17.0,watchOS 10.0,visionOS 1.0,macOS 14.0, *) {
             let anchor = anchor as? AttributeReference<SwiftUI.UnitPoint?>
             
             __content
@@ -2764,28 +2764,28 @@ struct _dialogSuppressionToggleModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 10.0,tvOS 17.0,iOS 17.0,macOS 14.0,visionOS 1.0, *)
+    @available(visionOS 1.0,tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0, *)
     init(_ titleKey: SwiftUI.LocalizedStringKey,isSuppressed: ChangeTracked<Swift.Bool>) {
         self.value = ._0(titleKey: titleKey)
         self.__0_isSuppressed = isSuppressed
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 10.0,tvOS 17.0,iOS 17.0,macOS 14.0,visionOS 1.0, *)
+    @available(visionOS 1.0,tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0, *)
     init(_ title: AttributeReference<String>,isSuppressed: ChangeTracked<Swift.Bool>) {
         self.value = ._1(title: title)
         self.__1_isSuppressed = isSuppressed
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 10.0,tvOS 17.0,iOS 17.0,macOS 14.0,visionOS 1.0, *)
+    @available(visionOS 1.0,tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0, *)
     init(_ label: TextReference,isSuppressed: ChangeTracked<Swift.Bool>) {
         self.value = ._2(label: label)
         self.__2_isSuppressed = isSuppressed
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 10.0,tvOS 17.0,iOS 17.0,macOS 14.0,visionOS 1.0, *)
+    @available(visionOS 1.0,tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0, *)
     init(isSuppressed: ChangeTracked<Swift.Bool>) {
         self.value = ._3
         self.__3_isSuppressed = isSuppressed
@@ -2798,7 +2798,7 @@ struct _dialogSuppressionToggleModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(titleKey):
-            if #available(watchOS 10.0,tvOS 17.0,iOS 17.0,macOS 14.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0, *) {
             let titleKey = titleKey as! SwiftUI.LocalizedStringKey
             
             __content
@@ -2809,7 +2809,7 @@ struct _dialogSuppressionToggleModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(title):
-            if #available(watchOS 10.0,tvOS 17.0,iOS 17.0,macOS 14.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0, *) {
             let title = title as! AttributeReference<String>
             
             __content
@@ -2820,7 +2820,7 @@ struct _dialogSuppressionToggleModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._2(label):
-            if #available(watchOS 10.0,tvOS 17.0,iOS 17.0,macOS 14.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0, *) {
             let label = label as! TextReference
             __content._observeTextReference(label, on: element, in: context) { __content in
             __content
@@ -2831,7 +2831,7 @@ struct _dialogSuppressionToggleModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case ._3:
-            if #available(watchOS 10.0,tvOS 17.0,iOS 17.0,macOS 14.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0, *) {
             
             
             __content
@@ -3099,7 +3099,7 @@ struct _fileDialogCustomizationIDModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(iOS 17.0,visionOS 1.0,macOS 14.0, *)
+    @available(macOS 14.0,visionOS 1.0,iOS 17.0, *)
     init(_ id: AttributeReference<Swift.String>) {
         self.value = ._0(id: id)
         
@@ -3112,7 +3112,7 @@ struct _fileDialogCustomizationIDModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(id):
-            if #available(iOS 17.0,visionOS 1.0,macOS 14.0, *) {
+            if #available(macOS 14.0,visionOS 1.0,iOS 17.0, *) {
             let id = id as! AttributeReference<Swift.String>
             
             __content
@@ -3146,7 +3146,7 @@ struct _fileDialogImportsUnresolvedAliasesModifier<R: RootRegistry>: ViewModifie
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(iOS 17.0,visionOS 1.0,macOS 14.0, *)
+    @available(macOS 14.0,visionOS 1.0,iOS 17.0, *)
     init(_ imports: AttributeReference<Swift.Bool>) {
         self.value = ._0(imports: imports)
         
@@ -3159,7 +3159,7 @@ struct _fileDialogImportsUnresolvedAliasesModifier<R: RootRegistry>: ViewModifie
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(imports):
-            if #available(iOS 17.0,visionOS 1.0,macOS 14.0, *) {
+            if #available(macOS 14.0,visionOS 1.0,iOS 17.0, *) {
             let imports = imports as! AttributeReference<Swift.Bool>
             
             __content
@@ -3404,7 +3404,7 @@ struct _focusEffectDisabledModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,macOS 14.0,tvOS 17.0,iOS 17.0,watchOS 10.0, *)
+    @available(watchOS 10.0,visionOS 1.0,tvOS 17.0,macOS 14.0,iOS 17.0, *)
     init(_ disabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(disabled: disabled)
         
@@ -3417,7 +3417,7 @@ struct _focusEffectDisabledModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(disabled):
-            if #available(visionOS 1.0,macOS 14.0,tvOS 17.0,iOS 17.0,watchOS 10.0, *) {
+            if #available(watchOS 10.0,visionOS 1.0,tvOS 17.0,macOS 14.0,iOS 17.0, *) {
             let disabled = disabled as! AttributeReference<Swift.Bool>
             
             __content
@@ -3503,14 +3503,14 @@ struct _focusableModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,macOS 12.0,tvOS 15.0,iOS 17.0,watchOS 8.0, *)
+    @available(watchOS 8.0,visionOS 1.0,tvOS 15.0,macOS 12.0,iOS 17.0, *)
     init(_ isFocusable: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(isFocusable: isFocusable)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,macOS 14.0,tvOS 17.0,iOS 17.0,watchOS 10.0, *)
+    @available(watchOS 10.0,visionOS 1.0,tvOS 17.0,macOS 14.0,iOS 17.0, *)
     init(_ isFocusable: AttributeReference<Swift.Bool> = .init(storage: .constant(true)), interactions: SwiftUI.FocusInteractions) {
         self.value = ._1(isFocusable: isFocusable, interactions: interactions)
         
@@ -3523,7 +3523,7 @@ struct _focusableModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(isFocusable):
-            if #available(visionOS 1.0,macOS 12.0,tvOS 15.0,iOS 17.0,watchOS 8.0, *) {
+            if #available(watchOS 8.0,visionOS 1.0,tvOS 15.0,macOS 12.0,iOS 17.0, *) {
             let isFocusable = isFocusable as! AttributeReference<Swift.Bool>
             
             __content
@@ -3534,7 +3534,7 @@ struct _focusableModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(isFocusable, interactions):
-            if #available(visionOS 1.0,macOS 14.0,tvOS 17.0,iOS 17.0,watchOS 10.0, *) {
+            if #available(watchOS 10.0,visionOS 1.0,tvOS 17.0,macOS 14.0,iOS 17.0, *) {
             let isFocusable = isFocusable as! AttributeReference<Swift.Bool>
 let interactions = interactions as! SwiftUI.FocusInteractions
             
@@ -3759,7 +3759,7 @@ struct _fullScreenCoverModifier<R: RootRegistry>: ViewModifier {
 @Event private var _0_onDismiss__0: Event.EventHandler
 
     #if os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 7.0,tvOS 14.0,iOS 14.0,visionOS 1.0, *)
+    @available(iOS 14.0,watchOS 7.0,tvOS 14.0,visionOS 1.0, *)
     init(isPresented: ChangeTracked<Swift.Bool>,onDismiss onDismiss__0: Event=Event(), content: ViewReference=ViewReference(value: [])) {
         self.value = ._0(content: content)
         self.__0_isPresented = isPresented
@@ -3773,7 +3773,7 @@ self.__0_onDismiss__0 = onDismiss__0
             fatalError("unreachable")
         #if os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(content):
-            if #available(watchOS 7.0,tvOS 14.0,iOS 14.0,visionOS 1.0, *) {
+            if #available(iOS 14.0,watchOS 7.0,tvOS 14.0,visionOS 1.0, *) {
             let content = content as! ViewReference
             
             __content
@@ -3807,7 +3807,7 @@ struct _gaugeStyleModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
-    @available(iOS 16.0,watchOS 7.0,macOS 13.0,visionOS 1.0, *)
+    @available(macOS 13.0,iOS 16.0,visionOS 1.0,watchOS 7.0, *)
     init(_ style: AnyGaugeStyle) {
         self.value = ._0(style: style)
         
@@ -3820,7 +3820,7 @@ struct _gaugeStyleModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
         case let ._0(style):
-            if #available(iOS 16.0,watchOS 7.0,macOS 13.0,visionOS 1.0, *) {
+            if #available(macOS 13.0,iOS 16.0,visionOS 1.0,watchOS 7.0, *) {
             let style = style as! AnyGaugeStyle
             
             __content
@@ -4254,7 +4254,7 @@ struct _groupBoxStyleModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(iOS 14.0,macOS 11.0,visionOS 1.0, *)
+    @available(macOS 11.0,visionOS 1.0,iOS 14.0, *)
     init(_ style: AnyGroupBoxStyle) {
         self.value = ._0(style: style)
         
@@ -4267,7 +4267,7 @@ struct _groupBoxStyleModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(style):
-            if #available(iOS 14.0,macOS 11.0,visionOS 1.0, *) {
+            if #available(macOS 11.0,visionOS 1.0,iOS 14.0, *) {
             let style = style as! AnyGroupBoxStyle
             
             __content
@@ -4587,14 +4587,14 @@ struct _hoverEffectModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(tvOS) || os(visionOS)
-    @available(tvOS 16.0,iOS 13.4,visionOS 1.0, *)
+    @available(tvOS 16.0,visionOS 1.0,iOS 13.4, *)
     init(_ effect: SwiftUI.HoverEffect = .automatic ) {
         self.value = ._0(effect: effect)
         
     }
     #endif
     #if os(iOS) || os(tvOS) || os(visionOS)
-    @available(tvOS 17.0,iOS 17.0,visionOS 1.0, *)
+    @available(tvOS 17.0,visionOS 1.0,iOS 17.0, *)
     init(_ effect: SwiftUI.HoverEffect = .automatic, isEnabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._1(effect: effect, isEnabled: isEnabled)
         
@@ -4607,7 +4607,7 @@ struct _hoverEffectModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(tvOS) || os(visionOS)
         case let ._0(effect):
-            if #available(tvOS 16.0,iOS 13.4,visionOS 1.0, *) {
+            if #available(tvOS 16.0,visionOS 1.0,iOS 13.4, *) {
             let effect = effect as! SwiftUI.HoverEffect 
             
             __content
@@ -4618,7 +4618,7 @@ struct _hoverEffectModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(tvOS) || os(visionOS)
         case let ._1(effect, isEnabled):
-            if #available(tvOS 17.0,iOS 17.0,visionOS 1.0, *) {
+            if #available(tvOS 17.0,visionOS 1.0,iOS 17.0, *) {
             let effect = effect as! SwiftUI.HoverEffect 
 let isEnabled = isEnabled as! AttributeReference<Swift.Bool>
             
@@ -4653,7 +4653,7 @@ struct _hoverEffectDisabledModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(tvOS) || os(visionOS)
-    @available(tvOS 17.0,iOS 17.0,visionOS 1.0, *)
+    @available(tvOS 17.0,visionOS 1.0,iOS 17.0, *)
     init(_ disabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(disabled: disabled)
         
@@ -4666,7 +4666,7 @@ struct _hoverEffectDisabledModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(tvOS) || os(visionOS)
         case let ._0(disabled):
-            if #available(tvOS 17.0,iOS 17.0,visionOS 1.0, *) {
+            if #available(tvOS 17.0,visionOS 1.0,iOS 17.0, *) {
             let disabled = disabled as! AttributeReference<Swift.Bool>
             
             __content
@@ -4841,7 +4841,7 @@ struct _indexViewStyleModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 8.0,tvOS 14.0,iOS 14.0,visionOS 1.0, *)
+    @available(visionOS 1.0,watchOS 8.0,tvOS 14.0,iOS 14.0, *)
     init(_ style: AnyIndexViewStyle) {
         self.value = ._0(style: style)
         
@@ -4854,7 +4854,7 @@ struct _indexViewStyleModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(style):
-            if #available(watchOS 8.0,tvOS 14.0,iOS 14.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,watchOS 8.0,tvOS 14.0,iOS 14.0, *) {
             let style = style as! AnyIndexViewStyle
             
             __content
@@ -4888,7 +4888,7 @@ struct _inspectorModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS)
-    @available(iOS 17.0,macOS 14.0, *)
+    @available(macOS 14.0,iOS 17.0, *)
     init(isPresented: ChangeTracked<Swift.Bool>,content: ViewReference=ViewReference(value: [])) {
         self.value = ._0(content: content)
         self.__0_isPresented = isPresented
@@ -4901,7 +4901,7 @@ struct _inspectorModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS)
         case let ._0(content):
-            if #available(iOS 17.0,macOS 14.0, *) {
+            if #available(macOS 14.0,iOS 17.0, *) {
             let content = content as! ViewReference
             
             __content
@@ -4940,14 +4940,14 @@ struct _inspectorColumnWidthModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS)
-    @available(iOS 17.0,macOS 14.0, *)
+    @available(macOS 14.0,iOS 17.0, *)
     init(min: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)), ideal: AttributeReference<CoreFoundation.CGFloat>,max: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)) ) {
         self.value = ._0(min: min, ideal: ideal, max: max)
         
     }
     #endif
     #if os(iOS) || os(macOS)
-    @available(iOS 17.0,macOS 14.0, *)
+    @available(macOS 14.0,iOS 17.0, *)
     init(_ width: AttributeReference<CoreFoundation.CGFloat>) {
         self.value = ._1(width: width)
         
@@ -4960,7 +4960,7 @@ struct _inspectorColumnWidthModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS)
         case let ._0(min, ideal, max):
-            if #available(iOS 17.0,macOS 14.0, *) {
+            if #available(macOS 14.0,iOS 17.0, *) {
             let min = min as? AttributeReference<CoreFoundation.CGFloat?>
 let ideal = ideal as! AttributeReference<CoreFoundation.CGFloat>
 let max = max as? AttributeReference<CoreFoundation.CGFloat?>
@@ -4973,7 +4973,7 @@ let max = max as? AttributeReference<CoreFoundation.CGFloat?>
         #endif
         #if os(iOS) || os(macOS)
         case let ._1(width):
-            if #available(iOS 17.0,macOS 14.0, *) {
+            if #available(macOS 14.0,iOS 17.0, *) {
             let width = width as! AttributeReference<CoreFoundation.CGFloat>
             
             __content
@@ -5101,7 +5101,7 @@ struct _invalidatableContentModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 10.0,visionOS 1.0,iOS 17.0,tvOS 17.0,macOS 14.0, *)
+    @available(iOS 17.0,watchOS 10.0,tvOS 17.0,macOS 14.0,visionOS 1.0, *)
     init(_ invalidatable: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(invalidatable: invalidatable)
         
@@ -5114,7 +5114,7 @@ struct _invalidatableContentModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(invalidatable):
-            if #available(watchOS 10.0,visionOS 1.0,iOS 17.0,tvOS 17.0,macOS 14.0, *) {
+            if #available(iOS 17.0,watchOS 10.0,tvOS 17.0,macOS 14.0,visionOS 1.0, *) {
             let invalidatable = invalidatable as! AttributeReference<Swift.Bool>
             
             __content
@@ -5163,28 +5163,28 @@ struct _keyboardShortcutModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(iOS 14.0,macOS 11.0,visionOS 1.0, *)
+    @available(macOS 11.0,visionOS 1.0,iOS 14.0, *)
     init(_ key: SwiftUI.KeyEquivalent,modifiers: SwiftUI.EventModifiers = .command ) {
         self.value = ._0(key: key, modifiers: modifiers)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(iOS 14.0,macOS 11.0,visionOS 1.0, *)
+    @available(macOS 11.0,visionOS 1.0,iOS 14.0, *)
     init(_ shortcut: SwiftUI.KeyboardShortcut) {
         self.value = ._1(shortcut: shortcut)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(iOS 15.4,macOS 12.3,visionOS 1.0, *)
+    @available(macOS 12.3,visionOS 1.0,iOS 15.4, *)
     init(_ shortcut: SwiftUI.KeyboardShortcut?) {
         self.value = ._2(shortcut: shortcut)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(iOS 15.0,macOS 12.0,visionOS 1.0, *)
+    @available(macOS 12.0,visionOS 1.0,iOS 15.0, *)
     init(_ key: SwiftUI.KeyEquivalent,modifiers: SwiftUI.EventModifiers = .command, localization: SwiftUI.KeyboardShortcut.Localization) {
         self.value = ._3(key: key, modifiers: modifiers, localization: localization)
         
@@ -5197,7 +5197,7 @@ struct _keyboardShortcutModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(key, modifiers):
-            if #available(iOS 14.0,macOS 11.0,visionOS 1.0, *) {
+            if #available(macOS 11.0,visionOS 1.0,iOS 14.0, *) {
             let key = key as! SwiftUI.KeyEquivalent
 let modifiers = modifiers as! SwiftUI.EventModifiers 
             
@@ -5209,7 +5209,7 @@ let modifiers = modifiers as! SwiftUI.EventModifiers
         #endif
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._1(shortcut):
-            if #available(iOS 14.0,macOS 11.0,visionOS 1.0, *) {
+            if #available(macOS 11.0,visionOS 1.0,iOS 14.0, *) {
             let shortcut = shortcut as! SwiftUI.KeyboardShortcut
             
             __content
@@ -5220,7 +5220,7 @@ let modifiers = modifiers as! SwiftUI.EventModifiers
         #endif
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._2(shortcut):
-            if #available(iOS 15.4,macOS 12.3,visionOS 1.0, *) {
+            if #available(macOS 12.3,visionOS 1.0,iOS 15.4, *) {
             let shortcut = shortcut as? SwiftUI.KeyboardShortcut
             
             __content
@@ -5231,7 +5231,7 @@ let modifiers = modifiers as! SwiftUI.EventModifiers
         #endif
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._3(key, modifiers, localization):
-            if #available(iOS 15.0,macOS 12.0,visionOS 1.0, *) {
+            if #available(macOS 12.0,visionOS 1.0,iOS 15.0, *) {
             let key = key as! SwiftUI.KeyEquivalent
 let modifiers = modifiers as! SwiftUI.EventModifiers 
 let localization = localization as! SwiftUI.KeyboardShortcut.Localization
@@ -5267,7 +5267,7 @@ struct _keyboardTypeModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(tvOS) || os(visionOS)
-    @available(iOS 13.0,tvOS 13.0,visionOS 1.0, *)
+    @available(tvOS 13.0,visionOS 1.0,iOS 13.0, *)
     init(_ type: UIKit.UIKeyboardType) {
         self.value = ._0(type: type)
         
@@ -5280,7 +5280,7 @@ struct _keyboardTypeModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(tvOS) || os(visionOS)
         case let ._0(type):
-            if #available(iOS 13.0,tvOS 13.0,visionOS 1.0, *) {
+            if #available(tvOS 13.0,visionOS 1.0,iOS 13.0, *) {
             let type = type as! UIKit.UIKeyboardType
             
             __content
@@ -5946,7 +5946,7 @@ struct _listRowSeparatorModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(iOS 15.0,visionOS 1.0,macOS 13.0, *)
+    @available(macOS 13.0,visionOS 1.0,iOS 15.0, *)
     init(_ visibility: AttributeReference<SwiftUI.Visibility>,edges: SwiftUI.VerticalEdge.Set = .all ) {
         self.value = ._0(visibility: visibility, edges: edges)
         
@@ -5959,7 +5959,7 @@ struct _listRowSeparatorModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(visibility, edges):
-            if #available(iOS 15.0,visionOS 1.0,macOS 13.0, *) {
+            if #available(macOS 13.0,visionOS 1.0,iOS 15.0, *) {
             let visibility = visibility as! AttributeReference<SwiftUI.Visibility>
 let edges = edges as! SwiftUI.VerticalEdge.Set 
             
@@ -5994,7 +5994,7 @@ struct _listRowSeparatorTintModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(iOS 15.0,visionOS 1.0,macOS 13.0, *)
+    @available(macOS 13.0,visionOS 1.0,iOS 15.0, *)
     init(_ color: Color.Resolvable?,edges: SwiftUI.VerticalEdge.Set = .all ) {
         self.value = ._0(color: color, edges: edges)
         
@@ -6007,7 +6007,7 @@ struct _listRowSeparatorTintModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(color, edges):
-            if #available(iOS 15.0,visionOS 1.0,macOS 13.0, *) {
+            if #available(macOS 13.0,visionOS 1.0,iOS 15.0, *) {
             let color = color as? Color.Resolvable
 let edges = edges as! SwiftUI.VerticalEdge.Set 
             
@@ -6089,7 +6089,7 @@ struct _listSectionSeparatorModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(iOS 15.0,visionOS 1.0,macOS 13.0, *)
+    @available(macOS 13.0,visionOS 1.0,iOS 15.0, *)
     init(_ visibility: AttributeReference<SwiftUI.Visibility>,edges: SwiftUI.VerticalEdge.Set = .all ) {
         self.value = ._0(visibility: visibility, edges: edges)
         
@@ -6102,7 +6102,7 @@ struct _listSectionSeparatorModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(visibility, edges):
-            if #available(iOS 15.0,visionOS 1.0,macOS 13.0, *) {
+            if #available(macOS 13.0,visionOS 1.0,iOS 15.0, *) {
             let visibility = visibility as! AttributeReference<SwiftUI.Visibility>
 let edges = edges as! SwiftUI.VerticalEdge.Set 
             
@@ -6137,7 +6137,7 @@ struct _listSectionSeparatorTintModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(iOS 15.0,visionOS 1.0,macOS 13.0, *)
+    @available(macOS 13.0,visionOS 1.0,iOS 15.0, *)
     init(_ color: Color.Resolvable?,edges: SwiftUI.VerticalEdge.Set = .all ) {
         self.value = ._0(color: color, edges: edges)
         
@@ -6150,7 +6150,7 @@ struct _listSectionSeparatorTintModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(color, edges):
-            if #available(iOS 15.0,visionOS 1.0,macOS 13.0, *) {
+            if #available(macOS 13.0,visionOS 1.0,iOS 15.0, *) {
             let color = color as? Color.Resolvable
 let edges = edges as! SwiftUI.VerticalEdge.Set 
             
@@ -6190,14 +6190,14 @@ struct _listSectionSpacingModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,iOS 17.0,watchOS 10.0, *)
+    @available(watchOS 10.0,visionOS 1.0,iOS 17.0, *)
     init(_ spacing: SwiftUI.ListSectionSpacing) {
         self.value = ._0(spacing: spacing)
         
     }
     #endif
     #if os(iOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,iOS 17.0,watchOS 10.0, *)
+    @available(watchOS 10.0,visionOS 1.0,iOS 17.0, *)
     init(_ spacing: AttributeReference<CoreFoundation.CGFloat>) {
         self.value = ._1(spacing: spacing)
         
@@ -6210,7 +6210,7 @@ struct _listSectionSpacingModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(visionOS) || os(watchOS)
         case let ._0(spacing):
-            if #available(visionOS 1.0,iOS 17.0,watchOS 10.0, *) {
+            if #available(watchOS 10.0,visionOS 1.0,iOS 17.0, *) {
             let spacing = spacing as! SwiftUI.ListSectionSpacing
             
             __content
@@ -6221,7 +6221,7 @@ struct _listSectionSpacingModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(visionOS) || os(watchOS)
         case let ._1(spacing):
-            if #available(visionOS 1.0,iOS 17.0,watchOS 10.0, *) {
+            if #available(watchOS 10.0,visionOS 1.0,iOS 17.0, *) {
             let spacing = spacing as! AttributeReference<CoreFoundation.CGFloat>
             
             __content
@@ -6349,7 +6349,7 @@ struct _menuIndicatorModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS)
-    @available(iOS 15.0,macOS 12.0,tvOS 17.0,visionOS 1.0, *)
+    @available(iOS 15.0,tvOS 17.0,macOS 12.0,visionOS 1.0, *)
     init(_ visibility: AttributeReference<SwiftUI.Visibility>) {
         self.value = ._0(visibility: visibility)
         
@@ -6362,7 +6362,7 @@ struct _menuIndicatorModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS)
         case let ._0(visibility):
-            if #available(iOS 15.0,macOS 12.0,tvOS 17.0,visionOS 1.0, *) {
+            if #available(iOS 15.0,tvOS 17.0,macOS 12.0,visionOS 1.0, *) {
             let visibility = visibility as! AttributeReference<SwiftUI.Visibility>
             
             __content
@@ -6443,7 +6443,7 @@ struct _menuStyleModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS)
-    @available(visionOS 1.0,tvOS 17.0,macOS 11.0,iOS 14.0, *)
+    @available(iOS 14.0,tvOS 17.0,macOS 11.0,visionOS 1.0, *)
     init(_ style: AnyMenuStyle) {
         self.value = ._0(style: style)
         
@@ -6456,7 +6456,7 @@ struct _menuStyleModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS)
         case let ._0(style):
-            if #available(visionOS 1.0,tvOS 17.0,macOS 11.0,iOS 14.0, *) {
+            if #available(iOS 14.0,tvOS 17.0,macOS 11.0,visionOS 1.0, *) {
             let style = style as! AnyMenuStyle
             
             __content
@@ -6678,7 +6678,7 @@ struct _navigationBarTitleDisplayModeModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,iOS 14.0,watchOS 8.0, *)
+    @available(watchOS 8.0,visionOS 1.0,iOS 14.0, *)
     init(_ displayMode: SwiftUI.NavigationBarItem.TitleDisplayMode) {
         self.value = ._0(displayMode: displayMode)
         
@@ -6691,7 +6691,7 @@ struct _navigationBarTitleDisplayModeModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(visionOS) || os(watchOS)
         case let ._0(displayMode):
-            if #available(visionOS 1.0,iOS 14.0,watchOS 8.0, *) {
+            if #available(watchOS 8.0,visionOS 1.0,iOS 14.0, *) {
             let displayMode = displayMode as! SwiftUI.NavigationBarItem.TitleDisplayMode
             
             __content
@@ -7023,7 +7023,7 @@ struct _navigationTitleModifier<R: RootRegistry>: ViewModifier {
     }
     
     #if os(watchOS)
-    @available(tvOS 14.0,iOS 14.0,macOS 11.0,watchOS 7.0, *)
+    @available(watchOS 7.0,macOS 11.0,iOS 14.0,tvOS 14.0, *)
     init(_ title: ViewReference=ViewReference(value: [])) {
         self.value = ._3(title: title)
         
@@ -7076,7 +7076,7 @@ struct _navigationTitleModifier<R: RootRegistry>: ViewModifier {
         
         #if os(watchOS)
         case let ._3(title):
-            if #available(tvOS 14.0,iOS 14.0,macOS 11.0,watchOS 7.0, *) {
+            if #available(watchOS 7.0,macOS 11.0,iOS 14.0,tvOS 14.0, *) {
             let title = title as! ViewReference
             
             __content
@@ -7261,7 +7261,7 @@ struct _onDeleteCommandModifier<R: RootRegistry>: ViewModifier {
 @Event private var _0_action__0: Event.EventHandler
 
     #if os(macOS)
-    @available(tvOS 13.0,macOS 10.15, *)
+    @available(macOS 10.15,tvOS 13.0, *)
     init(perform action__0: Event=Event()) {
         self.value = ._0
         self.__0_action__0 = action__0
@@ -7274,7 +7274,7 @@ struct _onDeleteCommandModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(macOS)
         case ._0:
-            if #available(tvOS 13.0,macOS 10.15, *) {
+            if #available(macOS 10.15,tvOS 13.0, *) {
             
             
             __content
@@ -7402,7 +7402,7 @@ struct _onHoverModifier<R: RootRegistry>: ViewModifier {
 @Event private var _0_action__1: Event.EventHandler
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(iOS 13.4,visionOS 1.0,macOS 10.15, *)
+    @available(macOS 10.15,visionOS 1.0,iOS 13.4, *)
     init(perform action__1: Event) {
         self.value = ._0
         self.__0_action__1 = action__1
@@ -7415,7 +7415,7 @@ struct _onHoverModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case ._0:
-            if #available(iOS 13.4,visionOS 1.0,macOS 10.15, *) {
+            if #available(macOS 10.15,visionOS 1.0,iOS 13.4, *) {
             
             
             __content
@@ -7456,7 +7456,7 @@ struct _onLongPressGestureModifier<R: RootRegistry>: ViewModifier {
 @Event private var _1_onPressingChanged__1: Event.EventHandler
 
     #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 6.0,macOS 10.15,tvOS 14.0,visionOS 1.0,iOS 13.0, *)
+    @available(watchOS 6.0,iOS 13.0,visionOS 1.0,macOS 10.15,tvOS 14.0, *)
     init(minimumDuration: AttributeReference<Swift.Double> = .init(storage: .constant(0.5)), maximumDistance: AttributeReference<CoreFoundation.CGFloat> = .init(storage: .constant(10)), perform action__0: Event,onPressingChanged onPressingChanged__1: Event=Event() ) {
         self.value = ._0(minimumDuration: minimumDuration, maximumDistance: maximumDistance)
         self.__0_action__0 = action__0
@@ -7464,7 +7464,7 @@ self.__0_onPressingChanged__1 = onPressingChanged__1
     }
     #endif
     #if os(tvOS)
-    @available(watchOS 6.0,macOS 10.15,tvOS 14.0,iOS 13.0, *)
+    @available(watchOS 6.0,iOS 13.0,macOS 10.15,tvOS 14.0, *)
     init(minimumDuration: AttributeReference<Swift.Double> = .init(storage: .constant(0.5)), perform action__0: Event,onPressingChanged onPressingChanged__1: Event=Event() ) {
         self.value = ._1(minimumDuration: minimumDuration)
         self.__1_action__0 = action__0
@@ -7478,7 +7478,7 @@ self.__1_onPressingChanged__1 = onPressingChanged__1
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
         case let ._0(minimumDuration, maximumDistance):
-            if #available(watchOS 6.0,macOS 10.15,tvOS 14.0,visionOS 1.0,iOS 13.0, *) {
+            if #available(watchOS 6.0,iOS 13.0,visionOS 1.0,macOS 10.15,tvOS 14.0, *) {
             let minimumDuration = minimumDuration as! AttributeReference<Swift.Double>
 let maximumDistance = maximumDistance as! AttributeReference<CoreFoundation.CGFloat>
             
@@ -7490,7 +7490,7 @@ let maximumDistance = maximumDistance as! AttributeReference<CoreFoundation.CGFl
         #endif
         #if os(tvOS)
         case let ._1(minimumDuration):
-            if #available(watchOS 6.0,macOS 10.15,tvOS 14.0,iOS 13.0, *) {
+            if #available(watchOS 6.0,iOS 13.0,macOS 10.15,tvOS 14.0, *) {
             let minimumDuration = minimumDuration as! AttributeReference<Swift.Double>
             
             __content
@@ -7620,7 +7620,7 @@ struct _onPlayPauseCommandModifier<R: RootRegistry>: ViewModifier {
 @Event private var _0_action__0: Event.EventHandler
 
     #if os(tvOS)
-    @available(tvOS 13.0,macOS 10.15, *)
+    @available(macOS 10.15,tvOS 13.0, *)
     init(perform action__0: Event=Event()) {
         self.value = ._0
         self.__0_action__0 = action__0
@@ -7633,7 +7633,7 @@ struct _onPlayPauseCommandModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(tvOS)
         case ._0:
-            if #available(tvOS 13.0,macOS 10.15, *) {
+            if #available(macOS 10.15,tvOS 13.0, *) {
             
             
             __content
@@ -7679,7 +7679,7 @@ struct _onTapGestureModifier<R: RootRegistry>: ViewModifier {
     }
     
     #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,macOS 14.0,iOS 17.0,watchOS 10.0, *)
+    @available(visionOS 1.0,macOS 14.0,watchOS 10.0,iOS 17.0, *)
     init(count: AttributeReference<Swift.Int> = .init(storage: .constant(1)), coordinateSpace: AnyCoordinateSpaceProtocol = .local, perform action__1: Event) {
         self.value = ._1(count: count, coordinateSpace: coordinateSpace)
         self.__1_action__1 = action__1
@@ -7703,7 +7703,7 @@ struct _onTapGestureModifier<R: RootRegistry>: ViewModifier {
         
         #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
         case let ._1(count, coordinateSpace):
-            if #available(visionOS 1.0,macOS 14.0,iOS 17.0,watchOS 10.0, *) {
+            if #available(visionOS 1.0,macOS 14.0,watchOS 10.0,iOS 17.0, *) {
             let count = count as! AttributeReference<Swift.Int>
 let coordinateSpace = coordinateSpace as! AnyCoordinateSpaceProtocol 
             
@@ -8209,7 +8209,7 @@ struct _popoverModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(iOS 13.0,macOS 10.15,visionOS 1.0, *)
+    @available(macOS 10.15,visionOS 1.0,iOS 13.0, *)
     init(isPresented: ChangeTracked<Swift.Bool>,attachmentAnchor: SwiftUI.PopoverAttachmentAnchor = .rect(.bounds), arrowEdge: SwiftUI.Edge = .top, content: ViewReference=ViewReference(value: [])) {
         self.value = ._0(attachmentAnchor: attachmentAnchor, arrowEdge: arrowEdge, content: content)
         self.__0_isPresented = isPresented
@@ -8222,7 +8222,7 @@ struct _popoverModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(attachmentAnchor, arrowEdge, content):
-            if #available(iOS 13.0,macOS 10.15,visionOS 1.0, *) {
+            if #available(macOS 10.15,visionOS 1.0,iOS 13.0, *) {
             let attachmentAnchor = attachmentAnchor as! SwiftUI.PopoverAttachmentAnchor 
 let arrowEdge = arrowEdge as! SwiftUI.Edge 
 let content = content as! ViewReference
@@ -8427,14 +8427,14 @@ struct _presentationBackgroundModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,macOS 13.3,tvOS 16.4,iOS 16.4,watchOS 9.4, *)
+    @available(watchOS 9.4,visionOS 1.0,tvOS 16.4,macOS 13.3,iOS 16.4, *)
     init(_ style: AnyShapeStyle.Resolvable) {
         self.value = ._0(style: style)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,macOS 13.3,tvOS 16.4,iOS 16.4,watchOS 9.4, *)
+    @available(watchOS 9.4,visionOS 1.0,tvOS 16.4,macOS 13.3,iOS 16.4, *)
     init(alignment: AttributeReference<SwiftUI.Alignment> = .init(storage: .constant(.center)), content: ViewReference=ViewReference(value: [])) {
         self.value = ._1(alignment: alignment, content: content)
         
@@ -8447,7 +8447,7 @@ struct _presentationBackgroundModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(style):
-            if #available(visionOS 1.0,macOS 13.3,tvOS 16.4,iOS 16.4,watchOS 9.4, *) {
+            if #available(watchOS 9.4,visionOS 1.0,tvOS 16.4,macOS 13.3,iOS 16.4, *) {
             let style = style as! AnyShapeStyle.Resolvable
             
             __content
@@ -8458,7 +8458,7 @@ struct _presentationBackgroundModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(alignment, content):
-            if #available(visionOS 1.0,macOS 13.3,tvOS 16.4,iOS 16.4,watchOS 9.4, *) {
+            if #available(watchOS 9.4,visionOS 1.0,tvOS 16.4,macOS 13.3,iOS 16.4, *) {
             let alignment = alignment as! AttributeReference<SwiftUI.Alignment>
 let content = content as! ViewReference
             
@@ -8493,7 +8493,7 @@ struct _presentationBackgroundInteractionModifier<R: RootRegistry>: ViewModifier
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,macOS 13.3,tvOS 16.4,iOS 16.4,watchOS 9.4, *)
+    @available(visionOS 1.0,watchOS 9.4,macOS 13.3,tvOS 16.4,iOS 16.4, *)
     init(_ interaction: SwiftUI.PresentationBackgroundInteraction) {
         self.value = ._0(interaction: interaction)
         
@@ -8506,7 +8506,7 @@ struct _presentationBackgroundInteractionModifier<R: RootRegistry>: ViewModifier
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(interaction):
-            if #available(visionOS 1.0,macOS 13.3,tvOS 16.4,iOS 16.4,watchOS 9.4, *) {
+            if #available(visionOS 1.0,watchOS 9.4,macOS 13.3,tvOS 16.4,iOS 16.4, *) {
             let interaction = interaction as! SwiftUI.PresentationBackgroundInteraction
             
             __content
@@ -8545,14 +8545,14 @@ struct _presentationCompactAdaptationModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,macOS 13.3,tvOS 16.4,iOS 16.4,watchOS 9.4, *)
+    @available(visionOS 1.0,watchOS 9.4,macOS 13.3,tvOS 16.4,iOS 16.4, *)
     init(_ adaptation: SwiftUI.PresentationAdaptation) {
         self.value = ._0(adaptation: adaptation)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,macOS 13.3,tvOS 16.4,iOS 16.4,watchOS 9.4, *)
+    @available(visionOS 1.0,watchOS 9.4,macOS 13.3,tvOS 16.4,iOS 16.4, *)
     init(horizontal horizontalAdaptation: SwiftUI.PresentationAdaptation,vertical verticalAdaptation: SwiftUI.PresentationAdaptation) {
         self.value = ._1(horizontalAdaptation: horizontalAdaptation, verticalAdaptation: verticalAdaptation)
         
@@ -8565,7 +8565,7 @@ struct _presentationCompactAdaptationModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(adaptation):
-            if #available(visionOS 1.0,macOS 13.3,tvOS 16.4,iOS 16.4,watchOS 9.4, *) {
+            if #available(visionOS 1.0,watchOS 9.4,macOS 13.3,tvOS 16.4,iOS 16.4, *) {
             let adaptation = adaptation as! SwiftUI.PresentationAdaptation
             
             __content
@@ -8576,7 +8576,7 @@ struct _presentationCompactAdaptationModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(horizontalAdaptation, verticalAdaptation):
-            if #available(visionOS 1.0,macOS 13.3,tvOS 16.4,iOS 16.4,watchOS 9.4, *) {
+            if #available(visionOS 1.0,watchOS 9.4,macOS 13.3,tvOS 16.4,iOS 16.4, *) {
             let horizontalAdaptation = horizontalAdaptation as! SwiftUI.PresentationAdaptation
 let verticalAdaptation = verticalAdaptation as! SwiftUI.PresentationAdaptation
             
@@ -8611,7 +8611,7 @@ struct _presentationContentInteractionModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,macOS 13.3,tvOS 16.4,iOS 16.4,watchOS 9.4, *)
+    @available(visionOS 1.0,watchOS 9.4,macOS 13.3,tvOS 16.4,iOS 16.4, *)
     init(_ behavior: SwiftUI.PresentationContentInteraction) {
         self.value = ._0(behavior: behavior)
         
@@ -8624,7 +8624,7 @@ struct _presentationContentInteractionModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(behavior):
-            if #available(visionOS 1.0,macOS 13.3,tvOS 16.4,iOS 16.4,watchOS 9.4, *) {
+            if #available(visionOS 1.0,watchOS 9.4,macOS 13.3,tvOS 16.4,iOS 16.4, *) {
             let behavior = behavior as! SwiftUI.PresentationContentInteraction
             
             __content
@@ -8658,7 +8658,7 @@ struct _presentationCornerRadiusModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,macOS 13.3,tvOS 16.4,iOS 16.4,watchOS 9.4, *)
+    @available(visionOS 1.0,watchOS 9.4,macOS 13.3,tvOS 16.4,iOS 16.4, *)
     init(_ cornerRadius: AttributeReference<CoreFoundation.CGFloat?>?) {
         self.value = ._0(cornerRadius: cornerRadius)
         
@@ -8671,7 +8671,7 @@ struct _presentationCornerRadiusModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(cornerRadius):
-            if #available(visionOS 1.0,macOS 13.3,tvOS 16.4,iOS 16.4,watchOS 9.4, *) {
+            if #available(visionOS 1.0,watchOS 9.4,macOS 13.3,tvOS 16.4,iOS 16.4, *) {
             let cornerRadius = cornerRadius as? AttributeReference<CoreFoundation.CGFloat?>
             
             __content
@@ -9255,21 +9255,21 @@ struct _safeAreaPaddingModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 10.0,tvOS 17.0,iOS 17.0,macOS 14.0,visionOS 1.0, *)
+    @available(visionOS 1.0,tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0, *)
     init(_ insets: SwiftUI.EdgeInsets) {
         self.value = ._0(insets: insets)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 10.0,tvOS 17.0,iOS 17.0,macOS 14.0,visionOS 1.0, *)
+    @available(visionOS 1.0,tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0, *)
     init(_ edges: SwiftUI.Edge.Set = .all, _ length: AttributeReference<CoreFoundation.CGFloat?>? = .init(storage: .constant(nil)) ) {
         self.value = ._1(edges: edges, length: length)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 10.0,tvOS 17.0,iOS 17.0,macOS 14.0,visionOS 1.0, *)
+    @available(visionOS 1.0,tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0, *)
     init(_ length: AttributeReference<CoreFoundation.CGFloat>) {
         self.value = ._2(length: length)
         
@@ -9282,7 +9282,7 @@ struct _safeAreaPaddingModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(insets):
-            if #available(watchOS 10.0,tvOS 17.0,iOS 17.0,macOS 14.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0, *) {
             let insets = insets as! SwiftUI.EdgeInsets
             
             __content
@@ -9293,7 +9293,7 @@ struct _safeAreaPaddingModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(edges, length):
-            if #available(watchOS 10.0,tvOS 17.0,iOS 17.0,macOS 14.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0, *) {
             let edges = edges as! SwiftUI.Edge.Set 
 let length = length as? AttributeReference<CoreFoundation.CGFloat?>
             
@@ -9305,7 +9305,7 @@ let length = length as? AttributeReference<CoreFoundation.CGFloat?>
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._2(length):
-            if #available(watchOS 10.0,tvOS 17.0,iOS 17.0,macOS 14.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0, *) {
             let length = length as! AttributeReference<CoreFoundation.CGFloat>
             
             __content
@@ -9717,7 +9717,7 @@ struct _scrollBounceBehaviorModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(iOS 16.4,watchOS 9.4,tvOS 16.4,macOS 13.3,visionOS 1.0, *)
+    @available(iOS 16.4,tvOS 16.4,watchOS 9.4,visionOS 1.0,macOS 13.3, *)
     init(_ behavior: SwiftUI.ScrollBounceBehavior,axes: SwiftUI.Axis.Set = [.vertical] ) {
         self.value = ._0(behavior: behavior, axes: axes)
         
@@ -9730,7 +9730,7 @@ struct _scrollBounceBehaviorModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(behavior, axes):
-            if #available(iOS 16.4,watchOS 9.4,tvOS 16.4,macOS 13.3,visionOS 1.0, *) {
+            if #available(iOS 16.4,tvOS 16.4,watchOS 9.4,visionOS 1.0,macOS 13.3, *) {
             let behavior = behavior as! SwiftUI.ScrollBounceBehavior
 let axes = axes as! SwiftUI.Axis.Set 
             
@@ -9765,7 +9765,7 @@ struct _scrollClipDisabledModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(iOS 17.0,watchOS 10.0,tvOS 17.0,macOS 14.0,visionOS 1.0, *)
+    @available(tvOS 17.0,iOS 17.0,watchOS 10.0,visionOS 1.0,macOS 14.0, *)
     init(_ disabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(disabled: disabled)
         
@@ -9778,7 +9778,7 @@ struct _scrollClipDisabledModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(disabled):
-            if #available(iOS 17.0,watchOS 10.0,tvOS 17.0,macOS 14.0,visionOS 1.0, *) {
+            if #available(tvOS 17.0,iOS 17.0,watchOS 10.0,visionOS 1.0,macOS 14.0, *) {
             let disabled = disabled as! AttributeReference<Swift.Bool>
             
             __content
@@ -9812,7 +9812,7 @@ struct _scrollContentBackgroundModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,macOS 13.0,iOS 16.0,watchOS 9.0, *)
+    @available(macOS 13.0,iOS 16.0,visionOS 1.0,watchOS 9.0, *)
     init(_ visibility: AttributeReference<SwiftUI.Visibility>) {
         self.value = ._0(visibility: visibility)
         
@@ -9825,7 +9825,7 @@ struct _scrollContentBackgroundModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
         case let ._0(visibility):
-            if #available(visionOS 1.0,macOS 13.0,iOS 16.0,watchOS 9.0, *) {
+            if #available(macOS 13.0,iOS 16.0,visionOS 1.0,watchOS 9.0, *) {
             let visibility = visibility as! AttributeReference<SwiftUI.Visibility>
             
             __content
@@ -9906,7 +9906,7 @@ struct _scrollDismissesKeyboardModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-    @available(iOS 16.0,watchOS 9.0,tvOS 16.0,macOS 13.0, *)
+    @available(watchOS 9.0,macOS 13.0,iOS 16.0,tvOS 16.0, *)
     init(_ mode: SwiftUI.ScrollDismissesKeyboardMode) {
         self.value = ._0(mode: mode)
         
@@ -9919,7 +9919,7 @@ struct _scrollDismissesKeyboardModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
         case let ._0(mode):
-            if #available(iOS 16.0,watchOS 9.0,tvOS 16.0,macOS 13.0, *) {
+            if #available(watchOS 9.0,macOS 13.0,iOS 16.0,tvOS 16.0, *) {
             let mode = mode as! SwiftUI.ScrollDismissesKeyboardMode
             
             __content
@@ -10005,14 +10005,14 @@ struct _scrollIndicatorsFlashModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(iOS 17.0,watchOS 10.0,tvOS 17.0,macOS 14.0,visionOS 1.0, *)
+    @available(watchOS 10.0,macOS 14.0,visionOS 1.0,iOS 17.0,tvOS 17.0, *)
     init(trigger value: AttributeReference<String>) {
         self.value = ._0(value: value)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(iOS 17.0,watchOS 10.0,tvOS 17.0,macOS 14.0,visionOS 1.0, *)
+    @available(watchOS 10.0,macOS 14.0,visionOS 1.0,iOS 17.0,tvOS 17.0, *)
     init(onAppear: AttributeReference<Swift.Bool>) {
         self.value = ._1(onAppear: onAppear)
         
@@ -10025,7 +10025,7 @@ struct _scrollIndicatorsFlashModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(value):
-            if #available(iOS 17.0,watchOS 10.0,tvOS 17.0,macOS 14.0,visionOS 1.0, *) {
+            if #available(watchOS 10.0,macOS 14.0,visionOS 1.0,iOS 17.0,tvOS 17.0, *) {
             let value = value as! AttributeReference<String>
             
             __content
@@ -10036,7 +10036,7 @@ struct _scrollIndicatorsFlashModifier<R: RootRegistry>: ViewModifier {
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(onAppear):
-            if #available(iOS 17.0,watchOS 10.0,tvOS 17.0,macOS 14.0,visionOS 1.0, *) {
+            if #available(watchOS 10.0,macOS 14.0,visionOS 1.0,iOS 17.0,tvOS 17.0, *) {
             let onAppear = onAppear as! AttributeReference<Swift.Bool>
             
             __content
@@ -10070,7 +10070,7 @@ struct _scrollPositionModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 10.0,tvOS 17.0,iOS 17.0,macOS 14.0,visionOS 1.0, *)
+    @available(visionOS 1.0,macOS 14.0,watchOS 10.0,tvOS 17.0,iOS 17.0, *)
     init(id: ChangeTracked<String?>,anchor: AttributeReference<SwiftUI.UnitPoint?>? = .init(storage: .constant(nil)) ) {
         self.value = ._0(anchor: anchor)
         self.__0_id = id
@@ -10083,7 +10083,7 @@ struct _scrollPositionModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(anchor):
-            if #available(watchOS 10.0,tvOS 17.0,iOS 17.0,macOS 14.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,macOS 14.0,watchOS 10.0,tvOS 17.0,iOS 17.0, *) {
             let anchor = anchor as? AttributeReference<SwiftUI.UnitPoint?>
             
             __content
@@ -10117,7 +10117,7 @@ struct _scrollTargetBehaviorModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0,visionOS 1.0, *)
+    @available(iOS 17.0,tvOS 17.0,watchOS 10.0,visionOS 1.0,macOS 14.0, *)
     init(_ behavior: AnyScrollTargetBehavior) {
         self.value = ._0(behavior: behavior)
         
@@ -10130,7 +10130,7 @@ struct _scrollTargetBehaviorModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(behavior):
-            if #available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0,visionOS 1.0, *) {
+            if #available(iOS 17.0,tvOS 17.0,watchOS 10.0,visionOS 1.0,macOS 14.0, *) {
             let behavior = behavior as! AnyScrollTargetBehavior
             
             __content
@@ -10164,7 +10164,7 @@ struct _scrollTargetLayoutModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0,visionOS 1.0, *)
+    @available(watchOS 10.0,macOS 14.0,visionOS 1.0,iOS 17.0,tvOS 17.0, *)
     init(isEnabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(isEnabled: isEnabled)
         
@@ -10177,7 +10177,7 @@ struct _scrollTargetLayoutModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(isEnabled):
-            if #available(iOS 17.0,watchOS 10.0,macOS 14.0,tvOS 17.0,visionOS 1.0, *) {
+            if #available(watchOS 10.0,macOS 14.0,visionOS 1.0,iOS 17.0,tvOS 17.0, *) {
             let isEnabled = isEnabled as! AttributeReference<Swift.Bool>
             
             __content
@@ -10211,7 +10211,7 @@ struct _searchDictationBehaviorModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(visionOS)
-    @available(iOS 17.0,visionOS 1.0, *)
+    @available(visionOS 1.0,iOS 17.0, *)
     init(_ dictationBehavior: SwiftUI.TextInputDictationBehavior) {
         self.value = ._0(dictationBehavior: dictationBehavior)
         
@@ -10224,7 +10224,7 @@ struct _searchDictationBehaviorModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(visionOS)
         case let ._0(dictationBehavior):
-            if #available(iOS 17.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,iOS 17.0, *) {
             let dictationBehavior = dictationBehavior as! SwiftUI.TextInputDictationBehavior
             
             __content
@@ -10258,7 +10258,7 @@ struct _searchPresentationToolbarBehaviorModifier<R: RootRegistry>: ViewModifier
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,tvOS 17.1,macOS 14.1,iOS 17.1,watchOS 10.1, *)
+    @available(iOS 17.1,watchOS 10.1,tvOS 17.1,macOS 14.1,visionOS 1.0, *)
     init(_ behavior: SwiftUI.SearchPresentationToolbarBehavior) {
         self.value = ._0(behavior: behavior)
         
@@ -10271,7 +10271,7 @@ struct _searchPresentationToolbarBehaviorModifier<R: RootRegistry>: ViewModifier
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(behavior):
-            if #available(visionOS 1.0,tvOS 17.1,macOS 14.1,iOS 17.1,watchOS 10.1, *) {
+            if #available(iOS 17.1,watchOS 10.1,tvOS 17.1,macOS 14.1,visionOS 1.0, *) {
             let behavior = behavior as! SwiftUI.SearchPresentationToolbarBehavior
             
             __content
@@ -10424,7 +10424,7 @@ struct _searchableModifier<R: RootRegistry>: ViewModifier {
     }
     
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(iOS 17.0,macOS 14.0,visionOS 1.0, *)
+    @available(macOS 14.0,visionOS 1.0,iOS 17.0, *)
     init(text: ChangeTracked<Swift.String>,isPresented: ChangeTracked<Swift.Bool>,placement: SwiftUI.SearchFieldPlacement = .automatic, prompt: TextReference? = nil ) {
         self.value = ._3(placement: placement, prompt: prompt)
         self.__3_text = text
@@ -10432,7 +10432,7 @@ self.__3_isPresented = isPresented
     }
     #endif
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(iOS 17.0,macOS 14.0,visionOS 1.0, *)
+    @available(macOS 14.0,visionOS 1.0,iOS 17.0, *)
     init(text: ChangeTracked<Swift.String>,isPresented: ChangeTracked<Swift.Bool>,placement: SwiftUI.SearchFieldPlacement = .automatic, prompt: SwiftUI.LocalizedStringKey) {
         self.value = ._4(placement: placement, prompt: prompt)
         self.__4_text = text
@@ -10440,7 +10440,7 @@ self.__4_isPresented = isPresented
     }
     #endif
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(iOS 17.0,macOS 14.0,visionOS 1.0, *)
+    @available(macOS 14.0,visionOS 1.0,iOS 17.0, *)
     init(text: ChangeTracked<Swift.String>,isPresented: ChangeTracked<Swift.Bool>,placement: SwiftUI.SearchFieldPlacement = .automatic, prompt: AttributeReference<String>) {
         self.value = ._5(placement: placement, prompt: prompt)
         self.__5_text = text
@@ -10487,7 +10487,7 @@ self.__5_isPresented = isPresented
         
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._3(placement, prompt):
-            if #available(iOS 17.0,macOS 14.0,visionOS 1.0, *) {
+            if #available(macOS 14.0,visionOS 1.0,iOS 17.0, *) {
             let placement = placement as! SwiftUI.SearchFieldPlacement 
 let prompt = prompt as? TextReference
             __content._observeTextReference(prompt, on: element, in: context) { __content in
@@ -10499,7 +10499,7 @@ let prompt = prompt as? TextReference
         #endif
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._4(placement, prompt):
-            if #available(iOS 17.0,macOS 14.0,visionOS 1.0, *) {
+            if #available(macOS 14.0,visionOS 1.0,iOS 17.0, *) {
             let placement = placement as! SwiftUI.SearchFieldPlacement 
 let prompt = prompt as! SwiftUI.LocalizedStringKey
             
@@ -10511,7 +10511,7 @@ let prompt = prompt as! SwiftUI.LocalizedStringKey
         #endif
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._5(placement, prompt):
-            if #available(iOS 17.0,macOS 14.0,visionOS 1.0, *) {
+            if #available(macOS 14.0,visionOS 1.0,iOS 17.0, *) {
             let placement = placement as! SwiftUI.SearchFieldPlacement 
 let prompt = prompt as! AttributeReference<String>
             
@@ -10546,7 +10546,7 @@ struct _selectionDisabledModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 10.0,visionOS 1.0,iOS 17.0,tvOS 17.0,macOS 14.0, *)
+    @available(iOS 17.0,watchOS 10.0,tvOS 17.0,macOS 14.0,visionOS 1.0, *)
     init(_ isDisabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(isDisabled: isDisabled)
         
@@ -10559,7 +10559,7 @@ struct _selectionDisabledModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(isDisabled):
-            if #available(watchOS 10.0,visionOS 1.0,iOS 17.0,tvOS 17.0,macOS 14.0, *) {
+            if #available(iOS 17.0,watchOS 10.0,tvOS 17.0,macOS 14.0,visionOS 1.0, *) {
             let isDisabled = isDisabled as! AttributeReference<Swift.Bool>
             
             __content
@@ -11064,7 +11064,7 @@ struct _swipeActionsModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
-    @available(iOS 15.0,watchOS 8.0,macOS 12.0,visionOS 1.0, *)
+    @available(watchOS 8.0,iOS 15.0,visionOS 1.0,macOS 12.0, *)
     init(edge: SwiftUI.HorizontalEdge = .trailing, allowsFullSwipe: AttributeReference<Swift.Bool> = .init(storage: .constant(true)), content: ViewReference=ViewReference(value: [])) {
         self.value = ._0(edge: edge, allowsFullSwipe: allowsFullSwipe, content: content)
         
@@ -11077,7 +11077,7 @@ struct _swipeActionsModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
         case let ._0(edge, allowsFullSwipe, content):
-            if #available(iOS 15.0,watchOS 8.0,macOS 12.0,visionOS 1.0, *) {
+            if #available(watchOS 8.0,iOS 15.0,visionOS 1.0,macOS 12.0, *) {
             let edge = edge as! SwiftUI.HorizontalEdge 
 let allowsFullSwipe = allowsFullSwipe as! AttributeReference<Swift.Bool>
 let content = content as! ViewReference
@@ -11118,14 +11118,14 @@ struct _symbolEffectModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 10.0,tvOS 17.0,iOS 17.0,macOS 14.0,visionOS 1.0, *)
+    @available(visionOS 1.0,macOS 14.0,watchOS 10.0,tvOS 17.0,iOS 17.0, *)
     init(_ effect: AnyIndefiniteSymbolEffect,options: Symbols.SymbolEffectOptions = .default, isActive: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(effect: effect, options: options, isActive: isActive)
         
     }
     #endif
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 10.0,tvOS 17.0,iOS 17.0,macOS 14.0,visionOS 1.0, *)
+    @available(visionOS 1.0,macOS 14.0,watchOS 10.0,tvOS 17.0,iOS 17.0, *)
     init(_ effect: AnyDiscreteSymbolEffect,options: Symbols.SymbolEffectOptions = .default, value: AttributeReference<String>) {
         self.value = ._1(effect: effect, options: options, value: value)
         
@@ -11138,7 +11138,7 @@ struct _symbolEffectModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(effect, options, isActive):
-            if #available(watchOS 10.0,tvOS 17.0,iOS 17.0,macOS 14.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,macOS 14.0,watchOS 10.0,tvOS 17.0,iOS 17.0, *) {
             let effect = effect as! AnyIndefiniteSymbolEffect
 let options = options as! Symbols.SymbolEffectOptions 
 let isActive = isActive as! AttributeReference<Swift.Bool>
@@ -11151,7 +11151,7 @@ let isActive = isActive as! AttributeReference<Swift.Bool>
         #endif
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(effect, options, value):
-            if #available(watchOS 10.0,tvOS 17.0,iOS 17.0,macOS 14.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,macOS 14.0,watchOS 10.0,tvOS 17.0,iOS 17.0, *) {
             let effect = effect as! AnyDiscreteSymbolEffect
 let options = options as! Symbols.SymbolEffectOptions 
 let value = value as! AttributeReference<String>
@@ -11187,7 +11187,7 @@ struct _symbolEffectsRemovedModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 10.0,visionOS 1.0,iOS 17.0,tvOS 17.0,macOS 14.0, *)
+    @available(iOS 17.0,watchOS 10.0,tvOS 17.0,macOS 14.0,visionOS 1.0, *)
     init(_ isEnabled: AttributeReference<Swift.Bool> = .init(storage: .constant(true)) ) {
         self.value = ._0(isEnabled: isEnabled)
         
@@ -11200,7 +11200,7 @@ struct _symbolEffectsRemovedModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(isEnabled):
-            if #available(watchOS 10.0,visionOS 1.0,iOS 17.0,tvOS 17.0,macOS 14.0, *) {
+            if #available(iOS 17.0,watchOS 10.0,tvOS 17.0,macOS 14.0,visionOS 1.0, *) {
             let isEnabled = isEnabled as! AttributeReference<Swift.Bool>
             
             __content
@@ -11422,7 +11422,7 @@ struct _tableStyleModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(visionOS 1.0,iOS 16.0,macOS 12.0, *)
+    @available(macOS 12.0,visionOS 1.0,iOS 16.0, *)
     init(_ style: AnyTableStyle) {
         self.value = ._0(style: style)
         
@@ -11435,7 +11435,7 @@ struct _tableStyleModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(style):
-            if #available(visionOS 1.0,iOS 16.0,macOS 12.0, *) {
+            if #available(macOS 12.0,visionOS 1.0,iOS 16.0, *) {
             let style = style as! AnyTableStyle
             
             __content
@@ -11516,7 +11516,7 @@ struct _textContentTypeModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(tvOS) || os(visionOS)
-    @available(iOS 13.0,tvOS 13.0,visionOS 1.0, *)
+    @available(tvOS 13.0,visionOS 1.0,iOS 13.0, *)
     init(_ textContentType: UIKit.UITextContentType?) {
         self.value = ._0(textContentType: textContentType)
         
@@ -11529,7 +11529,7 @@ struct _textContentTypeModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(tvOS) || os(visionOS)
         case let ._0(textContentType):
-            if #available(iOS 13.0,tvOS 13.0,visionOS 1.0, *) {
+            if #available(tvOS 13.0,visionOS 1.0,iOS 13.0, *) {
             let textContentType = textContentType as? UIKit.UITextContentType
             
             __content
@@ -11563,7 +11563,7 @@ struct _textEditorStyleModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(iOS 17.0,macOS 14.0,visionOS 1.0, *)
+    @available(macOS 14.0,visionOS 1.0,iOS 17.0, *)
     init(_ style: AnyTextEditorStyle) {
         self.value = ._0(style: style)
         
@@ -11576,7 +11576,7 @@ struct _textEditorStyleModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(style):
-            if #available(iOS 17.0,macOS 14.0,visionOS 1.0, *) {
+            if #available(macOS 14.0,visionOS 1.0,iOS 17.0, *) {
             let style = style as! AnyTextEditorStyle
             
             __content
@@ -11657,7 +11657,7 @@ struct _textInputAutocapitalizationModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(watchOS 8.0,tvOS 15.0,iOS 15.0,visionOS 1.0, *)
+    @available(visionOS 1.0,watchOS 8.0,tvOS 15.0,iOS 15.0, *)
     init(_ autocapitalization: SwiftUI.TextInputAutocapitalization?) {
         self.value = ._0(autocapitalization: autocapitalization)
         
@@ -11670,7 +11670,7 @@ struct _textInputAutocapitalizationModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(autocapitalization):
-            if #available(watchOS 8.0,tvOS 15.0,iOS 15.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,watchOS 8.0,tvOS 15.0,iOS 15.0, *) {
             let autocapitalization = autocapitalization as? SwiftUI.TextInputAutocapitalization
             
             __content
@@ -11704,7 +11704,7 @@ struct _textSelectionModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(visionOS)
-    @available(iOS 15.0,macOS 12.0,visionOS 1.0, *)
+    @available(visionOS 1.0,iOS 15.0,macOS 12.0, *)
     init(_ selectability: AnyTextSelectability) {
         self.value = ._0(selectability: selectability)
         
@@ -11717,7 +11717,7 @@ struct _textSelectionModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(visionOS)
         case let ._0(selectability):
-            if #available(iOS 15.0,macOS 12.0,visionOS 1.0, *) {
+            if #available(visionOS 1.0,iOS 15.0,macOS 12.0, *) {
             let selectability = selectability as! AnyTextSelectability
             
             __content
@@ -11890,7 +11890,7 @@ struct _toolbarModifier<R: RootRegistry>: ViewModifier {
     }
     
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0, *)
+    @available(iOS 17.0,watchOS 10.0,visionOS 1.0,macOS 14.0,tvOS 17.0, *)
     init(removing defaultItemKind: SwiftUI.ToolbarDefaultItemKind?) {
         self.value = ._1(defaultItemKind: defaultItemKind)
         
@@ -11928,7 +11928,7 @@ struct _toolbarModifier<R: RootRegistry>: ViewModifier {
         
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._1(defaultItemKind):
-            if #available(visionOS 1.0,tvOS 17.0,iOS 17.0,macOS 14.0,watchOS 10.0, *) {
+            if #available(iOS 17.0,watchOS 10.0,visionOS 1.0,macOS 14.0,tvOS 17.0, *) {
             let defaultItemKind = defaultItemKind as? SwiftUI.ToolbarDefaultItemKind
             
             __content
@@ -12148,7 +12148,7 @@ struct _toolbarTitleDisplayModeModifier<R: RootRegistry>: ViewModifier {
 
 
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-    @available(visionOS 1.0,tvOS 17.0,macOS 14.0,iOS 17.0,watchOS 10.0, *)
+    @available(watchOS 10.0,macOS 14.0,visionOS 1.0,iOS 17.0,tvOS 17.0, *)
     init(_ mode: SwiftUI.ToolbarTitleDisplayMode) {
         self.value = ._0(mode: mode)
         
@@ -12161,7 +12161,7 @@ struct _toolbarTitleDisplayModeModifier<R: RootRegistry>: ViewModifier {
             fatalError("unreachable")
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
         case let ._0(mode):
-            if #available(visionOS 1.0,tvOS 17.0,macOS 14.0,iOS 17.0,watchOS 10.0, *) {
+            if #available(watchOS 10.0,macOS 14.0,visionOS 1.0,iOS 17.0,tvOS 17.0, *) {
             let mode = mode as! SwiftUI.ToolbarTitleDisplayMode
             
             __content
@@ -13469,16 +13469,16 @@ indirect case chunk12(_BuiltinModifierChunk12)
 indirect case chunk13(_BuiltinModifierChunk13)
 indirect case chunk14(_BuiltinModifierChunk14)
 indirect case chunk15(_BuiltinModifierChunk15)
-        indirect case _Rotation3DEffectModifier(LiveViewNative._Rotation3DEffectModifier<R>)
-indirect case _PrefersDefaultFocusModifier(LiveViewNative._PrefersDefaultFocusModifier<R>)
-indirect case _MaskModifier(LiveViewNative._MaskModifier<R>)
-indirect case _FocusScopeModifier(LiveViewNative._FocusScopeModifier<R>)
-indirect case _PerspectiveRotationEffectModifier(LiveViewNative._PerspectiveRotationEffectModifier<R>)
-indirect case _SearchScopesModifier(LiveViewNative._SearchScopesModifier<R>)
-indirect case _SearchCompletionModifier(LiveViewNative._SearchCompletionModifier<R>)
-indirect case _OnSubmitModifier(LiveViewNative._OnSubmitModifier)
-indirect case _MatchedGeometryEffectModifier(LiveViewNative._MatchedGeometryEffectModifier<R>)
+        indirect case _PerspectiveRotationEffectModifier(LiveViewNative._PerspectiveRotationEffectModifier<R>)
 indirect case _PresentationDetentsModifier(LiveViewNative._PresentationDetentsModifier)
+indirect case _PrefersDefaultFocusModifier(LiveViewNative._PrefersDefaultFocusModifier<R>)
+indirect case _FocusScopeModifier(LiveViewNative._FocusScopeModifier<R>)
+indirect case _OnSubmitModifier(LiveViewNative._OnSubmitModifier)
+indirect case _Rotation3DEffectModifier(LiveViewNative._Rotation3DEffectModifier<R>)
+indirect case _SearchCompletionModifier(LiveViewNative._SearchCompletionModifier<R>)
+indirect case _MaskModifier(LiveViewNative._MaskModifier<R>)
+indirect case _SearchScopesModifier(LiveViewNative._SearchScopesModifier<R>)
+indirect case _MatchedGeometryEffectModifier(LiveViewNative._MatchedGeometryEffectModifier<R>)
         indirect case _customRegistryModifier(R.CustomModifier)
         indirect case _anyTextModifier(_AnyTextModifier<R>)
         indirect case _anyImageModifier(_AnyImageModifier<R>)
@@ -13519,25 +13519,25 @@ case let .chunk14(chunk):
     content.modifier(chunk)
 case let .chunk15(chunk):
     content.modifier(chunk)
-            case let ._Rotation3DEffectModifier(modifier):
+            case let ._PerspectiveRotationEffectModifier(modifier):
+    content.modifier(modifier)
+case let ._PresentationDetentsModifier(modifier):
     content.modifier(modifier)
 case let ._PrefersDefaultFocusModifier(modifier):
     content.modifier(modifier)
-case let ._MaskModifier(modifier):
-    content.modifier(modifier)
 case let ._FocusScopeModifier(modifier):
-    content.modifier(modifier)
-case let ._PerspectiveRotationEffectModifier(modifier):
-    content.modifier(modifier)
-case let ._SearchScopesModifier(modifier):
-    content.modifier(modifier)
-case let ._SearchCompletionModifier(modifier):
     content.modifier(modifier)
 case let ._OnSubmitModifier(modifier):
     content.modifier(modifier)
-case let ._MatchedGeometryEffectModifier(modifier):
+case let ._Rotation3DEffectModifier(modifier):
     content.modifier(modifier)
-case let ._PresentationDetentsModifier(modifier):
+case let ._SearchCompletionModifier(modifier):
+    content.modifier(modifier)
+case let ._MaskModifier(modifier):
+    content.modifier(modifier)
+case let ._SearchScopesModifier(modifier):
+    content.modifier(modifier)
+case let ._MatchedGeometryEffectModifier(modifier):
     content.modifier(modifier)
             case let ._customRegistryModifier(modifier):
                 content.modifier(modifier)
@@ -13785,16 +13785,16 @@ _truncationModeModifier<R>.name: _truncationModeModifier<R>.parser(in: context).
 _unredactedModifier<R>.name: _unredactedModifier<R>.parser(in: context).map({ Output.chunk15(.unredacted($0)) }).eraseToAnyParser(),
 _upperLimbVisibilityModifier<R>.name: _upperLimbVisibilityModifier<R>.parser(in: context).map({ Output.chunk15(.upperLimbVisibility($0)) }).eraseToAnyParser(),
 _zIndexModifier<R>.name: _zIndexModifier<R>.parser(in: context).map({ Output.chunk15(.zIndex($0)) }).eraseToAnyParser(),
-                    LiveViewNative._Rotation3DEffectModifier<R>.name: LiveViewNative._Rotation3DEffectModifier<R>.parser(in: context).map(Output._Rotation3DEffectModifier).eraseToAnyParser(),
-LiveViewNative._PrefersDefaultFocusModifier<R>.name: LiveViewNative._PrefersDefaultFocusModifier<R>.parser(in: context).map(Output._PrefersDefaultFocusModifier).eraseToAnyParser(),
-LiveViewNative._MaskModifier<R>.name: LiveViewNative._MaskModifier<R>.parser(in: context).map(Output._MaskModifier).eraseToAnyParser(),
-LiveViewNative._FocusScopeModifier<R>.name: LiveViewNative._FocusScopeModifier<R>.parser(in: context).map(Output._FocusScopeModifier).eraseToAnyParser(),
-LiveViewNative._PerspectiveRotationEffectModifier<R>.name: LiveViewNative._PerspectiveRotationEffectModifier<R>.parser(in: context).map(Output._PerspectiveRotationEffectModifier).eraseToAnyParser(),
-LiveViewNative._SearchScopesModifier<R>.name: LiveViewNative._SearchScopesModifier<R>.parser(in: context).map(Output._SearchScopesModifier).eraseToAnyParser(),
-LiveViewNative._SearchCompletionModifier<R>.name: LiveViewNative._SearchCompletionModifier<R>.parser(in: context).map(Output._SearchCompletionModifier).eraseToAnyParser(),
-LiveViewNative._OnSubmitModifier.name: LiveViewNative._OnSubmitModifier.parser(in: context).map(Output._OnSubmitModifier).eraseToAnyParser(),
-LiveViewNative._MatchedGeometryEffectModifier<R>.name: LiveViewNative._MatchedGeometryEffectModifier<R>.parser(in: context).map(Output._MatchedGeometryEffectModifier).eraseToAnyParser(),
+                    LiveViewNative._PerspectiveRotationEffectModifier<R>.name: LiveViewNative._PerspectiveRotationEffectModifier<R>.parser(in: context).map(Output._PerspectiveRotationEffectModifier).eraseToAnyParser(),
 LiveViewNative._PresentationDetentsModifier.name: LiveViewNative._PresentationDetentsModifier.parser(in: context).map(Output._PresentationDetentsModifier).eraseToAnyParser(),
+LiveViewNative._PrefersDefaultFocusModifier<R>.name: LiveViewNative._PrefersDefaultFocusModifier<R>.parser(in: context).map(Output._PrefersDefaultFocusModifier).eraseToAnyParser(),
+LiveViewNative._FocusScopeModifier<R>.name: LiveViewNative._FocusScopeModifier<R>.parser(in: context).map(Output._FocusScopeModifier).eraseToAnyParser(),
+LiveViewNative._OnSubmitModifier.name: LiveViewNative._OnSubmitModifier.parser(in: context).map(Output._OnSubmitModifier).eraseToAnyParser(),
+LiveViewNative._Rotation3DEffectModifier<R>.name: LiveViewNative._Rotation3DEffectModifier<R>.parser(in: context).map(Output._Rotation3DEffectModifier).eraseToAnyParser(),
+LiveViewNative._SearchCompletionModifier<R>.name: LiveViewNative._SearchCompletionModifier<R>.parser(in: context).map(Output._SearchCompletionModifier).eraseToAnyParser(),
+LiveViewNative._MaskModifier<R>.name: LiveViewNative._MaskModifier<R>.parser(in: context).map(Output._MaskModifier).eraseToAnyParser(),
+LiveViewNative._SearchScopesModifier<R>.name: LiveViewNative._SearchScopesModifier<R>.parser(in: context).map(Output._SearchScopesModifier).eraseToAnyParser(),
+LiveViewNative._MatchedGeometryEffectModifier<R>.name: LiveViewNative._MatchedGeometryEffectModifier<R>.parser(in: context).map(Output._MatchedGeometryEffectModifier).eraseToAnyParser(),
                 ]
 
                 let deprecations = [
@@ -13916,33 +13916,30 @@ extension AccessibilityChildBehavior: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
-            ConstantAtomLiteral("ignore").map({ () -> Self in
-
+            
+ConstantAtomLiteral("ignore").map({ () -> Self in
 
     return Self.ignore
 
-
-
-
 })
-ConstantAtomLiteral("contain").map({ () -> Self in
 
+
+ConstantAtomLiteral("contain").map({ () -> Self in
 
     return Self.contain
 
-
-
-
 })
-ConstantAtomLiteral("combine").map({ () -> Self in
 
+
+ConstantAtomLiteral("combine").map({ () -> Self in
 
     return Self.combine
 
-
-
-
 })
+
+                AtomLiteral().fail(outputType: AccessibilityChildBehavior.self) {
+                    ModifierParseError(error: .unknownArgument($0), metadata: context.metadata)
+                }
             }
         }
     }
@@ -13960,24 +13957,23 @@ extension AccessibilityLabeledPairRole: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
-            ConstantAtomLiteral("label").map({ () -> Self in
-
+            
+ConstantAtomLiteral("label").map({ () -> Self in
 
     return Self.label
 
-
-
-
 })
-ConstantAtomLiteral("content").map({ () -> Self in
 
+
+ConstantAtomLiteral("content").map({ () -> Self in
 
     return Self.content
 
-
-
-
 })
+
+                AtomLiteral().fail(outputType: AccessibilityLabeledPairRole.self) {
+                    ModifierParseError(error: .unknownArgument($0), metadata: context.metadata)
+                }
             }
         }
     }
@@ -13996,33 +13992,30 @@ extension AlternatingRowBackgroundBehavior: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
-            ConstantAtomLiteral("automatic").map({ () -> Self in
-#if os(macOS)
+            #if os(macOS)
+ConstantAtomLiteral("automatic").map({ () -> Self in
 
     return Self.automatic
 
-#else
-fatalError("'automatic' is not available on this OS")
-#endif
 })
-ConstantAtomLiteral("enabled").map({ () -> Self in
+#endif
 #if os(macOS)
+ConstantAtomLiteral("enabled").map({ () -> Self in
 
     return Self.enabled
 
-#else
-fatalError("'enabled' is not available on this OS")
-#endif
 })
-ConstantAtomLiteral("disabled").map({ () -> Self in
+#endif
 #if os(macOS)
+ConstantAtomLiteral("disabled").map({ () -> Self in
 
     return Self.disabled
 
-#else
-fatalError("'disabled' is not available on this OS")
-#endif
 })
+#endif
+                AtomLiteral().fail(outputType: AlternatingRowBackgroundBehavior.self) {
+                    ModifierParseError(error: .unknownArgument($0), metadata: context.metadata)
+                }
             }
         }
     }
@@ -14040,24 +14033,23 @@ extension Axis: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
-            ConstantAtomLiteral("horizontal").map({ () -> Self in
-
+            
+ConstantAtomLiteral("horizontal").map({ () -> Self in
 
     return Self.horizontal
 
-
-
-
 })
-ConstantAtomLiteral("vertical").map({ () -> Self in
 
+
+ConstantAtomLiteral("vertical").map({ () -> Self in
 
     return Self.vertical
 
-
-
-
 })
+
+                AtomLiteral().fail(outputType: Axis.self) {
+                    ModifierParseError(error: .unknownArgument($0), metadata: context.metadata)
+                }
             }
         }
     }
@@ -14076,33 +14068,30 @@ extension BadgeProminence: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
-            ConstantAtomLiteral("decreased").map({ () -> Self in
-#if os(iOS) || os(macOS) || os(visionOS)
+            #if os(iOS) || os(macOS) || os(visionOS)
+ConstantAtomLiteral("decreased").map({ () -> Self in
 
     return Self.decreased
 
-#else
-fatalError("'decreased' is not available on this OS")
-#endif
 })
-ConstantAtomLiteral("standard").map({ () -> Self in
+#endif
 #if os(iOS) || os(macOS) || os(visionOS)
+ConstantAtomLiteral("standard").map({ () -> Self in
 
     return Self.standard
 
-#else
-fatalError("'standard' is not available on this OS")
-#endif
 })
-ConstantAtomLiteral("increased").map({ () -> Self in
+#endif
 #if os(iOS) || os(macOS) || os(visionOS)
+ConstantAtomLiteral("increased").map({ () -> Self in
 
     return Self.increased
 
-#else
-fatalError("'increased' is not available on this OS")
-#endif
 })
+#endif
+                AtomLiteral().fail(outputType: BadgeProminence.self) {
+                    ModifierParseError(error: .unknownArgument($0), metadata: context.metadata)
+                }
             }
         }
     }
@@ -14139,195 +14128,156 @@ extension BlendMode: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
-            ConstantAtomLiteral("normal").map({ () -> Self in
-
+            
+ConstantAtomLiteral("normal").map({ () -> Self in
 
     return Self.normal
 
-
-
-
 })
-ConstantAtomLiteral("multiply").map({ () -> Self in
 
+
+ConstantAtomLiteral("multiply").map({ () -> Self in
 
     return Self.multiply
 
-
-
-
 })
-ConstantAtomLiteral("screen").map({ () -> Self in
 
+
+ConstantAtomLiteral("screen").map({ () -> Self in
 
     return Self.screen
 
-
-
-
 })
-ConstantAtomLiteral("overlay").map({ () -> Self in
 
+
+ConstantAtomLiteral("overlay").map({ () -> Self in
 
     return Self.overlay
 
-
-
-
 })
-ConstantAtomLiteral("darken").map({ () -> Self in
 
+
+ConstantAtomLiteral("darken").map({ () -> Self in
 
     return Self.darken
 
-
-
-
 })
-ConstantAtomLiteral("lighten").map({ () -> Self in
 
+
+ConstantAtomLiteral("lighten").map({ () -> Self in
 
     return Self.lighten
 
-
-
-
 })
-ConstantAtomLiteral("colorDodge").map({ () -> Self in
 
+
+ConstantAtomLiteral("colorDodge").map({ () -> Self in
 
     return Self.colorDodge
 
-
-
-
 })
-ConstantAtomLiteral("colorBurn").map({ () -> Self in
 
+
+ConstantAtomLiteral("colorBurn").map({ () -> Self in
 
     return Self.colorBurn
 
-
-
-
 })
-ConstantAtomLiteral("softLight").map({ () -> Self in
 
+
+ConstantAtomLiteral("softLight").map({ () -> Self in
 
     return Self.softLight
 
-
-
-
 })
-ConstantAtomLiteral("hardLight").map({ () -> Self in
 
+
+ConstantAtomLiteral("hardLight").map({ () -> Self in
 
     return Self.hardLight
 
-
-
-
 })
-ConstantAtomLiteral("difference").map({ () -> Self in
 
+
+ConstantAtomLiteral("difference").map({ () -> Self in
 
     return Self.difference
 
-
-
-
 })
-ConstantAtomLiteral("exclusion").map({ () -> Self in
 
+
+ConstantAtomLiteral("exclusion").map({ () -> Self in
 
     return Self.exclusion
 
-
-
-
 })
-ConstantAtomLiteral("hue").map({ () -> Self in
 
+
+ConstantAtomLiteral("hue").map({ () -> Self in
 
     return Self.hue
 
-
-
-
 })
-ConstantAtomLiteral("saturation").map({ () -> Self in
 
+
+ConstantAtomLiteral("saturation").map({ () -> Self in
 
     return Self.saturation
 
-
-
-
 })
-ConstantAtomLiteral("color").map({ () -> Self in
 
+
+ConstantAtomLiteral("color").map({ () -> Self in
 
     return Self.color
 
-
-
-
 })
-ConstantAtomLiteral("luminosity").map({ () -> Self in
 
+
+ConstantAtomLiteral("luminosity").map({ () -> Self in
 
     return Self.luminosity
 
-
-
-
 })
-ConstantAtomLiteral("sourceAtop").map({ () -> Self in
 
+
+ConstantAtomLiteral("sourceAtop").map({ () -> Self in
 
     return Self.sourceAtop
 
-
-
-
 })
-ConstantAtomLiteral("destinationOver").map({ () -> Self in
 
+
+ConstantAtomLiteral("destinationOver").map({ () -> Self in
 
     return Self.destinationOver
 
-
-
-
 })
-ConstantAtomLiteral("destinationOut").map({ () -> Self in
 
+
+ConstantAtomLiteral("destinationOut").map({ () -> Self in
 
     return Self.destinationOut
 
-
-
-
 })
-ConstantAtomLiteral("plusDarker").map({ () -> Self in
 
+
+ConstantAtomLiteral("plusDarker").map({ () -> Self in
 
     return Self.plusDarker
 
-
-
-
 })
-ConstantAtomLiteral("plusLighter").map({ () -> Self in
 
+
+ConstantAtomLiteral("plusLighter").map({ () -> Self in
 
     return Self.plusLighter
 
-
-
-
 })
+
+                AtomLiteral().fail(outputType: BlendMode.self) {
+                    ModifierParseError(error: .unknownArgument($0), metadata: context.metadata)
+                }
             }
         }
     }
@@ -14341,38 +14291,35 @@ ConstantAtomLiteral("plusLighter").map({ () -> Self in
 /// * `.enabled`
 /// * `.disabled`
 @_documentation(visibility: public)
-@available(iOS 17.0,macOS 14.0,watchOS 10.0,tvOS 17.0,visionOS 1.0, *)
+@available(macOS 14.0,iOS 17.0,visionOS 1.0,tvOS 17.0,watchOS 10.0, *)
 extension ButtonRepeatBehavior: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
-            ConstantAtomLiteral("automatic").map({ () -> Self in
-#if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+            #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+ConstantAtomLiteral("automatic").map({ () -> Self in
 
     return Self.automatic
 
-#else
-fatalError("'automatic' is not available on this OS")
-#endif
 })
-ConstantAtomLiteral("enabled").map({ () -> Self in
+#endif
 #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+ConstantAtomLiteral("enabled").map({ () -> Self in
 
     return Self.enabled
 
-#else
-fatalError("'enabled' is not available on this OS")
-#endif
 })
-ConstantAtomLiteral("disabled").map({ () -> Self in
+#endif
 #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+ConstantAtomLiteral("disabled").map({ () -> Self in
 
     return Self.disabled
 
-#else
-fatalError("'disabled' is not available on this OS")
-#endif
 })
+#endif
+                AtomLiteral().fail(outputType: ButtonRepeatBehavior.self) {
+                    ModifierParseError(error: .unknownArgument($0), metadata: context.metadata)
+                }
             }
         }
     }
@@ -14391,33 +14338,30 @@ extension ColorRenderingMode: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
-            ConstantAtomLiteral("nonLinear").map({ () -> Self in
-
+            
+ConstantAtomLiteral("nonLinear").map({ () -> Self in
 
     return Self.nonLinear
 
-
-
-
 })
-ConstantAtomLiteral("linear").map({ () -> Self in
 
+
+ConstantAtomLiteral("linear").map({ () -> Self in
 
     return Self.linear
 
-
-
-
 })
-ConstantAtomLiteral("extendedLinear").map({ () -> Self in
 
+
+ConstantAtomLiteral("extendedLinear").map({ () -> Self in
 
     return Self.extendedLinear
 
-
-
-
 })
+
+                AtomLiteral().fail(outputType: ColorRenderingMode.self) {
+                    ModifierParseError(error: .unknownArgument($0), metadata: context.metadata)
+                }
             }
         }
     }
@@ -14435,24 +14379,23 @@ extension ColorScheme: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
-            ConstantAtomLiteral("light").map({ () -> Self in
-
+            
+ConstantAtomLiteral("light").map({ () -> Self in
 
     return Self.light
 
-
-
-
 })
-ConstantAtomLiteral("dark").map({ () -> Self in
 
+
+ConstantAtomLiteral("dark").map({ () -> Self in
 
     return Self.dark
 
-
-
-
 })
+
+                AtomLiteral().fail(outputType: ColorScheme.self) {
+                    ModifierParseError(error: .unknownArgument($0), metadata: context.metadata)
+                }
             }
         }
     }
@@ -14465,29 +14408,28 @@ ConstantAtomLiteral("dark").map({ () -> Self in
 /// * `.tabView`
 /// * `.navigation`
 @_documentation(visibility: public)
-@available(macOS 14.0,iOS 17.0,visionOS 1.0,tvOS 17.0,watchOS 10.0, *)
+@available(watchOS 10.0,tvOS 17.0,visionOS 1.0,macOS 14.0,iOS 17.0, *)
 extension ContainerBackgroundPlacement: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
-            ConstantAtomLiteral("tabView").map({ () -> Self in
-#if os(watchOS)
-if #available(macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0, *) {
+            #if os(watchOS)
+ConstantAtomLiteral("tabView").map({ () -> Self in
+if #available(watchOS 10.0,tvOS 17.0,macOS 14.0,iOS 17.0, *) {
     return Self.tabView
 } else { fatalError("'tabView' is not available in this OS version") }
-#else
-fatalError("'tabView' is not available on this OS")
-#endif
 })
-ConstantAtomLiteral("navigation").map({ () -> Self in
+#endif
 #if os(watchOS)
-if #available(macOS 14.0,iOS 17.0,tvOS 17.0,watchOS 10.0, *) {
+ConstantAtomLiteral("navigation").map({ () -> Self in
+if #available(watchOS 10.0,tvOS 17.0,macOS 14.0,iOS 17.0, *) {
     return Self.navigation
 } else { fatalError("'navigation' is not available in this OS version") }
-#else
-fatalError("'navigation' is not available on this OS")
-#endif
 })
+#endif
+                AtomLiteral().fail(outputType: ContainerBackgroundPlacement.self) {
+                    ModifierParseError(error: .unknownArgument($0), metadata: context.metadata)
+                }
             }
         }
     }
@@ -14501,38 +14443,35 @@ fatalError("'navigation' is not available on this OS")
 /// * `.scrollContent`
 /// * `.scrollIndicators`
 @_documentation(visibility: public)
-@available(macOS 14.0,iOS 17.0,visionOS 1.0,tvOS 17.0,watchOS 10.0, *)
+@available(iOS 17.0,macOS 14.0,tvOS 17.0,visionOS 1.0,watchOS 10.0, *)
 extension ContentMarginPlacement: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
-            ConstantAtomLiteral("automatic").map({ () -> Self in
-#if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+            #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+ConstantAtomLiteral("automatic").map({ () -> Self in
 
     return Self.automatic
 
-#else
-fatalError("'automatic' is not available on this OS")
-#endif
 })
-ConstantAtomLiteral("scrollContent").map({ () -> Self in
+#endif
 #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+ConstantAtomLiteral("scrollContent").map({ () -> Self in
 
     return Self.scrollContent
 
-#else
-fatalError("'scrollContent' is not available on this OS")
-#endif
 })
-ConstantAtomLiteral("scrollIndicators").map({ () -> Self in
+#endif
 #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+ConstantAtomLiteral("scrollIndicators").map({ () -> Self in
 
     return Self.scrollIndicators
 
-#else
-fatalError("'scrollIndicators' is not available on this OS")
-#endif
 })
+#endif
+                AtomLiteral().fail(outputType: ContentMarginPlacement.self) {
+                    ModifierParseError(error: .unknownArgument($0), metadata: context.metadata)
+                }
             }
         }
     }
@@ -14554,60 +14493,51 @@ extension ContentShapeKinds: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
-            ConstantAtomLiteral("interaction").map({ () -> Self in
-
+            
+ConstantAtomLiteral("interaction").map({ () -> Self in
 
     return Self.interaction
 
-
-
-
 })
-ConstantAtomLiteral("dragPreview").map({ () -> Self in
+
 #if os(iOS) || os(macOS) || os(visionOS)
-if #available(watchOS 8.0,tvOS 15.0,iOS 15.0,visionOS 1.0,macOS 12.0, *) {
+ConstantAtomLiteral("dragPreview").map({ () -> Self in
+if #available(iOS 15.0,visionOS 1.0,tvOS 15.0,watchOS 8.0,macOS 12.0, *) {
     return Self.dragPreview
 } else { fatalError("'dragPreview' is not available in this OS version") }
-#else
-fatalError("'dragPreview' is not available on this OS")
-#endif
 })
-ConstantAtomLiteral("contextMenuPreview").map({ () -> Self in
+#endif
 #if os(iOS) || os(tvOS) || os(visionOS)
-if #available(watchOS 8.0,tvOS 17.0,iOS 15.0,visionOS 1.0,macOS 12.0, *) {
+ConstantAtomLiteral("contextMenuPreview").map({ () -> Self in
+if #available(iOS 15.0,visionOS 1.0,tvOS 17.0,watchOS 8.0,macOS 12.0, *) {
     return Self.contextMenuPreview
 } else { fatalError("'contextMenuPreview' is not available in this OS version") }
-#else
-fatalError("'contextMenuPreview' is not available on this OS")
-#endif
 })
-ConstantAtomLiteral("hoverEffect").map({ () -> Self in
+#endif
 #if os(iOS) || os(visionOS)
-if #available(watchOS 8.0,tvOS 15.0,iOS 15.0,visionOS 1.0,macOS 12.0, *) {
+ConstantAtomLiteral("hoverEffect").map({ () -> Self in
+if #available(iOS 15.0,visionOS 1.0,tvOS 15.0,watchOS 8.0,macOS 12.0, *) {
     return Self.hoverEffect
 } else { fatalError("'hoverEffect' is not available in this OS version") }
-#else
-fatalError("'hoverEffect' is not available on this OS")
-#endif
 })
-ConstantAtomLiteral("focusEffect").map({ () -> Self in
+#endif
 #if os(macOS) || os(watchOS)
-if #available(watchOS 8.0,tvOS 15.0,iOS 15.0,macOS 12.0, *) {
+ConstantAtomLiteral("focusEffect").map({ () -> Self in
+if #available(iOS 15.0,tvOS 15.0,watchOS 8.0,macOS 12.0, *) {
     return Self.focusEffect
 } else { fatalError("'focusEffect' is not available in this OS version") }
-#else
-fatalError("'focusEffect' is not available on this OS")
-#endif
 })
-ConstantAtomLiteral("accessibility").map({ () -> Self in
+#endif
 #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-if #available(macOS 14.0,watchOS 10.0,tvOS 17.0,visionOS 1.0,iOS 17.0, *) {
+ConstantAtomLiteral("accessibility").map({ () -> Self in
+if #available(tvOS 17.0,iOS 17.0,watchOS 10.0,visionOS 1.0,macOS 14.0, *) {
     return Self.accessibility
 } else { fatalError("'accessibility' is not available in this OS version") }
-#else
-fatalError("'accessibility' is not available on this OS")
-#endif
 })
+#endif
+                AtomLiteral().fail(outputType: ContentShapeKinds.self) {
+                    ModifierParseError(error: .unknownArgument($0), metadata: context.metadata)
+                }
             }
         }
     }
@@ -14623,56 +14553,49 @@ fatalError("'accessibility' is not available on this OS")
 /// * `.large`
 /// * `.extraLarge`
 @_documentation(visibility: public)
-@available(visionOS 1.0,macOS 10.15,iOS 15.0,watchOS 9.0, *)
+@available(watchOS 9.0,iOS 15.0,visionOS 1.0,macOS 10.15, *)
 extension ControlSize: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
-            ConstantAtomLiteral("mini").map({ () -> Self in
-#if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
+            #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
+ConstantAtomLiteral("mini").map({ () -> Self in
 
     return Self.mini
 
-#else
-fatalError("'mini' is not available on this OS")
-#endif
 })
-ConstantAtomLiteral("small").map({ () -> Self in
+#endif
 #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
+ConstantAtomLiteral("small").map({ () -> Self in
 
     return Self.small
 
-#else
-fatalError("'small' is not available on this OS")
-#endif
 })
-ConstantAtomLiteral("regular").map({ () -> Self in
+#endif
 #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
+ConstantAtomLiteral("regular").map({ () -> Self in
 
     return Self.regular
 
-#else
-fatalError("'regular' is not available on this OS")
-#endif
 })
-ConstantAtomLiteral("large").map({ () -> Self in
+#endif
 #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
-if #available(visionOS 1.0,macOS 11.0,iOS 15.0,watchOS 9.0, *) {
+ConstantAtomLiteral("large").map({ () -> Self in
+if #available(watchOS 9.0,iOS 15.0,visionOS 1.0,macOS 11.0, *) {
     return Self.large
 } else { fatalError("'large' is not available in this OS version") }
-#else
-fatalError("'large' is not available on this OS")
-#endif
 })
-ConstantAtomLiteral("extraLarge").map({ () -> Self in
+#endif
 #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
-if #available(visionOS 1.0,macOS 14.0,iOS 17.0,watchOS 10.0, *) {
+ConstantAtomLiteral("extraLarge").map({ () -> Self in
+if #available(watchOS 10.0,iOS 17.0,visionOS 1.0,macOS 14.0, *) {
     return Self.extraLarge
 } else { fatalError("'extraLarge' is not available in this OS version") }
-#else
-fatalError("'extraLarge' is not available on this OS")
-#endif
 })
+#endif
+                AtomLiteral().fail(outputType: ControlSize.self) {
+                    ModifierParseError(error: .unknownArgument($0), metadata: context.metadata)
+                }
             }
         }
     }
@@ -14690,24 +14613,23 @@ extension DefaultFocusEvaluationPriority: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
-            ConstantAtomLiteral("automatic").map({ () -> Self in
-
+            
+ConstantAtomLiteral("automatic").map({ () -> Self in
 
     return Self.automatic
 
-
-
-
 })
-ConstantAtomLiteral("userInitiated").map({ () -> Self in
 
+
+ConstantAtomLiteral("userInitiated").map({ () -> Self in
 
     return Self.userInitiated
 
-
-
-
 })
+
+                AtomLiteral().fail(outputType: DefaultFocusEvaluationPriority.self) {
+                    ModifierParseError(error: .unknownArgument($0), metadata: context.metadata)
+                }
             }
         }
     }
@@ -14721,38 +14643,35 @@ ConstantAtomLiteral("userInitiated").map({ () -> Self in
 /// * `.critical`
 /// * `.standard`
 @_documentation(visibility: public)
-@available(visionOS 1.0,iOS 17.0,tvOS 17.0,macOS 13.0,watchOS 10.0, *)
+@available(tvOS 17.0,iOS 17.0,watchOS 10.0,visionOS 1.0,macOS 13.0, *)
 extension DialogSeverity: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
-            ConstantAtomLiteral("automatic").map({ () -> Self in
-#if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+            #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+ConstantAtomLiteral("automatic").map({ () -> Self in
 
     return Self.automatic
 
-#else
-fatalError("'automatic' is not available on this OS")
-#endif
 })
-ConstantAtomLiteral("critical").map({ () -> Self in
+#endif
 #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+ConstantAtomLiteral("critical").map({ () -> Self in
 
     return Self.critical
 
-#else
-fatalError("'critical' is not available on this OS")
-#endif
 })
-ConstantAtomLiteral("standard").map({ () -> Self in
+#endif
 #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-if #available(visionOS 1.0,iOS 17.0,tvOS 17.0,macOS 14.0,watchOS 10.0, *) {
+ConstantAtomLiteral("standard").map({ () -> Self in
+if #available(tvOS 17.0,iOS 17.0,watchOS 10.0,visionOS 1.0,macOS 14.0, *) {
     return Self.standard
 } else { fatalError("'standard' is not available in this OS version") }
-#else
-fatalError("'standard' is not available on this OS")
-#endif
 })
+#endif
+                AtomLiteral().fail(outputType: DialogSeverity.self) {
+                    ModifierParseError(error: .unknownArgument($0), metadata: context.metadata)
+                }
             }
         }
     }
@@ -14771,33 +14690,30 @@ extension DigitalCrownRotationalSensitivity: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
-            ConstantAtomLiteral("low").map({ () -> Self in
-#if os(watchOS)
+            #if os(watchOS)
+ConstantAtomLiteral("low").map({ () -> Self in
 
     return Self.low
 
-#else
-fatalError("'low' is not available on this OS")
-#endif
 })
-ConstantAtomLiteral("medium").map({ () -> Self in
+#endif
 #if os(watchOS)
+ConstantAtomLiteral("medium").map({ () -> Self in
 
     return Self.medium
 
-#else
-fatalError("'medium' is not available on this OS")
-#endif
 })
-ConstantAtomLiteral("high").map({ () -> Self in
+#endif
 #if os(watchOS)
+ConstantAtomLiteral("high").map({ () -> Self in
 
     return Self.high
 
-#else
-fatalError("'high' is not available on this OS")
-#endif
 })
+#endif
+                AtomLiteral().fail(outputType: DigitalCrownRotationalSensitivity.self) {
+                    ModifierParseError(error: .unknownArgument($0), metadata: context.metadata)
+                }
             }
         }
     }
@@ -14814,15 +14730,16 @@ extension Edge3D: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
-            ConstantAtomLiteral("top").map({ () -> Self in
-#if os(visionOS)
+            #if os(visionOS)
+ConstantAtomLiteral("top").map({ () -> Self in
 
     return Self.top
 
-#else
-fatalError("'top' is not available on this OS")
-#endif
 })
+#endif
+                AtomLiteral().fail(outputType: Edge3D.self) {
+                    ModifierParseError(error: .unknownArgument($0), metadata: context.metadata)
+                }
             }
         }
     }
@@ -14846,78 +14763,65 @@ extension EventModifiers: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
-            ConstantAtomLiteral("capsLock").map({ () -> Self in
-
+            
+ConstantAtomLiteral("capsLock").map({ () -> Self in
 
     return Self.capsLock
 
-
-
-
 })
-ConstantAtomLiteral("shift").map({ () -> Self in
 
+
+ConstantAtomLiteral("shift").map({ () -> Self in
 
     return Self.shift
 
-
-
-
 })
-ConstantAtomLiteral("control").map({ () -> Self in
 
+
+ConstantAtomLiteral("control").map({ () -> Self in
 
     return Self.control
 
-
-
-
 })
-ConstantAtomLiteral("option").map({ () -> Self in
 
+
+ConstantAtomLiteral("option").map({ () -> Self in
 
     return Self.option
 
-
-
-
 })
-ConstantAtomLiteral("command").map({ () -> Self in
 
+
+ConstantAtomLiteral("command").map({ () -> Self in
 
     return Self.command
 
-
-
-
 })
-ConstantAtomLiteral("numericPad").map({ () -> Self in
 
+
+ConstantAtomLiteral("numericPad").map({ () -> Self in
 
     return Self.numericPad
 
-
-
-
 })
-ConstantAtomLiteral("function").map({ () -> Self in
 
+
+ConstantAtomLiteral("function").map({ () -> Self in
 
     return Self.function
 
-
-
-
 })
-ConstantAtomLiteral("all").map({ () -> Self in
 
+
+ConstantAtomLiteral("all").map({ () -> Self in
 
     return Self.all
 
-
-
-
 })
+
+                AtomLiteral().fail(outputType: EventModifiers.self) {
+                    ModifierParseError(error: .unknownArgument($0), metadata: context.metadata)
+                }
             }
         }
     }
@@ -14931,38 +14835,35 @@ ConstantAtomLiteral("all").map({ () -> Self in
 /// * `.includeHiddenFiles`
 /// * `.displayFileExtensions`
 @_documentation(visibility: public)
-@available(macOS 14.0,visionOS 1.0,iOS 17.0, *)
+@available(iOS 17.0,visionOS 1.0,macOS 14.0, *)
 extension FileDialogBrowserOptions: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
-            ConstantAtomLiteral("enumeratePackages").map({ () -> Self in
-#if os(iOS) || os(macOS) || os(visionOS)
+            #if os(iOS) || os(macOS) || os(visionOS)
+ConstantAtomLiteral("enumeratePackages").map({ () -> Self in
 
     return Self.enumeratePackages
 
-#else
-fatalError("'enumeratePackages' is not available on this OS")
-#endif
 })
-ConstantAtomLiteral("includeHiddenFiles").map({ () -> Self in
+#endif
 #if os(iOS) || os(macOS) || os(visionOS)
+ConstantAtomLiteral("includeHiddenFiles").map({ () -> Self in
 
     return Self.includeHiddenFiles
 
-#else
-fatalError("'includeHiddenFiles' is not available on this OS")
-#endif
 })
-ConstantAtomLiteral("displayFileExtensions").map({ () -> Self in
+#endif
 #if os(iOS) || os(macOS) || os(visionOS)
+ConstantAtomLiteral("displayFileExtensions").map({ () -> Self in
 
     return Self.displayFileExtensions
 
-#else
-fatalError("'displayFileExtensions' is not available on this OS")
-#endif
 })
+#endif
+                AtomLiteral().fail(outputType: FileDialogBrowserOptions.self) {
+                    ModifierParseError(error: .unknownArgument($0), metadata: context.metadata)
+                }
             }
         }
     }
@@ -14976,38 +14877,35 @@ fatalError("'displayFileExtensions' is not available on this OS")
 /// * `.edit`
 /// * `.automatic`
 @_documentation(visibility: public)
-@available(iOS 17.0,macOS 14.0,watchOS 10.0,tvOS 17.0,visionOS 1.0, *)
+@available(macOS 14.0,iOS 17.0,visionOS 1.0,tvOS 17.0,watchOS 10.0, *)
 extension FocusInteractions: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
-            ConstantAtomLiteral("activate").map({ () -> Self in
-#if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+            #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+ConstantAtomLiteral("activate").map({ () -> Self in
 
     return Self.activate
 
-#else
-fatalError("'activate' is not available on this OS")
-#endif
 })
-ConstantAtomLiteral("edit").map({ () -> Self in
+#endif
 #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+ConstantAtomLiteral("edit").map({ () -> Self in
 
     return Self.edit
 
-#else
-fatalError("'edit' is not available on this OS")
-#endif
 })
-ConstantAtomLiteral("automatic").map({ () -> Self in
+#endif
 #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+ConstantAtomLiteral("automatic").map({ () -> Self in
 
     return Self.automatic
 
-#else
-fatalError("'automatic' is not available on this OS")
-#endif
 })
+#endif
+                AtomLiteral().fail(outputType: FocusInteractions.self) {
+                    ModifierParseError(error: .unknownArgument($0), metadata: context.metadata)
+                }
             }
         }
     }
@@ -15027,42 +14925,37 @@ extension GestureMask: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
-            ConstantAtomLiteral("none").map({ () -> Self in
-
+            
+ConstantAtomLiteral("none").map({ () -> Self in
 
     return Self.none
 
-
-
-
 })
-ConstantAtomLiteral("gesture").map({ () -> Self in
 
+
+ConstantAtomLiteral("gesture").map({ () -> Self in
 
     return Self.gesture
 
-
-
-
 })
-ConstantAtomLiteral("subviews").map({ () -> Self in
 
+
+ConstantAtomLiteral("subviews").map({ () -> Self in
 
     return Self.subviews
 
-
-
-
 })
-ConstantAtomLiteral("all").map({ () -> Self in
 
+
+ConstantAtomLiteral("all").map({ () -> Self in
 
     return Self.all
 
-
-
-
 })
+
+                AtomLiteral().fail(outputType: GestureMask.self) {
+                    ModifierParseError(error: .unknownArgument($0), metadata: context.metadata)
+                }
             }
         }
     }
@@ -15081,33 +14974,30 @@ extension GlassBackgroundDisplayMode: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
-            ConstantAtomLiteral("always").map({ () -> Self in
-#if os(visionOS)
+            #if os(visionOS)
+ConstantAtomLiteral("always").map({ () -> Self in
 
     return Self.always
 
-#else
-fatalError("'always' is not available on this OS")
-#endif
 })
-ConstantAtomLiteral("implicit").map({ () -> Self in
+#endif
 #if os(visionOS)
+ConstantAtomLiteral("implicit").map({ () -> Self in
 
     return Self.implicit
 
-#else
-fatalError("'implicit' is not available on this OS")
-#endif
 })
-ConstantAtomLiteral("never").map({ () -> Self in
+#endif
 #if os(visionOS)
+ConstantAtomLiteral("never").map({ () -> Self in
 
     return Self.never
 
-#else
-fatalError("'never' is not available on this OS")
-#endif
 })
+#endif
+                AtomLiteral().fail(outputType: GlassBackgroundDisplayMode.self) {
+                    ModifierParseError(error: .unknownArgument($0), metadata: context.metadata)
+                }
             }
         }
     }
@@ -15128,51 +15018,44 @@ extension HorizontalAlignment: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
-            ConstantAtomLiteral("leading").map({ () -> Self in
-
+            
+ConstantAtomLiteral("leading").map({ () -> Self in
 
     return Self.leading
 
-
-
-
 })
-ConstantAtomLiteral("center").map({ () -> Self in
 
+
+ConstantAtomLiteral("center").map({ () -> Self in
 
     return Self.center
 
-
-
-
 })
-ConstantAtomLiteral("trailing").map({ () -> Self in
 
+
+ConstantAtomLiteral("trailing").map({ () -> Self in
 
     return Self.trailing
 
-
-
-
 })
-ConstantAtomLiteral("listRowSeparatorLeading").map({ () -> Self in
+
 #if os(iOS) || os(macOS) || os(visionOS)
-if #available(macOS 13.0,visionOS 1.0,iOS 16.0, *) {
+ConstantAtomLiteral("listRowSeparatorLeading").map({ () -> Self in
+if #available(iOS 16.0,visionOS 1.0,macOS 13.0, *) {
     return Self.listRowSeparatorLeading
 } else { fatalError("'listRowSeparatorLeading' is not available in this OS version") }
-#else
-fatalError("'listRowSeparatorLeading' is not available on this OS")
-#endif
 })
-ConstantAtomLiteral("listRowSeparatorTrailing").map({ () -> Self in
+#endif
 #if os(iOS) || os(macOS) || os(visionOS)
-if #available(macOS 13.0,visionOS 1.0,iOS 16.0, *) {
+ConstantAtomLiteral("listRowSeparatorTrailing").map({ () -> Self in
+if #available(iOS 16.0,visionOS 1.0,macOS 13.0, *) {
     return Self.listRowSeparatorTrailing
 } else { fatalError("'listRowSeparatorTrailing' is not available in this OS version") }
-#else
-fatalError("'listRowSeparatorTrailing' is not available on this OS")
-#endif
 })
+#endif
+                AtomLiteral().fail(outputType: HorizontalAlignment.self) {
+                    ModifierParseError(error: .unknownArgument($0), metadata: context.metadata)
+                }
             }
         }
     }
@@ -15190,24 +15073,23 @@ extension HorizontalEdge: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
-            ConstantAtomLiteral("leading").map({ () -> Self in
-
+            
+ConstantAtomLiteral("leading").map({ () -> Self in
 
     return Self.leading
 
-
-
-
 })
-ConstantAtomLiteral("trailing").map({ () -> Self in
 
+
+ConstantAtomLiteral("trailing").map({ () -> Self in
 
     return Self.trailing
 
-
-
-
 })
+
+                AtomLiteral().fail(outputType: HorizontalEdge.self) {
+                    ModifierParseError(error: .unknownArgument($0), metadata: context.metadata)
+                }
             }
         }
     }
@@ -15221,38 +15103,35 @@ ConstantAtomLiteral("trailing").map({ () -> Self in
 /// * `.highlight`
 /// * `.lift`
 @_documentation(visibility: public)
-@available(iOS 13.4,tvOS 16.0,visionOS 1.0, *)
+@available(iOS 13.4,visionOS 1.0,tvOS 16.0, *)
 extension HoverEffect: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
-            ConstantAtomLiteral("automatic").map({ () -> Self in
-#if os(iOS) || os(tvOS) || os(visionOS)
+            #if os(iOS) || os(tvOS) || os(visionOS)
+ConstantAtomLiteral("automatic").map({ () -> Self in
 
     return Self.automatic
 
-#else
-fatalError("'automatic' is not available on this OS")
-#endif
 })
-ConstantAtomLiteral("highlight").map({ () -> Self in
+#endif
 #if os(iOS) || os(tvOS) || os(visionOS)
-if #available(iOS 13.4,tvOS 17.0,visionOS 1.0, *) {
+ConstantAtomLiteral("highlight").map({ () -> Self in
+if #available(iOS 13.4,visionOS 1.0,tvOS 17.0, *) {
     return Self.highlight
 } else { fatalError("'highlight' is not available in this OS version") }
-#else
-fatalError("'highlight' is not available on this OS")
-#endif
 })
-ConstantAtomLiteral("lift").map({ () -> Self in
+#endif
 #if os(iOS) || os(tvOS) || os(visionOS)
+ConstantAtomLiteral("lift").map({ () -> Self in
 
     return Self.lift
 
-#else
-fatalError("'lift' is not available on this OS")
-#endif
 })
+#endif
+                AtomLiteral().fail(outputType: HoverEffect.self) {
+                    ModifierParseError(error: .unknownArgument($0), metadata: context.metadata)
+                }
             }
         }
     }
@@ -15265,29 +15144,28 @@ fatalError("'lift' is not available on this OS")
 /// * `.defaultAction`
 /// * `.cancelAction`
 @_documentation(visibility: public)
-@available(iOS 14.0,macOS 11.0,visionOS 1.0, *)
+@available(macOS 11.0,visionOS 1.0,iOS 14.0, *)
 extension KeyboardShortcut: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
-            ConstantAtomLiteral("defaultAction").map({ () -> Self in
-#if os(iOS) || os(macOS) || os(visionOS)
+            #if os(iOS) || os(macOS) || os(visionOS)
+ConstantAtomLiteral("defaultAction").map({ () -> Self in
 
     return Self.defaultAction
 
-#else
-fatalError("'defaultAction' is not available on this OS")
-#endif
 })
-ConstantAtomLiteral("cancelAction").map({ () -> Self in
+#endif
 #if os(iOS) || os(macOS) || os(visionOS)
+ConstantAtomLiteral("cancelAction").map({ () -> Self in
 
     return Self.cancelAction
 
-#else
-fatalError("'cancelAction' is not available on this OS")
-#endif
 })
+#endif
+                AtomLiteral().fail(outputType: KeyboardShortcut.self) {
+                    ModifierParseError(error: .unknownArgument($0), metadata: context.metadata)
+                }
             }
         }
     }
@@ -15306,33 +15184,30 @@ extension MatchedGeometryProperties: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
-            ConstantAtomLiteral("position").map({ () -> Self in
-
+            
+ConstantAtomLiteral("position").map({ () -> Self in
 
     return Self.position
 
-
-
-
 })
-ConstantAtomLiteral("size").map({ () -> Self in
 
+
+ConstantAtomLiteral("size").map({ () -> Self in
 
     return Self.size
 
-
-
-
 })
-ConstantAtomLiteral("frame").map({ () -> Self in
 
+
+ConstantAtomLiteral("frame").map({ () -> Self in
 
     return Self.frame
 
-
-
-
 })
+
+                AtomLiteral().fail(outputType: MatchedGeometryProperties.self) {
+                    ModifierParseError(error: .unknownArgument($0), metadata: context.metadata)
+                }
             }
         }
     }
@@ -15351,33 +15226,30 @@ extension MenuOrder: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
-            ConstantAtomLiteral("automatic").map({ () -> Self in
-
+            
+ConstantAtomLiteral("automatic").map({ () -> Self in
 
     return Self.automatic
 
-
-
-
 })
-ConstantAtomLiteral("priority").map({ () -> Self in
+
 #if os(iOS) || os(visionOS)
-if #available(visionOS 1.0,watchOS 9.0,macOS 13.0,tvOS 16.0,iOS 16.0, *) {
+ConstantAtomLiteral("priority").map({ () -> Self in
+if #available(watchOS 9.0,visionOS 1.0,iOS 16.0,macOS 13.0,tvOS 16.0, *) {
     return Self.priority
 } else { fatalError("'priority' is not available in this OS version") }
-#else
-fatalError("'priority' is not available on this OS")
-#endif
 })
-ConstantAtomLiteral("fixed").map({ () -> Self in
+#endif
 
+ConstantAtomLiteral("fixed").map({ () -> Self in
 
     return Self.fixed
 
-
-
-
 })
+
+                AtomLiteral().fail(outputType: MenuOrder.self) {
+                    ModifierParseError(error: .unknownArgument($0), metadata: context.metadata)
+                }
             }
         }
     }
@@ -15393,56 +15265,49 @@ ConstantAtomLiteral("fixed").map({ () -> Self in
 /// * `.sheet`
 /// * `.fullScreenCover`
 @_documentation(visibility: public)
-@available(iOS 16.4,macOS 13.3,watchOS 9.4,visionOS 1.0,tvOS 16.4, *)
+@available(iOS 16.4,watchOS 9.4,visionOS 1.0,tvOS 16.4,macOS 13.3, *)
 extension PresentationAdaptation: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
-            ConstantAtomLiteral("automatic").map({ () -> Self in
-#if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+            #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+ConstantAtomLiteral("automatic").map({ () -> Self in
 
     return Self.automatic
 
-#else
-fatalError("'automatic' is not available on this OS")
-#endif
 })
-ConstantAtomLiteral("none").map({ () -> Self in
+#endif
 #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+ConstantAtomLiteral("none").map({ () -> Self in
 
     return Self.none
 
-#else
-fatalError("'none' is not available on this OS")
-#endif
 })
-ConstantAtomLiteral("popover").map({ () -> Self in
+#endif
 #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+ConstantAtomLiteral("popover").map({ () -> Self in
 
     return Self.popover
 
-#else
-fatalError("'popover' is not available on this OS")
-#endif
 })
-ConstantAtomLiteral("sheet").map({ () -> Self in
+#endif
 #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+ConstantAtomLiteral("sheet").map({ () -> Self in
 
     return Self.sheet
 
-#else
-fatalError("'sheet' is not available on this OS")
-#endif
 })
-ConstantAtomLiteral("fullScreenCover").map({ () -> Self in
+#endif
 #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+ConstantAtomLiteral("fullScreenCover").map({ () -> Self in
 
     return Self.fullScreenCover
 
-#else
-fatalError("'fullScreenCover' is not available on this OS")
-#endif
 })
+#endif
+                AtomLiteral().fail(outputType: PresentationAdaptation.self) {
+                    ModifierParseError(error: .unknownArgument($0), metadata: context.metadata)
+                }
             }
         }
     }
@@ -15456,38 +15321,35 @@ fatalError("'fullScreenCover' is not available on this OS")
 /// * `.resizes`
 /// * `.scrolls`
 @_documentation(visibility: public)
-@available(iOS 16.4,macOS 13.3,watchOS 9.4,tvOS 16.4,visionOS 1.0, *)
+@available(watchOS 9.4,iOS 16.4,tvOS 16.4,visionOS 1.0,macOS 13.3, *)
 extension PresentationContentInteraction: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
-            ConstantAtomLiteral("automatic").map({ () -> Self in
-#if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+            #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+ConstantAtomLiteral("automatic").map({ () -> Self in
 
     return Self.automatic
 
-#else
-fatalError("'automatic' is not available on this OS")
-#endif
 })
-ConstantAtomLiteral("resizes").map({ () -> Self in
+#endif
 #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+ConstantAtomLiteral("resizes").map({ () -> Self in
 
     return Self.resizes
 
-#else
-fatalError("'resizes' is not available on this OS")
-#endif
 })
-ConstantAtomLiteral("scrolls").map({ () -> Self in
+#endif
 #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+ConstantAtomLiteral("scrolls").map({ () -> Self in
 
     return Self.scrolls
 
-#else
-fatalError("'scrolls' is not available on this OS")
-#endif
 })
+#endif
+                AtomLiteral().fail(outputType: PresentationContentInteraction.self) {
+                    ModifierParseError(error: .unknownArgument($0), metadata: context.metadata)
+                }
             }
         }
     }
@@ -15505,24 +15367,23 @@ extension Prominence: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
-            ConstantAtomLiteral("standard").map({ () -> Self in
-
+            
+ConstantAtomLiteral("standard").map({ () -> Self in
 
     return Self.standard
 
-
-
-
 })
-ConstantAtomLiteral("increased").map({ () -> Self in
 
+
+ConstantAtomLiteral("increased").map({ () -> Self in
 
     return Self.increased
 
-
-
-
 })
+
+                AtomLiteral().fail(outputType: Prominence.self) {
+                    ModifierParseError(error: .unknownArgument($0), metadata: context.metadata)
+                }
             }
         }
     }
@@ -15541,33 +15402,30 @@ extension RedactionReasons: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
-            ConstantAtomLiteral("placeholder").map({ () -> Self in
-
+            
+ConstantAtomLiteral("placeholder").map({ () -> Self in
 
     return Self.placeholder
 
-
-
-
 })
-ConstantAtomLiteral("privacy").map({ () -> Self in
 
+
+ConstantAtomLiteral("privacy").map({ () -> Self in
 
     return Self.privacy
 
-
-
-
 })
-ConstantAtomLiteral("invalidated").map({ () -> Self in
+
 #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
-if #available(tvOS 17.0,visionOS 1.0,watchOS 10.0,macOS 14.0,iOS 17.0, *) {
+ConstantAtomLiteral("invalidated").map({ () -> Self in
+if #available(iOS 17.0,tvOS 17.0,watchOS 10.0,visionOS 1.0,macOS 14.0, *) {
     return Self.invalidated
 } else { fatalError("'invalidated' is not available in this OS version") }
-#else
-fatalError("'invalidated' is not available on this OS")
-#endif
 })
+#endif
+                AtomLiteral().fail(outputType: RedactionReasons.self) {
+                    ModifierParseError(error: .unknownArgument($0), metadata: context.metadata)
+                }
             }
         }
     }
@@ -15585,24 +15443,23 @@ extension RoundedCornerStyle: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
-            ConstantAtomLiteral("circular").map({ () -> Self in
-
+            
+ConstantAtomLiteral("circular").map({ () -> Self in
 
     return Self.circular
 
-
-
-
 })
-ConstantAtomLiteral("continuous").map({ () -> Self in
 
+
+ConstantAtomLiteral("continuous").map({ () -> Self in
 
     return Self.continuous
 
-
-
-
 })
+
+                AtomLiteral().fail(outputType: RoundedCornerStyle.self) {
+                    ModifierParseError(error: .unknownArgument($0), metadata: context.metadata)
+                }
             }
         }
     }
@@ -15621,33 +15478,30 @@ extension SafeAreaRegions: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
-            ConstantAtomLiteral("container").map({ () -> Self in
-
+            
+ConstantAtomLiteral("container").map({ () -> Self in
 
     return Self.container
 
-
-
-
 })
-ConstantAtomLiteral("keyboard").map({ () -> Self in
 
+
+ConstantAtomLiteral("keyboard").map({ () -> Self in
 
     return Self.keyboard
 
-
-
-
 })
-ConstantAtomLiteral("all").map({ () -> Self in
 
+
+ConstantAtomLiteral("all").map({ () -> Self in
 
     return Self.all
 
-
-
-
 })
+
+                AtomLiteral().fail(outputType: SafeAreaRegions.self) {
+                    ModifierParseError(error: .unknownArgument($0), metadata: context.metadata)
+                }
             }
         }
     }
@@ -15665,24 +15519,23 @@ extension ScenePadding: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
-            ConstantAtomLiteral("minimum").map({ () -> Self in
-
+            
+ConstantAtomLiteral("minimum").map({ () -> Self in
 
     return Self.minimum
 
-
-
-
 })
-ConstantAtomLiteral("navigationBar").map({ () -> Self in
+
 #if os(watchOS)
-if #available(macOS 13.0,iOS 16.0,tvOS 16.0,watchOS 9.0, *) {
+ConstantAtomLiteral("navigationBar").map({ () -> Self in
+if #available(iOS 16.0,macOS 13.0,tvOS 16.0,watchOS 9.0, *) {
     return Self.navigationBar
 } else { fatalError("'navigationBar' is not available in this OS version") }
-#else
-fatalError("'navigationBar' is not available on this OS")
-#endif
 })
+#endif
+                AtomLiteral().fail(outputType: ScenePadding.self) {
+                    ModifierParseError(error: .unknownArgument($0), metadata: context.metadata)
+                }
             }
         }
     }
@@ -15696,38 +15549,35 @@ fatalError("'navigationBar' is not available on this OS")
 /// * `.always`
 /// * `.basedOnSize`
 @_documentation(visibility: public)
-@available(macOS 13.3,iOS 16.4,visionOS 1.0,tvOS 16.4,watchOS 9.4, *)
+@available(watchOS 9.4,tvOS 16.4,visionOS 1.0,macOS 13.3,iOS 16.4, *)
 extension ScrollBounceBehavior: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
-            ConstantAtomLiteral("automatic").map({ () -> Self in
-#if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+            #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+ConstantAtomLiteral("automatic").map({ () -> Self in
 
     return Self.automatic
 
-#else
-fatalError("'automatic' is not available on this OS")
-#endif
 })
-ConstantAtomLiteral("always").map({ () -> Self in
+#endif
 #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+ConstantAtomLiteral("always").map({ () -> Self in
 
     return Self.always
 
-#else
-fatalError("'always' is not available on this OS")
-#endif
 })
-ConstantAtomLiteral("basedOnSize").map({ () -> Self in
+#endif
 #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+ConstantAtomLiteral("basedOnSize").map({ () -> Self in
 
     return Self.basedOnSize
 
-#else
-fatalError("'basedOnSize' is not available on this OS")
-#endif
 })
+#endif
+                AtomLiteral().fail(outputType: ScrollBounceBehavior.self) {
+                    ModifierParseError(error: .unknownArgument($0), metadata: context.metadata)
+                }
             }
         }
     }
@@ -15742,47 +15592,42 @@ fatalError("'basedOnSize' is not available on this OS")
 /// * `.interactively`
 /// * `.never`
 @_documentation(visibility: public)
-@available(macOS 13.0,iOS 16.0,tvOS 16.0,watchOS 9.0, *)
+@available(watchOS 9.0,tvOS 16.0,macOS 13.0,iOS 16.0, *)
 extension ScrollDismissesKeyboardMode: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
-            ConstantAtomLiteral("automatic").map({ () -> Self in
-#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+            #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+ConstantAtomLiteral("automatic").map({ () -> Self in
 
     return Self.automatic
 
-#else
-fatalError("'automatic' is not available on this OS")
-#endif
 })
-ConstantAtomLiteral("immediately").map({ () -> Self in
+#endif
 #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+ConstantAtomLiteral("immediately").map({ () -> Self in
 
     return Self.immediately
 
-#else
-fatalError("'immediately' is not available on this OS")
-#endif
 })
-ConstantAtomLiteral("interactively").map({ () -> Self in
+#endif
 #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+ConstantAtomLiteral("interactively").map({ () -> Self in
 
     return Self.interactively
 
-#else
-fatalError("'interactively' is not available on this OS")
-#endif
 })
-ConstantAtomLiteral("never").map({ () -> Self in
+#endif
 #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+ConstantAtomLiteral("never").map({ () -> Self in
 
     return Self.never
 
-#else
-fatalError("'never' is not available on this OS")
-#endif
 })
+#endif
+                AtomLiteral().fail(outputType: ScrollDismissesKeyboardMode.self) {
+                    ModifierParseError(error: .unknownArgument($0), metadata: context.metadata)
+                }
             }
         }
     }
@@ -15802,42 +15647,37 @@ extension ScrollIndicatorVisibility: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
-            ConstantAtomLiteral("automatic").map({ () -> Self in
-
+            
+ConstantAtomLiteral("automatic").map({ () -> Self in
 
     return Self.automatic
 
-
-
-
 })
-ConstantAtomLiteral("visible").map({ () -> Self in
 
+
+ConstantAtomLiteral("visible").map({ () -> Self in
 
     return Self.visible
 
-
-
-
 })
-ConstantAtomLiteral("hidden").map({ () -> Self in
 
+
+ConstantAtomLiteral("hidden").map({ () -> Self in
 
     return Self.hidden
 
-
-
-
 })
-ConstantAtomLiteral("never").map({ () -> Self in
 
+
+ConstantAtomLiteral("never").map({ () -> Self in
 
     return Self.never
 
-
-
-
 })
+
+                AtomLiteral().fail(outputType: ScrollIndicatorVisibility.self) {
+                    ModifierParseError(error: .unknownArgument($0), metadata: context.metadata)
+                }
             }
         }
     }
@@ -15851,38 +15691,35 @@ ConstantAtomLiteral("never").map({ () -> Self in
 /// * `.onTextEntry`
 /// * `.onSearchPresentation`
 @_documentation(visibility: public)
-@available(iOS 16.4,tvOS 16.4,macOS 13.3,watchOS 9.4,visionOS 1.0, *)
+@available(iOS 16.4,tvOS 16.4,watchOS 9.4,visionOS 1.0,macOS 13.3, *)
 extension SearchScopeActivation: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
-            ConstantAtomLiteral("automatic").map({ () -> Self in
-#if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+            #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+ConstantAtomLiteral("automatic").map({ () -> Self in
 
     return Self.automatic
 
-#else
-fatalError("'automatic' is not available on this OS")
-#endif
 })
-ConstantAtomLiteral("onTextEntry").map({ () -> Self in
+#endif
 #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
+ConstantAtomLiteral("onTextEntry").map({ () -> Self in
 
     return Self.onTextEntry
 
-#else
-fatalError("'onTextEntry' is not available on this OS")
-#endif
 })
-ConstantAtomLiteral("onSearchPresentation").map({ () -> Self in
+#endif
 #if os(iOS) || os(macOS) || os(visionOS) || os(watchOS)
+ConstantAtomLiteral("onSearchPresentation").map({ () -> Self in
 
     return Self.onSearchPresentation
 
-#else
-fatalError("'onSearchPresentation' is not available on this OS")
-#endif
 })
+#endif
+                AtomLiteral().fail(outputType: SearchScopeActivation.self) {
+                    ModifierParseError(error: .unknownArgument($0), metadata: context.metadata)
+                }
             }
         }
     }
@@ -15901,33 +15738,30 @@ extension SearchSuggestionsPlacement: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
-            ConstantAtomLiteral("automatic").map({ () -> Self in
-
+            
+ConstantAtomLiteral("automatic").map({ () -> Self in
 
     return Self.automatic
 
-
-
-
 })
-ConstantAtomLiteral("menu").map({ () -> Self in
 
+
+ConstantAtomLiteral("menu").map({ () -> Self in
 
     return Self.menu
 
-
-
-
 })
-ConstantAtomLiteral("content").map({ () -> Self in
 
+
+ConstantAtomLiteral("content").map({ () -> Self in
 
     return Self.content
 
-
-
-
 })
+
+                AtomLiteral().fail(outputType: SearchSuggestionsPlacement.self) {
+                    ModifierParseError(error: .unknownArgument($0), metadata: context.metadata)
+                }
             }
         }
     }
@@ -15941,38 +15775,35 @@ ConstantAtomLiteral("content").map({ () -> Self in
 /// * `.enabled`
 /// * `.disabled`
 @_documentation(visibility: public)
-@available(visionOS 1.0,watchOS 10.0,macOS 14.0,tvOS 17.0,iOS 17.0, *)
+@available(watchOS 10.0,visionOS 1.0,iOS 17.0,macOS 14.0,tvOS 17.0, *)
 extension SpringLoadingBehavior: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
-            ConstantAtomLiteral("automatic").map({ () -> Self in
-#if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+            #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+ConstantAtomLiteral("automatic").map({ () -> Self in
 
     return Self.automatic
 
-#else
-fatalError("'automatic' is not available on this OS")
-#endif
 })
-ConstantAtomLiteral("enabled").map({ () -> Self in
+#endif
 #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+ConstantAtomLiteral("enabled").map({ () -> Self in
 
     return Self.enabled
 
-#else
-fatalError("'enabled' is not available on this OS")
-#endif
 })
-ConstantAtomLiteral("disabled").map({ () -> Self in
+#endif
 #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+ConstantAtomLiteral("disabled").map({ () -> Self in
 
     return Self.disabled
 
-#else
-fatalError("'disabled' is not available on this OS")
-#endif
 })
+#endif
+                AtomLiteral().fail(outputType: SpringLoadingBehavior.self) {
+                    ModifierParseError(error: .unknownArgument($0), metadata: context.metadata)
+                }
             }
         }
     }
@@ -15997,87 +15828,72 @@ extension SubmitLabel: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
-            ConstantAtomLiteral("done").map({ () -> Self in
-
+            
+ConstantAtomLiteral("done").map({ () -> Self in
 
     return Self.done
 
-
-
-
 })
-ConstantAtomLiteral("go").map({ () -> Self in
 
+
+ConstantAtomLiteral("go").map({ () -> Self in
 
     return Self.go
 
-
-
-
 })
-ConstantAtomLiteral("send").map({ () -> Self in
 
+
+ConstantAtomLiteral("send").map({ () -> Self in
 
     return Self.send
 
-
-
-
 })
-ConstantAtomLiteral("join").map({ () -> Self in
 
+
+ConstantAtomLiteral("join").map({ () -> Self in
 
     return Self.join
 
-
-
-
 })
-ConstantAtomLiteral("route").map({ () -> Self in
 
+
+ConstantAtomLiteral("route").map({ () -> Self in
 
     return Self.route
 
-
-
-
 })
-ConstantAtomLiteral("search").map({ () -> Self in
 
+
+ConstantAtomLiteral("search").map({ () -> Self in
 
     return Self.search
 
-
-
-
 })
-ConstantAtomLiteral("`return`").map({ () -> Self in
 
+
+ConstantAtomLiteral("`return`").map({ () -> Self in
 
     return Self.`return`
 
-
-
-
 })
-ConstantAtomLiteral("next").map({ () -> Self in
 
+
+ConstantAtomLiteral("next").map({ () -> Self in
 
     return Self.next
 
-
-
-
 })
-ConstantAtomLiteral("`continue`").map({ () -> Self in
 
+
+ConstantAtomLiteral("`continue`").map({ () -> Self in
 
     return Self.`continue`
 
-
-
-
 })
+
+                AtomLiteral().fail(outputType: SubmitLabel.self) {
+                    ModifierParseError(error: .unknownArgument($0), metadata: context.metadata)
+                }
             }
         }
     }
@@ -16095,24 +15911,23 @@ extension SubmitTriggers: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
-            ConstantAtomLiteral("text").map({ () -> Self in
-
+            
+ConstantAtomLiteral("text").map({ () -> Self in
 
     return Self.text
 
-
-
-
 })
-ConstantAtomLiteral("search").map({ () -> Self in
 
+
+ConstantAtomLiteral("search").map({ () -> Self in
 
     return Self.search
 
-
-
-
 })
+
+                AtomLiteral().fail(outputType: SubmitTriggers.self) {
+                    ModifierParseError(error: .unknownArgument($0), metadata: context.metadata)
+                }
             }
         }
     }
@@ -16124,20 +15939,21 @@ ConstantAtomLiteral("search").map({ () -> Self in
 /// Possible values:
 /// * `.sidebarToggle`
 @_documentation(visibility: public)
-@available(visionOS 1.0,iOS 17.0,tvOS 17.0,macOS 14.0,watchOS 10.0, *)
+@available(tvOS 17.0,iOS 17.0,watchOS 10.0,visionOS 1.0,macOS 14.0, *)
 extension ToolbarDefaultItemKind: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
-            ConstantAtomLiteral("sidebarToggle").map({ () -> Self in
-#if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+            #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+ConstantAtomLiteral("sidebarToggle").map({ () -> Self in
 
     return Self.sidebarToggle
 
-#else
-fatalError("'sidebarToggle' is not available on this OS")
-#endif
 })
+#endif
+                AtomLiteral().fail(outputType: ToolbarDefaultItemKind.self) {
+                    ModifierParseError(error: .unknownArgument($0), metadata: context.metadata)
+                }
             }
         }
     }
@@ -16157,42 +15973,37 @@ extension ToolbarRole: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
-            ConstantAtomLiteral("automatic").map({ () -> Self in
-
+            
+ConstantAtomLiteral("automatic").map({ () -> Self in
 
     return Self.automatic
 
-
-
-
 })
-ConstantAtomLiteral("navigationStack").map({ () -> Self in
+
 #if os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
-if #available(iOS 16.0,macOS 13.0,watchOS 9.0,tvOS 16.0,visionOS 1.0, *) {
+ConstantAtomLiteral("navigationStack").map({ () -> Self in
+if #available(macOS 13.0,iOS 16.0,visionOS 1.0,tvOS 16.0,watchOS 9.0, *) {
     return Self.navigationStack
 } else { fatalError("'navigationStack' is not available in this OS version") }
-#else
-fatalError("'navigationStack' is not available on this OS")
-#endif
 })
-ConstantAtomLiteral("browser").map({ () -> Self in
+#endif
 #if os(iOS) || os(visionOS)
-if #available(iOS 16.0,macOS 13.0,watchOS 9.0,tvOS 16.0,visionOS 1.0, *) {
+ConstantAtomLiteral("browser").map({ () -> Self in
+if #available(macOS 13.0,iOS 16.0,visionOS 1.0,tvOS 16.0,watchOS 9.0, *) {
     return Self.browser
 } else { fatalError("'browser' is not available in this OS version") }
-#else
-fatalError("'browser' is not available on this OS")
-#endif
 })
-ConstantAtomLiteral("editor").map({ () -> Self in
+#endif
 #if os(iOS) || os(macOS) || os(visionOS)
-if #available(iOS 16.0,macOS 13.0,watchOS 9.0,tvOS 16.0,visionOS 1.0, *) {
+ConstantAtomLiteral("editor").map({ () -> Self in
+if #available(macOS 13.0,iOS 16.0,visionOS 1.0,tvOS 16.0,watchOS 9.0, *) {
     return Self.editor
 } else { fatalError("'editor' is not available in this OS version") }
-#else
-fatalError("'editor' is not available on this OS")
-#endif
 })
+#endif
+                AtomLiteral().fail(outputType: ToolbarRole.self) {
+                    ModifierParseError(error: .unknownArgument($0), metadata: context.metadata)
+                }
             }
         }
     }
@@ -16207,47 +16018,42 @@ fatalError("'editor' is not available on this OS")
 /// * `.inlineLarge`
 /// * `.inline`
 @_documentation(visibility: public)
-@available(iOS 17.0,macOS 14.0,watchOS 10.0,visionOS 1.0,tvOS 17.0, *)
+@available(iOS 17.0,watchOS 10.0,visionOS 1.0,tvOS 17.0,macOS 14.0, *)
 extension ToolbarTitleDisplayMode: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
-            ConstantAtomLiteral("automatic").map({ () -> Self in
-#if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+            #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+ConstantAtomLiteral("automatic").map({ () -> Self in
 
     return Self.automatic
 
-#else
-fatalError("'automatic' is not available on this OS")
-#endif
 })
-ConstantAtomLiteral("large").map({ () -> Self in
+#endif
 #if os(iOS) || os(visionOS) || os(watchOS)
+ConstantAtomLiteral("large").map({ () -> Self in
 
     return Self.large
 
-#else
-fatalError("'large' is not available on this OS")
-#endif
 })
-ConstantAtomLiteral("inlineLarge").map({ () -> Self in
+#endif
 #if os(iOS) || os(macOS) || os(visionOS)
+ConstantAtomLiteral("inlineLarge").map({ () -> Self in
 
     return Self.inlineLarge
 
-#else
-fatalError("'inlineLarge' is not available on this OS")
-#endif
 })
-ConstantAtomLiteral("inline").map({ () -> Self in
+#endif
 #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+ConstantAtomLiteral("inline").map({ () -> Self in
 
     return Self.inline
 
-#else
-fatalError("'inline' is not available on this OS")
-#endif
 })
+#endif
+                AtomLiteral().fail(outputType: ToolbarTitleDisplayMode.self) {
+                    ModifierParseError(error: .unknownArgument($0), metadata: context.metadata)
+                }
             }
         }
     }
@@ -16268,51 +16074,44 @@ extension VerticalAlignment: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
-            ConstantAtomLiteral("top").map({ () -> Self in
-
+            
+ConstantAtomLiteral("top").map({ () -> Self in
 
     return Self.top
 
-
-
-
 })
-ConstantAtomLiteral("center").map({ () -> Self in
 
+
+ConstantAtomLiteral("center").map({ () -> Self in
 
     return Self.center
 
-
-
-
 })
-ConstantAtomLiteral("bottom").map({ () -> Self in
 
+
+ConstantAtomLiteral("bottom").map({ () -> Self in
 
     return Self.bottom
 
-
-
-
 })
-ConstantAtomLiteral("firstTextBaseline").map({ () -> Self in
 
+
+ConstantAtomLiteral("firstTextBaseline").map({ () -> Self in
 
     return Self.firstTextBaseline
 
-
-
-
 })
-ConstantAtomLiteral("lastTextBaseline").map({ () -> Self in
 
+
+ConstantAtomLiteral("lastTextBaseline").map({ () -> Self in
 
     return Self.lastTextBaseline
 
-
-
-
 })
+
+                AtomLiteral().fail(outputType: VerticalAlignment.self) {
+                    ModifierParseError(error: .unknownArgument($0), metadata: context.metadata)
+                }
             }
         }
     }
@@ -16330,24 +16129,23 @@ extension VerticalEdge: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
-            ConstantAtomLiteral("top").map({ () -> Self in
-
+            
+ConstantAtomLiteral("top").map({ () -> Self in
 
     return Self.top
 
-
-
-
 })
-ConstantAtomLiteral("bottom").map({ () -> Self in
 
+
+ConstantAtomLiteral("bottom").map({ () -> Self in
 
     return Self.bottom
 
-
-
-
 })
+
+                AtomLiteral().fail(outputType: VerticalEdge.self) {
+                    ModifierParseError(error: .unknownArgument($0), metadata: context.metadata)
+                }
             }
         }
     }
@@ -16366,33 +16164,30 @@ extension Visibility: ParseableModifierValue {
     public static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
         ImplicitStaticMember {
             OneOf {
-            ConstantAtomLiteral("automatic").map({ () -> Self in
-
+            
+ConstantAtomLiteral("automatic").map({ () -> Self in
 
     return Self.automatic
 
-
-
-
 })
-ConstantAtomLiteral("visible").map({ () -> Self in
 
+
+ConstantAtomLiteral("visible").map({ () -> Self in
 
     return Self.visible
 
-
-
-
 })
-ConstantAtomLiteral("hidden").map({ () -> Self in
 
+
+ConstantAtomLiteral("hidden").map({ () -> Self in
 
     return Self.hidden
 
-
-
-
 })
+
+                AtomLiteral().fail(outputType: Visibility.self) {
+                    ModifierParseError(error: .unknownArgument($0), metadata: context.metadata)
+                }
             }
         }
     }

--- a/Sources/LiveViewNativeStylesheet/Parsing/External/ParseableModifier.swift
+++ b/Sources/LiveViewNativeStylesheet/Parsing/External/ParseableModifier.swift
@@ -29,6 +29,22 @@ public struct _ErrorParse<Input, Output, Parsers: Parser>: Parser where Parsers.
     }
 }
 
+public extension Parser {
+    func fail<Output, ErrorType: Error>(outputType _: Output.Type = Output.self, _ makeError: @escaping (Self.Output) -> ErrorType) -> some Parser<Input, Output> {
+        MapFailParser<Self, Output, ErrorType>(parser: self, makeError: makeError)
+    }
+    
+}
+struct MapFailParser<ParserType: Parser, Output, ErrorType: Error>: Parser {
+    let parser: ParserType
+    let makeError: (ParserType.Output) -> ErrorType
+    
+    func parse(_ input: inout ParserType.Input) throws -> Output {
+        let error = try parser.parse(&input)
+        throw makeError(error)
+    }
+}
+
 public enum ArgumentParseError: LocalizedError {
     case unknownArgument(String)
     

--- a/Sources/ModifierGenerator/Subcommands/Source.swift
+++ b/Sources/ModifierGenerator/Subcommands/Source.swift
@@ -298,7 +298,6 @@ extension ModifierGenerator {
                                         ? AvailabilityArgumentListSyntax([])
                                         : memberAvailability
                                     return #"""
-                                    ConstantAtomLiteral("\#(`case`)").map({ () -> Self in
                                     \#(
                                         memberAvailability.isEmpty
                                         ? ""
@@ -312,15 +311,17 @@ extension ModifierGenerator {
                                                 .joined(separator: " || "))
                                         """
                                     )
+                                    ConstantAtomLiteral("\#(`case`)").map({ () -> Self in
                                     \#(availability.isEmpty ? "" : "if #available(\(availability), *) {")
                                         return Self.\#(`case`)
                                     \#(availability.isEmpty ? "" : #"} else { fatalError("'\#(`case`)' is not available in this OS version") }"#)
-                                    \#(memberAvailability.isEmpty ? "" : "#else")
-                                    \#(memberAvailability.isEmpty ? "" : #"fatalError("'\#(`case`)' is not available on this OS")"#)
-                                    \#(memberAvailability.isEmpty ? "" : "#endif")
                                     })
+                                    \#(memberAvailability.isEmpty ? "" : "#endif")
                                     """#
                                 }).joined(separator: "\n"))
+                                    AtomLiteral().fail(outputType: \(type).self) {
+                                        ModifierParseError(error: .unknownArgument($0), metadata: context.metadata)
+                                    }
                                 }
                             }
                         }


### PR DESCRIPTION
Closes #1408 

Previously, if an enum type that isn't available on a certain platform was found in a stylesheet, the app could crash.

This adds a `Parser.fail` function, which is used to handle the error properly. The error message can be seen in the logs as:

```
1 | modifier(arg1: <unavailable value>)
  | ^ Clause `modifier(arg1:)` failed:
  |   - Incorrect value passed to argument `arg1`. Expected `<type>` but got `<unavailable value>`. 
```