### PR TITLE
Fix `live_patch` handling

### DIFF
--- a/Sources/LiveViewNative/Coordinators/LiveNavigationEntry.swift
+++ b/Sources/LiveViewNative/Coordinators/LiveNavigationEntry.swift
@@ -11,15 +11,20 @@ import SwiftUI
 public struct LiveNavigationEntry<R: RootRegistry>: Hashable {
     public let url: URL
     public let coordinator: LiveViewCoordinator<R>
+    
+    let mode: LiveRedirect.Mode
+    
     let navigationTransition: Any?
     let pendingView: (any View)?
     
     public static func == (lhs: Self, rhs: Self) -> Bool {
         lhs.url == rhs.url && lhs.coordinator === rhs.coordinator
+        && lhs.mode == rhs.mode
     }
     
     public func hash(into hasher: inout Hasher) {
         hasher.combine(url)
         hasher.combine(ObjectIdentifier(coordinator))
+        hasher.combine(mode)
     }
 }

--- a/Sources/LiveViewNative/Coordinators/LiveSessionCoordinator.swift
+++ b/Sources/LiveViewNative/Coordinators/LiveSessionCoordinator.swift
@@ -100,7 +100,7 @@ public class LiveSessionCoordinator<R: RootRegistry>: ObservableObject {
             try? LiveViewNativeCore.storeSessionCookie("\(cookie.name)=\(cookie.value)", self.url.absoluteString)
         }
         
-        self.navigationPath = [.init(url: url, coordinator: .init(session: self, url: self.url), navigationTransition: nil, pendingView: nil)]
+        self.navigationPath = [.init(url: url, coordinator: .init(session: self, url: self.url), mode: .replaceTop, navigationTransition: nil, pendingView: nil)]
 
         self.mergedEventSubjects = self.navigationPath.first!.coordinator.eventSubject.compactMap({ [weak self] value in
             self.map({ ($0.navigationPath.first!.coordinator, value) })
@@ -112,28 +112,64 @@ public class LiveSessionCoordinator<R: RootRegistry>: ObservableObject {
         $navigationPath.scan(([LiveNavigationEntry<R>](), [LiveNavigationEntry<R>]()), { ($0.1, $1) }).sink { [weak self] prev, next in
             guard let self else { return }
             Task {
-                try await prev.last?.coordinator.disconnect()
                 if prev.count > next.count {
-                    let targetEntry = self.liveSocket!.getEntries()[next.count - 1]
-                    next.last?.coordinator.join(
-                        try await self.liveSocket!.traverseTo(targetEntry.id,
-                                                              .some([
-                                                                  "_format": .str(string: LiveSessionParameters.platform),
-                                                                  "_interface": .object(object: LiveSessionParameters.platformParams)
-                                                              ]),
-                                                              nil)
-                    )
+                    // backward navigation
+                    
+                    // if the coordinator is connected, the mode was a `patch`, and the new entry has the same coordinator
+                    // send a `live_patch` event and keep the same coordinator.
+                    switch prev.last!.mode {
+                    case .patch:
+                        if case .connected = prev.last?.coordinator.state,
+                            next.last?.coordinator === prev.last?.coordinator
+                        {
+                            _ = try await prev.last?.coordinator.doPushEvent(
+                                "live_patch",
+                                payload: .jsonPayload(json: .object(object: [
+                                    "url": .str(string: next.last!.url.absoluteString)
+                                ]))
+                            )
+                            next.last!.coordinator.url = next.last!.url
+                            next.last!.coordinator.objectWillChange.send()
+                            if next.count <= 1 { // if we navigated back to the root page, trigger an update on the session too
+                                self.objectWillChange.send()
+                            }
+                            return
+                        }
+                    case .replaceTop:
+                        try await prev.last?.coordinator.disconnect()
+                        let targetEntry = self.liveSocket!.getEntries()[next.count - 1]
+                        next.last?.coordinator.join(
+                            try await self.liveSocket!.traverseTo(
+                                targetEntry.id,
+                                .some([
+                                    "_format": .str(string: LiveSessionParameters.platform),
+                                    "_interface": .object(object: LiveSessionParameters.platformParams)
+                                ]),
+                                nil
+                            )
+                        )
+                    }
                 } else if next.count > prev.count && prev.count > 0 {
                     // forward navigation (from `redirect` or `<NavigationLink>`)
-                    next.last?.coordinator.join(
-                        try await self.liveSocket!.navigate(next.last!.url.absoluteString,
-                                                            .some([
-                                                                "_format": .str(string: LiveSessionParameters.platform),
-                                                                "_interface": .object(object: LiveSessionParameters.platformParams)
-                                                            ]),
-                                                            NavOptions(action: .push))
-                    )
+                    
+                    // if the coordinator instance is the same and its connected, we don't need to handle a connection.
+                    switch next.last!.mode {
+                    case .patch:
+                        next.last?.coordinator.url = next.last!.url
+                        return
+                    case .replaceTop:
+                        try await prev.last?.coordinator.disconnect()
+                        next.last?.coordinator.join(
+                            try await self.liveSocket!.navigate(next.last!.url.absoluteString,
+                                                                .some([
+                                                                    "_format": .str(string: LiveSessionParameters.platform),
+                                                                    "_interface": .object(object: LiveSessionParameters.platformParams)
+                                                                ]),
+                                                                NavOptions(action: .push))
+                        )
+                    }
                 } else if next.count == prev.count {
+                    try await prev.last?.coordinator.disconnect()
                     guard let liveChannel =
                             try await self.liveSocket?.navigate(next.last!.url.absoluteString,
                                                                 .some([
@@ -318,7 +354,7 @@ public class LiveSessionCoordinator<R: RootRegistry>: ObservableObject {
                 if case .user(user: "assets_change") = event.event {
                     Task { @MainActor in
                         await self.disconnect()
-                        self.navigationPath = [.init(url: self.url, coordinator: .init(session: self, url: self.url), navigationTransition: nil, pendingView: nil)]
+                        self.navigationPath = [.init(url: self.url, coordinator: .init(session: self, url: self.url), mode: .replaceTop, navigationTransition: nil, pendingView: nil)]
                         await self.connect()
                         self.lastReloadTime = Date()
                     }
@@ -374,7 +410,7 @@ public class LiveSessionCoordinator<R: RootRegistry>: ObservableObject {
         await self.disconnect()
         if let url {
             self.url = url
-            self.navigationPath = [.init(url: self.url, coordinator: self.navigationPath.first!.coordinator, navigationTransition: nil, pendingView: nil)]
+            self.navigationPath = [.init(url: self.url, coordinator: self.navigationPath.first!.coordinator, mode: .replaceTop, navigationTransition: nil, pendingView: nil)]
         }
         await self.connect(httpMethod: httpMethod, httpBody: httpBody, additionalHeaders: headers)
 //        do {
@@ -440,7 +476,7 @@ public class LiveSessionCoordinator<R: RootRegistry>: ObservableObject {
         switch redirect.mode {
         case .replaceTop:
             let coordinator = LiveViewCoordinator(session: self, url: redirect.to)
-            let entry = LiveNavigationEntry(url: redirect.to, coordinator: coordinator, navigationTransition: navigationTransition, pendingView: pendingView)
+            let entry = LiveNavigationEntry(url: redirect.to, coordinator: coordinator, mode: redirect.mode, navigationTransition: navigationTransition, pendingView: pendingView)
             switch redirect.kind {
             case .push:
                 navigationPath.append(entry)
@@ -458,7 +494,7 @@ public class LiveSessionCoordinator<R: RootRegistry>: ObservableObject {
             // patch is like `replaceTop`, but it does not disconnect.
             let coordinator = navigationPath.last!.coordinator
             coordinator.url = redirect.to
-            let entry = LiveNavigationEntry(url: redirect.to, coordinator: coordinator, navigationTransition: navigationTransition, pendingView: pendingView)
+            let entry = LiveNavigationEntry(url: redirect.to, coordinator: coordinator, mode: redirect.mode, navigationTransition: navigationTransition, pendingView: pendingView)
             switch redirect.kind {
             case .push:
                 navigationPath.append(entry)

--- a/Sources/LiveViewNative/Live/LiveView.swift
+++ b/Sources/LiveViewNative/Live/LiveView.swift
@@ -288,7 +288,7 @@ struct PhxMain<R: RootRegistry>: View {
     @EnvironmentObject private var session: LiveSessionCoordinator<R>
     
     var body: some View {
-        NavStackEntryView(.init(url: context.coordinator.url, coordinator: context.coordinator, navigationTransition: nil, pendingView: nil))
+        NavStackEntryView(.init(url: context.coordinator.url, coordinator: context.coordinator, mode: .replaceTop, navigationTransition: nil, pendingView: nil))
     }
 }
 

--- a/Sources/LiveViewNative/NavStackEntryView.swift
+++ b/Sources/LiveViewNative/NavStackEntryView.swift
@@ -70,6 +70,11 @@ struct NavStackEntryView<R: RootRegistry>: View {
                             .transition(coordinator.session.configuration.transition ?? .identity)
                     }
                 }
+            } else {
+                SwiftUI.ZStack {
+                    SwiftUI.Rectangle().fill(.red)
+                    SwiftUI.Text("\(coordinator.url) != \(entry.url)")
+                }
             }
         }
         .animation(coordinator.session.configuration.transition.map({ _ in .default }), value: coordinator.state.isConnected)

--- a/Sources/LiveViewNative/Views/Layout Containers/Presentation Containers/NavigationLink.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Presentation Containers/NavigationLink.swift
@@ -123,6 +123,7 @@ struct NavigationLink<Root: RootRegistry>: View {
                         value: LiveNavigationEntry(
                             url: url,
                             coordinator: LiveViewCoordinator(session: $liveElement.context.coordinator.session, url: url),
+                            mode: .replaceTop,
                             navigationTransition: nil, // FIXME: navigationTransition
                             pendingView: pendingView
                         )


### PR DESCRIPTION
The navigation mode is now saved to the `navigationPath`, and `live_patch` events are sent to the server when navigating backward from a patch.

Forward navigation is now also handled correctly by skipping the reconnect on a patch.