### PR TITLE
Include deprecated modifiers

### DIFF
--- a/Sources/LiveViewNative/Stylesheets/ResolvableTypes/SwiftUI/Styles/MenuButtonStyle.swift
+++ b/Sources/LiveViewNative/Stylesheets/ResolvableTypes/SwiftUI/Styles/MenuButtonStyle.swift
@@ -1,0 +1,27 @@
+//
+//  MenuButtonStyle.swift
+//  LiveViewNative
+//
+//  Created by Carson Katri on 3/11/25.
+//
+
+#if os(macOS)
+import SwiftUI
+import LiveViewNativeCore
+import LiveViewNativeStylesheet
+
+@ASTDecodable("MenuButtonStyle")
+enum StylesheetResolvableMenuButtonStyle: StylesheetResolvable, @preconcurrency Decodable {
+    case `default`
+    
+    func resolve<R>(on element: ElementNode, in context: LiveContext<R>) -> DefaultMenuButtonStyle where R : RootRegistry {
+        return DefaultMenuButtonStyle()
+    }
+}
+
+extension StylesheetResolvableMenuButtonStyle: AttributeDecodable {
+    nonisolated init(from attribute: Attribute?, on element: ElementNode) throws {
+        self = .default
+    }
+}
+#endif

--- a/Sources/LiveViewNative/Stylesheets/ResolvableTypes/SwiftUI/Styles/NavigationViewStyle.swift
+++ b/Sources/LiveViewNative/Stylesheets/ResolvableTypes/SwiftUI/Styles/NavigationViewStyle.swift
@@ -1,0 +1,24 @@
+//
+//  NavigationViewStyle.swift
+//  LiveViewNative
+//
+//  Created by Carson Katri on 3/6/25.
+//
+
+import SwiftUI
+import LiveViewNativeStylesheet
+import LiveViewNativeCore
+
+struct StylesheetResolvableNavigationViewStyle: StylesheetResolvable, @preconcurrency Decodable, @preconcurrency AttributeDecodable {
+    init(from decoder: any Decoder) throws {
+        fatalError("`NavigationViewStyle` is deprecated")
+    }
+    
+    init(from attribute: Attribute?, on element: ElementNode) throws {
+        fatalError("`NavigationViewStyle` is deprecated")
+    }
+    
+    func resolve<R>(on element: ElementNode, in context: LiveContext<R>) -> DefaultNavigationViewStyle where R : RootRegistry {
+        fatalError("`NavigationViewStyle` is deprecated")
+    }
+}

--- a/Sources/LiveViewNative/Stylesheets/ResolvableTypes/UIKit.swift
+++ b/Sources/LiveViewNative/Stylesheets/ResolvableTypes/UIKit.swift
@@ -400,6 +400,29 @@ extension UIKeyboardType: @preconcurrency AttributeDecodable {
         }
     }
 }
+
+extension UITextAutocapitalizationType {
+    @ASTDecodable("UITextAutocapitalizationType")
+    enum Resolvable: StylesheetResolvable, @preconcurrency Decodable {
+        case none
+        case words
+        case sentences
+        case allCharacters
+        
+        func resolve<R>(on element: ElementNode, in context: LiveContext<R>) -> UITextAutocapitalizationType where R : RootRegistry {
+            switch self {
+            case .none:
+                return .none
+            case .words:
+                return .words
+            case .sentences:
+                return .sentences
+            case .allCharacters:
+                return .allCharacters
+            }
+        }
+    }
+}
 #endif
 
 #endif

--- a/Sources/ModifierGenerator/ModifierGenerator.swift
+++ b/Sources/ModifierGenerator/ModifierGenerator.swift
@@ -17,6 +17,9 @@ struct ModifierGenerator: ParsableCommand {
     import Spatial
     import Symbols
     import LiveViewNativeStylesheet
+    import OSLog
+    
+    private let __generatedModifierLogger = Logger(subsystem: "LiveViewNative", category: "Stylesheet") 
     
     """#
     

--- a/Sources/ModifierGenerator/StyleDefinitionGenerator/makeResolvableType.swift
+++ b/Sources/ModifierGenerator/StyleDefinitionGenerator/makeResolvableType.swift
@@ -75,7 +75,7 @@ extension StyleDefinitionGenerator {
             .filter {
                 $0.isValidModifier
                 && $0.genericParameterClause == nil && $0.genericWhereClause == nil
-                && !$0.attributes.isDeprecated
+                && !$0.attributes.isObsoleted
                 && $0.optionalMark == nil
             }
             .map { $0.normalizedParameterTypes() }
@@ -84,7 +84,7 @@ extension StyleDefinitionGenerator {
             .filter(\.modifiers.isAccessible)
             .filter {
                 $0.isValidModifier
-                && !$0.attributes.isDeprecated
+                && !$0.attributes.isObsoleted
                 && !$0.modifiers.contains(where: { $0.name.tokenKind == .keyword(.static) })
                 && (
                     $0.signature.returnClause?.type.as(IdentifierTypeSyntax.self)?.name.tokenKind == .keyword(.Self)
@@ -99,7 +99,7 @@ extension StyleDefinitionGenerator {
             .filter {
                 $0.isValidModifier
                 && $0.genericParameterClause == nil && $0.genericWhereClause == nil
-                && !$0.attributes.isDeprecated
+                && !$0.attributes.isObsoleted
                 && !$0.name.isOperatorToken
                 && $0.modifiers.contains(where: { $0.name.tokenKind == .keyword(.static) })
                 && (
@@ -112,7 +112,7 @@ extension StyleDefinitionGenerator {
         let staticMembers = members
             .compactMap({ $0.decl.as(VariableDeclSyntax.self) })
             .filter({
-                !$0.attributes.isDeprecated
+                !$0.attributes.isObsoleted
                 && !$0.bindings.contains(where: { $0.pattern.as(IdentifierPatternSyntax.self)?.identifier.text.starts(with: "_") ?? false })
                 && $0.modifiers.contains(where: { $0.name.tokenKind == .keyword(.static) })
                 && $0.modifiers.isAccessible

--- a/Sources/SwiftSyntaxExtensions/Types.swift
+++ b/Sources/SwiftSyntaxExtensions/Types.swift
@@ -83,6 +83,22 @@ public extension TypeSyntaxProtocol {
             return false
         }
         
+        // SwiftUI.ContextMenu<MenuItems> is not allowed
+        if let memberType = self.as(MemberTypeSyntax.self),
+           memberType.baseType.as(IdentifierTypeSyntax.self)?.name.text == "SwiftUI",
+           memberType.name.text == "ContextMenu"
+        {
+            return false
+        }
+        
+        // SwiftUI.Alert is not allowed
+        if let memberType = self.as(MemberTypeSyntax.self),
+           memberType.baseType.as(IdentifierTypeSyntax.self)?.name.text == "SwiftUI",
+           memberType.name.text == "Alert"
+        {
+            return false
+        }
+        
         // Swift.Optional<() -> ()> with a function wrapped type is not allowed
         if let memberType = self.as(MemberTypeSyntax.self),
            memberType.baseType.as(MemberTypeSyntax.self)?.name.text == "Swift",


### PR DESCRIPTION
Deprecated modifiers will now be included in the generated output to preserve compatibility with older platform versions.

When a deprecated modifier is decoded, it will log a warning. If a deprecation message is included in SwiftUI, that message will be in the warning.

```
'tabItem' is deprecated: Use `Tab(title:image:value:content:)` and related initializers instead
```