### PR TITLE
Refactor mix lvn.install reference

### DIFF
--- a/livebooks/create-a-swiftui-application.livemd
+++ b/livebooks/create-a-swiftui-application.livemd
@@ -66,7 +66,7 @@ Mix.install(
 
 This guide will teach you how to set up a SwiftUI Application for LiveView Native.
 
-Typically, we recommend using the `mix lvn.install` task as described in [Getting Started](https://hexdocs.pm/live_view_native/readme.html#getting-started) to add LiveView Native to a Phoenix project. However, we will walk through the steps of manually setting up an Xcode iOS project to learn how the iOS side of a LiveView Native application works.
+Typically, we recommend using the `mix lvn.setup` task as described in [Getting Started](https://hexdocs.pm/live_view_native/readme.html#getting-started) to add LiveView Native to a Phoenix project. However, we will walk through the steps of manually setting up an Xcode iOS project to learn how the iOS side of a LiveView Native application works.
 
 In future lessons, you'll use this iOS application to view iOS examples in the Xcode simulator (or a physical device if you prefer.)
 

--- a/livebooks/forms-and-validation.livemd
+++ b/livebooks/forms-and-validation.livemd
@@ -89,7 +89,7 @@ Follow the [LiveView Native Form Installation Guide](https://github.com/liveview
 
 ## Creating a Basic Form
 
-The LiveView Native `mix lvn.install` task generates a [core_components.swiftui.ex](https://github.com/liveview-native/liveview-client-swiftui/blob/main/priv/templates/lvn.swiftui.gen/core_components.ex) file for native SwiftUI function components similar to the [core_components.ex](https://github.com/phoenixframework/phoenix/blob/main/priv/templates/phx.gen.live/core_components.ex) file generated in a traditional phoenix application for web function components.
+The LiveView Native `mix lvn.setup.gen` task generates a [core_components.swiftui.ex](https://github.com/liveview-native/liveview-client-swiftui/blob/main/priv/templates/lvn.swiftui.gen/core_components.ex) file for native SwiftUI function components similar to the [core_components.ex](https://github.com/phoenixframework/phoenix/blob/main/priv/templates/phx.gen.live/core_components.ex) file generated in a traditional phoenix application for web function components.
 
 See Phoenix's [Components and HEEx](https://hexdocs.pm/phoenix/components.html) HexDoc documentation if you need a primer on function components.
 

--- a/livebooks/markdown/create-a-swiftui-application.md
+++ b/livebooks/markdown/create-a-swiftui-application.md
@@ -6,7 +6,7 @@
 
 This guide will teach you how to set up a SwiftUI Application for LiveView Native.
 
-Typically, we recommend using the `mix lvn.install` task as described in [Getting Started](https://hexdocs.pm/live_view_native/readme.html#getting-started) to add LiveView Native to a Phoenix project. However, we will walk through the steps of manually setting up an Xcode iOS project to learn how the iOS side of a LiveView Native application works.
+Typically, we recommend using the `mix lvn.setup` task as described in [Getting Started](https://hexdocs.pm/live_view_native/readme.html#getting-started) to add LiveView Native to a Phoenix project. However, we will walk through the steps of manually setting up an Xcode iOS project to learn how the iOS side of a LiveView Native application works.
 
 In future lessons, you'll use this iOS application to view iOS examples in the Xcode simulator (or a physical device if you prefer.)
 

--- a/livebooks/markdown/forms-and-validation.md
+++ b/livebooks/markdown/forms-and-validation.md
@@ -16,7 +16,7 @@ Follow the [LiveView Native Form Installation Guide](https://github.com/liveview
 
 ## Creating a Basic Form
 
-The LiveView Native `mix lvn.install` task generates a [core_components.swiftui.ex](https://github.com/liveview-native/liveview-client-swiftui/blob/main/priv/templates/lvn.swiftui.gen/core_components.ex) file for native SwiftUI function components similar to the [core_components.ex](https://github.com/phoenixframework/phoenix/blob/main/priv/templates/phx.gen.live/core_components.ex) file generated in a traditional phoenix application for web function components.
+The LiveView Native `mix lvn.setup.gen` task generates a [core_components.swiftui.ex](https://github.com/liveview-native/liveview-client-swiftui/blob/main/priv/templates/lvn.swiftui.gen/core_components.ex) file for native SwiftUI function components similar to the [core_components.ex](https://github.com/phoenixframework/phoenix/blob/main/priv/templates/phx.gen.live/core_components.ex) file generated in a traditional phoenix application for web function components.
 
 See Phoenix's [Components and HEEx](https://hexdocs.pm/phoenix/components.html) HexDoc documentation if you need a primer on function components.
 


### PR DESCRIPTION
The references to `mix lvn.install` are changed. Brooklyn wondered if these sections should be deleted now.