### PR TITLE
Add `patch` support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - LiveViewNative.SwiftUI.Client
+- `NavigationLink` supports the `data-phx-link` attribute to switch between `redirect` (default) and `patch` navigation
 - `NavigationLink` can perform a replace navigation by setting the `data-phx-link-state` attribute to `replace`
 - `NavigationLink` takes a `destination` template to customize the connecting phase View for its navigation event.
 

--- a/Sources/LiveViewNative/Views/Layout Containers/Presentation Containers/NavigationLink.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Presentation Containers/NavigationLink.swift
@@ -21,6 +21,14 @@ private let logger = Logger(subsystem: "LiveViewNative", category: "NavigationLi
 /// </NavigationLink>
 /// ```
 ///
+/// Use the `data-phx-link` attribute to switch between `redirect` and `patch` modes.
+///
+/// ```html
+/// <NavigationLink data-phx-link="patch" destination={"/?id={@product.id}"}>
+///     <Text><%= @product.name %></Text>
+/// </NavigationLink>
+/// ```
+///
 /// Use the `data-phx-link-state` attribute to do a `replace` navigation instead of a `push`.
 /// This will replace the current route with the destination.
 ///


### PR DESCRIPTION
The `data-phx-link` attribute can be used to set the link to `redirect` or `patch` mode.