### PR TITLE
retain cycle fix

### DIFF
--- a/Sources/LiveViewNative/Coordinators/LiveViewCoordinator.swift
+++ b/Sources/LiveViewNative/Coordinators/LiveViewCoordinator.swift
@@ -239,8 +239,7 @@ public class LiveViewCoordinator<R: RootRegistry>: ObservableObject {
 
     func bindEventListener() {
         self.eventListenerLoop = Task { [weak self, weak channel] in
-            guard let channel else { return }
-            let eventListener = channel.eventStream()
+            let eventListener = channel!.eventStream()
             for try await event in eventListener {
                 guard let self else { return }
                 guard !Task.isCancelled else { return }

--- a/Sources/LiveViewNative/Coordinators/LiveViewCoordinator.swift
+++ b/Sources/LiveViewNative/Coordinators/LiveViewCoordinator.swift
@@ -238,7 +238,7 @@ public class LiveViewCoordinator<R: RootRegistry>: ObservableObject {
     }
 
     func bindEventListener() {
-        self.eventListenerLoop = Task { [weak self, weak channel] in
+        self.eventListenerLoop = Task { [weak self, unowned channel] in
             let eventListener = channel!.eventStream()
             for try await event in eventListener {
                 guard let self else { return }


### PR DESCRIPTION
because the channel never is upgraded to a strong reference it is retained after close, you can confirm this in the xcode memory graph view.