### PR TITLE
Properly resolve optional type erasers

### DIFF
--- a/Sources/SwiftSyntaxExtensions/ValueResolution.swift
+++ b/Sources/SwiftSyntaxExtensions/ValueResolution.swift
@@ -117,7 +117,10 @@ public extension FunctionParameterSyntax {
             // value.resolve(on: __element, in: __context)
             var resolvedAttribute = FunctionCallExprSyntax.resolveAttributeReference(parameterReference)
             // a resolvable value should call `resolve(...)` again
-            if attributeReferenceType.genericArgumentClause!.arguments.first!.argument.as(IdentifierTypeSyntax.self)?.name.text.starts(with: "StylesheetResolvable") ?? false {
+            if attributeReferenceType.genericArgumentClause!.arguments.first!.argument.as(IdentifierTypeSyntax.self)?.name.text.starts(with: "StylesheetResolvable")
+                ?? attributeReferenceType.genericArgumentClause!.arguments.first!.argument.as(OptionalTypeSyntax.self)?.wrappedType.as(IdentifierTypeSyntax.self)?.name.text.starts(with: "StylesheetResolvable")
+                ?? false
+            {
                 resolvedAttribute = FunctionCallExprSyntax.resolveAttributeReference(resolvedAttribute)
             }
             // InlineViewReference should call `resolve(...)` again


### PR DESCRIPTION
This resolves an issue with the `tint` modifier, where the Color was not properly applied, and fell back to `Color.red`.

Its possible this also affected other modifiers that had optional type eraser types as arguments.