### PR TITLE
Remove change collection for `ChangeTracked`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Changed
 
 ## Fixed
-- Updates to change-tracked properties no longer occur on the next RunLoop, fixing modal dismissal on macOS
+- Updates to change-tracked properties no longer occur on the next RunLoop, fixing modal dismissal on macOS (#1450)
 
 ## [0.3.0] 2024-08-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Changed
 
 ## Fixed
+- Updates to change-tracked properties no longer occur on the next RunLoop, fixing modal dismissal on macOS
 
 ## [0.3.0] 2024-08-21
 

--- a/Sources/LiveViewNative/Coordinators/LiveViewCoordinator.swift
+++ b/Sources/LiveViewNative/Coordinators/LiveViewCoordinator.swift
@@ -293,7 +293,6 @@ public class LiveViewCoordinator<R: RootRegistry>: ObservableObject {
         channel.on("phx_close") { [weak self, weak channel] message in
             Task { @MainActor in
                 guard channel === self?.channel else { return }
-                print("State changed to: phx_close")
                 self?.internalState = .disconnected
             }
         }

--- a/Sources/LiveViewNative/Property Wrappers/ChangeTracked.swift
+++ b/Sources/LiveViewNative/Property Wrappers/ChangeTracked.swift
@@ -102,9 +102,7 @@ extension ChangeTracked where Value: AttributeDecodable {
                 self.previousValue = value
             }
             cancellable = localValueChanged
-                .collect(.byTime(RunLoop.current, RunLoop.current.minimumTolerance))
-                .compactMap(\.last)
-                .sink(receiveValue: { [weak self] localValue in
+                .sink(receiveValue: { @MainActor [weak self] localValue in
                     self?.objectWillChange.send()
                     self?.value = localValue
                     Task { [weak self] in
@@ -118,8 +116,7 @@ extension ChangeTracked where Value: AttributeDecodable {
             // set current value to previousValue and trigger update to sync with attribute value
             // (may be delayed from localValueChanged due to debounce/throttle)
             didSendCancellable = changeTracked.event.owner.handler.didSendSubject
-                .collect(.byTime(RunLoop.current, RunLoop.current.minimumTolerance))
-                .sink { [weak self] _ in
+                .sink { @MainActor [weak self] _ in
                     guard let self
                     else { return }
                     self.previousValue = self.value


### PR DESCRIPTION
This removes the `collect(.byTime(...))` call in `ChangeTracked`. I'm not sure why we were collecting the values here:

1. Most elements will only send one change per RunLoop iteration
2. Updating the localValue on the next RunLoop can cause animation hitches as seen in the `alert` modifier on macOS.

I believe this was leftover from `native_bindings`, which would collect all updates during a RunLoop and batch them together.