### PR TITLE
Apply various @MainActor annotations

### DIFF
--- a/Sources/LiveViewNative/Property Wrappers/LiveContext.swift
+++ b/Sources/LiveViewNative/Property Wrappers/LiveContext.swift
@@ -21,6 +21,7 @@ import LiveViewNativeCore
 /// }
 /// ```
 @propertyWrapper
+@MainActor
 public struct LiveContext<R: RootRegistry>: DynamicProperty {
     @Environment(\.anyLiveContextStorage) private var anyStorage
     

--- a/Sources/LiveViewNative/Protocols/ContentBuilder.swift
+++ b/Sources/LiveViewNative/Protocols/ContentBuilder.swift
@@ -215,6 +215,7 @@ import LiveViewNativeStylesheet
 ///     }
 /// }
 /// ```
+@MainActor
 public protocol ContentBuilder {
     /// An enum with the supported element names.
     associatedtype TagName: RawRepresentable<String>
@@ -333,6 +334,7 @@ public struct ContentBuilderContext<R: RootRegistry, Builder: ContentBuilder>: D
         )
     }
     
+    @MainActor
     public struct Value {
         let coordinatorEnvironment: CoordinatorEnvironment?
         public let context: LiveContext<R>
@@ -352,7 +354,8 @@ public struct ContentBuilderContext<R: RootRegistry, Builder: ContentBuilder>: D
         public var document: Document? {
             context.coordinator.document
         }
-        
+      
+        @MainActor
         func value<OtherBuilder: ContentBuilder>(for _: OtherBuilder.Type = OtherBuilder.self) -> ContentBuilderContext<R, OtherBuilder>.Value {
             return .init(
                 coordinatorEnvironment: coordinatorEnvironment,
@@ -373,6 +376,7 @@ public struct ContentBuilderContext<R: RootRegistry, Builder: ContentBuilder>: D
         stylesheetResolver.resolvedStylesheet = stylesheet.flatMap({ try? Self.resolveStylesheet($0) }) ?? [:]
     }
     
+    @MainActor
     static func resolveStylesheet(
         _ stylesheet: Stylesheet<R>
     ) throws -> [String:[BuilderModifierContainer<Builder>]] {

--- a/Sources/LiveViewNative/Registries/AggregateRegistry.swift
+++ b/Sources/LiveViewNative/Registries/AggregateRegistry.swift
@@ -78,6 +78,7 @@ public macro Registries() = #externalMacro(module: "LiveViewNativeMacros", type:
 /// - ``Registry2``
 /// - ``Registry3``
 /// - ``Registry4``
+@MainActor
 public protocol AggregateRegistry: RootRegistry {
     /// The combined registry type.
     ///
@@ -138,6 +139,7 @@ public enum _EitherCustomModifier<First: CustomRegistry, Second: CustomRegistry>
     public struct _ParserType: Parser {
         let context: ParseableModifierContext
         
+        @MainActor
         public func parse(_ input: inout Substring.UTF8View) throws -> _EitherCustomModifier<First, Second> {
             let copy = input
             let firstError: ModifierParseError?

--- a/Sources/LiveViewNative/Registries/CustomRegistry.swift
+++ b/Sources/LiveViewNative/Registries/CustomRegistry.swift
@@ -71,6 +71,7 @@ public macro Addon() = #externalMacro(module: "LiveViewNativeMacros", type: "Add
 /// ### Supporting Types
 /// - ``EmptyRegistry``
 /// - ``ViewModifierBuilder``
+@MainActor
 public protocol CustomRegistry<Root> {
     /// The root custom registry type that the live view coordinator and context use.
     ///

--- a/Sources/LiveViewNative/Stylesheets/AttributeReference.swift
+++ b/Sources/LiveViewNative/Stylesheets/AttributeReference.swift
@@ -56,6 +56,7 @@ public struct AttributeReference<Value: ParseableModifierValue & AttributeDecoda
         .map(Self.init)
     }
     
+    @MainActor
     public func resolve<R: RootRegistry>(on element: ElementNode, in context: LiveContext<R>) -> Value {
         switch storage {
         case .constant(let value):

--- a/Sources/LiveViewNative/Stylesheets/Modifiers/Shapes/RotationModifier.swift
+++ b/Sources/LiveViewNative/Stylesheets/Modifiers/Shapes/RotationModifier.swift
@@ -40,6 +40,7 @@ struct _RotationModifier<Root: RootRegistry>: ShapeModifier {
         self.anchor = anchor
     }
 
+    @MainActor
     func apply(to shape: AnyShape, on element: ElementNode, in context: LiveContext<Root>) -> some SwiftUI.Shape {
         return shape.rotation(angle.resolve(on: element, in: context), anchor: anchor.resolve(on: element, in: context))
     }

--- a/Sources/LiveViewNative/Stylesheets/Modifiers/Shapes/ScaleModifier.swift
+++ b/Sources/LiveViewNative/Stylesheets/Modifiers/Shapes/ScaleModifier.swift
@@ -46,6 +46,7 @@ struct _ScaleModifier<Root: RootRegistry>: ShapeModifier {
         self.value = ._1(scale: scale, anchor: anchor)
     }
 
+    @MainActor
     func apply(to shape: AnyShape, on element: ElementNode, in context: LiveContext<Root>) -> some SwiftUI.Shape {
         switch value {
         case let ._0(x, y, anchor):

--- a/Sources/LiveViewNative/Stylesheets/Modifiers/Shapes/ShapeBooleanModifiers.swift
+++ b/Sources/LiveViewNative/Stylesheets/Modifiers/Shapes/ShapeBooleanModifiers.swift
@@ -75,6 +75,7 @@ struct _UnionModifier<Root: RootRegistry>: ShapeModifier {
         self.eoFill = eoFill
     }
 
+    @MainActor
     func apply(to shape: AnyShape, on element: ElementNode, in context: LiveContext<Root>) -> some SwiftUI.Shape {
         if #available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *) {
             return AnyShape(shape.union(other, eoFill: eoFill.resolve(on: element, in: context)))

--- a/Sources/LiveViewNative/Stylesheets/Modifiers/Shapes/ShapeModifier.swift
+++ b/Sources/LiveViewNative/Stylesheets/Modifiers/Shapes/ShapeModifier.swift
@@ -13,6 +13,7 @@ protocol ShapeModifier<Root> {
     associatedtype Root: RootRegistry
     associatedtype ModifiedShape: SwiftUI.Shape
     
+    @MainActor
     func apply(to shape: SwiftUI.AnyShape, on element: ElementNode, in context: LiveContext<Root>) -> ModifiedShape
 }
 
@@ -21,7 +22,7 @@ protocol ShapeFinalizerModifier<Root> {
     associatedtype Root: RootRegistry
     associatedtype FinalizedShape: SwiftUI.View
     
-    @ViewBuilder
+    @ViewBuilder @MainActor
     func apply(to shape: SwiftUI.AnyShape, on element: ElementNode, in context: LiveContext<Root>) -> FinalizedShape
 }
 

--- a/Sources/LiveViewNative/Stylesheets/Modifiers/Shapes/StrokeModifier.swift
+++ b/Sources/LiveViewNative/Stylesheets/Modifiers/Shapes/StrokeModifier.swift
@@ -55,7 +55,7 @@ struct _StrokeModifier<Root: RootRegistry>: ShapeFinalizerModifier {
         self.storage = ._1(content: content, lineWidth: lineWidth, antialiased: antialiased)
     }
     
-    @ViewBuilder
+    @ViewBuilder @MainActor
     func apply(to shape: AnyShape, on element: ElementNode, in context: LiveContext<Root>) -> some View {
         switch storage {
         case ._0(let content, let style, let antialiased):

--- a/Sources/LiveViewNative/Stylesheets/Modifiers/Shapes/TransformModifier.swift
+++ b/Sources/LiveViewNative/Stylesheets/Modifiers/Shapes/TransformModifier.swift
@@ -34,6 +34,7 @@ struct _TransformModifier<Root: RootRegistry>: ShapeModifier {
         self.transform = transform
     }
 
+    @MainActor
     func apply(to shape: AnyShape, on element: ElementNode, in context: LiveContext<Root>) -> some SwiftUI.Shape {
         return shape.transform(transform)
     }

--- a/Sources/LiveViewNative/Stylesheets/ParseableTypes/AnyGesture+ParseableModifierValue.swift
+++ b/Sources/LiveViewNative/Stylesheets/ParseableTypes/AnyGesture+ParseableModifierValue.swift
@@ -110,6 +110,7 @@ struct _AnyGesture: ParseableModifierValue {
     let gesture: AnyGesture<Any>
     let members: [Member]
     
+    @MainActor
     func resolve<R: RootRegistry>(on element: ElementNode, in context: LiveContext<R>) -> AnyGesture<Any> {
         members.reduce(gesture) { gesture, member in
             return member.apply(to: gesture, on: element, in: context)
@@ -199,6 +200,7 @@ struct _AnyGesture: ParseableModifierValue {
             }
         }
         
+        @MainActor
         func apply<R: RootRegistry>(to gesture: AnyGesture<Any>, on element: ElementNode, in context: LiveContext<R>) -> AnyGesture<Any> {
             switch self {
             case .sequenced(let sequenced):

--- a/Sources/LiveViewNative/Stylesheets/ParseableTypes/ListItemTint+ParseableModifierValue.swift
+++ b/Sources/LiveViewNative/Stylesheets/ParseableTypes/ListItemTint+ParseableModifierValue.swift
@@ -35,6 +35,7 @@ extension ListItemTint {
         
         let storage: Storage
         
+        @MainActor
         func resolve<R: RootRegistry>(on element: ElementNode, in context: LiveContext<R>) -> ListItemTint {
             switch storage {
             case .monochrome:

--- a/Sources/LiveViewNative/Stylesheets/ParseableTypes/ShapeStyles/AnyShapeStyle+ParseableModifierValue.swift
+++ b/Sources/LiveViewNative/Stylesheets/ParseableTypes/ShapeStyles/AnyShapeStyle+ParseableModifierValue.swift
@@ -163,6 +163,7 @@ public extension AnyShapeStyle {
         let storage: Storage
         let modifiers: [StyleModifier]
         
+        @MainActor
         public func resolve<R: RootRegistry>(on element: ElementNode, in context: LiveContext<R>) -> AnyShapeStyle {
             let base: any ShapeStyle = switch storage {
             case .value(let value):
@@ -332,6 +333,7 @@ public extension AnyShapeStyle {
                 self = .stops(stops: stops, center: center, startAngle: startAngle, endAngle: endAngle)
             }
             
+            @MainActor
             func resolve<R: RootRegistry>(on element: ElementNode, in context: LiveContext<R>) -> any ShapeStyle {
                 switch self {
                 case .anyGradient(let gradient, let center, let startAngle, let endAngle):
@@ -371,6 +373,7 @@ public extension AnyShapeStyle {
                 self = .stops(stops: stops, center: center, angle: angle)
             }
             
+            @MainActor
             func resolve(on element: ElementNode, in context: LiveContext<some RootRegistry>) -> any ShapeStyle {
                 switch self {
                 case .anyGradient(let gradient, let center, let angle):
@@ -410,6 +413,7 @@ public extension AnyShapeStyle {
                 self = .anyGradient(gradient: gradient, center: center, startRadiusFraction: startRadiusFraction, endRadiusFraction: endRadiusFraction)
             }
             
+            @MainActor
             func resolve(on element: ElementNode, in context: LiveContext<some RootRegistry>) -> any ShapeStyle {
                 switch self {
                 case .gradient(let gradient, let center, let startRadiusFraction, let endRadiusFraction):
@@ -449,6 +453,7 @@ public extension AnyShapeStyle {
                 self = .anyGradient(gradient: gradient, startPoint: startPoint, endPoint: endPoint)
             }
             
+            @MainActor
             func resolve(on element: ElementNode, in context: LiveContext<some RootRegistry>) -> any ShapeStyle {
                 switch self {
                 case .gradient(let gradient, let startPoint, let endPoint):
@@ -508,6 +513,7 @@ public extension AnyShapeStyle {
                 self = .anyGradient(gradient: gradient, center: center, startRadius: startRadius, endRadius: endRadius)
             }
             
+            @MainActor
             func resolve(on element: ElementNode, in context: LiveContext<some RootRegistry>) -> any ShapeStyle {
                 switch self {
                 case .gradient(let gradient, let center, let startRadius, let endRadius):
@@ -615,6 +621,7 @@ public extension AnyShapeStyle {
             }
             
             /// Apply this modifier to an existing `ShapeStyle`.
+            @MainActor
             func apply(to style: some ShapeStyle, on element: ElementNode, in context: LiveContext<some RootRegistry>) -> any ShapeStyle {
                 switch self {
                 case let .blendMode(blendMode):
@@ -642,6 +649,7 @@ public extension AnyShapeStyle {
             }
             
             /// Use this modifier itself as a `ShapeStyle`. SwiftUI will apply it to the foreground style.
+            @MainActor
             func resolve(on element: ElementNode, in context: LiveContext<some RootRegistry>) -> any ShapeStyle {
                 switch self {
                 case let .blendMode(blendMode):

--- a/Sources/LiveViewNative/Stylesheets/ParseableTypes/ShapeStyles/Color+ParseableModifierValue.swift
+++ b/Sources/LiveViewNative/Stylesheets/ParseableTypes/ShapeStyles/Color+ParseableModifierValue.swift
@@ -103,6 +103,7 @@ public extension SwiftUI.Color {
             self.modifiers = modifiers
         }
         
+        @MainActor
         public func resolve<R: RootRegistry>(on element: ElementNode, in context: LiveContext<R>) -> SwiftUI.Color {
             let base = switch storage {
             case let .reference(name):
@@ -341,6 +342,7 @@ enum ColorModifier {
         }
     }
     
+    @MainActor
     func apply(to color: SwiftUI.Color, on element: ElementNode, in context: LiveContext<some RootRegistry>) -> SwiftUI.Color {
         switch self {
         case let .opacity(opacity):

--- a/Sources/LiveViewNative/Stylesheets/ParseableTypes/ShapeStyles/Gradient+ParseableModifierValue.swift
+++ b/Sources/LiveViewNative/Stylesheets/ParseableTypes/ShapeStyles/Gradient+ParseableModifierValue.swift
@@ -34,6 +34,7 @@ extension AnyGradient {
             }
         }
         
+        @MainActor
         func resolve(on element: ElementNode, in context: LiveContext<some RootRegistry>) -> AnyGradient {
             color.resolve(on: element, in: context).gradient
         }
@@ -73,6 +74,7 @@ extension Gradient {
             }
         }
         
+        @MainActor
         func resolve(on element: ElementNode, in context: LiveContext<some RootRegistry>) -> Gradient {
             switch self {
             case .colors(let colors):
@@ -120,6 +122,7 @@ extension Gradient.Stop {
             }
         }
         
+        @MainActor
         func resolve(on element: ElementNode, in context: LiveContext<some RootRegistry>) -> Gradient.Stop {
             .init(color: color.resolve(on: element, in: context), location: location.resolve(on: element, in: context))
         }

--- a/Sources/LiveViewNative/Stylesheets/ParseableTypes/ShapeStyles/ShadowStyle+ParseableModifierValue.swift
+++ b/Sources/LiveViewNative/Stylesheets/ParseableTypes/ShapeStyles/ShadowStyle+ParseableModifierValue.swift
@@ -51,6 +51,7 @@ enum _ShadowStyle: ParseableModifierValue {
         }
     }
     
+    @MainActor
     func resolve(on element: ElementNode, in context: LiveContext<some RootRegistry>) -> ShadowStyle {
         switch self {
         case .drop(let drop):

--- a/Sources/LiveViewNative/Stylesheets/ParseableTypes/Text+ParseableModifierValue.swift
+++ b/Sources/LiveViewNative/Stylesheets/ParseableTypes/Text+ParseableModifierValue.swift
@@ -97,6 +97,7 @@ enum _AnyTextLineStyle: ParseableModifierValue {
         }
     }
     
+    @MainActor
     func resolve<R: RootRegistry>(on element: ElementNode, in context: LiveContext<R>) -> SwiftUI.Text.LineStyle {
         switch self {
         case .single:

--- a/Sources/LiveViewNative/Stylesheets/ViewReference.swift
+++ b/Sources/LiveViewNative/Stylesheets/ViewReference.swift
@@ -162,6 +162,7 @@ struct _TextReferenceObserver: ViewModifier {
 struct ToolbarContentReference: ParseableModifierValue {
     let value: [String]
     
+    @MainActor
     func resolve<R: RootRegistry>(on element: ElementNode, in context: LiveContext<R>) -> some ToolbarContent {
         ToolbarTreeBuilder<R>().fromNodes(
             value.reduce(into: [LiveViewNativeCore.Node]()) {
@@ -204,6 +205,7 @@ struct ToolbarContentReference: ParseableModifierValue {
 struct CustomizableToolbarContentReference: ParseableModifierValue {
     let value: [String]
     
+    @MainActor
     func resolve<R: RootRegistry>(on element: ElementNode, in context: LiveContext<R>) -> some CustomizableToolbarContent {
         CustomizableToolbarTreeBuilder<R>().fromNodes(
             value.reduce(into: [LiveViewNativeCore.Node]()) {

--- a/Sources/LiveViewNative/ViewTree.swift
+++ b/Sources/LiveViewNative/ViewTree.swift
@@ -10,6 +10,7 @@ import SwiftUI
 import LiveViewNativeCore
 import LiveViewNativeStylesheet
 
+@MainActor
 struct ViewTreeBuilder<R: RootRegistry> {
     func fromNodes(_ nodes: NodeChildrenSequence, coordinator: LiveViewCoordinator<R>, url: URL) -> some View {
         let context = LiveContextStorage(coordinator: coordinator, url: url)

--- a/Sources/LiveViewNative/_GeneratedModifiers.swift
+++ b/Sources/LiveViewNative/_GeneratedModifiers.swift
@@ -13562,6 +13562,7 @@ case let ._MatchedGeometryEffectModifier(modifier):
             
             let context: ParseableModifierContext
             
+            @MainActor
             func parse(_ input: inout Substring.UTF8View) throws -> Output {
                 let parsers = [
                     _accessibilityActionModifier<R>.name: _accessibilityActionModifier<R>.parser(in: context).map({ Output.chunk0(.accessibilityAction($0)) }).eraseToAnyParser(),


### PR DESCRIPTION
In Xcode 16 `View` automatically gets `@MainActor` applied. This breaks creating a custom LVN Addon as the `static lookup(_:,element:)` is not isolated to the main actor, which the Swift compiler doesn't allow. 

I went through the exercise of annotating `CustomRegistry` as `@MainActor` and working through the many follow-ups of annotating other things also as `@MainActor`. 

This is now working in my early test cases, but I'm by no means sure that this is the right approach here. Hence, marking this as a draft for now.