### PR TITLE
Allow to set optional headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Added
 - `LiveViewNative.SwiftUI.normalize_os_version/1`
 - `LiveViewNative.SwiftUI.normalize_app_version/1`
+- Optional `LiveSessionConfiguration.headers`, sent when fetching the dead render (#1456)
 
 ## Changed
 - Submitting a form will remove focus from all fields (#1451)

--- a/Sources/LiveViewNative/Coordinators/LiveSessionConfiguration.swift
+++ b/Sources/LiveViewNative/Coordinators/LiveSessionConfiguration.swift
@@ -15,6 +15,11 @@ public struct LiveSessionConfiguration {
     ///
     /// By default, no connection params are provided.
     public var connectParams: ((URL) -> [String: Any])? = nil
+  
+    /// Optional headers that are passed along with estabilishing the initial connection.
+    ///
+    /// By default, no addtional headers are provided.
+    public var headers: [String: String] = [:]
     
     /// The URL session configuration the coordinator will use for performing HTTP and socket requests.
     /// 
@@ -34,10 +39,12 @@ public struct LiveSessionConfiguration {
     
     public init(
         connectParams: ((URL) -> [String: Any])? = nil,
+        headers: [String: String] = [:],
         urlSessionConfiguration: URLSessionConfiguration = .default,
         transition: AnyTransition? = nil,
         reconnectBehavior: ReconnectBehavior = .exponential
     ) {
+        self.headers = headers
         self.connectParams = connectParams
         self.urlSessionConfiguration = urlSessionConfiguration
         self.transition = transition

--- a/Sources/LiveViewNative/Coordinators/LiveSessionConfiguration.swift
+++ b/Sources/LiveViewNative/Coordinators/LiveSessionConfiguration.swift
@@ -16,7 +16,7 @@ public struct LiveSessionConfiguration {
     /// By default, no connection params are provided.
     public var connectParams: ((URL) -> [String: Any])? = nil
   
-    /// Optional headers that are passed along with estabilishing the initial connection.
+    /// Optional headers that are sent when fetching the dead render.
     ///
     /// By default, no addtional headers are provided.
     public var headers: [String: String] = [:]

--- a/Sources/LiveViewNative/Coordinators/LiveSessionConfiguration.swift
+++ b/Sources/LiveViewNative/Coordinators/LiveSessionConfiguration.swift
@@ -18,8 +18,8 @@ public struct LiveSessionConfiguration {
   
     /// Optional headers that are sent when fetching the dead render.
     ///
-    /// By default, no addtional headers are provided.
-    public var headers: [String: String] = [:]
+    /// By default, no additional headers are provided.
+    public var headers: [String: String]? = nil
     
     /// The URL session configuration the coordinator will use for performing HTTP and socket requests.
     /// 
@@ -39,7 +39,7 @@ public struct LiveSessionConfiguration {
     
     public init(
         connectParams: ((URL) -> [String: Any])? = nil,
-        headers: [String: String] = [:],
+        headers: [String: String]? = nil,
         urlSessionConfiguration: URLSessionConfiguration = .default,
         transition: AnyTransition? = nil,
         reconnectBehavior: ReconnectBehavior = .exponential

--- a/Sources/LiveViewNative/Coordinators/LiveSessionCoordinator.swift
+++ b/Sources/LiveViewNative/Coordinators/LiveSessionCoordinator.swift
@@ -323,11 +323,10 @@ public class LiveSessionCoordinator<R: RootRegistry>: ObservableObject {
     func deadRender(for request: URLRequest) async throws -> (String, HTTPURLResponse) {
         var request = request
         request.url = request.url!.appendingLiveViewItems(R.self)
+        request.allHTTPHeaderFields = configuration.headers
+        
         if domValues != nil {
             request.setValue(domValues.phxCSRFToken, forHTTPHeaderField: "x-csrf-token")
-        }
-        for (header, value) in configuration.headers {
-            request.setValue(value, forHTTPHeaderField: header)
         }
         
         let data: Data

--- a/Sources/LiveViewNative/Coordinators/LiveSessionCoordinator.swift
+++ b/Sources/LiveViewNative/Coordinators/LiveSessionCoordinator.swift
@@ -326,6 +326,9 @@ public class LiveSessionCoordinator<R: RootRegistry>: ObservableObject {
         if domValues != nil {
             request.setValue(domValues.phxCSRFToken, forHTTPHeaderField: "x-csrf-token")
         }
+        for (header, value) in configuration.headers {
+            request.setValue(value, forHTTPHeaderField: header)
+        }
         
         let data: Data
         let response: URLResponse


### PR DESCRIPTION
These are passed on to Phoenix when the LiveView makes the initial connection. 

Sample use case: Passing an "Authorization" HTTP header to authenticate a user in the LiveView with a token that's fetched outside of LiveView and stored in the user's keychain. That particular header should not be set on [`URLSessionConfiguration`](https://developer.apple.com/documentation/foundation/urlsessionconfiguration/1411532-httpadditionalheaders) directly.

[Related Slack thread](https://elixir-lang.slack.com/archives/C041F3EQHFS/p1726716326675869) for reference.