### PR TITLE
rc-4 changes: Add additional headers to connect, reconnect endpoints on coordinator

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "6a5ddfa26364abe0acd53c4af877d94a75bd5865a0fe9de361261256db6916f3",
+  "originHash" : "f9084835ddc2d4db4a43a936bfe07b6b768f92c32fab7a578eb25826ad91bd16",
   "pins" : [
     {
       "identity" : "liveview-native-core",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/liveview-native/liveview-native-core",
       "state" : {
-        "revision" : "74f5044cba915d87cbc4b882b23a1bc6291b3a37",
-        "version" : "0.4.0-rc-3"
+        "revision" : "9c975bc915feb0b000f1f24ac10ba1958b8bdfc8",
+        "version" : "0.4.0-rc-4"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,7 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         .package(url: "https://github.com/apple/swift-async-algorithms", from: "1.0.0"),
-        .package(url: "https://github.com/liveview-native/liveview-native-core", exact: "0.4.0-rc-3"),
+        .package(url: "https://github.com/liveview-native/liveview-native-core", exact: "0.4.0-rc-4"),
         
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.5.0"),
         .package(url: "https://github.com/swiftlang/swift-markdown.git", from: "0.2.0"),

--- a/Sources/LiveViewNative/Live/ReconnectLiveViewAction.swift
+++ b/Sources/LiveViewNative/Live/ReconnectLiveViewAction.swift
@@ -11,14 +11,14 @@ import SwiftUI
 @MainActor
 public struct ReconnectLiveViewAction {
     let baseURL: URL?
-    let action: (_ url: URL?, _ httpMethod: String?, _ httpBody: Data?) async -> ()
+    let action: (_ url: URL?, _ httpMethod: String?, _ httpBody: Data?, _ headers: [String: String]?) async -> ()
     
     public func callAsFunction(_ style: ReconnectionStyle = .automatic) async {
         switch style {
         case .automatic:
-            await action(nil, nil, nil)
+            await action(nil, nil, nil, nil)
         case .restart:
-            await action(baseURL, nil, nil)
+            await action(baseURL, nil, nil, nil)
         }
     }
     
@@ -33,7 +33,7 @@ public struct ReconnectLiveViewAction {
 extension EnvironmentValues {
     @MainActor
     private enum ReconnectLiveViewActionKey: @preconcurrency EnvironmentKey {
-        static let defaultValue: ReconnectLiveViewAction = .init(baseURL: nil, action: { _, _, _ in })
+        static let defaultValue: ReconnectLiveViewAction = .init(baseURL: nil, action: { _, _, _, _ in })
     }
     
     /// An action that calls ``LiveSessionCoordinator/reconnect(url:httpMethod:httpBody:)`` in the current context.


### PR DESCRIPTION
We need the ability to add additional headers in `connect`, `reconnect`. phoenix will throw a csrf error on live form submission unless `content-type` is set to `application/x-www-form-urlencoded`.  This can already be done by changing the configured headers on the coordinator, but this is more explicit and avoid bugs where setting and unsetting them globally leaves them in the wrong state after a failed connection.