### PR TITLE
Ignore leading dots and trailing semicolons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `NavigationLink` can perform a replace navigation by setting the `data-phx-link-state` attribute to `replace`
 - `NavigationLink` takes a `destination` template to customize the connecting phase View for its navigation event.
 - The `data-confirm` attribute can be added to elements to show a confirmation dialog before sending an event
+- modifiers will ignore leading `.` and trailing `;`
 
 ### Changed
 

--- a/lib/live_view_native/swiftui/rules_parser/modifiers.ex
+++ b/lib/live_view_native/swiftui/rules_parser/modifiers.ex
@@ -281,8 +281,10 @@ defmodule LiveViewNative.SwiftUI.RulesParser.Modifiers do
   defparsec(
     :modifier,
     ignore_whitespace()
+    |> optional(ignore_dot())
     |> concat(modifier_name())
     |> concat(modifier_brackets.(nested: false))
+    |> optional(ignore_semicolon())
     |> post_traverse({PostProcessors, :to_function_call_ast, []}),
     export_combinator: true
   )

--- a/lib/live_view_native/swiftui/rules_parser/tokens.ex
+++ b/lib/live_view_native/swiftui/rules_parser/tokens.ex
@@ -113,6 +113,14 @@ defmodule LiveViewNative.SwiftUI.RulesParser.Tokens do
     combinator |> ignore(optional(whitespace(min: 1)))
   end
 
+  def ignore_dot(combinator \\ empty()) do
+    combinator |> ignore(string("."))
+  end
+
+  def ignore_semicolon(combinator \\ empty()) do
+    combinator |> ignore(string(";"))
+  end
+
   # @tuple_children [
   #   parsec(:nested_attribute),
   #   atom(),

--- a/test/live_view_native/swiftui/rules_parser_test.exs
+++ b/test/live_view_native/swiftui/rules_parser_test.exs
@@ -27,7 +27,7 @@ defmodule LiveViewNative.SwiftUI.RulesParserTest do
                annotations: true
              ) ==
                output
-      end
+    end
 
     test "parses modifier function definition with annotation (2)" do
       {line, input} = {__ENV__.line,"""
@@ -40,6 +40,27 @@ defmodule LiveViewNative.SwiftUI.RulesParserTest do
         {:font, [file: __ENV__.file, line: line, module: __ENV__.module, source: "font(.largeTitle)"], [{:., [file: __ENV__.file, line: line, module: __ENV__.module, source: "font(.largeTitle)"], [nil, :largeTitle]}]},
         {:bold, [file: __ENV__.file, line: line + 1, module: __ENV__.module, source: "bold(true)"], [true]},
         {:italic, [file: __ENV__.file, line: line + 2, module: __ENV__.module, source: "italic(true)"], [true]}
+      ]
+
+      assert parse(input,
+          file: __ENV__.file,
+          module: __ENV__.module,
+          line: line,
+          annotations: true
+        ) == output
+    end
+
+    test "ignores leading . and trailing ;" do
+      {line, input} = {__ENV__.line,"""
+      .font(.largeTitle);
+      .bold(true);
+      .italic(true);
+      """}
+
+      output = [
+        {:font, [file: __ENV__.file, line: line, module: __ENV__.module, source: ".font(.largeTitle);"], [{:., [file: __ENV__.file, line: line, module: __ENV__.module, source: ".font(.largeTitle);"], [nil, :largeTitle]}]},
+        {:bold, [file: __ENV__.file, line: line + 1, module: __ENV__.module, source: ".bold(true);"], [true]},
+        {:italic, [file: __ENV__.file, line: line + 2, module: __ENV__.module, source: ".italic(true);"], [true]}
       ]
 
       assert parse(input,


### PR DESCRIPTION
This should make porting rules from SwiftUI examples easier

Now all of these formats are accepted:

```
foo()
.foo()
foo();
.foo();
```

This is to solve two annoyances:

1. copying modifiers from SwiftUI examples has leading `.` on each modifier. Now you can just drop these in.
2. People familiar with CSS have been adding `;` at the end of each line. This was re-inforced when we support `;` separator in the `style` attr in-template.