### PR TITLE
don't cancel running reconnect

### DIFF
--- a/Sources/LiveViewNative/Coordinators/LiveSessionCoordinator.swift
+++ b/Sources/LiveViewNative/Coordinators/LiveSessionCoordinator.swift
@@ -40,7 +40,7 @@ public class LiveSessionCoordinator<R: RootRegistry>: ObservableObject {
     public private(set) var url: URL
     
     private var lastReloadTime = Date.distantPast
-    let debounceTime = 0.300
+    let debounceTime : TimeInterval =  0.5
     
     /// The current navigation path this live view is rendering.
     @Published public internal(set) var navigationPath = [LiveNavigationEntry<R>]()

--- a/Sources/LiveViewNative/Coordinators/LiveSessionCoordinator.swift
+++ b/Sources/LiveViewNative/Coordinators/LiveSessionCoordinator.swift
@@ -298,6 +298,7 @@ public class LiveSessionCoordinator<R: RootRegistry>: ObservableObject {
                     try await self.disconnect()
                     self.navigationPath = [.init(url: self.url, coordinator: .init(session: self, url: self.url), navigationTransition: nil, pendingView: nil)]
                     try await self.connect()
+                    return
                 default:
                     continue
                 }
@@ -321,10 +322,6 @@ public class LiveSessionCoordinator<R: RootRegistry>: ObservableObject {
                 }
                 
                 self.navigationPath = [self.navigationPath.first!]
-            }
-            
-            if let liveReloadListenerLoop {
-                liveReloadListenerLoop.cancel()
             }
             
             if self.liveReloadChannel?.channel().status() == .joined {

--- a/Sources/LiveViewNative/Coordinators/LiveSessionCoordinator.swift
+++ b/Sources/LiveViewNative/Coordinators/LiveSessionCoordinator.swift
@@ -298,7 +298,6 @@ public class LiveSessionCoordinator<R: RootRegistry>: ObservableObject {
                     try await self.disconnect()
                     self.navigationPath = [.init(url: self.url, coordinator: .init(session: self, url: self.url), navigationTransition: nil, pendingView: nil)]
                     try await self.connect()
-                    return
                 default:
                     continue
                 }


### PR DESCRIPTION
It seems that `assets_change` events cancel the parent event during reconnect causing the connect to be aborted.