### PR TITLE
Prevent nonexistant variant from breaking MacOs Desktop Builds

### DIFF
--- a/Sources/LiveViewNative/Stylesheets/ResolvableTypes/SwiftUI/Styles/ListStyle.swift
+++ b/Sources/LiveViewNative/Stylesheets/ResolvableTypes/SwiftUI/Styles/ListStyle.swift
@@ -82,15 +82,14 @@ extension View {
         case .grouped:
             self.listStyle(.grouped)
         #endif
-        #if os(iOS) || os(macOS)
+        #if os(iOS) || os(macOS) || os(visionOS)
         case .inset:
             self.listStyle(.inset)
+        #endif
             
         #if os(iOS) || os(visionOS)
         case .insetGrouped:
             self.listStyle(.insetGrouped)
-        #endif
-            
         #endif
         case .plain:
             self.listStyle(.plain)

--- a/Sources/LiveViewNative/Stylesheets/ResolvableTypes/SwiftUI/Styles/ListStyle.swift
+++ b/Sources/LiveViewNative/Stylesheets/ResolvableTypes/SwiftUI/Styles/ListStyle.swift
@@ -85,8 +85,12 @@ extension View {
         #if os(iOS) || os(macOS)
         case .inset:
             self.listStyle(.inset)
+            
+        #if os(iOS) || os(visionOS)
         case .insetGrouped:
             self.listStyle(.insetGrouped)
+        #endif
+            
         #endif
         case .plain:
             self.listStyle(.plain)


### PR DESCRIPTION
The macro conditionals aren't quite right for `insetgrouped` causing a compilation error on desktop MacOs