### PR TITLE
Use value from document as default for unbound `FormState`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `+` characters are properly encoded as `%2B` in form events (#1449)
 - Fixed retain cycle in `LiveViewCoordinator` (#1455)
 - Made `StylesheetCache` thread-safe, fixing occasional crashes (#1461)
+- Form elements outside of a `LiveForm` will show the value provided in the template (#1464)
 
 ## [0.3.0] 2024-08-21
 

--- a/Sources/LiveViewNative/Property Wrappers/FormState.swift
+++ b/Sources/LiveViewNative/Property Wrappers/FormState.swift
@@ -128,7 +128,9 @@ public struct FormState<Value: FormValue> {
             case .unknown:
                 fatalError("@FormState cannot be accessed before being installed in a view")
             case .local:
-                return defaultValue
+                return element.attribute(named: valueAttribute)
+                    .flatMap({ Value.fromAttribute($0, on: element) })
+                    ?? defaultValue
             case .form(let formModel):
                 guard let elementName = element.attributeValue(for: "name") else {
                     logger.log(level: .error, "Expected @FormState in form mode to have element with name")

--- a/Sources/LiveViewNative/Property Wrappers/FormState.swift
+++ b/Sources/LiveViewNative/Property Wrappers/FormState.swift
@@ -58,7 +58,7 @@ private let logger = Logger(subsystem: "LiveViewNative", category: "FormState")
 public struct FormState<Value: FormValue> {
     private let defaultValue: Value
     private let sendChangeEvents: Bool
-    @StateObject private var data = FormStateData<Value>()
+    @StateObject private var data: FormStateData<Value>
     
     let valueAttribute: AttributeName
     
@@ -98,6 +98,7 @@ public struct FormState<Value: FormValue> {
         self.valueAttribute = valueAttribute
         self.defaultValue = `default`
         self.sendChangeEvents = sendChangeEvents
+        self._data = StateObject(wrappedValue: FormStateData<Value>(default: `default`))
     }
     
     /// Convenience initializer that creates a `FormState` property wrapper with `nil` as its default value.
@@ -128,9 +129,7 @@ public struct FormState<Value: FormValue> {
             case .unknown:
                 fatalError("@FormState cannot be accessed before being installed in a view")
             case .local:
-                return element.attribute(named: valueAttribute)
-                    .flatMap({ Value.fromAttribute($0, on: element) })
-                    ?? defaultValue
+                return data.localValue
             case .form(let formModel):
                 guard let elementName = element.attributeValue(for: "name") else {
                     logger.log(level: .error, "Expected @FormState in form mode to have element with name")
@@ -150,7 +149,7 @@ public struct FormState<Value: FormValue> {
             case .unknown:
                 fatalError("@FormState cannot be accessed before being installed in a view")
             case .local:
-                break
+                data.localValue = newValue
             case .form(let formModel):
                 guard let elementName = element.attributeValue(for: "name") else {
                     logger.log(level: .error, "Expected @FormState in form mode to have element with name")
@@ -185,7 +184,8 @@ public struct FormState<Value: FormValue> {
     
     private func resolveMode() {
         let elementName = element.attributeValue(for: "name")
-        if case .unknown = data.mode {
+        switch data.mode {
+        case .unknown:
             if let formModel {
                 if let elementName {
                     data.bind(
@@ -206,7 +206,13 @@ public struct FormState<Value: FormValue> {
             } else {
                 logger.warning("Form element used outside of a <LiveForm>. This may not behave as expected.")
                 data.mode = .local
+                data.localValue = initialValue
             }
+        case .local:
+            guard !isFocused && !isEditing else { return }
+            data.localValue = initialValue
+        default:
+            break
         }
     }
     
@@ -240,9 +246,16 @@ extension FormState: DynamicProperty {
 // It also serves to notify SwiftUI when this @FormState's particular field has changed (as opposed to updates for other fields).
 private class FormStateData<Value: FormValue>: ObservableObject {
     var mode: Mode = .unknown
+    
+    var localValue: Value
+    
     private var cancellable: AnyCancellable?
     private var elementCancellable: AnyCancellable?
     private var focusCancellable: AnyCancellable?
+    
+    init(default localValue: Value) {
+        self.localValue = localValue
+    }
     
     func bind(
         _ formModel: FormModel,


### PR DESCRIPTION
Closes #1438 

Previously, `FormState` would use the client-provided fallback value instead of the value in the document when not bound to a `LiveForm`.

Now, any values passed in the template will be used. `Toggle` will reflect the `isOn` attribute, `TextField` will show the provided `text` content, etc. Any fields not bound to a form with a default value cannot be updated. They will revert back to the state provided by the template if modified.

https://github.com/user-attachments/assets/3e1dc603-35ac-40af-b227-c097d471054f
