### PR TITLE
Expose generated Resolvable types for addons

### DIFF
--- a/Sources/ASTDecodableImplementation/Decoders/InitializerClausesDecoder.swift
+++ b/Sources/ASTDecodableImplementation/Decoders/InitializerClausesDecoder.swift
@@ -34,6 +34,7 @@ struct InitializerClausesDecoder<TypeSyntaxType: TypeSyntaxProtocol> {
         let errorReference = DeclReferenceExprSyntax(baseName: errorName)
         
         return StructDeclSyntax(
+            attributes: [.attribute(AttributeSyntax(attributeName: IdentifierTypeSyntax(name: .identifier("MainActor"))))],
             name: name,
             inheritanceClause: InheritanceClauseSyntax(inheritedTypes: [
                 // @preconcurrency Swift.Decodable

--- a/Sources/LiveViewNative/LiveViewNative.docc/AddCustomModifier.md
+++ b/Sources/LiveViewNative/LiveViewNative.docc/AddCustomModifier.md
@@ -112,6 +112,42 @@ labeled(as: 5)
 labeled(as: "Label")
 ```
 
+``ASTDecodable(_:options:)`` will also synthesize decoders for enum cases, static functions, static members, properties, and member functions.
+To exclude any of these declarations from the decoder, either prefix them with an underscore (`_`), or define them in an extension.
+Static functions, static members, properties, and member functions will only receive a synthesized decoder if they return `Self` (or a type name that matches the declaration ``ASTDecodable(_:options:)`` is attached to).
+
+```swift
+@ASTDecodable("MyType")
+enum MyType: Decodable {
+    init() {} // decodable
+    
+    case enumCase // decodable
+    
+    static func staticFunction() -> Self { ... } // decodable
+    static func staticFunction() -> OtherType { ... } // not decodable
+    static func _staticFunction() -> OtherType { ... } // not decodable
+    
+    static var staticMember: Self { ... } // decodable
+    static var staticMember: OtherType { ... } // not decodable
+    static var _staticMember: OtherType { ... } // not decodable
+    
+    func memberFunction() -> Self { ... } // decodable
+    func memberFunction() -> OtherType { ... } // not decodable
+    func _memberFunction() -> OtherType { ... } // not decodable
+    
+    var property: Self { ... } // decodable
+    var property: OtherType { ... } // not decodable
+    var _property: OtherType { ... } // not decodable
+}
+
+extension MyType {
+    static func staticFunction() -> Self { ... } // not decodable
+    static var staticMember: Self { ... } // not decodable
+    func memberFunction() -> Self { ... } // not decodable
+    var property: Self { ... } // not decodable
+}
+```
+
 ### Attribute References
 Any type that conforms to ``AttributeDecodable`` can be wrapped with ``AttributeReference``.
 

--- a/Sources/LiveViewNative/LiveViewNative.docc/AddCustomModifier.md
+++ b/Sources/LiveViewNative/LiveViewNative.docc/AddCustomModifier.md
@@ -23,21 +23,27 @@ public extension Addons {
 ```
 
 Then, add an enum called `CustomModifier` that has cases for each modifier to include.
-The framework uses this type to parse modifiers in a stylesheet.
+The framework uses this type to decode modifiers in a stylesheet.
 
-Use the ``CustomModifierGroupParser`` to include multiple modifiers.
+Conform to the `Decodable` protocol and attempt to decode each modifier type in the `init(from:)` implementation.
+
+`init(from:)` *must* throw if no modifiers can be decoded.
+If your `CustomModifier` catches unknown modifiers, modifiers from other addons will get ignored.
 
 ```swift
 @Addon
 struct MyAddon<Root: RootRegistry> {
-    enum CustomModifier: ViewModifier, ParseableModifierValue {
+    enum CustomModifier: ViewModifier, @preconcurrency Decodable {
         case myFirstModifier(MyFirstModifier<Root>)
         case mySecondModifier(MySecondModifier<Root>)
-        
-        static func parser(in context: ParseableModifierContext) -> some Parser<Substring.UTF8View, Self> {
-            CustomModifierGroupParser(output: Self.self) {
-                MyFirstModifier<Root>.parser(in: context).map(Self.myFirstModifier)
-                MySecondModifier<Root>.parser(in: context).map(Self.mySecondModifier)
+
+        init(from decoder: any Decoder) throws {
+            let container = try decoder.singleValueContainer()
+
+            if let modifier = try? container.decode(MyFirstModifier<Root>.self) {
+                self = .myFirstModifier(modifier)
+            } else {
+                self = .mySecondModifier(try container.decode(MySecondModifier<Root>.self))
             }
         }
         
@@ -53,48 +59,193 @@ struct MyAddon<Root: RootRegistry> {
 }
 ```
 
-## Parseable Modifiers
+## Decoding Modifiers
 
-Each modifier should conform to ``LiveViewNativeStylesheet/ParseableModifierValue``.
-You can use the ``LiveViewNativeStylesheet/ParseableExpression()`` macro to synthesize this conformance.
-
-The macro will synthesize a parser for each `init` clause.
-
-Any type conforming to ``LiveViewNativeStylesheet/ParseableModifierValue`` can be used as an argument in an `init` clause.
+LiveView Native allows you to write modifiers in a stylesheet or `style` attribute with Swift syntax.
+These modifiers are converted to an abstract syntax tree format and encoded to JSON.
 
 ```swift
-@ParseableExpression
-struct MyFirstModifier<Root: RootRegistry>: ViewModifier {
-    static var name: String { "myFirstModifier" }
+// stylesheet:
+foregroundStyle(Color.red)
+```
 
-    let color: Color
+```json
+["foregroundStyle", { ... }, [[".", { ... }, ["Color", "red"]]]]
+```
 
-    init(_ color: Color) {
-        self.color = color
+Each modifier conforms to `Decodable`, and is expected to decode itself from this JSON format.
+
+### Automatic Decoding
+The ``ASTDecodable(_:options:)`` macro can synthesize a decoder directly from your Swift code.
+
+Add the ``ASTDecodable(_:options:)`` macro to your struct, and pass it the name of the modifier.
+
+It will synthesize a decoder for each `init` clause in the struct.
+
+```swift
+@ASTDecodable("labeled")
+struct LabeledModifier<Root: RootRegistry>: ViewModifier, @preconcurrency Decodable {
+    let label: String
+
+    init(as label: Int) {
+        self.label = String(label)
     }
 
-    init(red: Double, green: Double, blue: Double) {
-        self.color = Color(.sRGB, red: red, green: green, blue: blue)
+    init(as label: String) {
+        self.label = label
     }
     
     func body(content: Content) -> some View {
-        content
-            .bold()
-            .background(color)
+        LabeledContent {
+            content
+        } label: {
+            Text(label)
+        }
     }
 }
 ```
 
-In the stylesheet, you can use either clause:
+In the stylesheet, you can use either `init`:
 
 ```swift
-// myFirstModifier(_:)
-myFirstModifier(.red)
-myFirstModifier(.blue)
-myFirstModifier(Color(white: 0.5))
+labeled(as: 5)
+labeled(as: "Label")
+```
 
-// myFirstModifier(red:green:blue:)
-myFirstModifier(red: 1, green: 0.5, blue: 0)
+### Attribute References
+Any type that conforms to ``AttributeDecodable`` can be wrapped with ``AttributeReference``.
+
+This will make it usable with the `attr(<name>)` helper in a stylesheet.
+
+Use the ``ObservedElement`` and ``LiveContext`` property wrappers to access the element and context needed to resolve these references.
+
+```swift
+@ASTDecodable("labeled")
+struct LabeledModifier<Root: RootRegistry>: ViewModifier, @preconcurrency Decodable {
+    @ObservedElement private var element
+    @LiveContext<Root> private var context
+
+    let label: AttributeReference<String>
+
+    init(as label: AttributeReference<String>) {
+        self.label = label
+    }
+    
+    func body(content: Content) -> some View {
+        LabeledContent {
+            content
+        } label: {
+            Text(label.resolve(on: element, in: context))
+        }
+    }
+}
+```
+
+```elixir
+"my-title" do
+    labeled(as: attr("label"))
+end
+```
+
+```html
+<Element class="my-title" label="My Label" />
+```
+
+### Resolvable Types
+Stylesheets are static assets, and the modifiers defined in your templates do not change after the application loads.
+However, some of their properties can be dynamic using helpers like `attr(<name>)` or `gesture_state(...)`.
+
+The ``StylesheetResolvable`` protocol defines a type that must be resolved before it can be used.
+Many types built-in to SwiftUI have been given a nested `Resolvable` type that conforms to this protocol.
+This nested type can be used to decode a SwiftUI primitive in your modifier.
+
+Call ``StylesheetResolvable/resolve(on:in:)`` to get the resolved value for an ``ElementNode`` in a ``LiveContext``.
+Use the ``ObservedElement`` and ``LiveContext`` property wrappers to access the element and context needed to resolve these types.
+
+For example, SwiftUI has a built-in `HorizontalAlignment` type. We can use `HorizontalAlignment.Resolvable` to include this in our custom modifier.
+
+```swift
+@ASTDecodable("labeled")
+struct LabeledModifier<Root: RootRegistry>: ViewModifier, @preconcurrency Decodable {
+    let label: String
+    let alignment: HorizontalAlignment.Resolvable
+
+    init(as label: String, alignment: HorizontalAlignment.Resolvable) {
+        self.label = label
+        self.alignment = alignment
+    }
+    
+    func body(content: Content) -> some View {
+        VStack(alignment: alignment.resolve(on: element, in: context)) {
+            Text(label)
+            content
+        }
+    }
+}
+```
+```swift
+// stylesheet:
+labeled(as: "Label", alignment: .trailing)
+```
+
+#### Resolvable Protocols
+
+Some protocols also have ``StylesheetResolvable`` implementations.
+For example, to use `some ShapeStyle` in your modifier, use the ``StylesheetResolvableShapeStyle`` type.
+It will resolve to a type-erased `ShapeStyle`.
+
+```swift
+@ASTDecodable("fillBackground")
+struct FillBackgroundModifier<Root: RootRegistry>: ViewModifier, @preconcurrency Decodable {
+    let fill: StylesheetResolvableShapeStyle
+
+    init(_ fill: StylesheetResolvableShapeStyle) {
+        self.fill = fill
+    }
+    
+    func body(content: Content) -> some View {
+        content.background(fill)
+    }
+}
+```
+```swift
+// stylesheet:
+fillBackground(.regularMaterial)
+fillBackground(.red.opacity(attr("opacity")))
+```
+
+#### Custom Resolvable Types
+
+You can also conform your own types to `StylesheetResolvable`. This is most useful when you want some properties of your type to support the `attr(<name>)` helper.
+
+```swift
+struct Video {
+    let url: String
+    let resolution: Int
+
+    @ASTDecodable("Video")
+    struct Resolvable: StylesheetResolvable, Decodable {
+        let url: AttributeReference<String>
+        let resolution: AttributeReference<Int>
+
+        init(_ url: AttributeReference<String>, in resolution: AttributeReference<Int>) {
+            self.url = url
+            self.resolution = resolution
+        }
+
+        func resolve(on element: ElementNode, in context: LiveContext<some RootRegistry>) -> Video {
+            Video(
+                url: url.resolve(on: element, in: context),
+                resolution: resolution.resolve(on: element, in: context)
+            )
+        }
+    }
+}
+```
+```swift
+// stylesheet:
+backgroundVideo(Video("...", in: 1080))
+backgroundVideo(Video(attr("url"), in: attr("resolution")))
 ```
 
 ### Nested Content
@@ -103,10 +254,8 @@ Use ``ObservedElement`` and ``LiveContext`` to access properties/children of the
 The ``ViewReference`` type can be used to refer to nested children with a `template` attribute.
 
 ```swift
-@ParseableExpression
-struct MyBackgroundModifier<Root: RootRegistry>: ViewModifier {
-    static var name: String { "myBackground" }
-
+@ASTDecodable("myBackground")
+struct MyBackgroundModifier<Root: RootRegistry>: ViewModifier, @preconcurrency Decodable {
     @ObservedElement private var element
     @LiveContext<Root> private var context
 
@@ -117,7 +266,9 @@ struct MyBackgroundModifier<Root: RootRegistry>: ViewModifier {
     }
     
     func body(content: Content) -> some View {
-        content.background(content.resolve(on: element, in: context))
+        content.background {
+            content.resolve(on: element, in: context)
+        }
     }
 }
 ```
@@ -132,39 +283,4 @@ end
 <Element class="my-background">
     <Text template="my_content">Nested Content</Text>
 </Element>
-```
-
-### Attribute References
-Any type that conforms to ``AttributeDecodable`` can be wrapped with ``AttributeReference``.
-
-This will make it usable with the `attr(<name>)` helper in a stylesheet.
-
-```swift
-@ParseableExpression
-struct MyTitleModifier<Root: RootRegistry>: ViewModifier {
-    static var name: String { "myTitle" }
-
-    @ObservedElement private var element
-    @LiveContext<Root> private var context
-
-    let title: AttributeReference<String>
-
-    init(_ title: AttributeReference<String>) {
-        self.title = title
-    }
-    
-    func body(content: Content) -> some View {
-        content.navigationTitle(title.resolve(on: element, in: context))
-    }
-}
-```
-
-```elixir
-"my-title" do
-    myTitle(attr("title"))
-end
-```
-
-```html
-<Element class="my-title" title="My Title" />
 ```

--- a/Sources/LiveViewNative/Protocols/ContentBuilder.swift
+++ b/Sources/LiveViewNative/Protocols/ContentBuilder.swift
@@ -680,6 +680,7 @@ public extension ContentBuilder {
 /// Modifiers must be decoded from the ``ContentBuilder/decodeModifier(_:from:registry:)``.
 ///
 /// - Note: Keys are automatically converted from `camelCase` to `snake_case` in the decoder.
+@MainActor
 public protocol ContentModifier<Builder>: Decodable {
     associatedtype Builder: ContentBuilder
     func apply<R: RootRegistry>(
@@ -689,7 +690,7 @@ public protocol ContentModifier<Builder>: Decodable {
     ) -> Builder.Content
 }
 
-public struct EmptyContentModifier<Builder: ContentBuilder>: ContentModifier {
+public struct EmptyContentModifier<Builder: ContentBuilder>: ContentModifier, @preconcurrency Decodable {
     public init() {}
     
     public func apply<R>(
@@ -705,4 +706,10 @@ public struct EmptyContentModifier<Builder: ContentBuilder>: ContentModifier {
 
 enum ContentBuilderError: Error {
     case unknownTag(String)
+}
+
+extension StylesheetResolvable {
+    public func resolve<Builder: ContentBuilder, R: RootRegistry>(on element: ElementNode, in context: Builder.Context<R>) -> Resolved {
+        self.resolve(on: element, in: context.context)
+    }
 }

--- a/Sources/LiveViewNative/Stylesheets/ResolvableTypes/Accessibility.swift
+++ b/Sources/LiveViewNative/Stylesheets/ResolvableTypes/Accessibility.swift
@@ -12,7 +12,7 @@ import LiveViewNativeCore
 
 extension Accessibility.AXCustomContent.Importance {
     @ASTDecodable("Importance")
-    enum Resolvable: StylesheetResolvable, @preconcurrency Decodable {
+    public enum Resolvable: StylesheetResolvable, @preconcurrency Decodable {
         case __constant(Accessibility.AXCustomContent.Importance)
         
         case `default`
@@ -20,7 +20,7 @@ extension Accessibility.AXCustomContent.Importance {
     }
 }
 
-extension Accessibility.AXCustomContent.Importance.Resolvable {
+public extension Accessibility.AXCustomContent.Importance.Resolvable {
     @MainActor func resolve<R: RootRegistry>(on element: ElementNode, in context: LiveContext<R>) -> Accessibility.AXCustomContent.Importance {
         switch self {
         case let .__constant(value):
@@ -33,22 +33,22 @@ extension Accessibility.AXCustomContent.Importance.Resolvable {
     }
 }
 
-struct StylesheetResolvableAXChartDescriptorRepresentable: StylesheetResolvable, @preconcurrency Decodable, @preconcurrency AXChartDescriptorRepresentable {
-    init(from decoder: any Decoder) throws {
+public struct StylesheetResolvableAXChartDescriptorRepresentable: StylesheetResolvable, @preconcurrency Decodable, @preconcurrency AXChartDescriptorRepresentable {
+    public init(from decoder: any Decoder) throws {
         fatalError("'AXChartDescriptor' is not supported")
     }
     
-    func makeChartDescriptor() -> AXChartDescriptor {
+    public func makeChartDescriptor() -> AXChartDescriptor {
         fatalError("'AXChartDescriptor' is not supported")
     }
     
-    func resolve<R>(on element: ElementNode, in context: LiveContext<R>) -> Self where R : RootRegistry {
+    public func resolve<R>(on element: ElementNode, in context: LiveContext<R>) -> Self where R : RootRegistry {
         return self
     }
 }
 
 extension StylesheetResolvableAXChartDescriptorRepresentable: @preconcurrency AttributeDecodable {
-    init(from attribute: Attribute?, on element: ElementNode) throws {
+    public init(from attribute: Attribute?, on element: ElementNode) throws {
         fatalError("'AXChartDescriptor' is not supported")
     }
 }

--- a/Sources/LiveViewNative/Stylesheets/ResolvableTypes/AppKit.swift
+++ b/Sources/LiveViewNative/Stylesheets/ResolvableTypes/AppKit.swift
@@ -12,7 +12,7 @@ import LiveViewNativeStylesheet
 
 extension NSTextContentType {
     @ASTDecodable("NSTextContentType")
-    enum Resolvable: StylesheetResolvable, @preconcurrency Decodable, @preconcurrency AttributeDecodable {
+    public enum Resolvable: StylesheetResolvable, @preconcurrency Decodable, @preconcurrency AttributeDecodable {
         case username
         case password
         case oneTimeCode
@@ -59,7 +59,7 @@ extension NSTextContentType {
     }
 }
 
-extension NSTextContentType.Resolvable {
+public extension NSTextContentType.Resolvable {
     func resolve<R: RootRegistry>(on element: ElementNode, in context: LiveContext<R>) -> NSTextContentType {
         switch self {
         case .username:

--- a/Sources/LiveViewNative/Stylesheets/ResolvableTypes/CoreGraphics.swift
+++ b/Sources/LiveViewNative/Stylesheets/ResolvableTypes/CoreGraphics.swift
@@ -11,7 +11,7 @@ import LiveViewNativeStylesheet
 extension CGPoint {
     @ASTDecodable("CGPoint")
     @MainActor
-    enum Resolvable: StylesheetResolvable, @preconcurrency Decodable {
+    public enum Resolvable: StylesheetResolvable, @preconcurrency Decodable {
         case __constant(CGPoint)
         case _init(x: AttributeReference<CGFloat>, y: AttributeReference<CGFloat>)
         
@@ -23,7 +23,7 @@ extension CGPoint {
     }
 }
 
-extension CGPoint.Resolvable {
+public extension CGPoint.Resolvable {
     @MainActor
     func resolve<R: RootRegistry>(on element: ElementNode, in context: LiveContext<R>) -> CGPoint {
         switch self {
@@ -38,7 +38,7 @@ extension CGPoint.Resolvable {
 extension CGVector {
     @ASTDecodable("CGVector")
     @MainActor
-    enum Resolvable: StylesheetResolvable, @preconcurrency Decodable {
+    public enum Resolvable: StylesheetResolvable, @preconcurrency Decodable {
         case __constant(CGVector)
         case _init(dx: AttributeReference<CGFloat>, dy: AttributeReference<CGFloat>)
         
@@ -50,7 +50,7 @@ extension CGVector {
     }
 }
 
-extension CGVector.Resolvable {
+public extension CGVector.Resolvable {
     @MainActor
     func resolve<R: RootRegistry>(on element: ElementNode, in context: LiveContext<R>) -> CGVector {
         switch self {
@@ -64,12 +64,12 @@ extension CGVector.Resolvable {
 
 extension CGSize {
     @MainActor
-    enum Resolvable: StylesheetResolvable, @preconcurrency Decodable {
+    public enum Resolvable: StylesheetResolvable, @preconcurrency Decodable {
         case __constant(CGSize)
         case _reference(AttributeReference<CGSize>)
         case _ast(ASTCGSize)
         
-        init(from decoder: any Decoder) throws {
+        public init(from decoder: any Decoder) throws {
             var container = try decoder.singleValueContainer()
             
             if let reference = try? container.decode(AttributeReference<CGSize>.self) {
@@ -80,7 +80,7 @@ extension CGSize {
         }
         
         @ASTDecodable("CGSize")
-        enum ASTCGSize: @preconcurrency Decodable {
+        public enum ASTCGSize: @preconcurrency Decodable {
             case _init(width: AttributeReference<CGFloat>, height: AttributeReference<CGFloat>)
             
             init(width: AttributeReference<CGFloat>, height: AttributeReference<CGFloat>) {
@@ -90,7 +90,7 @@ extension CGSize {
     }
 }
 
-extension CGSize.Resolvable {
+public extension CGSize.Resolvable {
     @MainActor
     func resolve<R: RootRegistry>(on element: ElementNode, in context: LiveContext<R>) -> CGSize {
         switch self {
@@ -107,7 +107,7 @@ extension CGSize.Resolvable {
 extension CGRect {
     @ASTDecodable("CGRect")
     @MainActor
-    enum Resolvable: StylesheetResolvable, @preconcurrency Decodable {
+    public enum Resolvable: StylesheetResolvable, @preconcurrency Decodable {
         case __constant(CGRect)
         case _init1(origin: CGPoint.Resolvable, size: CGSize.Resolvable)
         case _init2(x: AttributeReference<CGFloat>, y: AttributeReference<CGFloat>, width: AttributeReference<CGFloat>, height: AttributeReference<CGFloat>)
@@ -122,7 +122,7 @@ extension CGRect {
     }
 }
 
-extension CGRect.Resolvable {
+public extension CGRect.Resolvable {
     @MainActor
     func resolve<R: RootRegistry>(on element: ElementNode, in context: LiveContext<R>) -> CGRect {
         switch self {
@@ -138,12 +138,12 @@ extension CGRect.Resolvable {
 
 extension CGPath {
     @ASTDecodable("CGPath")
-    enum Resolvable: StylesheetResolvable, @preconcurrency Decodable {
+    public enum Resolvable: StylesheetResolvable, @preconcurrency Decodable {
         case __constant(CGPath)
     }
 }
 
-extension CGPath.Resolvable {
+public extension CGPath.Resolvable {
     @MainActor
     func resolve<R: RootRegistry>(on element: ElementNode, in context: LiveContext<R>) -> CGPath {
         switch self {
@@ -155,12 +155,12 @@ extension CGPath.Resolvable {
 
 extension CGMutablePath {
     @ASTDecodable("CGMutablePath")
-    enum Resolvable: StylesheetResolvable, @preconcurrency Decodable {
+    public enum Resolvable: StylesheetResolvable, @preconcurrency Decodable {
         case __constant(CGMutablePath)
     }
 }
 
-extension CGMutablePath.Resolvable {
+public extension CGMutablePath.Resolvable {
     @MainActor
     func resolve<R: RootRegistry>(on element: ElementNode, in context: LiveContext<R>) -> CGMutablePath {
         switch self {
@@ -172,7 +172,7 @@ extension CGMutablePath.Resolvable {
 
 extension CGLineCap {
     @ASTDecodable("CGLineCap")
-    enum Resolvable: StylesheetResolvable, @preconcurrency Decodable {
+    public enum Resolvable: StylesheetResolvable, @preconcurrency Decodable {
         case __constant(CGLineCap)
         case butt
         case round
@@ -180,7 +180,7 @@ extension CGLineCap {
     }
 }
 
-extension CGLineCap.Resolvable {
+public extension CGLineCap.Resolvable {
     @MainActor
     func resolve<R: RootRegistry>(on element: ElementNode, in context: LiveContext<R>) -> CGLineCap {
         switch self {
@@ -198,7 +198,7 @@ extension CGLineCap.Resolvable {
 
 extension CGLineJoin {
     @ASTDecodable("CGLineJoin")
-    enum Resolvable: StylesheetResolvable, @preconcurrency Decodable {
+    public enum Resolvable: StylesheetResolvable, @preconcurrency Decodable {
         case __constant(CGLineJoin)
         case miter
         case round
@@ -206,7 +206,7 @@ extension CGLineJoin {
     }
 }
 
-extension CGLineJoin.Resolvable {
+public extension CGLineJoin.Resolvable {
     @MainActor
     func resolve<R: RootRegistry>(on element: ElementNode, in context: LiveContext<R>) -> CGLineJoin {
         switch self {
@@ -224,12 +224,12 @@ extension CGLineJoin.Resolvable {
 
 extension CGAffineTransform {
     @ASTDecodable("CGAffineTransform")
-    enum Resolvable: StylesheetResolvable, @preconcurrency Decodable {
+    public enum Resolvable: StylesheetResolvable, @preconcurrency Decodable {
         case __constant(CGAffineTransform)
     }
 }
 
-extension CGAffineTransform.Resolvable {
+public extension CGAffineTransform.Resolvable {
     @MainActor
     func resolve<R: RootRegistry>(on element: ElementNode, in context: LiveContext<R>) -> CGAffineTransform {
         switch self {
@@ -241,12 +241,12 @@ extension CGAffineTransform.Resolvable {
 
 extension CGImage {
     @ASTDecodable("CGImage")
-    enum Resolvable: StylesheetResolvable, @preconcurrency Decodable {
+    public enum Resolvable: StylesheetResolvable, @preconcurrency Decodable {
         case __constant(CGImage)
     }
 }
 
-extension CGImage.Resolvable {
+public extension CGImage.Resolvable {
     @MainActor
     func resolve<R: RootRegistry>(on element: ElementNode, in context: LiveContext<R>) -> CGImage {
         switch self {
@@ -258,12 +258,12 @@ extension CGImage.Resolvable {
 
 extension CGColor {
     @ASTDecodable("CGColor")
-    enum Resolvable: StylesheetResolvable, @preconcurrency Decodable {
+    public enum Resolvable: StylesheetResolvable, @preconcurrency Decodable {
         case __constant(CGColor)
     }
 }
 
-extension CGColor.Resolvable {
+public extension CGColor.Resolvable {
     @MainActor
     func resolve<R: RootRegistry>(on element: ElementNode, in context: LiveContext<R>) -> CGColor {
         switch self {
@@ -274,7 +274,7 @@ extension CGColor.Resolvable {
 }
 
 extension CGFloat {
-    enum Resolvable: StylesheetResolvable, @preconcurrency Decodable {
+    public enum Resolvable: StylesheetResolvable, @preconcurrency Decodable {
         case __constant(CGFloat)
         case reference(AttributeReference<CGFloat>)
         
@@ -284,7 +284,7 @@ extension CGFloat {
             case pi
         }
         
-        init(from decoder: any Decoder) throws {
+        public init(from decoder: any Decoder) throws {
             let container = try decoder.singleValueContainer()
             if let member = try? container.decode(Member.self) {
                 switch member {
@@ -298,7 +298,7 @@ extension CGFloat {
             }
         }
         
-        func resolve<R>(on element: ElementNode, in context: LiveContext<R>) -> CGFloat where R : RootRegistry {
+        public func resolve<R>(on element: ElementNode, in context: LiveContext<R>) -> CGFloat where R : RootRegistry {
             switch self {
             case let .__constant(constant):
                 return constant

--- a/Sources/LiveViewNative/Stylesheets/ResolvableTypes/CoreText.swift
+++ b/Sources/LiveViewNative/Stylesheets/ResolvableTypes/CoreText.swift
@@ -9,13 +9,13 @@ import CoreText
 import LiveViewNativeStylesheet
 
 extension CoreText.CTFont {
-    enum Resolvable: StylesheetResolvable, @preconcurrency Decodable {
-        init(from decoder: any Decoder) throws {
+    public enum Resolvable: StylesheetResolvable, @preconcurrency Decodable {
+        public init(from decoder: any Decoder) throws {
             fatalError("CTFont is not available")
         }
         
         @MainActor
-        func resolve<R: RootRegistry>(on element: ElementNode, in context: LiveContext<R>) -> CoreText.CTFont {
+        public func resolve<R: RootRegistry>(on element: ElementNode, in context: LiveContext<R>) -> CoreText.CTFont {
             fatalError("CTFont is not available")
         }
     }

--- a/Sources/LiveViewNative/Stylesheets/ResolvableTypes/DeveloperToolsSupport.swift
+++ b/Sources/LiveViewNative/Stylesheets/ResolvableTypes/DeveloperToolsSupport.swift
@@ -11,13 +11,13 @@ import LiveViewNativeStylesheet
 @available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *)
 extension ColorResource {
     @ASTDecodable("ColorResource")
-    enum Resolvable: StylesheetResolvable, @preconcurrency Decodable {
+    public enum Resolvable: StylesheetResolvable, @preconcurrency Decodable {
         case __constant(ColorResource)
     }
 }
 
 @available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *)
-extension ColorResource.Resolvable {
+public extension ColorResource.Resolvable {
     @MainActor
     func resolve<R: RootRegistry>(on element: ElementNode, in context: LiveContext<R>) -> ColorResource {
         switch self {
@@ -30,13 +30,13 @@ extension ColorResource.Resolvable {
 @available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *)
 extension ImageResource {
     @ASTDecodable("ImageResource")
-    enum Resolvable: StylesheetResolvable, @preconcurrency Decodable {
+    public enum Resolvable: StylesheetResolvable, @preconcurrency Decodable {
         case __constant(ImageResource)
     }
 }
 
 @available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *)
-extension ImageResource.Resolvable {
+public extension ImageResource.Resolvable {
     @MainActor
     func resolve<R: RootRegistry>(on element: ElementNode, in context: LiveContext<R>) -> ImageResource {
         switch self {

--- a/Sources/LiveViewNative/Stylesheets/ResolvableTypes/Foundation.swift
+++ b/Sources/LiveViewNative/Stylesheets/ResolvableTypes/Foundation.swift
@@ -11,7 +11,7 @@ import LiveViewNativeCore
 
 extension Calendar {
     @ASTDecodable("Calendar")
-    enum Resolvable: StylesheetResolvable, @preconcurrency Decodable {
+    public enum Resolvable: StylesheetResolvable, @preconcurrency Decodable {
         case _current
         case _autoupdatingCurrent
         
@@ -20,7 +20,7 @@ extension Calendar {
     }
 }
 
-extension Calendar.Resolvable {
+public extension Calendar.Resolvable {
     @MainActor
     func resolve<R: RootRegistry>(on element: ElementNode, in context: LiveContext<R>) -> Calendar {
         switch self {
@@ -34,7 +34,7 @@ extension Calendar.Resolvable {
 
 extension Locale {
     @ASTDecodable("Locale")
-    enum Resolvable: StylesheetResolvable, @preconcurrency Decodable {
+    public enum Resolvable: StylesheetResolvable, @preconcurrency Decodable {
         case _current
         case _autoupdatingCurrent
         
@@ -43,7 +43,7 @@ extension Locale {
     }
 }
 
-extension Locale.Resolvable {
+public extension Locale.Resolvable {
     @MainActor
     func resolve<R: RootRegistry>(on element: ElementNode, in context: LiveContext<R>) -> Locale {
         switch self {
@@ -58,7 +58,7 @@ extension Locale.Resolvable {
 extension Locale.Language {
     @ASTDecodable("Language")
     @MainActor
-    enum Resolvable: StylesheetResolvable, @preconcurrency Decodable {
+    public enum Resolvable: StylesheetResolvable, @preconcurrency Decodable {
         case __constant(Locale.Language)
         case _init(identifier: AttributeReference<String>)
         
@@ -68,7 +68,7 @@ extension Locale.Language {
     }
 }
 
-extension Locale.Language.Resolvable {
+public extension Locale.Language.Resolvable {
     @MainActor
     func resolve<R: RootRegistry>(on element: ElementNode, in context: LiveContext<R>) -> Locale.Language {
         switch self {
@@ -82,7 +82,7 @@ extension Locale.Language.Resolvable {
 
 extension Date.ComponentsFormatStyle.Field {
     @ASTDecodable("Field")
-    enum Resolvable: StylesheetResolvable, @preconcurrency Decodable {
+    public enum Resolvable: StylesheetResolvable, @preconcurrency Decodable {
         case __constant(Date.ComponentsFormatStyle.Field)
         case _day
         case _hour
@@ -102,7 +102,7 @@ extension Date.ComponentsFormatStyle.Field {
     }
 }
 
-extension Date.ComponentsFormatStyle.Field.Resolvable {
+public extension Date.ComponentsFormatStyle.Field.Resolvable {
     @MainActor
     func resolve<R: RootRegistry>(on element: ElementNode, in context: LiveContext<R>) -> Date.ComponentsFormatStyle.Field {
         switch self {
@@ -128,7 +128,7 @@ extension Date.ComponentsFormatStyle.Field.Resolvable {
 
 extension NumberFormatStyleConfiguration.SignDisplayStrategy {
     @ASTDecodable("SignDisplayStrategy")
-    enum Resolvable: StylesheetResolvable, @preconcurrency Decodable {
+    public enum Resolvable: StylesheetResolvable, @preconcurrency Decodable {
         case __constant(NumberFormatStyleConfiguration.SignDisplayStrategy)
         case _automatic
         case _never
@@ -142,7 +142,7 @@ extension NumberFormatStyleConfiguration.SignDisplayStrategy {
     }
 }
 
-extension NumberFormatStyleConfiguration.SignDisplayStrategy.Resolvable {
+public extension NumberFormatStyleConfiguration.SignDisplayStrategy.Resolvable {
     @MainActor
     func resolve<R: RootRegistry>(on element: ElementNode, in context: LiveContext<R>) -> NumberFormatStyleConfiguration.SignDisplayStrategy {
         switch self {
@@ -160,7 +160,7 @@ extension NumberFormatStyleConfiguration.SignDisplayStrategy.Resolvable {
 
 extension Bundle {
     @ASTDecodable("Bundle")
-    enum Resolvable: StylesheetResolvable, @preconcurrency Decodable {
+    public enum Resolvable: StylesheetResolvable, @preconcurrency Decodable {
         case __constant(Bundle)
         case _init(url: URL)
         
@@ -170,7 +170,7 @@ extension Bundle {
     }
 }
 
-extension Bundle.Resolvable {
+public extension Bundle.Resolvable {
     @MainActor
     func resolve<R: RootRegistry>(on element: ElementNode, in context: LiveContext<R>) -> Bundle {
         switch self {
@@ -185,7 +185,7 @@ extension Bundle.Resolvable {
 extension LocalizedStringResource {
     @ASTDecodable("LocalizedStringResource")
     @MainActor
-    enum Resolvable: StylesheetResolvable, @preconcurrency Decodable {
+    public enum Resolvable: StylesheetResolvable, @preconcurrency Decodable {
         case __constant(LocalizedStringResource)
         case _init(key: AttributeReference<String>)
         
@@ -195,7 +195,7 @@ extension LocalizedStringResource {
     }
 }
 
-extension LocalizedStringResource.Resolvable {
+public extension LocalizedStringResource.Resolvable {
     @MainActor func resolve<R: RootRegistry>(on element: ElementNode, in context: LiveContext<R>) -> LocalizedStringResource {
         switch self {
         case let .__constant(value):
@@ -208,12 +208,12 @@ extension LocalizedStringResource.Resolvable {
 
 extension DateInterval {
     @ASTDecodable("DateInterval")
-    enum Resolvable: StylesheetResolvable, @preconcurrency Decodable {
+    public enum Resolvable: StylesheetResolvable, @preconcurrency Decodable {
         case __constant(DateInterval)
     }
 }
 
-extension DateInterval.Resolvable {
+public extension DateInterval.Resolvable {
     @MainActor func resolve<R: RootRegistry>(on element: ElementNode, in context: LiveContext<R>) -> DateInterval {
         switch self {
         case let .__constant(value):
@@ -224,12 +224,12 @@ extension DateInterval.Resolvable {
 
 extension AttributedString {
     @ASTDecodable("AttributedString")
-    enum Resolvable: StylesheetResolvable, @preconcurrency Decodable {
+    public enum Resolvable: StylesheetResolvable, @preconcurrency Decodable {
         case __constant(AttributedString)
     }
 }
 
-extension AttributedString.Resolvable {
+public extension AttributedString.Resolvable {
     @MainActor func resolve<R: RootRegistry>(on element: ElementNode, in context: LiveContext<R>) -> AttributedString {
         switch self {
         case let .__constant(value):
@@ -238,18 +238,18 @@ extension AttributedString.Resolvable {
     }
 }
 
-struct StylesheetResolvableLocalizedError: @preconcurrency Decodable, StylesheetResolvable, LocalizedError, @preconcurrency AttributeDecodable {
-    let errorDescription: String?
+public struct StylesheetResolvableLocalizedError: @preconcurrency Decodable, StylesheetResolvable, LocalizedError, @preconcurrency AttributeDecodable {
+    public let errorDescription: String?
     
-    init(from decoder: any Decoder) throws {
+    public init(from decoder: any Decoder) throws {
         self.errorDescription = try decoder.singleValueContainer().decode(String?.self)
     }
     
-    func resolve<R>(on element: ElementNode, in context: LiveContext<R>) -> Self where R : RootRegistry {
+    public func resolve<R>(on element: ElementNode, in context: LiveContext<R>) -> Self where R : RootRegistry {
         return self
     }
     
-    init(from attribute: Attribute?, on element: ElementNode) throws {
+    public init(from attribute: Attribute?, on element: ElementNode) throws {
         self.errorDescription = attribute?.value
     }
 }

--- a/Sources/LiveViewNative/Stylesheets/ResolvableTypes/QuartzCore.swift
+++ b/Sources/LiveViewNative/Stylesheets/ResolvableTypes/QuartzCore.swift
@@ -11,12 +11,12 @@ import LiveViewNativeStylesheet
 
 extension CATransform3D {
     @ASTDecodable("CATransform3D")
-    enum Resolvable: StylesheetResolvable, @preconcurrency Decodable {
+    public enum Resolvable: StylesheetResolvable, @preconcurrency Decodable {
         case __constant(CATransform3D)
     }
 }
 
-extension CATransform3D.Resolvable {
+public extension CATransform3D.Resolvable {
     @MainActor
     func resolve<R: RootRegistry>(on element: ElementNode, in context: LiveContext<R>) -> CATransform3D {
         switch self {

--- a/Sources/LiveViewNative/Stylesheets/ResolvableTypes/Spatial.swift
+++ b/Sources/LiveViewNative/Stylesheets/ResolvableTypes/Spatial.swift
@@ -11,7 +11,7 @@ import LiveViewNativeStylesheet
 extension Spatial.Size3D {
     @ASTDecodable("Size3D")
     @MainActor
-    enum Resolvable: StylesheetResolvable, @preconcurrency Decodable {
+    public enum Resolvable: StylesheetResolvable, @preconcurrency Decodable {
         case __constant(Spatial.Size3D)
         case _init(width: AttributeReference<Double>, height: AttributeReference<Double>, depth: AttributeReference<Double>)
         
@@ -21,7 +21,7 @@ extension Spatial.Size3D {
     }
 }
 
-extension Spatial.Size3D.Resolvable {
+public extension Spatial.Size3D.Resolvable {
     @MainActor func resolve<R: RootRegistry>(on element: ElementNode, in context: LiveContext<R>) -> Spatial.Size3D {
         switch self {
         case let .__constant(value):

--- a/Sources/LiveViewNative/Stylesheets/ResolvableTypes/StandardLibrary.swift
+++ b/Sources/LiveViewNative/Stylesheets/ResolvableTypes/StandardLibrary.swift
@@ -11,7 +11,7 @@ import LiveViewNativeCore
 extension AnyHashable {
     @ASTDecodable("AnyHashable")
     @MainActor
-    enum Resolvable: StylesheetResolvable, @preconcurrency Decodable {
+    public enum Resolvable: StylesheetResolvable, @preconcurrency Decodable {
         case __constant(AnyHashable)
         case _string(AttributeReference<String>)
         
@@ -21,7 +21,7 @@ extension AnyHashable {
     }
 }
 
-extension AnyHashable.Resolvable {
+public extension AnyHashable.Resolvable {
     @MainActor func resolve<R: RootRegistry>(on element: ElementNode, in context: LiveContext<R>) -> AnyHashable {
         switch self {
         case let .__constant(value):
@@ -33,20 +33,20 @@ extension AnyHashable.Resolvable {
 }
 
 extension Character {
-    struct Resolvable: @preconcurrency Decodable, StylesheetResolvable {
+    public struct Resolvable: @preconcurrency Decodable, StylesheetResolvable {
         let value: AttributeReference<String>
         
-        init(from decoder: any Decoder) throws {
+        public init(from decoder: any Decoder) throws {
             self.value = try decoder.singleValueContainer().decode(AttributeReference<String>.self)
         }
         
-        @MainActor func resolve<R: RootRegistry>(on element: ElementNode, in context: LiveContext<R>) -> Character {
+        @MainActor public func resolve<R: RootRegistry>(on element: ElementNode, in context: LiveContext<R>) -> Character {
             Character(value.resolve(on: element, in: context))
         }
     }
 }
 
-enum StylesheetResolvableRangeExpression: Decodable {
+public enum StylesheetResolvableRangeExpression: Decodable {
     case __never
     
     func resolve<R: RootRegistry, Bound>(on element: ElementNode, in context: LiveContext<R>) -> Range<Bound> {
@@ -55,13 +55,13 @@ enum StylesheetResolvableRangeExpression: Decodable {
 }
 
 extension StylesheetResolvableRangeExpression: @preconcurrency AttributeDecodable {
-    nonisolated init(from attribute: Attribute?, on element: ElementNode) throws {
+    public nonisolated init(from attribute: Attribute?, on element: ElementNode) throws {
         fatalError()
     }
 }
 
 extension Double {
-    enum Resolvable: StylesheetResolvable, @preconcurrency Decodable {
+    public enum Resolvable: StylesheetResolvable, @preconcurrency Decodable {
         case __constant(Double)
         case reference(AttributeReference<Double>)
         
@@ -71,7 +71,7 @@ extension Double {
             case pi
         }
         
-        init(from decoder: any Decoder) throws {
+        public init(from decoder: any Decoder) throws {
             let container = try decoder.singleValueContainer()
             
             if let member = try? container.decode(Member.self) {
@@ -86,7 +86,7 @@ extension Double {
             }
         }
         
-        func resolve<R>(on element: ElementNode, in context: LiveContext<R>) -> Double where R : RootRegistry {
+        public func resolve<R>(on element: ElementNode, in context: LiveContext<R>) -> Double where R : RootRegistry {
             switch self {
             case let .__constant(constant):
                 return constant

--- a/Sources/LiveViewNative/Stylesheets/ResolvableTypes/SwiftUI/Anchor.swift
+++ b/Sources/LiveViewNative/Stylesheets/ResolvableTypes/SwiftUI/Anchor.swift
@@ -10,7 +10,7 @@ import LiveViewNativeStylesheet
 
 extension Anchor.Source {
     @ASTDecodable("Source")
-    enum Resolvable: @preconcurrency Decodable, StylesheetResolvable {
+    public enum Resolvable: @preconcurrency Decodable, StylesheetResolvable {
         case point(CGPoint.Resolvable)
         case unitPoint(UnitPoint.Resolvable)
         
@@ -31,7 +31,7 @@ extension Anchor.Source {
     }
 }
 
-extension Anchor.Source.Resolvable {
+public extension Anchor.Source.Resolvable {
     func resolve<R: RootRegistry>(on element: ElementNode, in context: LiveContext<R>) -> Anchor<Value>.Source {
         switch self {
         case let .point(point):

--- a/Sources/LiveViewNative/Stylesheets/ResolvableTypes/SwiftUI/EdgeSet.swift
+++ b/Sources/LiveViewNative/Stylesheets/ResolvableTypes/SwiftUI/EdgeSet.swift
@@ -10,12 +10,12 @@ import LiveViewNativeStylesheet
 
 extension Edge.Set {
     @MainActor
-    indirect enum Resolvable: StylesheetResolvable, @preconcurrency Swift.Decodable {
+    public indirect enum Resolvable: StylesheetResolvable, @preconcurrency Swift.Decodable {
         case __constant(Edge.Set)
         case member(Member)
         case set([Edge.Set.Resolvable])
         
-        init(from decoder: any Decoder) throws {
+        public init(from decoder: any Decoder) throws {
             let container = try decoder.singleValueContainer()
             
             if let member = try? container.decode(Member.self) {
@@ -27,7 +27,7 @@ extension Edge.Set {
         
         @ASTDecodable("Set")
         @MainActor
-        indirect enum Member: @preconcurrency Decodable {
+        public indirect enum Member: @preconcurrency Decodable {
             case top
             case leading
             case bottom
@@ -49,7 +49,7 @@ extension Edge.Set {
     }
 }
 
-extension Edge.Set.Resolvable {
+public extension Edge.Set.Resolvable {
     @MainActor func resolve<R: RootRegistry>(on element: ElementNode, in context: LiveContext<R>) -> Edge.Set {
         switch self {
         case let .__constant(__value):

--- a/Sources/LiveViewNative/Stylesheets/ResolvableTypes/SwiftUI/NamedCoordinateSpace.swift
+++ b/Sources/LiveViewNative/Stylesheets/ResolvableTypes/SwiftUI/NamedCoordinateSpace.swift
@@ -12,7 +12,7 @@ import LiveViewNativeCore
 @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
 extension NamedCoordinateSpace {
     @ASTDecodable("NamedCoordinateSpace")
-    enum Resolvable: StylesheetResolvable, @preconcurrency Decodable {
+    public enum Resolvable: StylesheetResolvable, @preconcurrency Decodable {
         case __constant(NamedCoordinateSpace)
         
         case named(AttributeReference<String>)
@@ -26,13 +26,13 @@ extension NamedCoordinateSpace {
 }
 
 extension Axis.Resolvable: @preconcurrency AttributeDecodable {
-    init(from attribute: Attribute?, on element: ElementNode) throws {
+    public init(from attribute: Attribute?, on element: ElementNode) throws {
         self = .__constant(try Axis(from: attribute, on: element))
     }
 }
 
 @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
-extension NamedCoordinateSpace.Resolvable {
+public extension NamedCoordinateSpace.Resolvable {
     @MainActor func resolve<R: RootRegistry>(on element: ElementNode, in context: LiveContext<R>) -> NamedCoordinateSpace {
         switch self {
         case let .__constant(value):

--- a/Sources/LiveViewNative/Stylesheets/ResolvableTypes/SwiftUI/ScrollTargetBehavior.swift
+++ b/Sources/LiveViewNative/Stylesheets/ResolvableTypes/SwiftUI/ScrollTargetBehavior.swift
@@ -25,7 +25,7 @@ enum StylesheetResolvableScrollTargetBehavior: StylesheetResolvable, @preconcurr
 
 @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
 extension ViewAlignedScrollTargetBehavior.LimitBehavior.Resolvable: @preconcurrency AttributeDecodable {
-    init(from attribute: Attribute?, on element: ElementNode) throws {
+    public init(from attribute: Attribute?, on element: ElementNode) throws {
         switch attribute?.value {
         case "automatic":
             self = .automatic

--- a/Sources/LiveViewNative/Stylesheets/ResolvableTypes/SwiftUI/Styles/IndexViewStyle.swift
+++ b/Sources/LiveViewNative/Stylesheets/ResolvableTypes/SwiftUI/Styles/IndexViewStyle.swift
@@ -22,7 +22,7 @@ enum StylesheetResolvableIndexViewStyle: StylesheetResolvable, @preconcurrency D
 }
 
 extension PageIndexViewStyle.BackgroundDisplayMode.Resolvable: AttributeDecodable {
-    nonisolated init(from attribute: Attribute?, on element: ElementNode) throws {
+    public nonisolated init(from attribute: Attribute?, on element: ElementNode) throws {
         fatalError()
     }
 }

--- a/Sources/LiveViewNative/Stylesheets/ResolvableTypes/SwiftUI/Styles/ShapeStyle.swift
+++ b/Sources/LiveViewNative/Stylesheets/ResolvableTypes/SwiftUI/Styles/ShapeStyle.swift
@@ -9,8 +9,8 @@ import SwiftUI
 import LiveViewNativeStylesheet
 import LiveViewNativeCore
 
-indirect enum StylesheetResolvableShapeStyle: StylesheetResolvable, @preconcurrency ShapeStyle, @preconcurrency Decodable {
-    typealias Resolved = AnyShapeStyle
+public indirect enum StylesheetResolvableShapeStyle: StylesheetResolvable, @preconcurrency ShapeStyle, @preconcurrency Decodable {
+    public typealias Resolved = AnyShapeStyle
     
     case color(Color.Resolvable)
     case angularGradient(AngularGradient.Resolvable)
@@ -22,7 +22,7 @@ indirect enum StylesheetResolvableShapeStyle: StylesheetResolvable, @preconcurre
     case semantic(SemanticShapeStyle)
     case modified(ModifiedShapeStyle)
     
-    struct ModifiedShapeStyle: StylesheetResolvable, @preconcurrency Decodable {
+    public struct ModifiedShapeStyle: StylesheetResolvable, @preconcurrency Decodable {
         let base: StylesheetResolvableShapeStyle
         let modifier: Modifier
         
@@ -81,7 +81,7 @@ indirect enum StylesheetResolvableShapeStyle: StylesheetResolvable, @preconcurre
             }
         }
         
-        init(from decoder: any Decoder) throws {
+        public init(from decoder: any Decoder) throws {
             var container = try decoder.unkeyedContainer()
             
             _ = try container.decode(ASTNode.Identifiers.MemberAccess.self)
@@ -92,7 +92,7 @@ indirect enum StylesheetResolvableShapeStyle: StylesheetResolvable, @preconcurre
             self.modifier = try arguments.decode(Modifier.self)
         }
         
-        func resolve(
+        public func resolve(
             on element: ElementNode,
             in context: LiveContext<some RootRegistry>
         ) -> AnyShapeStyle {
@@ -124,7 +124,7 @@ indirect enum StylesheetResolvableShapeStyle: StylesheetResolvable, @preconcurre
     }
     
     @ASTDecodable("ShapeStyle")
-    enum MaterialShapeStyle: StylesheetResolvable, @preconcurrency Decodable {
+    public enum MaterialShapeStyle: StylesheetResolvable, @preconcurrency Decodable {
         case regularMaterial
         case thickMaterial
         case thinMaterial
@@ -136,7 +136,7 @@ indirect enum StylesheetResolvableShapeStyle: StylesheetResolvable, @preconcurre
         case bar
         #endif
         
-        func resolve<R>(on element: ElementNode, in context: LiveContext<R>) -> Material where R : RootRegistry {
+        public func resolve<R>(on element: ElementNode, in context: LiveContext<R>) -> Material where R : RootRegistry {
             if #available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 10.0, *) {
                 switch self {
                 case .regularMaterial:
@@ -161,7 +161,7 @@ indirect enum StylesheetResolvableShapeStyle: StylesheetResolvable, @preconcurre
     }
     
     @ASTDecodable("ShapeStyle")
-    enum SemanticShapeStyle: @preconcurrency Decodable {
+    public enum SemanticShapeStyle: @preconcurrency Decodable {
         case foreground
         case background
         #if os(iOS) || os(macOS) || os(visionOS)
@@ -226,7 +226,7 @@ indirect enum StylesheetResolvableShapeStyle: StylesheetResolvable, @preconcurre
         }
     }
     
-    init(from decoder: any Decoder) throws {
+    public init(from decoder: any Decoder) throws {
         var container = try decoder.singleValueContainer()
         
         if let color = try? container.decode(Color.Resolvable.self) {
@@ -262,7 +262,7 @@ indirect enum StylesheetResolvableShapeStyle: StylesheetResolvable, @preconcurre
     }
 }
 
-extension StylesheetResolvableShapeStyle {
+public extension StylesheetResolvableShapeStyle {
     func resolve(in environment: EnvironmentValues) -> AnyShapeStyle {
         return AnyShapeStyle(.red)
     }
@@ -292,21 +292,21 @@ extension StylesheetResolvableShapeStyle {
 }
 
 extension StylesheetResolvableShapeStyle: @preconcurrency AttributeDecodable {
-    init(from attribute: Attribute?, on element: ElementNode) throws {
+    public init(from attribute: Attribute?, on element: ElementNode) throws {
         fatalError()
     }
 }
 
 extension HierarchicalShapeStyle {
     @ASTDecodable("HierarchicalShapeStyle")
-    enum Resolvable: StylesheetResolvable, @preconcurrency Decodable {
+    public enum Resolvable: StylesheetResolvable, @preconcurrency Decodable {
         case primary
         case secondary
         case tertiary
         case quaternary
         case quinary
         
-        func resolve<R>(on element: ElementNode, in context: LiveContext<R>) -> HierarchicalShapeStyle where R : RootRegistry {
+        public func resolve<R>(on element: ElementNode, in context: LiveContext<R>) -> HierarchicalShapeStyle where R : RootRegistry {
             switch self {
             case .primary:
                 return .primary
@@ -329,7 +329,7 @@ extension HierarchicalShapeStyle {
 
 extension AngularGradient {
     @ASTDecodable("AngularGradient")
-    enum Resolvable: StylesheetResolvable, @preconcurrency Decodable {
+    public enum Resolvable: StylesheetResolvable, @preconcurrency Decodable {
         case _angularGradient(gradient: Gradient.Resolvable, center: UnitPoint.Resolvable, startAngle: Angle.Resolvable, endAngle: Angle.Resolvable)
         case _angularColors(colors: [Color.Resolvable], center: UnitPoint.Resolvable, startAngle: Angle.Resolvable, endAngle: Angle.Resolvable)
         case _angularStops(stops: [Gradient.Stop.Resolvable], center: UnitPoint.Resolvable, startAngle: Angle.Resolvable, endAngle: Angle.Resolvable)
@@ -381,7 +381,7 @@ extension AngularGradient {
             ._conicStops(stops: stops, center: center, angle: angle)
         }
         
-        func resolve<R>(on element: ElementNode, in context: LiveContext<R>) -> AngularGradient where R : RootRegistry {
+        public func resolve<R>(on element: ElementNode, in context: LiveContext<R>) -> AngularGradient where R : RootRegistry {
             switch self {
             case let ._angularGradient(gradient, center, startAngle, endAngle):
                 return .init(
@@ -429,7 +429,7 @@ extension AngularGradient {
 
 extension LinearGradient {
     @ASTDecodable("LinearGradient")
-    enum Resolvable: StylesheetResolvable, @preconcurrency Decodable {
+    public enum Resolvable: StylesheetResolvable, @preconcurrency Decodable {
         case _initGradient(gradient: Gradient.Resolvable, startPoint: UnitPoint.Resolvable, endPoint: UnitPoint.Resolvable)
         case _initColors(colors: [Color.Resolvable], startPoint: UnitPoint.Resolvable, endPoint: UnitPoint.Resolvable)
         case _initStops(stops: [Gradient.Stop.Resolvable], startPoint: UnitPoint.Resolvable, endPoint: UnitPoint.Resolvable)
@@ -456,7 +456,7 @@ extension LinearGradient {
             ._initStops(stops: stops, startPoint: startPoint, endPoint: endPoint)
         }
         
-        func resolve<R>(on element: ElementNode, in context: LiveContext<R>) -> LinearGradient where R : RootRegistry {
+        public func resolve<R>(on element: ElementNode, in context: LiveContext<R>) -> LinearGradient where R : RootRegistry {
             switch self {
             case ._initGradient(let gradient, let startPoint, let endPoint):
                 return .init(
@@ -483,7 +483,7 @@ extension LinearGradient {
 
 extension RadialGradient {
     @ASTDecodable("RadialGradient")
-    enum Resolvable: StylesheetResolvable, @preconcurrency Decodable {
+    public enum Resolvable: StylesheetResolvable, @preconcurrency Decodable {
         case _initGradient(gradient: Gradient.Resolvable, center: UnitPoint.Resolvable, startRadius: CGFloat.Resolvable, endRadius: CGFloat.Resolvable)
         case _initColors(colors: [Color.Resolvable], center: UnitPoint.Resolvable, startRadius: CGFloat.Resolvable, endRadius: CGFloat.Resolvable)
         case _initStops(stops: [Gradient.Stop.Resolvable], center: UnitPoint.Resolvable, startRadius: CGFloat.Resolvable, endRadius: CGFloat.Resolvable)
@@ -510,7 +510,7 @@ extension RadialGradient {
             ._initStops(stops: stops, center: center, startRadius: startRadius, endRadius: endRadius)
         }
         
-        func resolve<R>(on element: ElementNode, in context: LiveContext<R>) -> RadialGradient where R : RootRegistry {
+        public func resolve<R>(on element: ElementNode, in context: LiveContext<R>) -> RadialGradient where R : RootRegistry {
             switch self {
             case ._initGradient(let gradient, let center, let startRadius, let endRadius):
                 return .init(
@@ -540,7 +540,7 @@ extension RadialGradient {
 
 extension ImagePaint {
     @ASTDecodable("ImagePaint")
-    enum Resolvable: StylesheetResolvable, @preconcurrency Decodable {
+    public enum Resolvable: StylesheetResolvable, @preconcurrency Decodable {
         case _init(image: Image.Resolvable, sourceRect: CGRect.Resolvable, scale: CGFloat.Resolvable)
         
         init(image: Image.Resolvable, sourceRect: CGRect.Resolvable = .__constant(CGRect(x: 0, y: 0, width: 1, height: 1)), scale: CGFloat.Resolvable = .__constant(1)) {
@@ -551,7 +551,7 @@ extension ImagePaint {
             ._init(image: image, sourceRect: sourceRect, scale: scale)
         }
         
-        func resolve<R>(on element: ElementNode, in context: LiveContext<R>) -> ImagePaint where R : RootRegistry {
+        public func resolve<R>(on element: ElementNode, in context: LiveContext<R>) -> ImagePaint where R : RootRegistry {
             switch self {
             case let ._init(image, sourceRect, scale):
                 return .init(
@@ -566,7 +566,7 @@ extension ImagePaint {
 
 extension ShadowStyle {
     @ASTDecodable("ShadowStyle")
-    enum Resolvable: StylesheetResolvable, @preconcurrency Decodable {
+    public enum Resolvable: StylesheetResolvable, @preconcurrency Decodable {
         case __constant(ShadowStyle)
         case _drop(
             color: Color.Resolvable,
@@ -599,7 +599,7 @@ extension ShadowStyle {
             ._inner(color: color, radius: radius, x: x, y: y)
         }
         
-        func resolve<R>(on element: ElementNode, in context: LiveContext<R>) -> ShadowStyle where R : RootRegistry {
+        public func resolve<R>(on element: ElementNode, in context: LiveContext<R>) -> ShadowStyle where R : RootRegistry {
             switch self {
             case .__constant(let style):
                 return style

--- a/Sources/LiveViewNative/Stylesheets/ResolvableTypes/SwiftUI/Styles/TabViewStyle.swift
+++ b/Sources/LiveViewNative/Stylesheets/ResolvableTypes/SwiftUI/Styles/TabViewStyle.swift
@@ -52,7 +52,7 @@ enum StylesheetResolvableTabViewStyle: StylesheetResolvable, @preconcurrency Dec
 
 #if os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
 extension PageTabViewStyle.IndexDisplayMode.Resolvable: @preconcurrency AttributeDecodable {
-    init(from attribute: Attribute?, on element: ElementNode) throws {
+    public init(from attribute: Attribute?, on element: ElementNode) throws {
         switch attribute?.value {
         case "always":
             self = .__constant(.always)

--- a/Sources/LiveViewNative/Stylesheets/ResolvableTypes/SwiftUI/Styles/TabViewStyle.swift
+++ b/Sources/LiveViewNative/Stylesheets/ResolvableTypes/SwiftUI/Styles/TabViewStyle.swift
@@ -70,7 +70,7 @@ extension PageTabViewStyle.IndexDisplayMode.Resolvable: @preconcurrency Attribut
 #if os(watchOS)
 @available(watchOS 10, *)
 extension VerticalPageTabViewStyle.TransitionStyle.Resolvable: @preconcurrency AttributeDecodable {
-    init(from attribute: Attribute?, on element: ElementNode) throws {
+    public init(from attribute: Attribute?, on element: ElementNode) throws {
         switch attribute?.value {
         case "automatic":
             self = .__constant(.automatic)

--- a/Sources/LiveViewNative/Stylesheets/ResolvableTypes/Symbols.swift
+++ b/Sources/LiveViewNative/Stylesheets/ResolvableTypes/Symbols.swift
@@ -186,7 +186,7 @@ extension View {
 extension Symbols.SymbolEffectOptions {
     @ASTDecodable("SymbolEffectOptions")
     @MainActor
-    indirect enum Resolvable: StylesheetResolvable, @preconcurrency Decodable {
+    public indirect enum Resolvable: StylesheetResolvable, @preconcurrency Decodable {
         case __constant(SymbolEffectOptions)
         
         case `default`
@@ -217,7 +217,7 @@ extension Symbols.SymbolEffectOptions {
 
 @available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
 extension SymbolEffectOptions.RepeatBehavior.Resolvable: @preconcurrency AttributeDecodable {
-    init(from attribute: Attribute?, on element: ElementNode) throws {
+    public init(from attribute: Attribute?, on element: ElementNode) throws {
         switch attribute?.value {
         case "continuous":
             self = .continuous
@@ -230,7 +230,7 @@ extension SymbolEffectOptions.RepeatBehavior.Resolvable: @preconcurrency Attribu
 }
 
 @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
-extension SymbolEffectOptions.Resolvable {
+public extension SymbolEffectOptions.Resolvable {
     @MainActor func resolve<R: RootRegistry>(on element: ElementNode, in context: LiveContext<R>) -> SymbolEffectOptions {
         switch self {
         case let .__constant(value):
@@ -265,7 +265,7 @@ extension SymbolEffectOptions.Resolvable {
 extension SymbolEffectOptions.RepeatBehavior {
     @ASTDecodable("RepeatBehavior")
     @MainActor
-    enum Resolvable: StylesheetResolvable, @preconcurrency Decodable {
+    public enum Resolvable: StylesheetResolvable, @preconcurrency Decodable {
         case continuous
         case periodic
         
@@ -277,7 +277,7 @@ extension SymbolEffectOptions.RepeatBehavior {
 }
 
 @available(iOS 18, macOS 15, tvOS 18, visionOS 2, watchOS 11, *)
-extension SymbolEffectOptions.RepeatBehavior.Resolvable {
+public extension SymbolEffectOptions.RepeatBehavior.Resolvable {
     @MainActor func resolve<R: RootRegistry>(on element: ElementNode, in context: LiveContext<R>) -> SymbolEffectOptions.RepeatBehavior {
         switch self {
         case .continuous:

--- a/Sources/LiveViewNative/Stylesheets/ResolvableTypes/UIKit.swift
+++ b/Sources/LiveViewNative/Stylesheets/ResolvableTypes/UIKit.swift
@@ -13,7 +13,7 @@ import LiveViewNativeCore
 #if os(iOS) || os(tvOS) || os(visionOS)
 extension UITextContentType {
     @ASTDecodable("UITextContentType")
-    enum Resolvable: StylesheetResolvable, @preconcurrency Decodable {
+    public enum Resolvable: StylesheetResolvable, @preconcurrency Decodable {
         case namePrefix
         case name
         case nameSuffix
@@ -61,7 +61,7 @@ extension UITextContentType {
     }
 }
 
-extension UITextContentType.Resolvable {
+public extension UITextContentType.Resolvable {
     func resolve<R>(on element: ElementNode, in context: LiveContext<R>) -> UITextContentType where R : RootRegistry {
         switch self {
         case .namePrefix:
@@ -221,7 +221,7 @@ extension UITextContentType.Resolvable {
 }
 
 extension UITextContentType.Resolvable: @preconcurrency AttributeDecodable {
-    init(from attribute: Attribute?, on element: ElementNode) throws {
+    public init(from attribute: Attribute?, on element: ElementNode) throws {
         switch attribute?.value {
         case "namePrefix":
             self = .namePrefix
@@ -321,7 +321,7 @@ extension UITextContentType.Resolvable: @preconcurrency AttributeDecodable {
 #if os(iOS) || os(tvOS) || os(visionOS)
 extension UIKeyboardType {
     @ASTDecodable("UIKeyboardType")
-    enum Resolvable: StylesheetResolvable, @preconcurrency Decodable {
+    public enum Resolvable: StylesheetResolvable, @preconcurrency Decodable {
         case `default`
         case asciiCapable
         case numbersAndPunctuation
@@ -337,7 +337,7 @@ extension UIKeyboardType {
     }
 }
 
-extension UIKeyboardType.Resolvable {
+public extension UIKeyboardType.Resolvable {
     func resolve<R>(on element: ElementNode, in context: LiveContext<R>) -> UIKeyboardType where R : RootRegistry {
         switch self {
         case .default:

--- a/Sources/LiveViewNative/Stylesheets/ResolvableTypes/WatchKit.swift
+++ b/Sources/LiveViewNative/Stylesheets/ResolvableTypes/WatchKit.swift
@@ -12,7 +12,7 @@ import LiveViewNativeCore
 
 extension WKTextContentType {
     @ASTDecodable("WKTextContentType")
-    enum Resolvable: StylesheetResolvable, @preconcurrency Decodable, @preconcurrency AttributeDecodable {
+    public enum Resolvable: StylesheetResolvable, @preconcurrency Decodable, @preconcurrency AttributeDecodable {
         case name
         case namePrefix
         case givenName
@@ -43,7 +43,7 @@ extension WKTextContentType {
     }
 }
 
-extension WKTextContentType.Resolvable {
+public extension WKTextContentType.Resolvable {
     func resolve<R>(on element: ElementNode, in context: LiveContext<R>) -> WKTextContentType where R : RootRegistry {
         switch self {
         case .name:

--- a/Sources/LiveViewNative/Stylesheets/StylesheetResolvable.swift
+++ b/Sources/LiveViewNative/Stylesheets/StylesheetResolvable.swift
@@ -3,23 +3,23 @@ import LiveViewNativeStylesheet
 import LiveViewNativeCore
 
 @MainActor
-protocol StylesheetResolvable {
+public protocol StylesheetResolvable {
     associatedtype Resolved
     
     func resolve<R: RootRegistry>(on element: ElementNode, in context: LiveContext<R>) -> Resolved
 }
 
-enum StylesheetResolvableSet<T>: @preconcurrency Decodable, StylesheetResolvable where T: Decodable & StylesheetResolvable, T.Resolved: Hashable {
-    typealias Resolved = Set<T.Resolved>
+public enum StylesheetResolvableSet<T>: @preconcurrency Decodable, StylesheetResolvable where T: Decodable & StylesheetResolvable, T.Resolved: Hashable {
+    public typealias Resolved = Set<T.Resolved>
     
     case constant(Set<T.Resolved>)
     case resolvable([T])
     
-    init(from decoder: any Decoder) throws {
+    public init(from decoder: any Decoder) throws {
         self = .resolvable(try decoder.singleValueContainer().decode([T].self))
     }
     
-    func resolve<R: RootRegistry>(on element: ElementNode, in context: LiveContext<R>) -> Set<T.Resolved> {
+    public func resolve<R: RootRegistry>(on element: ElementNode, in context: LiveContext<R>) -> Set<T.Resolved> {
         switch self {
         case let .constant(value):
             return value
@@ -30,7 +30,7 @@ enum StylesheetResolvableSet<T>: @preconcurrency Decodable, StylesheetResolvable
 }
 
 extension StylesheetResolvableSet: @preconcurrency AttributeDecodable {
-    init(from attribute: Attribute?, on element: ElementNode) throws {
+    public init(from attribute: Attribute?, on element: ElementNode) throws {
         guard let value = attribute?.value
         else { throw AttributeDecodingError.badValue(Self.self) }
         self = .resolvable(try makeJSONDecoder().decode([T].self, from: Data(value.utf8)))
@@ -38,17 +38,17 @@ extension StylesheetResolvableSet: @preconcurrency AttributeDecodable {
 }
 
 extension Array: StylesheetResolvable where Element: StylesheetResolvable {
-    typealias Resolved = [Element.Resolved]
+    public typealias Resolved = [Element.Resolved]
     
-    func resolve<R: RootRegistry>(on element: ElementNode, in context: LiveContext<R>) -> Resolved {
+    public func resolve<R: RootRegistry>(on element: ElementNode, in context: LiveContext<R>) -> Resolved {
         self.map({ $0.resolve(on: element, in: context) })
     }
 }
 
 extension Optional: StylesheetResolvable where Wrapped: StylesheetResolvable {
-    typealias Resolved = Optional<Wrapped.Resolved>
+    public typealias Resolved = Optional<Wrapped.Resolved>
     
-    func resolve<R: RootRegistry>(on element: ElementNode, in context: LiveContext<R>) -> Resolved {
+    public func resolve<R: RootRegistry>(on element: ElementNode, in context: LiveContext<R>) -> Resolved {
         switch self {
         case .none:
             return .none

--- a/Sources/ModifierGenerator/StyleDefinitionGenerator/makeResolvableType.swift
+++ b/Sources/ModifierGenerator/StyleDefinitionGenerator/makeResolvableType.swift
@@ -123,7 +123,7 @@ extension StyleDefinitionGenerator {
         
         let resolvableEnum = EnumDeclSyntax(
             attributes: node.fullyResolvedAvailabilityAttributes,
-            modifiers: [DeclModifierSyntax(name: .keyword(.indirect))],
+            modifiers: [DeclModifierSyntax(name: .keyword(.public)), DeclModifierSyntax(name: .keyword(.indirect))],
             name: .identifier("Resolvable"),
             inheritanceClause: InheritanceClauseSyntax {
                 InheritedTypeSyntax(type: IdentifierTypeSyntax(name: .identifier("StylesheetResolvable")))
@@ -288,6 +288,7 @@ extension StyleDefinitionGenerator {
         
         let resolveMethodExtension = ExtensionDeclSyntax(
             attributes: node.fullyResolvedAvailabilityAttributes,
+            modifiers: [DeclModifierSyntax(name: .keyword(.public))],
             extendedType: MemberTypeSyntax(baseType: node.fullyResolvedType, name: .identifier("Resolvable"))
         ) {
             // @MainActor func resolve<R>(on element: ElementNode, in context: LiveContext<R>)


### PR DESCRIPTION
The code-generated `Resolvable` subtypes were made public for use in addons.

For example, an addon can now create a modifier that has a `Alignment.Resolvable` argument.

The `StylesheetResolvable` protocol was also made public, and an extension to implement `resolve` that takes a `ContentBuilder.Context` instead of a `LiveContext`.