### PR TITLE
Expose FileUpload types and API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `data-confirm` attribute can be added to elements to show a confirmation dialog before sending an event
 - `LiveSessionCoordinator.receiveEvent(_:for:)` and `LiveViewCoordinator.receiveEvent(_:for:)` to receive events with `Decodable` type payloads
 - modifiers will ignore leading `.` and trailing `;`
+- `FileUpload` type and `LiveViewModel.fileUpload(id:)` allow you to access queued files by their `phx-upload-ref` to create previews before upload
 
 ### Changed
 

--- a/Sources/LiveViewNative/ViewModel.swift
+++ b/Sources/LiveViewNative/ViewModel.swift
@@ -37,7 +37,7 @@ public class LiveViewModel: ObservableObject {
         self.forms.removeAll()
     }
     
-    func fileUpload(id: String) -> FormModel.FileUpload? {
+    public func fileUpload(id: String) -> FormModel.FileUpload? {
         for (_, form) in forms {
             guard let file = form.fileUploads.first(where: { $0.id == id })
             else { continue }
@@ -71,9 +71,9 @@ public class FormModel: ObservableObject, CustomDebugStringConvertible {
     var formWillSubmit = PassthroughSubject<(), Never>()
     
     var fileUploads: [FileUpload] = []
-    struct FileUpload {
-        let id: String
-        let data: Data
+    public struct FileUpload: Identifiable {
+        public let id: String
+        public let data: Data
         let upload: () async throws -> ()
     }
     


### PR DESCRIPTION
The `FileUpload` type and `LiveViewModel.fileUpload(id:)` allow you to create custom previews for selected files, similar to the `<.live_img_preview>` component.

For example, here is a custom View that generates a thumbnail preview for a selected video file.
It can be used in place of `live_img_preview`:

```heex
<LiveVideoPreview data-phx-upload-ref={entry.upload_ref} />
```

```swift
import AVKit

@LiveElement
struct LiveVideoPreview<Root: RootRegistry>: View {
    @LiveAttribute("data-phx-upload-ref")
    private var phxUploadRef: String?
    
    @LiveElementIgnored
    @EnvironmentObject
    private var liveViewModel: LiveViewModel
    
    @LiveElementIgnored
    @State
    private var thumbnail: Image?
    
    var body: some View {
        if let phxUploadRef,
           let upload = liveViewModel.fileUpload(id: phxUploadRef)
        {
            VStack {
                if let thumbnail {
                    thumbnail
                        .resizable()
                        .scaledToFit()
                } else {
                    ProgressView()
                }
            }
            .task {
                self.thumbnail = try? await thumbnail(for: upload.data, at: .zero)
            }
        }
    }
    
    func thumbnail(for data: Data, at time: CMTime) async throws -> Image {
        let url = FileManager.default.temporaryDirectory
            .appendingPathComponent(UUID().uuidString)
            .appendingPathExtension("mov")
        try? data.write(to: url)
        let asset = AVURLAsset(url: url)
        let generator = AVAssetImageGenerator(asset: asset)
        
        defer {
            // cleanup temporary file
            try? FileManager.default.removeItem(at: url)
        }
        
        return try await withCheckedThrowingContinuation { continuation in
            generator.generateCGImageAsynchronously(for: time) { image, time, error in
                if let image {
                    continuation.resume(
                        returning: Image(uiImage: UIImage(cgImage: image))
                    )
                } else if let error {
                    print(error)
                    continuation.resume(throwing: error)
                }
            }
        }
    }
}

extension Addons {
    @Addon
    struct VideoPreviews<Root: RootRegistry> {
        public enum TagName: String {
            case liveVideoPreview = "LiveVideoPreview"
        }
        
        @MainActor
        @ViewBuilder
        public static func lookup(_ name: TagName, element: ElementNode) -> some View {
            switch name {
            case .liveVideoPreview:
                LiveVideoPreview<Root>()
            }
        }
    }
}
```