### PR TITLE
Add `:section` slot to `simple_form`.

### DIFF
--- a/priv/templates/lvn.swiftui.gen/core_components.ex
+++ b/priv/templates/lvn.swiftui.gen/core_components.ex
@@ -416,14 +416,11 @@ defmodule <%= inspect context.web_module %>.CoreComponents.<%= inspect context.m
           <%%= render_slot(@inner_block, f) %>
         <%% else %>
           <%%= for section <- @section do %>
-            <Section isExpanded={Map.get(section, :is_expanded, true)}>
-              <Text :if={not is_nil(Map.get(section, :header))} template={:header}>
-                <%%= Map.get(section, :header) %>
-              </Text>
+            <Section>
+              <Text :if={not is_nil(Map.get(section, :header))} template={:header} content={Map.get(section, :header)} />
+
               <%%= render_slot(section) %>
-              <Text :if={not is_nil(Map.get(section, :footer))} template={:footer}>
-                <%%= Map.get(section, :footer) %>
-              </Text>
+              <Text :if={not is_nil(Map.get(section, :footer))} template={:footer} content={Map.get(section, :footer)} />
             </Section>
           <%% end %>
         <%% end %>

--- a/priv/templates/lvn.swiftui.gen/core_components.ex
+++ b/priv/templates/lvn.swiftui.gen/core_components.ex
@@ -400,15 +400,34 @@ defmodule <%= inspect context.web_module %>.CoreComponents.<%= inspect context.m
     include: ~w(autocomplete name rel action enctype method novalidate target multipart),
     doc: "the arbitrary attributes to apply to the form tag"
 
-  slot :inner_block, required: true
+  slot :inner_block, required: true, doc: "won't be rendered if section slots are passed in"
   slot :actions, doc: "the slot for form actions, such as a submit button"
+  slot :section, required: false, doc: "slot for creating sections inside the form" do
+    attr :is_expanded, :boolean, doc: "a boolean value that determines the section’s expansion state (expanded or collapsed)"
+    attr :header, :string, doc: "text to use as a section's header"
+    attr :footer, :string, doc: "text to use as a section's footer"
+  end
 
   def simple_form(assigns) do
     ~LVN"""
     <.form :let={f} for={@for} as={@as} {@rest}>
       <Form>
-        <%%= render_slot(@inner_block, f) %>
-        <Section>
+        <%%= if @section == [] do %>
+          <%%= render_slot(@inner_block, f) %>
+        <%% else %>
+          <%%= for section <- @section do %>
+            <Section isExpanded={Map.get(section, :is_expanded, true)}>
+              <Text :if={not is_nil(Map.get(section, :header))} template={:header}>
+                <%%= Map.get(section, :header) %>
+              </Text>
+              <%%= render_slot(section) %>
+              <Text :if={not is_nil(Map.get(section, :footer))} template={:footer}>
+                <%%= Map.get(section, :footer) %>
+              </Text>
+            </Section>
+          <%% end %>
+        <%% end %>
+        <Section :if={@actions != []}>
           <%%= for action <- @actions do %>
             <%%= render_slot(action, f) %>
           <%% end %>

--- a/test/live_view_native/swiftui/core_components_test.exs
+++ b/test/live_view_native/swiftui/core_components_test.exs
@@ -54,9 +54,9 @@ defmodule LiveViewNative.SwiftUI.CoreComponentsTest do
       """
 
       assert t2h(template) ==
-               ~X"""
-                <LiveHiddenField name="test-name" value="123" />
-               """
+        ~X"""
+       <LiveHiddenField name="test-name" value="123" />
+      """
     end
 
     test "TextFieldLink" do
@@ -67,16 +67,16 @@ defmodule LiveViewNative.SwiftUI.CoreComponentsTest do
       """
 
       assert t2h(template) ==
-               ~X"""
-               <VStack alignment="leading">
-                 <LabeledContent>
-                   <Text template="label">test-label</Text>
-                   <TextFieldLink name="test-name" value="123" prompt="test-prompt">
-                     test-label
-                   </TextFieldLink>
-                 </LabeledContent>
-               </VStack>
-               """
+        ~X"""
+        <VStack alignment="leading">
+          <LabeledContent>
+            <Text template="label">test-label</Text>
+            <TextFieldLink name="test-name" value="123" prompt="test-prompt">
+              test-label
+            </TextFieldLink>
+          </LabeledContent>
+        </VStack>
+        """
     end
 
     test "DatePicker" do
@@ -87,13 +87,13 @@ defmodule LiveViewNative.SwiftUI.CoreComponentsTest do
       """
 
       assert t2h(template) ==
-               ~X"""
-               <VStack alignment="leading">
-                 <DatePicker name="test-name" selection="123">
-                   test-label
-                 </DatePicker>
-               </VStack>
-               """
+        ~X"""
+        <VStack alignment="leading">
+          <DatePicker name="test-name" selection="123">
+            test-label
+          </DatePicker>
+        </VStack>
+        """
     end
 
     test "MultiDatePicker" do
@@ -104,14 +104,14 @@ defmodule LiveViewNative.SwiftUI.CoreComponentsTest do
       """
 
       assert t2h(template) ==
-               ~X"""
-               <VStack alignment="leading">
-                 <LabeledContent>
-                   <Text template="label">test-label</Text>
-                   <MultiDatePicker name="test-name" selection="123">test-label</MultiDatePicker>
-                 </LabeledContent>
-               </VStack>
-               """
+        ~X"""
+        <VStack alignment="leading">
+          <LabeledContent>
+            <Text template="label">test-label</Text>
+            <MultiDatePicker name="test-name" selection="123">test-label</MultiDatePicker>
+          </LabeledContent>
+        </VStack>
+        """
     end
 
     test "Picker" do
@@ -122,16 +122,16 @@ defmodule LiveViewNative.SwiftUI.CoreComponentsTest do
       """
 
       assert t2h(template) ==
-               ~X"""
-               <VStack alignment="leading">
-                 <Picker name="test-name" selection="123">
-                   <Text template="label">test-label</Text>
-                   <Text tag="b">
-                     a
-                   </Text>
-                 </Picker>
-               </VStack>
-               """
+        ~X"""
+        <VStack alignment="leading">
+          <Picker name="test-name" selection="123">
+            <Text template="label">test-label</Text>
+            <Text tag="b">
+              a
+            </Text>
+          </Picker>
+        </VStack>
+        """
     end
 
     test "Slider" do
@@ -142,14 +142,14 @@ defmodule LiveViewNative.SwiftUI.CoreComponentsTest do
       """
 
       assert t2h(template) ==
-               ~X"""
-               <VStack alignment="leading">
-                 <LabeledContent>
-                   <Text template="label">test-label</Text>
-                   <Slider name="test-name" value="123" lowerBound="1" upperBound="200">test-label</Slider>
-                 </LabeledContent>
-               </VStack>
-               """
+        ~X"""
+        <VStack alignment="leading">
+          <LabeledContent>
+            <Text template="label">test-label</Text>
+            <Slider name="test-name" value="123" lowerBound="1" upperBound="200">test-label</Slider>
+          </LabeledContent>
+        </VStack>
+        """
     end
 
     test "Stepper" do
@@ -160,14 +160,14 @@ defmodule LiveViewNative.SwiftUI.CoreComponentsTest do
       """
 
       assert t2h(template) ==
-               ~X"""
-               <VStack alignment="leading">
-                 <LabeledContent>
-                   <Text template="label">test-label</Text>
-                   <Stepper name="test-name" value="123"></Stepper>
-                 </LabeledContent>
-               </VStack>
-               """
+        ~X"""
+        <VStack alignment="leading">
+          <LabeledContent>
+            <Text template="label">test-label</Text>
+            <Stepper name="test-name" value="123"></Stepper>
+          </LabeledContent>
+        </VStack>
+        """
     end
 
     test "TextEditor" do
@@ -178,14 +178,14 @@ defmodule LiveViewNative.SwiftUI.CoreComponentsTest do
       """
 
       assert t2h(template) ==
-               ~X"""
-               <VStack alignment="leading">
-                 <LabeledContent>
-                   <Text template="label">test-label</Text>
-                   <TextEditor name="test-name" text="123" />
-                 </LabeledContent>
-               </VStack>
-               """
+        ~X"""
+        <VStack alignment="leading">
+          <LabeledContent>
+            <Text template="label">test-label</Text>
+            <TextEditor name="test-name" text="123" />
+          </LabeledContent>
+        </VStack>
+        """
     end
 
     test "TextField" do
@@ -196,11 +196,11 @@ defmodule LiveViewNative.SwiftUI.CoreComponentsTest do
       """
 
       assert t2h(template) ==
-               ~X"""
-               <VStack alignment="leading">
-                 <TextField name="test-name" text="123" prompt="test-prompt">test-label</TextField>
-               </VStack>
-               """
+        ~X"""
+        <VStack alignment="leading">
+          <TextField name="test-name" text="123" prompt="test-prompt">test-label</TextField>
+        </VStack>
+        """
     end
 
     test "TextField with placeholder" do
@@ -211,11 +211,11 @@ defmodule LiveViewNative.SwiftUI.CoreComponentsTest do
       """
 
       assert t2h(template) ==
-               ~X"""
-               <VStack alignment="leading">
-                 <TextField name="test-name" text="123" prompt="test-prompt">test-placeholder</TextField>
-               </VStack>
-               """
+        ~X"""
+        <VStack alignment="leading">
+          <TextField name="test-name" text="123" prompt="test-prompt">test-placeholder</TextField>
+        </VStack>
+        """
     end
 
     test "SecureField" do
@@ -226,11 +226,11 @@ defmodule LiveViewNative.SwiftUI.CoreComponentsTest do
       """
 
       assert t2h(template) ==
-               ~X"""
-               <VStack alignment="leading">
-                 <SecureField name="test-name" text="123" prompt="test-prompt">test-label</SecureField>
-               </VStack>
-               """
+        ~X"""
+        <VStack alignment="leading">
+          <SecureField name="test-name" text="123" prompt="test-prompt">test-label</SecureField>
+        </VStack>
+        """
     end
 
     test "SecureField with placeholder" do
@@ -241,11 +241,11 @@ defmodule LiveViewNative.SwiftUI.CoreComponentsTest do
       """
 
       assert t2h(template) ==
-               ~X"""
-               <VStack alignment="leading">
-                 <SecureField name="test-name" text="123" prompt="test-prompt">test-placeholder</SecureField>
-               </VStack>
-               """
+        ~X"""
+        <VStack alignment="leading">
+          <SecureField name="test-name" text="123" prompt="test-prompt">test-placeholder</SecureField>
+        </VStack>
+        """
     end
 
     test "Toggle" do
@@ -256,14 +256,14 @@ defmodule LiveViewNative.SwiftUI.CoreComponentsTest do
       """
 
       assert t2h(template) ==
-               ~X"""
-               <VStack alignment="leading">
-                 <LabeledContent>
-                   <Text template="label">test-label</Text>
-                   <Toggle name="test-name" isOn="true"></Toggle>
-                 </LabeledContent>
-               </VStack>
-               """
+        ~X"""
+        <VStack alignment="leading">
+          <LabeledContent>
+            <Text template="label">test-label</Text>
+            <Toggle name="test-name" isOn="true"></Toggle>
+          </LabeledContent>
+        </VStack>
+        """
     end
   end
 
@@ -278,24 +278,30 @@ defmodule LiveViewNative.SwiftUI.CoreComponentsTest do
       """
 
       assert t2h(template) ==
-               ~X"""
-               <Group style="font(.caption); foregroundStyle(.red)">
-                 <Text>Error!</Text>
-               </Group>
-               """
+        ~X"""
+        <Group style="font(.caption); foregroundStyle(.red)">
+          <Text>Error!</Text>
+        </Group>
+        """
+
     end
+
   end
 
   describe "header/1" do
+
   end
 
   describe "modal/1" do
+
   end
 
   describe "flash/1" do
+
   end
 
   describe "flash_group/1" do
+
   end
 
   describe "simple_form/1" do
@@ -306,17 +312,17 @@ defmodule LiveViewNative.SwiftUI.CoreComponentsTest do
       assigns = %{form: form}
 
       template = ~LVN"""
-      <.simple_form for={@form}>
-      </.simple_form>
-      """
+        <.simple_form for={@form}>
+        </.simple_form>
+        """
 
       assert t2h(template) ==
-               ~X"""
-               <LiveForm>
-                 <Form>
-                 </Form>
-               </LiveForm>
-               """
+        ~X"""
+        <LiveForm>
+          <Form>
+          </Form>
+        </LiveForm>
+        """
     end
 
     test "can render form with an input" do
@@ -356,22 +362,22 @@ defmodule LiveViewNative.SwiftUI.CoreComponentsTest do
       assigns = %{form: form}
 
       template = ~LVN"""
-      <.simple_form for={@form}>
-        <:section header="Name">
-          <.input field={@form[:first_name]} label="First name"/>
-          <.input field={@form[:last_name]} label="Last name"/>
-        </:section>
-        <:section footer="We will contact you here.">
-          <.input field={@form[:email]} label="Email"/>
-        </:section>
-        <:section header="Extra info" footer="We will use this for..." is_expanded="false">
-          <.input field={@form[:more_info]} label="More info"/>
-        </:section>
-      </.simple_form>
-      """
+        <.simple_form for={@form}>
+          <:section header="Name">
+            <.input field={@form[:first_name]} label="First name"/>
+            <.input field={@form[:last_name]} label="Last name"/>
+          </:section>
+          <:section footer="We will contact you here.">
+            <.input field={@form[:email]} label="Email"/>
+          </:section>
+          <:section header="Extra info" footer="We will use this for..." is_expanded="false">
+            <.input field={@form[:more_info]} label="More info"/>
+          </:section>
+        </.simple_form>
+        """
 
       assert t2h(template) ==
-               trim(~X"""
+        trim(~X"""
                <LiveForm>
                  <Form>
                    <Section>
@@ -497,15 +503,17 @@ defmodule LiveViewNative.SwiftUI.CoreComponentsTest do
       """
 
       assert t2h(template) ==
-               ~X"""
-               <Button>
-                 Send!
-               </Button>
-               """
+        ~X"""
+        <Button>
+          Send!
+        </Button>
+        """
+
     end
   end
 
   describe "table" do
+
   end
 
   describe "list/1" do
@@ -521,18 +529,18 @@ defmodule LiveViewNative.SwiftUI.CoreComponentsTest do
       """
 
       assert t2h(template) ==
-               ~X"""
-               <List>
-                 <LabeledContent>
-                   <Text template="label">Foo</Text>
-                   <Text>Foo</Text>
-                 </LabeledContent>
-                 <LabeledContent>
-                   <Text template="label">Bar</Text>
-                   <Text>Bar</Text>
-                 </LabeledContent>
-               </List>
-               """
+        ~X"""
+        <List>
+          <LabeledContent>
+            <Text template="label">Foo</Text>
+            <Text>Foo</Text>
+          </LabeledContent>
+          <LabeledContent>
+            <Text template="label">Bar</Text>
+            <Text>Bar</Text>
+          </LabeledContent>
+        </List>
+        """
     end
   end
 
@@ -541,22 +549,25 @@ defmodule LiveViewNative.SwiftUI.CoreComponentsTest do
       assigns = %{}
 
       template = ~LVN"""
-      <.icon name="star"/>
-      """
+        <.icon name="star"/>
+        """
 
       assert t2h(template) ==
-               ~X"""
-               <Image systemName="star"/>
-               """
+        ~X"""
+        <Image systemName="star"/>
+        """
     end
   end
 
   describe "image/1" do
+
   end
 
   describe "translate_error/1" do
+
   end
 
   describe "translate_errors/1" do
+
   end
 end

--- a/test/live_view_native/swiftui/core_components_test.exs
+++ b/test/live_view_native/swiftui/core_components_test.exs
@@ -54,9 +54,9 @@ defmodule LiveViewNative.SwiftUI.CoreComponentsTest do
       """
 
       assert t2h(template) ==
-        ~X"""
-       <LiveHiddenField name="test-name" value="123" />
-      """
+               ~X"""
+                <LiveHiddenField name="test-name" value="123" />
+               """
     end
 
     test "TextFieldLink" do
@@ -67,16 +67,16 @@ defmodule LiveViewNative.SwiftUI.CoreComponentsTest do
       """
 
       assert t2h(template) ==
-        ~X"""
-        <VStack alignment="leading">
-          <LabeledContent>
-            <Text template="label">test-label</Text>
-            <TextFieldLink name="test-name" value="123" prompt="test-prompt">
-              test-label
-            </TextFieldLink>
-          </LabeledContent>
-        </VStack>
-        """
+               ~X"""
+               <VStack alignment="leading">
+                 <LabeledContent>
+                   <Text template="label">test-label</Text>
+                   <TextFieldLink name="test-name" value="123" prompt="test-prompt">
+                     test-label
+                   </TextFieldLink>
+                 </LabeledContent>
+               </VStack>
+               """
     end
 
     test "DatePicker" do
@@ -87,13 +87,13 @@ defmodule LiveViewNative.SwiftUI.CoreComponentsTest do
       """
 
       assert t2h(template) ==
-        ~X"""
-        <VStack alignment="leading">
-          <DatePicker name="test-name" selection="123">
-            test-label
-          </DatePicker>
-        </VStack>
-        """
+               ~X"""
+               <VStack alignment="leading">
+                 <DatePicker name="test-name" selection="123">
+                   test-label
+                 </DatePicker>
+               </VStack>
+               """
     end
 
     test "MultiDatePicker" do
@@ -104,14 +104,14 @@ defmodule LiveViewNative.SwiftUI.CoreComponentsTest do
       """
 
       assert t2h(template) ==
-        ~X"""
-        <VStack alignment="leading">
-          <LabeledContent>
-            <Text template="label">test-label</Text>
-            <MultiDatePicker name="test-name" selection="123">test-label</MultiDatePicker>
-          </LabeledContent>
-        </VStack>
-        """
+               ~X"""
+               <VStack alignment="leading">
+                 <LabeledContent>
+                   <Text template="label">test-label</Text>
+                   <MultiDatePicker name="test-name" selection="123">test-label</MultiDatePicker>
+                 </LabeledContent>
+               </VStack>
+               """
     end
 
     test "Picker" do
@@ -122,16 +122,16 @@ defmodule LiveViewNative.SwiftUI.CoreComponentsTest do
       """
 
       assert t2h(template) ==
-        ~X"""
-        <VStack alignment="leading">
-          <Picker name="test-name" selection="123">
-            <Text template="label">test-label</Text>
-            <Text tag="b">
-              a
-            </Text>
-          </Picker>
-        </VStack>
-        """
+               ~X"""
+               <VStack alignment="leading">
+                 <Picker name="test-name" selection="123">
+                   <Text template="label">test-label</Text>
+                   <Text tag="b">
+                     a
+                   </Text>
+                 </Picker>
+               </VStack>
+               """
     end
 
     test "Slider" do
@@ -142,14 +142,14 @@ defmodule LiveViewNative.SwiftUI.CoreComponentsTest do
       """
 
       assert t2h(template) ==
-        ~X"""
-        <VStack alignment="leading">
-          <LabeledContent>
-            <Text template="label">test-label</Text>
-            <Slider name="test-name" value="123" lowerBound="1" upperBound="200">test-label</Slider>
-          </LabeledContent>
-        </VStack>
-        """
+               ~X"""
+               <VStack alignment="leading">
+                 <LabeledContent>
+                   <Text template="label">test-label</Text>
+                   <Slider name="test-name" value="123" lowerBound="1" upperBound="200">test-label</Slider>
+                 </LabeledContent>
+               </VStack>
+               """
     end
 
     test "Stepper" do
@@ -160,14 +160,14 @@ defmodule LiveViewNative.SwiftUI.CoreComponentsTest do
       """
 
       assert t2h(template) ==
-        ~X"""
-        <VStack alignment="leading">
-          <LabeledContent>
-            <Text template="label">test-label</Text>
-            <Stepper name="test-name" value="123"></Stepper>
-          </LabeledContent>
-        </VStack>
-        """
+               ~X"""
+               <VStack alignment="leading">
+                 <LabeledContent>
+                   <Text template="label">test-label</Text>
+                   <Stepper name="test-name" value="123"></Stepper>
+                 </LabeledContent>
+               </VStack>
+               """
     end
 
     test "TextEditor" do
@@ -178,14 +178,14 @@ defmodule LiveViewNative.SwiftUI.CoreComponentsTest do
       """
 
       assert t2h(template) ==
-        ~X"""
-        <VStack alignment="leading">
-          <LabeledContent>
-            <Text template="label">test-label</Text>
-            <TextEditor name="test-name" text="123" />
-          </LabeledContent>
-        </VStack>
-        """
+               ~X"""
+               <VStack alignment="leading">
+                 <LabeledContent>
+                   <Text template="label">test-label</Text>
+                   <TextEditor name="test-name" text="123" />
+                 </LabeledContent>
+               </VStack>
+               """
     end
 
     test "TextField" do
@@ -196,11 +196,11 @@ defmodule LiveViewNative.SwiftUI.CoreComponentsTest do
       """
 
       assert t2h(template) ==
-        ~X"""
-        <VStack alignment="leading">
-          <TextField name="test-name" text="123" prompt="test-prompt">test-label</TextField>
-        </VStack>
-        """
+               ~X"""
+               <VStack alignment="leading">
+                 <TextField name="test-name" text="123" prompt="test-prompt">test-label</TextField>
+               </VStack>
+               """
     end
 
     test "TextField with placeholder" do
@@ -211,11 +211,11 @@ defmodule LiveViewNative.SwiftUI.CoreComponentsTest do
       """
 
       assert t2h(template) ==
-        ~X"""
-        <VStack alignment="leading">
-          <TextField name="test-name" text="123" prompt="test-prompt">test-placeholder</TextField>
-        </VStack>
-        """
+               ~X"""
+               <VStack alignment="leading">
+                 <TextField name="test-name" text="123" prompt="test-prompt">test-placeholder</TextField>
+               </VStack>
+               """
     end
 
     test "SecureField" do
@@ -226,11 +226,11 @@ defmodule LiveViewNative.SwiftUI.CoreComponentsTest do
       """
 
       assert t2h(template) ==
-        ~X"""
-        <VStack alignment="leading">
-          <SecureField name="test-name" text="123" prompt="test-prompt">test-label</SecureField>
-        </VStack>
-        """
+               ~X"""
+               <VStack alignment="leading">
+                 <SecureField name="test-name" text="123" prompt="test-prompt">test-label</SecureField>
+               </VStack>
+               """
     end
 
     test "SecureField with placeholder" do
@@ -241,11 +241,11 @@ defmodule LiveViewNative.SwiftUI.CoreComponentsTest do
       """
 
       assert t2h(template) ==
-        ~X"""
-        <VStack alignment="leading">
-          <SecureField name="test-name" text="123" prompt="test-prompt">test-placeholder</SecureField>
-        </VStack>
-        """
+               ~X"""
+               <VStack alignment="leading">
+                 <SecureField name="test-name" text="123" prompt="test-prompt">test-placeholder</SecureField>
+               </VStack>
+               """
     end
 
     test "Toggle" do
@@ -256,14 +256,14 @@ defmodule LiveViewNative.SwiftUI.CoreComponentsTest do
       """
 
       assert t2h(template) ==
-        ~X"""
-        <VStack alignment="leading">
-          <LabeledContent>
-            <Text template="label">test-label</Text>
-            <Toggle name="test-name" isOn="true"></Toggle>
-          </LabeledContent>
-        </VStack>
-        """
+               ~X"""
+               <VStack alignment="leading">
+                 <LabeledContent>
+                   <Text template="label">test-label</Text>
+                   <Toggle name="test-name" isOn="true"></Toggle>
+                 </LabeledContent>
+               </VStack>
+               """
     end
   end
 
@@ -278,30 +278,24 @@ defmodule LiveViewNative.SwiftUI.CoreComponentsTest do
       """
 
       assert t2h(template) ==
-        ~X"""
-        <Group style="font(.caption); foregroundStyle(.red)">
-          <Text>Error!</Text>
-        </Group>
-        """
-
+               ~X"""
+               <Group style="font(.caption); foregroundStyle(.red)">
+                 <Text>Error!</Text>
+               </Group>
+               """
     end
-
   end
 
   describe "header/1" do
-
   end
 
   describe "modal/1" do
-
   end
 
   describe "flash/1" do
-
   end
 
   describe "flash_group/1" do
-
   end
 
   describe "simple_form/1" do
@@ -312,17 +306,17 @@ defmodule LiveViewNative.SwiftUI.CoreComponentsTest do
       assigns = %{form: form}
 
       template = ~LVN"""
-        <.simple_form for={@form}>
-        </.simple_form>
-        """
+      <.simple_form for={@form}>
+      </.simple_form>
+      """
 
       assert t2h(template) ==
-        ~X"""
-        <LiveForm>
-          <Form>
-          </Form>
-        </LiveForm>
-        """
+               ~X"""
+               <LiveForm>
+                 <Form>
+                 </Form>
+               </LiveForm>
+               """
     end
 
     test "can render form with an input" do
@@ -332,25 +326,31 @@ defmodule LiveViewNative.SwiftUI.CoreComponentsTest do
       assigns = %{form: form}
 
       template = ~LVN"""
-        <.simple_form for={@form}>
-          <.input field={@form[:email]} label="Email"/>
-        </.simple_form>
-        """
+      <.simple_form for={@form}>
+        <.input field={@form[:email]} label="Email"/>
+      </.simple_form>
+      """
 
       assert t2h(template) ==
-        ~X"""
-        <LiveForm>
-          <Form>
-            <VStack alignment="leading">
-              <TextField id="user_email" name="user[email]" style="" text="test@example.com">Email</TextField>
-            </VStack>
-          </Form>
-        </LiveForm>
-        """
+               ~X"""
+               <LiveForm>
+                 <Form>
+                   <VStack alignment="leading">
+                     <TextField id="user_email" name="user[email]" style="" text="test@example.com">Email</TextField>
+                   </VStack>
+                 </Form>
+               </LiveForm>
+               """
     end
 
     test "can render multiple sections in order" do
-      params = %{"email" => "test@example.com", "first_name" => "Gloria", "last_name" => "Fuertes", "more_info" => "More info here"}
+      params = %{
+        "email" => "test@example.com",
+        "first_name" => "Gloria",
+        "last_name" => "Fuertes",
+        "more_info" => "More info here"
+      }
+
       form = to_form(params, as: "user")
 
       assigns = %{form: form}
@@ -371,65 +371,37 @@ defmodule LiveViewNative.SwiftUI.CoreComponentsTest do
       """
 
       assert t2h(template) ==
-        trim(~X"""
-        <LiveForm>
-          <Form>
-            <Section isExpanded="true">
-              <Text template="header">Name</Text>
-              <VStack alignment="leading">
-                <TextField id="user_first_name" name="user[first_name]" style="" text="Gloria">First name</TextField>
-              </VStack>
-              <VStack alignment="leading">
-                <TextField id="user_last_name" name="user[last_name]" style="" text="Fuertes">Last name</TextField>
-              </VStack>
-            </Section>
-            <Section isExpanded="true">
-              <VStack alignment="leading">
-                <TextField id="user_email" name="user[email]" style="" text="test@example.com">Email</TextField>
-              </VStack>
-              <Text template="footer">We will contact you here.</Text>
-            </Section>
-            <Section isExpanded="false">
-              <Text template="header">Extra info</Text>
-              <VStack alignment="leading">
-                <TextField id="user_more_info" name="user[more_info]" style="" text="More info here">More info</TextField>
-              </VStack>
-              <Text template="footer">We will use this for...</Text>
-            </Section>
-          </Form>
-        </LiveForm>
-        """)
+               trim(~X"""
+               <LiveForm>
+                 <Form>
+                   <Section>
+                     <Text template="header" content="Name" />
+                     <VStack alignment="leading">
+                       <TextField id="user_first_name" name="user[first_name]" style="" text="Gloria">First name</TextField>
+                     </VStack>
+                     <VStack alignment="leading">
+                       <TextField id="user_last_name" name="user[last_name]" style="" text="Fuertes">Last name</TextField>
+                     </VStack>
+                   </Section>
+                   <Section>
+                     <VStack alignment="leading">
+                       <TextField id="user_email" name="user[email]" style="" text="test@example.com">Email</TextField>
+                     </VStack>
+                     <Text template="footer" content="We will contact you here." />
+                   </Section>
+                   <Section>
+                     <Text template="header" content="Extra info" />
+                     <VStack alignment="leading">
+                       <TextField id="user_more_info" name="user[more_info]" style="" text="More info here">More info</TextField>
+                     </VStack>
+                     <Text template="footer" content="We will use this for..." />
+                   </Section>
+                 </Form>
+               </LiveForm>
+               """)
     end
 
-    test "can give a isExpanded value to Section" do
-      params = %{"email" => "test@example.com"}
-      form = to_form(params, as: "user")
-
-      assigns = %{expand?: false, form: form}
-
-      template = ~LVN"""
-      <.simple_form for={@form}>
-        <:section is_expanded={@expand?}>
-          <.input field={@form[:email]} label="Email"/>
-        </:section>
-      </.simple_form>
-      """
-
-      assert t2h(template) ==
-        trim(~X"""
-        <LiveForm>
-          <Form>
-            <Section isExpanded="false">
-              <VStack alignment="leading">
-                <TextField id="user_email" name="user[email]" style="" text="test@example.com">Email</TextField>
-              </VStack>
-            </Section>
-          </Form>
-        </LiveForm>
-        """)
-    end
-
-    test "can render sectionn with footer" do
+    test "can render section with footer" do
       params = %{"email" => "test@example.com"}
       form = to_form(params, as: "user")
 
@@ -444,20 +416,18 @@ defmodule LiveViewNative.SwiftUI.CoreComponentsTest do
       """
 
       assert t2h(template) ==
-        trim(~X"""
-        <LiveForm>
-          <Form>
-            <Section isExpanded="true">
-              <VStack alignment="leading">
-                <TextField id="user_email" name="user[email]" style="" text="test@example.com">Email</TextField>
-              </VStack>
-              <Text template="footer">
-                A footer
-              </Text>
-            </Section>
-          </Form>
-        </LiveForm>
-        """)
+               trim(~X"""
+               <LiveForm>
+                 <Form>
+                   <Section>
+                     <VStack alignment="leading">
+                       <TextField id="user_email" name="user[email]" style="" text="test@example.com">Email</TextField>
+                     </VStack>
+                     <Text template="footer" content="A footer" />
+                   </Section>
+                 </Form>
+               </LiveForm>
+               """)
     end
 
     test "can render section with header" do
@@ -475,23 +445,21 @@ defmodule LiveViewNative.SwiftUI.CoreComponentsTest do
       """
 
       assert t2h(template) ==
-        trim(~X"""
-        <LiveForm>
-          <Form>
-            <Section isExpanded="true">
-              <Text template="header">
-                A header
-              </Text>
-              <VStack alignment="leading">
-                <TextField id="user_email" name="user[email]" style="" text="test@example.com">Email</TextField>
-              </VStack>
-            </Section>
-          </Form>
-        </LiveForm>
-        """)
+               trim(~X"""
+               <LiveForm>
+                 <Form>
+                   <Section>
+                     <Text template="header" content="A header" />
+                     <VStack alignment="leading">
+                       <TextField id="user_email" name="user[email]" style="" text="test@example.com">Email</TextField>
+                     </VStack>
+                   </Section>
+                 </Form>
+               </LiveForm>
+               """)
     end
 
-    test "can render section without attributes" do
+    test "can render section" do
       params = %{"email" => "test@example.com"}
       form = to_form(params, as: "user")
 
@@ -506,17 +474,17 @@ defmodule LiveViewNative.SwiftUI.CoreComponentsTest do
       """
 
       assert t2h(template) ==
-        ~X"""
-        <LiveForm>
-          <Form>
-            <Section isExpanded="true">
-              <VStack alignment="leading">
-                <TextField id="user_email" name="user[email]" style="" text="test@example.com">Email</TextField>
-              </VStack>
-            </Section>
-          </Form>
-        </LiveForm>
-        """
+               ~X"""
+               <LiveForm>
+                 <Form>
+                   <Section>
+                     <VStack alignment="leading">
+                       <TextField id="user_email" name="user[email]" style="" text="test@example.com">Email</TextField>
+                     </VStack>
+                   </Section>
+                 </Form>
+               </LiveForm>
+               """
     end
   end
 
@@ -529,17 +497,15 @@ defmodule LiveViewNative.SwiftUI.CoreComponentsTest do
       """
 
       assert t2h(template) ==
-        ~X"""
-        <Button>
-          Send!
-        </Button>
-        """
-
+               ~X"""
+               <Button>
+                 Send!
+               </Button>
+               """
     end
   end
 
   describe "table" do
-
   end
 
   describe "list/1" do
@@ -555,18 +521,18 @@ defmodule LiveViewNative.SwiftUI.CoreComponentsTest do
       """
 
       assert t2h(template) ==
-        ~X"""
-        <List>
-          <LabeledContent>
-            <Text template="label">Foo</Text>
-            <Text>Foo</Text>
-          </LabeledContent>
-          <LabeledContent>
-            <Text template="label">Bar</Text>
-            <Text>Bar</Text>
-          </LabeledContent>
-        </List>
-        """
+               ~X"""
+               <List>
+                 <LabeledContent>
+                   <Text template="label">Foo</Text>
+                   <Text>Foo</Text>
+                 </LabeledContent>
+                 <LabeledContent>
+                   <Text template="label">Bar</Text>
+                   <Text>Bar</Text>
+                 </LabeledContent>
+               </List>
+               """
     end
   end
 
@@ -575,25 +541,22 @@ defmodule LiveViewNative.SwiftUI.CoreComponentsTest do
       assigns = %{}
 
       template = ~LVN"""
-        <.icon name="star"/>
-        """
+      <.icon name="star"/>
+      """
 
       assert t2h(template) ==
-        ~X"""
-        <Image systemName="star"/>
-        """
+               ~X"""
+               <Image systemName="star"/>
+               """
     end
   end
 
   describe "image/1" do
-
   end
 
   describe "translate_error/1" do
-
   end
 
   describe "translate_errors/1" do
-
   end
 end


### PR DESCRIPTION
This PR adds a `:section` slot to `simple_form/1`. The slot can receive the following optional attributes:

- ~`is_expanded`, boolean. Will be set as `isExpanded` in the sections. Defaults to true.~
- `header`, string. Will add a `<Text template={:header}></Text>` with the same content to the `Section`.
- `footer`, string. Same as header, but with template `footer`.

Also renders conditionally the `Section` containing the actions.

One final caveat is that if any `:section` slot is present, then `@inner_block` is not rendered. This prevents undefined behaviour or expectations to arise.

## Questions

1. ~Should `is_expanded` be `isExpanded` to be closer to SwiftUI or keep it closer to Elixir?~
2. I could not figure out how to read the SwiftUI documentation so I'm not sure if I'm missing something.