### PR TITLE
reconnect livechannel on error

### DIFF
--- a/Sources/LiveViewNative/Coordinators/LiveSessionCoordinator.swift
+++ b/Sources/LiveViewNative/Coordinators/LiveSessionCoordinator.swift
@@ -266,15 +266,7 @@ public class LiveSessionCoordinator<R: RootRegistry>: ObservableObject {
                 }
             }
             
-            let liveChannel = try await self.liveSocket!.joinLiveviewChannel(
-                .some([
-                    "_format": .str(string: LiveSessionParameters.platform),
-                    "_interface": .object(object: LiveSessionParameters.platformParams)
-                ]),
-                nil
-            )
-            
-            self.navigationPath.last!.coordinator.join(liveChannel)
+            try await self.joinLiveViewChannel()
             
             self.state = .connected
             
@@ -327,6 +319,18 @@ public class LiveSessionCoordinator<R: RootRegistry>: ObservableObject {
             }
             
         }
+    }
+    
+    func joinLiveViewChannel() async throws {
+        let liveChannel = try await self.liveSocket!.joinLiveviewChannel(
+                .some([
+                    "_format": .str(string: LiveSessionParameters.platform),
+                    "_interface": .object(object: LiveSessionParameters.platformParams)
+                ]),
+                nil
+        )
+            
+        self.navigationPath.last?.coordinator.join(liveChannel)
     }
 
     private func disconnect(preserveNavigationPath: Bool = false) async {

--- a/Sources/LiveViewNative/Coordinators/LiveViewCoordinator.swift
+++ b/Sources/LiveViewNative/Coordinators/LiveViewCoordinator.swift
@@ -345,6 +345,13 @@ public class LiveViewCoordinator<R: RootRegistry>: ObservableObject {
     }
 
     func join(_ liveChannel: LiveViewNativeCore.LiveChannel) {
+        if let old = self.liveChannel {
+            let channel = old.channel()
+            Task { @MainActor in
+                try await channel.shutdown()
+            }
+        }
+        
         self.liveChannel = liveChannel
         let channel = liveChannel.channel()
         self.channel = channel

--- a/Sources/LiveViewNative/Coordinators/LiveViewCoordinator.swift
+++ b/Sources/LiveViewNative/Coordinators/LiveViewCoordinator.swift
@@ -272,6 +272,10 @@ public class LiveViewCoordinator<R: RootRegistry>: ObservableObject {
                     switch event.event {
                     case .phoenix(phoenix: .error):
                         logger.error("encountered error in reply - channel reconnecting");
+                        if let liveChannel {
+                            let channel = liveChannel.channel()
+                            try await channel.shutdown()
+                        }
                         try await session.joinLiveViewChannel()
                     case .user(user: "diff"):
                         switch event.payload {
@@ -345,12 +349,6 @@ public class LiveViewCoordinator<R: RootRegistry>: ObservableObject {
     }
 
     func join(_ liveChannel: LiveViewNativeCore.LiveChannel) {
-        if let old = self.liveChannel {
-            let channel = old.channel()
-            Task { @MainActor in
-                try await channel.shutdown()
-            }
-        }
         
         self.liveChannel = liveChannel
         let channel = liveChannel.channel()

--- a/Sources/LiveViewNative/Coordinators/LiveViewCoordinator.swift
+++ b/Sources/LiveViewNative/Coordinators/LiveViewCoordinator.swift
@@ -270,6 +270,9 @@ public class LiveViewCoordinator<R: RootRegistry>: ObservableObject {
                 guard !Task.isCancelled else { return }
                 do {
                     switch event.event {
+                    case .phoenix(phoenix: .error):
+                        logger.error("encountered error in reply - channel reconnecting");
+                        try await session.joinLiveViewChannel()
                     case .user(user: "diff"):
                         switch event.payload {
                         case let .jsonPayload(json):


### PR DESCRIPTION
presently the liveview channel enters a zombie state - claiming to be joined, after it's Genserver counterpart has panicked and exited. this is expected behavior without and error handling clause to reconnect.