### PR TITLE
prevent leak when reconnecting from error view

### DIFF
--- a/Sources/LiveViewNative/Coordinators/LiveSessionCoordinator.swift
+++ b/Sources/LiveViewNative/Coordinators/LiveSessionCoordinator.swift
@@ -216,6 +216,10 @@ public class LiveSessionCoordinator<R: RootRegistry>: ObservableObject {
                 try await socket.shutdown()
             }
             
+            if let liveReloadChannel {
+                try? await liveReloadChannel.shutdownParentSocket()
+            }
+            
             let adapter = ReconnectStrategyAdapter(self.configuration.reconnectBehavior)
             
             self.liveSocket = try await LiveSocket(
@@ -287,7 +291,7 @@ public class LiveSessionCoordinator<R: RootRegistry>: ObservableObject {
     func overrideLiveReloadChannel(channel: LiveChannel) async throws {
         
         if let liveReloadChannel {
-            try await liveReloadChannel.shutdownParentSocket()
+            try? await liveReloadChannel.shutdownParentSocket()
             self.liveReloadChannel = nil
         }
         


### PR DESCRIPTION
When connecting from an error view the livereload channel is not properly freed. This ammends that to prevent a resource leak when reconnecting from the error view.