### PR TITLE
New member expression syntax

### DIFF
--- a/lib/live_view_native/swiftui/rules_parser/modifiers.ex
+++ b/lib/live_view_native/swiftui/rules_parser/modifiers.ex
@@ -94,7 +94,7 @@ defmodule LiveViewNative.SwiftUI.RulesParser.Modifiers do
     |> post_traverse({PostProcessors, :chain_ast, []})
   )
 
-  defparsec(
+  defparsecp(
     :ime,
     choice([
       parsec(:ime1),

--- a/lib/live_view_native/swiftui/rules_parser/modifiers.ex
+++ b/lib/live_view_native/swiftui/rules_parser/modifiers.ex
@@ -94,7 +94,7 @@ defmodule LiveViewNative.SwiftUI.RulesParser.Modifiers do
     |> post_traverse({PostProcessors, :chain_ast, []})
   )
 
-  defparsecp(
+  defparsec(
     :ime,
     choice([
       parsec(:ime1),

--- a/lib/live_view_native/swiftui/rules_parser/post_processors.ex
+++ b/lib/live_view_native/swiftui/rules_parser/post_processors.ex
@@ -96,28 +96,31 @@ defmodule LiveViewNative.SwiftUI.RulesParser.PostProcessors do
 
   defp combine_chain_ast_parts(outer, inner) when is_atom(outer) do
     if Regex.match?(~r/^[A-Z]/, Atom.to_string(outer)) do
-      {:., [], [outer, inner]}
+      {:., [], [inner, outer]}
     else
       case outer do
         {:., annotations, [nil, part]} ->
-          {:., annotations, [nil, {:., annotations, [part, inner]}]}
+          {:., annotations, [{:., annotations, [nil, inner]}, part]}
 
         _ ->
-          {:., [], [outer, inner]}
+          {:., [], [inner, outer]}
       end
     end
   end
 
   defp combine_chain_ast_parts({:., annotations, [nil, part]}, inner) do
-    {:., annotations, [nil, {:., annotations, [part, inner]}]}
+    {:., annotations, [{:., annotations, [nil, inner]}, part]}
   end
 
   defp combine_chain_ast_parts(outer, inner) do
-    {:., [], [outer, inner]}
+    {:., [], [inner, outer]}
   end
 
   def chain_ast(rest, sections, context, {_line, _}, _byte_offset) do
-    sections = Enum.reduce(sections, &combine_chain_ast_parts/2)
+    sections =
+      sections
+      |> Enum.reverse()
+      |> Enum.reduce(&combine_chain_ast_parts/2)
 
     {rest, [sections], context}
   end

--- a/test/live_view_native/swiftui/rules_parser_test.exs
+++ b/test/live_view_native/swiftui/rules_parser_test.exs
@@ -96,8 +96,8 @@ defmodule LiveViewNative.SwiftUI.RulesParserTest do
 
       assert parse(input) == output
 
-      input = "Color.blue.opacity(0.2).blendMode(.multiply).mix(with: .orange).opacity(0.7)"
-      output = {:., [], [{:., [], [{:., [], [{:., [], [{:., [], [:Color, :blue]}, {:opacity, [], [0.2]}]}, {:blendMode, [], [{:., [], [nil, :multiply]}]}]}, {:mix, [], [[with: {:., [], [nil, :orange]}]]}]}, {:opacity, [], [0.7]}]}
+      input = "background(Color.blue.opacity(0.2).blendMode(.multiply).mix(with: .orange).opacity(0.7))"
+      output = {:background, [], [{:., [], [{:., [], [{:., [], [{:., [], [{:., [], [:Color, :blue]}, {:opacity, [], [0.2]}]}, {:blendMode, [], [{:., [], [nil, :multiply]}]}]}, {:mix, [], [{:with, {:., [], [nil, :orange]}}]}]}, {:opacity, [], [0.7]}]}]}
 
       assert parse(input) == output
     end
@@ -182,15 +182,7 @@ defmodule LiveViewNative.SwiftUI.RulesParserTest do
     test "parses complex modifier chains" do
       input = "color(color: .foo.bar.baz(1, 2).qux)"
 
-      output =
-        {:color, [],
-         [
-           {
-             :color,
-               {:., [],
-                [nil, {:., [], [:foo, {:., [], [:bar, {:., [], [{:baz, [], [1, 2]}, :qux]}]}]}]}
-           }
-         ]}
+      output = {:color, [], [color: {:., [], [{:., [], [{:., [], [{:., [], [nil, :foo]}, :bar]}, {:baz, [], [1, 2]}]}, :qux]}]}
 
       assert parse(input) == output
     end
@@ -384,7 +376,7 @@ defmodule LiveViewNative.SwiftUI.RulesParserTest do
 
     test "gesture" do
       input = ~s{offset(x: gesture_state(:drag, .translation.width))}
-      output = {:offset, [], [{:x, {:__gesture_state__, [], [{:":", [], "drag"}, {:., [], [nil, {:., [], [:translation, :width]}]}]}}]}
+      output = {:offset, [], [{:x, {:__gesture_state__, [], [{:":", [], "drag"}, {:., [], [{:., [], [nil, :translation]}, :width]}]}}]}
 
       assert parse(input) == output
 

--- a/test/live_view_native/swiftui/rules_parser_test.exs
+++ b/test/live_view_native/swiftui/rules_parser_test.exs
@@ -97,7 +97,7 @@ defmodule LiveViewNative.SwiftUI.RulesParserTest do
       assert parse(input) == output
 
       input = "Color.blue.opacity(0.2).blendMode(.multiply).mix(with: .orange).opacity(0.7)"
-      output = {:., [], [{:., [], [{:., [], [{:., [], [{:., [], [:Color, :blue]}, {:opacity, [], [0.2]}]}, {:blendMode, [], [{:., [], [nil, :multiply]}]}]}, {:mix, [], [[:with: {:., [], [nil, :orange]}]]}]}, {:opacity, [], [0.7]}]}
+      output = {:., [], [{:., [], [{:., [], [{:., [], [{:., [], [:Color, :blue]}, {:opacity, [], [0.2]}]}, {:blendMode, [], [{:., [], [nil, :multiply]}]}]}, {:mix, [], [[with: {:., [], [nil, :orange]}]]}]}, {:opacity, [], [0.7]}]}
 
       assert parse(input) == output
     end

--- a/test/live_view_native/swiftui/rules_parser_test.exs
+++ b/test/live_view_native/swiftui/rules_parser_test.exs
@@ -138,9 +138,9 @@ defmodule LiveViewNative.SwiftUI.RulesParserTest do
     end
 
     test "parses naked chained IME" do
-      input = "font(.largerTitle.red)"
+      input = "font(.largeTitle.red)"
 
-      output = {:font, [], [{:., [], [{:., [], [nil, :largerTitle]}, :red]}]}
+      output = {:font, [], [{:., [], [{:., [], [nil, :largeTitle]}, :red]}]}
 
       assert parse(input) == output
     end

--- a/test/live_view_native/swiftui/rules_parser_test.exs
+++ b/test/live_view_native/swiftui/rules_parser_test.exs
@@ -182,7 +182,17 @@ defmodule LiveViewNative.SwiftUI.RulesParserTest do
     test "parses complex modifier chains" do
       input = "color(color: .foo.bar.baz(1, 2).qux)"
 
-      output = {:color, [], [color: {:., [], [{:., [], [{:., [], [{:., [], [nil, :foo]}, :bar]}, {:baz, [], [1, 2]}]}, :qux]}]}
+      output =
+        {:color, [],
+          [
+            {
+              :color,
+                {:., [],
+                  [{:., [], [{:., [], [{:., [], [nil, :foo]}, :bar]}, {:baz, [], [1, 2]}]}, :qux]
+              }
+            }
+          ]
+        }
 
       assert parse(input) == output
     end

--- a/test/live_view_native/swiftui/rules_parser_test.exs
+++ b/test/live_view_native/swiftui/rules_parser_test.exs
@@ -29,7 +29,7 @@ defmodule LiveViewNative.SwiftUI.RulesParserTest do
                output
       end
 
-      test "parses modifier function definition with annotation (2)" do
+    test "parses modifier function definition with annotation (2)" do
       {line, input} = {__ENV__.line,"""
       font(.largeTitle)
       bold(true)
@@ -92,8 +92,12 @@ defmodule LiveViewNative.SwiftUI.RulesParserTest do
 
     test "parses a naked IME" do
       input = "font(.largeTitle)"
-
       output = {:font, [], [{:., [], [nil, :largeTitle]}]}
+
+      assert parse(input) == output
+
+      input = "Color.blue.opacity(0.2).blendMode(.multiply).mix(with: .orange).opacity(0.7)"
+      output = {:., [], [{:., [], [{:., [], [{:., [], [{:., [], [:Color, :blue]}, {:opacity, [], [0.2]}]}, {:blendMode, [], [{:., [], [nil, :multiply]}]}]}, {:mix, [], [[:with: {:., [], [nil, :orange]}]]}]}, {:opacity, [], [0.7]}]}
 
       assert parse(input) == output
     end
@@ -116,8 +120,7 @@ defmodule LiveViewNative.SwiftUI.RulesParserTest do
       input = "font(color: Color.red.shadow(.thick))"
 
       output =
-        {:font, [],
-         [{:color, {:., [], [:Color, {:., [], [:red, {:shadow, [], [{:., [], [nil, :thick]}]}]}]}}]}
+        {:font, [], [{:color, {:., [], [{:., [], [:Color, :red]}, {:shadow, [], [{:., [], [nil, :thick]}]}]}}]}
 
       assert parse(input) == output
 
@@ -135,9 +138,9 @@ defmodule LiveViewNative.SwiftUI.RulesParserTest do
     end
 
     test "parses naked chained IME" do
-      input = "font(.largeTitle.red)"
+      input = "font(.largerTitle.red)"
 
-      output = {:font, [], [{:., [], [nil, {:., [], [:largeTitle, :red]}]}]}
+      output = {:font, [], [{:., [], [{:., [], [nil, :largerTitle]}, :red]}]}
 
       assert parse(input) == output
     end


### PR DESCRIPTION
Per-Carson's request the representation of member expressions is going to change to make the SwiftUI parsing easier to reason about

@NduatiK I've made a few updates to the tsets but after those tests are green I suspect other tests will fail as the new format hasn't been update everywhere in the test suite,

More details on the syntax

<img width="673" alt="Screenshot 2025-02-11 at 10 56 27 PM" src="https://github.com/user-attachments/assets/a625e6b0-46d5-4eeb-bee3-dcdc249c112c" />

I seem to recall that @NduatiK or @carson-katri recommended this format last year. 