### PR TITLE
Adds VStack Alignment Example #1507

### DIFF
--- a/Sources/LiveViewNative/Views/Layout Containers/Stacks/VStack.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Stacks/VStack.swift
@@ -10,7 +10,7 @@ import SwiftUI
 /// Container that lays out its children in a vertical line.
 ///
 /// ```html
-/// <VStack>
+/// <VStack alignment="leading">
 ///     <Text>Top</Text>
 ///     <Text>Bottom</Text>
 /// </VStack>


### PR DESCRIPTION
Addresses #1507 


There is more discussion likely needed as to whether or not pushing a `.` at the start of `.leading` is necessary or not, but as this convention only appears in styles consistently, the near term solution could just be improving the docs with a simple example. This PR adds such an example to the `VStack` default example.