### PR TITLE
Fix retain cycle in LiveViewCoordinator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Changed
 
 ## Fixed
+- Fixed retain cycle in `LiveViewCoordinator`
 
 ## [0.3.0] 2024-08-21
 

--- a/Sources/LiveViewNative/Coordinators/LiveSessionCoordinator.swift
+++ b/Sources/LiveViewNative/Coordinators/LiveSessionCoordinator.swift
@@ -479,11 +479,11 @@ public class LiveSessionCoordinator<R: RootRegistry>: ObservableObject {
         }.receive("error") { msg in
             logger.debug("[LiveReload] error connecting to channel: \(msg.payload)")
         }
-        self.liveReloadChannel!.on("assets_change") { [unowned self] _ in
+        self.liveReloadChannel!.on("assets_change") { [weak self] _ in
             logger.debug("[LiveReload] assets changed, reloading")
             Task {
                 // need to fully reconnect (rather than just re-join channel) because the elixir code reloader only triggers on http reqs
-                await self.reconnect()
+                await self?.reconnect()
             }
         }
     }

--- a/Sources/LiveViewNative/Coordinators/LiveSessionCoordinator.swift
+++ b/Sources/LiveViewNative/Coordinators/LiveSessionCoordinator.swift
@@ -395,9 +395,12 @@ public class LiveSessionCoordinator<R: RootRegistry>: ObservableObject {
             var wsEndpoint = URLComponents(url: self.url, resolvingAgainstBaseURL: true)!
             wsEndpoint.scheme = self.url.scheme == "https" ? "wss" : "ws"
             wsEndpoint.path = "/live/websocket"
+            let configuration = self.urlSession.configuration
             let socket = Socket(
                 endPoint: wsEndpoint.string!,
-                transport: { [unowned self] in URLSessionTransport(url: $0, configuration: self.urlSession.configuration) },
+                transport: {
+                    URLSessionTransport(url: $0, configuration: configuration)
+                },
                 paramsClosure: {
                     [
                         "_csrf_token": domValues.phxCSRFToken,

--- a/Sources/LiveViewNative/Coordinators/LiveViewCoordinator.swift
+++ b/Sources/LiveViewNative/Coordinators/LiveViewCoordinator.swift
@@ -32,7 +32,7 @@ public class LiveViewCoordinator<R: RootRegistry>: ObservableObject {
         internalState
     }
     
-    @_spi(LiveForm) public weak var session: LiveSessionCoordinator<R>!
+    @_spi(LiveForm) public private(set) weak var session: LiveSessionCoordinator<R>!
     var url: URL
     
     private var channel: Channel?

--- a/Sources/LiveViewNative/Coordinators/LiveViewCoordinator.swift
+++ b/Sources/LiveViewNative/Coordinators/LiveViewCoordinator.swift
@@ -32,7 +32,7 @@ public class LiveViewCoordinator<R: RootRegistry>: ObservableObject {
         internalState
     }
     
-    @_spi(LiveForm) public let session: LiveSessionCoordinator<R>
+    @_spi(LiveForm) public weak var session: LiveSessionCoordinator<R>!
     var url: URL
     
     private var channel: Channel?
@@ -62,10 +62,11 @@ public class LiveViewCoordinator<R: RootRegistry>: ObservableObject {
         
         self.handleEvent("native_redirect") { [weak self] payload in
             guard let self,
-                  let redirect = LiveRedirect(from: payload, relativeTo: self.url)
+                  let redirect = LiveRedirect(from: payload, relativeTo: self.url),
+                  let session = self.session
             else { return }
-            Task { [weak session] in
-                try await session?.redirect(redirect)
+            Task {
+                try await session.redirect(redirect)
             }
         }
     }


### PR DESCRIPTION
`LiveViewCoordinator` is initialised from `LiveSessionCoordinator`, which gets passed in as a parameter to `init` and then retained by the view coordinator. This causes a retain cycle.

Additionally, this is also retained by the `handleEvent` as `session` was used directly in the closure, which then retained it.

This commit fixes both by using a weak reference from the view coordinator to the session coordinator, and accessing the session via the weak `self` reference.